### PR TITLE
fix(kyc): disambiguate the gauge service tag from the event sourceService const

### DIFF
--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
@@ -117,7 +117,7 @@ class OrphanedPartyGauge(
 
     private fun gauge(r: MeterRegistry, name: String, holder: AtomicLong) {
         Gauge.builder(name, holder) { it.get().toDouble() }
-            .tag("service", SERVICE)
+            .tag("service", METRICS_SERVICE_TAG)
             .strongReference(true)
             .register(r)
     }
@@ -173,7 +173,7 @@ class OrphanedPartyGauge(
     }
 
     private companion object {
-        const val SERVICE = "kyc"
+        const val METRICS_SERVICE_TAG = "kyc"
         const val WORKFLOW_NAME = "kyc-orphaned-party-detection"
         val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }


### PR DESCRIPTION
## Co a proč

Main-red oprava: gate `source-service-convention` hlásil `UNRESOLVED — ambiguous` pro
`KycEvent`, protože modul deklaroval `SERVICE` dvakrát s různými hodnotami —
`OrphanedPartyGauge.SERVICE = "kyc"` (Micrometer tag) vs `KycEvent.SERVICE = "kyc-service"`
(emitovaný sourceService, správně dle konvence).

Gauge konstanta se jmenuje `METRICS_SERVICE_TAG`; **hodnota `"kyc"` se nemění** — žádný
dashboard/alert selector se nedotkne, event value se nemění.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → ne; přejmenování konstanty bez změny hodnoty.
- [x] PII path changed? → ne.
- [x] Cardholder data path changed? → ne.

Refs #5902
