### PR TITLE
fix(dispute): announce a dispute that ends through the update path — every withdrawal was silent

### DIFF
--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
@@ -107,19 +107,29 @@ class DisputeService(
                     resolution = request.resolution ?: dispute.resolution,
                     chargebackAmount = request.chargebackAmount ?: dispute.chargebackAmount,
                     resolvedBy = request.resolvedBy ?: dispute.resolvedBy,
-                    resolvedAt = if (request.status in listOf(
-                            DisputeStatus.RESOLVED_CUSTOMER,
-                            DisputeStatus.RESOLVED_MERCHANT,
-                            DisputeStatus.WITHDRAWN,
-                        )
-                    ) {
+                    resolvedAt = if (request.status in TERMINAL_STATUSES) {
                         OffsetDateTime.now(clock)
                     } else {
                         dispute.resolvedAt
                     },
                     updatedAt = OffsetDateTime.now(clock),
                 )
-                disputeRepo.update(updated).flatMap { saved ->
+                // A dispute that ENDS here must announce it exactly as `resolve` does.
+                // engagement-service applies an ADR-0220 D3.5 targeting exclusion on
+                // `dispute.opened` and lifts it ONLY on `dispute.resolved`
+                // (DisputeOpenedEventConsumer:26-27), so a dispute that reaches a terminal state
+                // through this path without the event leaves that customer excluded permanently.
+                // `withdraw()` delegates here, so every withdrawal took that path. The timeline row
+                // below is internal to this service and reaches no consumer.
+                // Guarded on the PREVIOUS status so a repeated PUT of an already-terminal status
+                // does not re-announce; the empty list makes this call identical to the one-arg
+                // overload, which the repository implements with the same @WithTransaction.
+                val messages = if (updated.status in TERMINAL_STATUSES && dispute.status !in TERMINAL_STATUSES) {
+                    listOf(resolvedOutboxMessage(updated))
+                } else {
+                    emptyList()
+                }
+                disputeRepo.update(updated, messages).flatMap { saved ->
                     val event = DisputeTimelineEvent(
                         disputeId = saved.id,
                         eventType = "STATUS_CHANGED",
@@ -300,7 +310,9 @@ class DisputeService(
         // would never lift. Additive, and `dispute.remediation_requested` already carries one.
         payload = """{"eventType":"dispute.resolved","disputeId":"${dispute.id}",""" +
             """"reference":"${dispute.reference}","partyId":"${dispute.partyId}",""" +
-            """"outcome":"${dispute.remediationOutcome}",""" +
+            // WITHDRAWN reaches this builder with no remediation outcome; interpolating it
+            // straight would put the four-character string "null" in a quoted field.
+            """"outcome":${dispute.remediationOutcome?.let { "\"$it\"" } ?: "null"},""" +
             """"status":"${dispute.status}","resolvedAt":"${dispute.resolvedAt}",""" +
             """"occurredAt":"${dispute.resolvedAt?.toInstant() ?: Instant.now(clock)}",""" +
             """"sourceService":"$SOURCE_SERVICE"}""",
@@ -346,6 +358,18 @@ class DisputeService(
 
     companion object {
         private val BANK_TIME: ZoneId = ZoneId.of("Europe/Prague")
+
+        /**
+         * The states in which a dispute is over. Shared by [update] between the `resolvedAt` stamp
+         * and the `dispute.resolved` emission so the two can never disagree about what "terminal"
+         * means -- before this they were the same three names written out twice, one of which
+         * emitted nothing.
+         */
+        internal val TERMINAL_STATUSES = setOf(
+            DisputeStatus.RESOLVED_CUSTOMER,
+            DisputeStatus.RESOLVED_MERCHANT,
+            DisputeStatus.WITHDRAWN,
+        )
 
         /** States from which a remediation resolution may be recorded (evidence-gathering states). */
         internal val RESOLVABLE_FROM = setOf(

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
@@ -154,11 +154,19 @@ class DisputeServiceTest {
             updatedAt = now,
         )
         val update = UpdateDisputeRequest(status = DisputeStatus.RESOLVED_CUSTOMER, resolvedBy = "caseworker")
+        val outbox = slot<List<OutboxMessage>>()
         every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
-        every { disputeRepo.update(any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        every { disputeRepo.update(any(), capture(outbox)) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
         every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
 
         val result = service.update(id, update).await().indefinitely()
+
+        // The dispute ENDS here, so it must announce itself: engagement-service lifts its ADR-0220
+        // targeting exclusion only on `dispute.resolved`, so without this the customer stays
+        // excluded forever. The timeline row is internal and reaches no consumer.
+        assertThat(outbox.captured).singleElement()
+            .satisfies({ m -> assertThat(m.eventType).isEqualTo("dispute.resolved") })
+        assertThat(outbox.captured.single().payload).contains(existing.partyId.toString())
 
         assertThat(result.status).isEqualTo(DisputeStatus.RESOLVED_CUSTOMER)
         assertThat(result.resolvedBy).isEqualTo("caseworker")
@@ -166,8 +174,41 @@ class DisputeServiceTest {
         assertThat(result.updatedAt).isNotNull()
 
         verify(exactly = 1) { disputeRepo.findById(id) }
-        verify(exactly = 1) { disputeRepo.update(any()) }
+        verify(exactly = 1) { disputeRepo.update(any(), any()) }
         verify(exactly = 1) { timelineRepo.save(any()) }
+    }
+
+    @Test
+    fun `a non-terminal status change announces nothing`() {
+        val id = UUID.randomUUID()
+        val existing = Dispute(
+            id = id,
+            reference = "DSP-3000",
+            transactionId = UUID.randomUUID(),
+            accountId = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            disputeType = DisputeType.OTHER,
+            amount = BigDecimal("5.00"),
+            transactionDate = today,
+            filingDate = today,
+            resolutionDeadline = today.plusDays(45),
+            createdAt = now,
+            updatedAt = now,
+        )
+        val outbox = slot<List<OutboxMessage>>()
+        every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
+        every { disputeRepo.update(any(), capture(outbox)) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
+
+        val result = service.update(id, UpdateDisputeRequest(status = DisputeStatus.UNDER_REVIEW)).await()
+            .indefinitely()
+
+        // The counter-case to the two tests above. Without it, "emits on terminal" would also pass
+        // for an implementation that emits on EVERY update -- which would tell engagement to lift
+        // an exclusion while the dispute is still open.
+        assertThat(result.status).isEqualTo(DisputeStatus.UNDER_REVIEW)
+        assertThat(result.resolvedAt).isNull()
+        assertThat(outbox.captured).isEmpty()
     }
 
     @Test
@@ -187,11 +228,19 @@ class DisputeServiceTest {
             createdAt = now,
             updatedAt = now,
         )
+        val outbox = slot<List<OutboxMessage>>()
         every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
-        every { disputeRepo.update(any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        every { disputeRepo.update(any(), capture(outbox)) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
         every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
 
         val result = service.withdraw(id, "customer").await().indefinitely()
+
+        // `withdraw` delegates to `update`, so before this fix EVERY withdrawal was silent.
+        assertThat(outbox.captured).singleElement()
+            .satisfies({ m -> assertThat(m.eventType).isEqualTo("dispute.resolved") })
+        // WITHDRAWN carries no remediation outcome: it must serialise as JSON null, not as the
+        // four-character string "null" inside quotes.
+        assertThat(outbox.captured.single().payload).contains("\"outcome\":null")
 
         assertThat(result.status).isEqualTo(DisputeStatus.WITHDRAWN)
         assertThat(result.resolution).isEqualTo(DisputeResolution.WITHDRAWN)
@@ -199,7 +248,7 @@ class DisputeServiceTest {
         assertThat(result.updatedAt).isNotNull()
 
         verify(exactly = 1) { disputeRepo.findById(id) }
-        verify(exactly = 1) { disputeRepo.update(any()) }
+        verify(exactly = 1) { disputeRepo.update(any(), any()) }
         verify(exactly = 1) { timelineRepo.save(any()) }
     }
 


### PR DESCRIPTION
## The defect

A dispute reaching a **terminal** status through `DisputeService.update` wrote no outbox message. `withdraw()` delegates to `update()`, so **every withdrawal was silent**.

```kotlin
disputeRepo.update(updated).flatMap { saved ->          // one-arg overload: no outbox
    val event = DisputeTimelineEvent(
        eventType = "STATUS_CHANGED",                    // internal timeline row
        ...
    )
    timelineRepo.save(event).map { saved }
}
```

That `eventType = "STATUS_CHANGED"` is easy to misread as an emission — the field is spelled the same as the real thing. It is a `DisputeTimelineEvent`, internal to this service, and reaches no consumer. The service's actual outbox messages are built in named helpers (`openedOutboxMessage`, `resolvedOutboxMessage`, `remediationRequestedOutboxMessage`) and carry dotted names.

So the same terminal state was reachable two ways with different observability:

| path | on the wire |
|---|---|
| `resolve()` → `doResolve()` | `dispute.resolved` ✔ |
| `update(status = RESOLVED_CUSTOMER)` | nothing ✘ |
| `withdraw()` → `update(...)` | nothing ✘ |

`update` explicitly handles `RESOLVED_CUSTOMER`, `RESOLVED_MERCHANT` and `WITHDRAWN` — it stamps `resolvedAt` for exactly those three — so this is not a path that merely *could* end a dispute.

## Why it matters, concretely

`openbank-engagement-service` applies an **ADR-0220 D3.5 targeting exclusion** when it sees `dispute.opened` and lifts it **only** on `dispute.resolved`:

> `dispute.opened` applies the exclusion, `dispute.resolved` lifts it
> — `DisputeOpenedEventConsumer.kt:26-27`

A customer whose dispute was withdrawn, or resolved through `update` rather than `resolve`, therefore stayed excluded from targeting **permanently**.

The KDoc on `resolvedOutboxMessage` already names this exact risk, which is what makes the gap an omission rather than a design choice:

> without it a consumer can learn that a customer entered dispute but never that they left it, so an ADR-0220 exclusion applied on open would never lift

## The change

1. `update()` passes `resolvedOutboxMessage(updated)` to the **two-arg** repository overload. That overload is `@WithTransaction` (`DisputeRepositories.kt:73-83`), so the status change and the event commit together; with an empty list it is byte-for-byte equivalent to the one-arg version, so the non-terminal path is unchanged.
2. Guarded on the **previous** status (`dispute.status !in TERMINAL_STATUSES`) so a repeated `PUT` of an already-terminal status does not re-announce.
3. `TERMINAL_STATUSES` extracted and used for **both** the `resolvedAt` stamp and the emission. They were the same three names written out twice before, one of which emitted nothing — exactly the drift that let this happen.
4. A null `remediationOutcome` now serialises as JSON `null` rather than the four-character string `"null"` in a quoted field. `WITHDRAWN` reaches the builder with no outcome; `resolve` always sets one, so **that payload is unchanged**. The engagement consumer reads only `eventType` and `partyId`, so nothing downstream depends on the old rendering.

## Verification — falsified in both directions

The two existing tests mocked the **one-arg** overload, which is precisely why they could not catch this. They now capture the outbox list and assert the event. A third test covers the counter-case.

| tree | result |
|---|---|
| fix in place | **13/13 green**, 0 failures, 0 errors, **0 skipped** (JUnit XML) |
| production reverted, tests kept | **3 red** — both existing tests plus the counter-test |
| guard removed (`if (true)`, emit on every update) | **exactly 1 red — the counter-test**, other 12 green |

That third row is the one worth reading. Reverting production reddens the counter-test too, but only because the mock shape no longer matches — that is not evidence it detects over-emission. Removing just the guard proves it discriminates: without it, "emits on terminal" would also pass for an implementation that emits on **every** update, which would tell engagement to lift an exclusion while the dispute is still open.

`ktlintCheck` + `detekt` green.

**Local verification note:** this machine's shared Gradle state broke mid-session — every build failed with 58 `libs.*`-unresolved errors in `openbank-agent-service/build.gradle.kts`, reproducible from a **fresh worktree on pristine `origin/main`** and on a module that had compiled an hour earlier, with no relevant commit in 24h and 7 concurrent Gradle daemons sharing `~/.gradle`. Everything above was therefore run under an isolated `--gradle-user-home`, not the shared one. The repo is fine; the machine is not.

## Scope

`openbank-dispute-service` is not in `rules.yaml: money_path_services`. No API surface change, no migration, no new event type — `dispute.resolved` already exists on `openbank.dispute.events` and the baseline pins the topic, not the payload. This adds an **occurrence** of an existing event on a path that had none.

Refs #8745

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [x] Cardholder data path changed? → tag `pci-review-required`.

Checked against the diff: two files, no `@Suppress`/`as Any` added, no dependency file touched, no secret-shaped line. No auth, crypto or payment path changes. The event payload carries `partyId`, which it already carried on this exact event type from the `resolve` path — this change adds no field and no new recipient, it only makes an existing event fire on a path that was silent.
