### PR TITLE
fix(domestic-payment): disambiguate SOURCE_SERVICE const collisions + gate budget repair

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -200,6 +200,7 @@ gates:
   # it deliberately does not check REACHABILITY — a script invoked from a workflow that
   # never runs still counts as wired. Registering here is what puts them on a PR lane.
   - id: alert-rca-ledger-guards
+    budget_seconds: 15   # one script self-test run
     selftest_exempt: "is-a-test-suite — the run: IS alert-rca-ledger.py --self-test"
     name: "alert-RCA ledger guards (MTTR granularity, recurrence, observation coverage)"
     group: lint
@@ -210,6 +211,7 @@ gates:
       python3 .github/scripts/alert-rca-ledger.py --self-test
 
   - id: standing-critical-digest-guards
+    budget_seconds: 15   # one script self-test run
     selftest_exempt: "is-a-test-suite — the run: IS standing-critical-digest.py --self-test"
     name: "standing-critical digest guards (severity filter, observation envelope)"
     group: lint
@@ -1919,6 +1921,7 @@ gates:
   # 2026-08-20: a money-path prefix, an added `PUT /pulls/{n}/merge`, and a deleted bound each make
   # it exit 1; removing either half of `evaluate` makes the self-test go red.
   - id: agent-bounded-write-surface
+    budget_seconds: 20   # rules.yaml + agent charter scan
     min_subjects: 20   # the money_path_services entries the bound is checked against; 23 today
                         # (2026-08-20). A gate that resolves an empty list would pass everything,
                         # so the floor moves with the list rather than tracking it exactly.
@@ -2563,6 +2566,7 @@ gates:
   # baseline entry pins the (module, value) pair, so lending drifting to a third spelling still
   # fails. ENFORCED.
   - id: source-service-convention
+    budget_seconds: 30   # whole-fleet Kotlin scan
     name: "sourceService == module directory name (issues #5256/#5902, enforced)"
     group: kotlin
     mode: enforced
@@ -4788,6 +4792,7 @@ gates:
   # live admin actor is reported undeclared, and with its bypass_mode pinned to `always`
   # both directions report — red both ways, green only on the shipped declaration.
   - id: ruleset-bypass-actors
+    budget_seconds: 20   # one GitHub API read + compare
     name: "who may bypass main-protection is pinned, and widening it fails a PR (Refs #4828, enforced)"
     group: lint
     mode: enforced

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
@@ -49,7 +49,7 @@ data class DelegatedSpendReservationSnapshot(
     init {
         require(schemaVersion == SCHEMA_VERSION) { "Unsupported reservation schema version: $schemaVersion" }
         require(aggregateType == AGGREGATE_TYPE) { "Unexpected aggregateType: $aggregateType" }
-        require(sourceService == SOURCE_SERVICE) { "Unexpected sourceService: $sourceService" }
+        require(sourceService == EXPECTED_SOURCE_SERVICE) { "Unexpected sourceService: $sourceService" }
         require(resourceType == ACCOUNT_RESOURCE_TYPE) { "Domestic payment reservation must target ACCOUNT" }
         require(operationType == OPERATION_TYPE) { "Unexpected reservation operationType: $operationType" }
         require(amount > BigDecimal.ZERO) { "Reservation amount must be positive" }
@@ -106,7 +106,7 @@ data class DelegatedSpendReservationSnapshot(
         /** Producer-owned discriminator accepted by the projection; this service does not emit it. */
         const val SOURCE_EVENT_TYPE = "DelegationSpendReservationStateChanged"
         const val AGGREGATE_TYPE = "DelegationSpendReservation"
-        const val SOURCE_SERVICE = "delegation-service"
+        const val EXPECTED_SOURCE_SERVICE = "delegation-service"
         const val ACCOUNT_RESOURCE_TYPE = "ACCOUNT"
         const val OPERATION_TYPE = "DOMESTIC_PAYMENT"
         const val SCHEMA_VERSION = 1L

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DelegatedSpendFinalizedAbsentPactFixture.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DelegatedSpendFinalizedAbsentPactFixture.kt
@@ -48,7 +48,7 @@ object DelegatedSpendFinalizedAbsentPactFixture {
             reservationVersion = DelegatedSpendReservationSnapshot.RESERVED_VERSION,
             schemaVersion = DelegatedSpendReservationSnapshot.SCHEMA_VERSION,
             aggregateType = DelegatedSpendReservationSnapshot.AGGREGATE_TYPE,
-            sourceService = DelegatedSpendReservationSnapshot.SOURCE_SERVICE,
+            sourceService = DelegatedSpendReservationSnapshot.EXPECTED_SOURCE_SERVICE,
             createdAt = Instant.parse("2026-09-01T12:00:00Z"),
             settledAt = null,
             occurredAt = Instant.parse("2026-09-01T12:00:00Z"),

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
@@ -117,7 +117,7 @@ class OrphanedPartyGauge(
 
     private fun gauge(r: MeterRegistry, name: String, holder: AtomicLong) {
         Gauge.builder(name, holder) { it.get().toDouble() }
-            .tag("service", SERVICE)
+            .tag("service", METRICS_SERVICE_TAG)
             .strongReference(true)
             .register(r)
     }
@@ -173,7 +173,7 @@ class OrphanedPartyGauge(
     }
 
     private companion object {
-        const val SERVICE = "kyc"
+        const val METRICS_SERVICE_TAG = "kyc"
         const val WORKFLOW_NAME = "kyc-orphaned-party-detection"
         val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }


### PR DESCRIPTION
## Co a proč

Main-red oprava: gate `source-service-convention` hlásil `UNRESOLVED — ambiguous` ve dvou
modulech, každý z jiného důvodu — a protože gate skenuje celou fleet, **žádný z půl-fixů by
sám CI nezazelenil** (každý PR by viděl druhou službu stále rozbitou). Obě přejmenování
proto jedou v jednom PR; release-please atribuuje podle dotčených souborů, takže releasnou
se obě služby správně.

1. **domestic-payment**: `DelegatedSpendBinding` (KONZUMENT delegation streamu, sám neemituje)
   držel `SOURCE_SERVICE = "delegation-service"` jako inbound origin check; vedle něj
   `DelegatedSpendFinalizedAbsentEvent` emituje `SOURCE_SERVICE = "domestic-payment"`.
   Kolize jména → bindingova konstanta je `EXPECTED_SOURCE_SERVICE`.
2. **kyc-service**: `OrphanedPartyGauge.SERVICE = "kyc"` (Micrometer tag) kolidoval s
   `KycEvent.SERVICE = "kyc-service"` (emitovaný sourceService, správně). Gauge konstanta je
   `METRICS_SERVICE_TAG`; **hodnota `"kyc"` se nemění** — žádný dashboard/alert selector
   se nedotkne.

Obě změny jsou čistá přejmenování konstant, emitované hodnoty netknuté. Gate po obou fixech
lokálně: 0 findings / 28 producers.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → ne; přejmenování konstant bez změny hodnot.
- [x] PII path changed? → ne.
- [x] Cardholder data path changed? → ne.

Refs #5902
