### PR TITLE
fix(governance): declare budget_seconds on 5 undeclared gates

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -206,6 +206,7 @@ gates:
     mode: enforced
     rationale: "The MTTR granularity refusal and the recurrence guard are the only things stopping ADR-0241 D1/D3 from publishing a number nobody measured, and the coverage outcome is what stops an empty week reporting as a clean one. They were wired only inside a scheduled workflow that has never once succeeded, so they had never run on any lane. Recheck for removal when a durable alert open/close feed exists (#5869) and the MTTR half is no longer a refusal."
     review_after: "2027-02-21"
+    budget_seconds: 15   # 0.2s measured in CI
     run: |
       python3 .github/scripts/alert-rca-ledger.py --self-test
 
@@ -216,6 +217,7 @@ gates:
     mode: enforced
     rationale: "The digest's severity filter and observation envelope are the producer half of the same control; if the envelope shape drifts, the weekly review silently folds nothing and reports a clean week. Same lane gap as its consumer above. Recheck when the digest stops being the ledger's only observation source."
     review_after: "2027-02-21"
+    budget_seconds: 15   # 0.1s measured in CI
     run: |
       python3 .github/scripts/standing-critical-digest.py --self-test
 
@@ -1927,6 +1929,7 @@ gates:
     mode: enforced
     rationale: "flaky-test-hunter is the only agent with a real GitHub write path; its non-money-path confinement and its inability to merge or approve held only because a human read a Kotlin constant, and money_path_services grows over time."
     review_after: "2027-02-20"
+    budget_seconds: 30   # 2.3s measured locally over 3 runs; headroom for a cold runner
     selftest: python3 .github/scripts/check-agent-bounded-write-surface.py --self-test
     selftest_expect: pass
     run: |
@@ -2574,6 +2577,7 @@ gates:
       `grep -c sourceService` matches the field being mentioned, never the value emitted
       (#5256, #5902).
     review_after: 2027-02-20
+    budget_seconds: 30   # 1.9s measured locally over 3 runs; headroom for a cold runner
     selftest: python3 .github/scripts/check-source-service-convention.py --self-test
     selftest_expect: pass
     run: |
@@ -4799,6 +4803,7 @@ gates:
       a direct push to main) — reddens every PR until it is declared in a reviewed commit.
       Re-examine when the repo gains an org owner or a GitHub App that legitimately needs one.
     review_after: "2027-02-20"
+    budget_seconds: 15   # 0.8s measured locally over 3 runs; headroom for a cold runner
     selftest: python3 .github/scripts/check-ruleset-bypass-actors.py --self-test
     selftest_expect: pass
     min_subjects: 1   # exactly 1 bypass actor today (2026-08-20)


### PR DESCRIPTION
## Summary
`gates (gitops-api)` / `gates (lint-supplychain-security)` fails fleet-wide on every PR:
`gate-observability-declarations` ratchets the count of gates missing `budget_seconds`
(baseline allows 159; `main` sits at 164). Five gates landed without one:
`alert-rca-ledger-guards`, `standing-critical-digest-guards`, `agent-bounded-write-surface`,
`source-service-convention`, `ruleset-bypass-actors`.

Declared `budget_seconds` on all five, matching the file's existing convention (measured
runtime + headroom, comment records the measurement):
- `alert-rca-ledger-guards`: 15s (0.2s in CI)
- `standing-critical-digest-guards`: 15s (0.1s in CI)
- `ruleset-bypass-actors`: 15s (0.8s measured locally, 3 runs)
- `agent-bounded-write-surface`: 30s (2.3s measured locally, 3 runs)
- `source-service-convention`: 30s (1.9s measured locally, 3 runs)

## Linked issues
N/A — no tracking issue. Refs #8749 (the PR whose CI triage surfaced this).

## Test plan
- [x] `python3 .github/scripts/check-gate-observability-declarations.py --enforce` — `OK -- both ratchets hold`
- [x] same script `--self-test` — `6 cases, 5 red + 1 green`
