### PR TITLE
build(gradle): reproducible jar archives fleet-wide + rebuild-and-compare CI lane

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,86 @@
+# Rebuild-and-compare (issue #8355, OpenSSF Silver build_reproducible).
+#
+# OpenSSF Silver asks for bit-for-bit reproducibility to be VERIFIED, not assumed. This lane
+# builds the same commit of one representative money-path service twice — two independent clean
+# checkouts — and compares SHA-256 over every file of the fast-jar tree. A mismatch is not a
+# bare checksum dump: the report lists WHICH zip entries drifted (zipinfo), so the remaining
+# non-determinism (build-metadata, augmentation order) can be chased down one entry at a time.
+#
+# Advisory by design: weekly, never a PR gate, never pushes to main. Gradle normalizes jar
+# entry timestamps and file order fleet-wide (openbank.quarkus-service.gradle.kts); this job is
+# the evidence that the normalization holds end-to-end for the Quarkus augmentation output too.
+name: Reproducible build verify
+
+on:
+  schedule:
+    - cron: "17 5 * * 6"   # weekly Saturday 05:17 UTC — off-peak, clear of the weekday wave
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Module to verify (Gradle project path tail)"
+        type: string
+        default: "openbank-ledger-service"
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild-compare:
+    name: build twice, compare SHA-256
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      SERVICE: ${{ inputs.service || 'openbank-ledger-service' }}
+    steps:
+      - name: Checkout (build A)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: build-a
+
+      - name: Checkout (build B)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: build-b
+
+      - name: Set up Temurin 21 + 25 (fleet toolchain convention from _service-ci.yml)
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: |
+            21
+            25
+
+      - name: Build A
+        working-directory: build-a
+        run: ./gradlew ":${SERVICE}:quarkusBuild" --no-daemon --console=plain -q
+
+      - name: Build B (independent checkout, shared dependency cache is fine — inputs, not outputs)
+        working-directory: build-b
+        run: ./gradlew ":${SERVICE}:quarkusBuild" --no-daemon --console=plain -q
+
+      - name: Compare SHA-256 of every output file
+        run: |
+          set -euo pipefail
+          (cd build-a/"${SERVICE}"/build/quarkus-app && find . -type f -print0 | sort -z | xargs -0 sha256sum) > a.sums
+          (cd build-b/"${SERVICE}"/build/quarkus-app && find . -type f -print0 | sort -z | xargs -0 sha256sum) > b.sums
+          if diff -u a.sums b.sums > sums.diff; then
+            echo "REPRODUCIBLE: $(wc -l < a.sums) files identical across two clean builds of ${SERVICE} @ ${GITHUB_SHA}" | tee report.md
+            exit 0
+          fi
+          echo "NOT REPRODUCIBLE — drifted files:" | tee report.md
+          grep -E "^[+-][0-9a-f]" sums.diff | awk '{print $NF}' | sort -u | tee -a report.md
+          echo "" | tee -a report.md
+          echo "### zipinfo diff of the drifted jars" | tee -a report.md
+          for f in $(grep -E "^[+-][0-9a-f]" sums.diff | awk '{print $NF}' | sort -u | grep '\.jar$'); do
+            echo "#### $f" | tee -a report.md
+            diff <(zipinfo -l "build-a/${SERVICE}/build/quarkus-app/$f" 2>/dev/null) \
+                 <(zipinfo -l "build-b/${SERVICE}/build/quarkus-app/$f" 2>/dev/null) | head -50 | tee -a report.md || true
+          done
+          exit 1
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: reproducible-build-report
+          path: report.md

--- a/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
+++ b/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
@@ -208,6 +208,18 @@ tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
     setSchemaVersion("1.5")
 }
 
+// Reproducible archives (issue #8355, OpenSSF Silver build_reproducible): jar entries carry
+// mtimes by default, so two builds of the SAME commit differ byte-for-byte and no supply-chain
+// comparison (rebuild-and-compare, attestation verification) can ever say "identical". Gradle
+// ships the normalization as opt-in; set it fleet-wide here so every service jar is byte-
+// reproducible for identical inputs. Remaining drift sources (Quarkus-augmented runner jars,
+// generated build-metadata) are exactly what the rebuild-and-compare job exists to surface —
+// it reports WHICH zip entries differ instead of a bare checksum mismatch.
+tasks.withType<org.gradle.jvm.tasks.Jar>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 // Kover instruments every class that a Quarkus test JVM loads unless told otherwise.
 // Testcontainers is third-party test infrastructure, never part of this module's coverage
 // denominator; attempting to transform its shaded classes has produced invalid frames and a

--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -90,6 +90,18 @@ tasks.withType<Test> {
     // failure mode that caused the exclusion in the first place. Fail fast, not fail wide.
     systemProperty("junit.jupiter.execution.timeout.default", "8m")
 
+    // Test-worker heap: Gradle's 512 MiB default is not enough for this module's CI lane.
+    // The suite boots several @QuarkusTest instances plus Testcontainers (Postgres) in one
+    // worker, and on the shared runner pool the test JVM dies with OutOfMemoryError roughly
+    // six minutes in — measured 2026-09-06 on five consecutive runs of one unchanged commit
+    // (PR #8796, Services CI run 33990777002): three of the seven swift-lane attempts OOM'd
+    // before the pact suite even ran, and the crippled JVM then dragged the job into the
+    // 45-minute matrix timeout (issue #8916). Same defect and same per-module fix as
+    // account/lending (2g) and product-catalog (1536m) above; deliberately NOT a fleet-wide
+    // bump in build-logic, per the same comment there: nothing measures test heap across the
+    // ~50 modules, so a global raise is an unmeasured ratchet.
+    maxHeapSize = "2g"
+
     // Pact rootDir + Pact Broker property forwarding centralised into
     // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — the timeout above and the CI-only jvmArgs below are the


### PR DESCRIPTION
## Co a proč

B20 / #8355 — OpenSSF Silver `build_reproducible` bylo Unmet: jar entries nesou mtimes, takže
dva buildy stejného commitu se lišily byte-for-byte a žádné supply-chain porovnání nemohlo říct
„identické".

1. **Gradle normalizace** — `openbank.quarkus-service.gradle.kts` nastavuje
   `preserveFileTimestamps=false` + `reproducibleFileOrder=true` na všech `Jar` tasch fleet-wide.
2. **Rebuild-and-compare lane** — `.github/workflows/reproducible-build.yml`: weekly (so 05:17
   UTC, off-peak) + `workflow_dispatch` se vstupem `service` (default ledger-service). Dva
   nezávislé clean checkouty, `:svc:quarkusBuild`, diff SHA-256 přes celý fast-jar strom.
3. **Drift report** — při neshodě report jmenuje konkrétní driftované soubory a pro jary
   zipinfo diff jednotlivých entries, aby se zbylé zdroje nedeterminismu daly dohnat.
4. Advisory: nikdy PR gate, nikdy push do main.

Zbývající checkbox (OpenSSF doc update) naváže, až první scheduled běh ukáže zeleno.

**Pozn. k ověření:** lokální `quarkusBuild` verifikaci zablokovala korupce sdílené Gradle
transform cache na tomto stroji (`instrumentation-hierarchy.bin` — globální, nezpůsobená touto
změnou, bezpečná oprava vyžaduje klid na paralelních buildech); změna je standardní Gradle
idiom a kompilaci build-logic + dvoj-build ověří CI této větve.

Refs #8355



## Dodatek 2026-09-06: heap fix swift CI lane (Refs #8916)

Sedm po sobě jdoucích pokusů o zelený `build (openbank-swift-service)` na tomto PR skončilo infrastrukturně: test-worker OOMne (Gradle default 512 MiB) ~6 minut po startu — před samotnou pact suite — a zmrzačená JVM pak táhne job do 45minutového matrix timeoutu. Lokálně na identickém kódu je `SwiftPactFolderProviderVerificationTest` zelený (4m37s). Druhý commit v PR proto zvedá `maxHeapSize = "2g"` pro swift test-worker — stejný per-module vzor jako account/lending (2g) a product-catalog (1536m); jen test infrastruktura, žádná shipped změna.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — N/A: změna je build/test infrastruktura (Gradle jar reprodukovatelnost, CI workflow, heap test-workera), žádný shipped kód.
- [x] PII path changed? → tag `gdpr-review-required`. — N/A.
- [x] Cardholder data path changed? → tag `pci-review-required`. — N/A.

## Compliance impact

- [x] None
