### PR TITLE
fix(governance): drain paid-off psd2 idempotency baseline entries

### DIFF
--- a/.github/gates/idempotency-parity-baseline.txt
+++ b/.github/gates/idempotency-parity-baseline.txt
@@ -8,24 +8,9 @@
 # Every entry below is one service's PIS/SCA surface and each is a real, live defect, not a
 # tidiness item. They are declared rather than fixed in the gate's own PR because correcting a
 # published header name is an api-contract change on a money-path service (two approvals plus a
-# threat model, rules.yaml money_path_services) and because the psd2 correction has to choose
-# between renaming the contract and renaming the binding — a decision with different blast radii
-# for existing TPP integrations. Landing the gate first stops the SIXTH occurrence; it does not
-# pretend the five are acceptable.
-
-# psd2 PIS: the contract tells a TPP to send X-Idempotency-Key and the handler binds
-# Idempotency-Key, so `idempotencyKey` is null on every spec-conformant request. PisResource's
-# shared initiatePayment() then throws Psd2RequestFormatException("Idempotency-Key header is
-# required") BEFORE the store lookup — so this is not a degraded replay guarantee, it rejects
-# the call outright. Both SEPA products are affected.
-openbank-psd2-service name-mismatch POST /open-banking/v2/payments/instant-sepa-credit-transfers
-openbank-psd2-service name-mismatch POST /open-banking/v2/payments/sepa-credit-transfers
-
-# psd2 PIS, the other two products: the handler binds Idempotency-Key and requires it non-blank
-# through the same initiatePayment(), and the published operation declares no idempotency header
-# at all — so a client generated from the contract sends none and is rejected the same way.
-openbank-psd2-service bound-not-published POST /open-banking/v2/payments/domestic-cz
-openbank-psd2-service bound-not-published POST /open-banking/v2/payments/sipo
+# threat model, rules.yaml money_path_services). The psd2 entries have since been paid off
+# (contract and binding reconciled) and drained from this list — landing the gate first stopped
+# the sixth occurrence; it never pretended the earlier ones were acceptable.
 
 # sca-service: ScaResource.initiate implements a full Redis replay guard (store get, store save,
 # 300s TTL, X-Idempotency-Replayed on the hit) keyed on Idempotency-Key falling back to


### PR DESCRIPTION
## Summary
`gates (gitops-api)` fails fleet-wide on every PR right now: `idempotency-contract-parity`
reports 4 STALE baseline entries for `openbank-psd2-service` (2 name-mismatch, 2
bound-not-published). Re-running the checker at current `main` HEAD confirms all four
are no longer real findings — the psd2 contract/binding drift was already fixed
elsewhere; only the declared-backlog file was never drained.

Deleted the four stale lines and trimmed the prose block that described them, keeping
the still-live sca-service entry.

## Test plan
- [x] `python3 .github/scripts/check-idempotency-contract-parity.py --enforce --baseline .github/gates/idempotency-parity-baseline.txt` — `0 NEW, 0 stale`
- [x] same script `--self-test` — still passes (24 cases)
