### PR TITLE
docs(governance): event_change graduation evidence — 0 false positives across 59 exercised event changes

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -335,6 +335,24 @@ change_requirements:
     gate: schema-compat
     enforced: advisory
     target_enforce_date: "2026-09-15"   # ADR-0144
+    # GRADUATION EVIDENCE, measured 2026-09-05. Replayed check-event-schema-compat.py over the
+    # REAL population — the 20 commits in 90 days touching a file that contains `DomainEvent(`,
+    # found with `git grep -l`, not by path name — and the gate was demonstrably exercised:
+    # 59 event-class property-set changes across DelegationEvents, ConsentEvents and others.
+    # It flagged none, correctly: every delta was an ADDED field, which is backward compatible.
+    # False positives on real history: 0 of 20. Same evidence shape #3438 used before
+    # graduating threat-model-diff.
+    #
+    # Two caveats worth carrying, because the first four attempts at this measurement all
+    # produced clean-looking numbers that meant nothing:
+    #   * it only became meaningful after #8713 fixed a parser blind spot — a KDoc inside a
+    #     constructor parameter list hid the parameter after it, so 15 properties fleet-wide
+    #     were invisible and REMOVING one produced no finding at all;
+    #   * selecting commits by path name (`*Event*.kt`, `*/events/*`) gave 40 commits of which
+    #     ZERO touched an event file. Select the population from the code, never from names.
+    #
+    # NOT evidenced: no commit in the window REMOVED or retyped a field, so those paths rest on
+    # the gate's own --self-test (17 cases), not on history.
     # CI producer is LIVE (advisory): .github/scripts/check-event-schema-compat.py runs in
     # the "Validate manifests" job on every PR — diff-scoped over DomainEvent data classes
     # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,


### PR DESCRIPTION
## What this answers

`event_change` carries `target_enforce_date: 2026-09-15` — **ten days out** — with no evidence attached either way. This records the measurement the decision needs.

## The measurement

Replayed `check-event-schema-compat.py` over the **real population**: the 20 commits in 90 days touching a file that contains `DomainEvent(`, found with `git grep -l` rather than by path name.

```
20 commits replayed, all 20 touched an event file
59 event-class property-set changes exercised
0 findings, 0 script errors
```

The gate was **demonstrably working, not merely silent** — 59 deltas across `DelegationEvents`, `ConsentEvents` and others. It flagged none, correctly: every delta was an **added** field, which is backward compatible.

**False positives on real history: 0 of 20.** Same evidence shape #3438 used before graduating `threat-model-diff`.

## Why the caveats are in the record, not just the result

The first four attempts each produced a clean-looking number that meant nothing — and the second would have read as the most convincing of all:

| attempt | result | what it actually was |
|---|---|---|
| 1 | 40/40 pass | parser blind spot — a KDoc inside a ctor parameter list hid the parameter after it. 15 properties fleet-wide invisible; **removing one produced no finding**. Fixed in #8713 |
| 2 | 40/40 pass | **zero** of those 40 commits touched a file containing `DomainEvent(` — selected by path name, so the gate had nothing to compare |
| 3 | 1 "failure" | a **root commit**: `<sha>^` does not resolve, the script died on `git diff`, and my loop counted any non-zero exit as a finding |
| 4 | "0 touched" | an empty argument in my own verification `git show` |
| 5 | **valid** | the numbers above |

So the note records **how the population was chosen**, not only what came out.

## What this does not evidence

**No commit in the window removed or retyped a field.** Those paths rest on the gate's own `--self-test` (17 cases), not on history. Stated in place rather than left for the reader to assume.

## Scope

No behaviour change — the rule stays advisory with its date; this is evidence for whoever decides on 2026-09-15.

- `check-gate-graduation`: 18 advisory rules, all with live dates.
- `gen-rules-opa-data.py`: no diff.
- `yamllint`, `gate-lifecycle-metadata`, `advisory-gate-registration`: pass.

## Linked issues

Refs #8713 — the parser fix without which this measurement was meaningless.
Refs #8690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
