### PR TITLE
ci(gates): resolve a sourceService constant in its own file first

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -204,6 +204,7 @@ gates:
     name: "alert-RCA ledger guards (MTTR granularity, recurrence, observation coverage)"
     group: lint
     mode: enforced
+    budget_seconds: 30   # 4.1s measured locally under load; a self-test only, no tree walk
     rationale: "The MTTR granularity refusal and the recurrence guard are the only things stopping ADR-0241 D1/D3 from publishing a number nobody measured, and the coverage outcome is what stops an empty week reporting as a clean one. They were wired only inside a scheduled workflow that has never once succeeded, so they had never run on any lane. Recheck for removal when a durable alert open/close feed exists (#5869) and the MTTR half is no longer a refusal."
     review_after: "2027-02-21"
     run: |
@@ -214,6 +215,7 @@ gates:
     name: "standing-critical digest guards (severity filter, observation envelope)"
     group: lint
     mode: enforced
+    budget_seconds: 30   # 4.2s measured locally under load; a self-test only, no tree walk
     rationale: "The digest's severity filter and observation envelope are the producer half of the same control; if the envelope shape drifts, the weekly review silently folds nothing and reports a clean week. Same lane gap as its consumer above. Recheck when the digest stops being the ledger's only observation source."
     review_after: "2027-02-21"
     run: |
@@ -1925,6 +1927,7 @@ gates:
     name: "agent bounded GitHub write surface (ADR-0031 D9 phase 3, enforced)"
     group: registry
     mode: enforced
+    budget_seconds: 30   # 5.0s measured locally under load over the charter set
     rationale: "flaky-test-hunter is the only agent with a real GitHub write path; its non-money-path confinement and its inability to merge or approve held only because a human read a Kotlin constant, and money_path_services grows over time."
     review_after: "2027-02-20"
     selftest: python3 .github/scripts/check-agent-bounded-write-surface.py --self-test
@@ -2566,6 +2569,7 @@ gates:
     name: "sourceService == module directory name (issues #5256/#5902, enforced)"
     group: kotlin
     mode: enforced
+    budget_seconds: 60   # 14.1s measured locally under load; walks every module src/main
     min_subjects: 20
     rationale: >-
       `source_service` is the column every audit and analytics query groups by, so a producer
@@ -4791,6 +4795,7 @@ gates:
     name: "who may bypass main-protection is pinned, and widening it fails a PR (Refs #4828, enforced)"
     group: lint
     mode: enforced
+    budget_seconds: 60   # network-bound: one GitHub rulesets API read, so this covers a slow API, not local work
     rationale: >
       The bypass surface of main-protection is a repository SETTING, not a file: it is edited
       in the Settings UI, produces no diff and no red check, and is observable only by asking

--- a/.github/scripts/check-source-service-convention.py
+++ b/.github/scripts/check-source-service-convention.py
@@ -191,7 +191,19 @@ def module_consts(module: pathlib.Path):
     return consts
 
 
-def _resolve(expr: str, consts):
+def file_consts(path: pathlib.Path):
+    """const name -> set of distinct string values declared in THIS FILE alone."""
+    consts = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if _COMMENT_LINE.match(line):
+            continue
+        m = _CONST_DECL.search(line)
+        if m:
+            consts.setdefault(m.group(1), set()).add(m.group(2))
+    return consts
+
+
+def _resolve(expr: str, consts, own_file_consts=None):
     """(value, None) when the emitted value is knowable, (None, reason) when it is not.
 
     (None, None) means "not a write site" — a RECOGNISED pass-through of somebody else's value.
@@ -222,6 +234,22 @@ def _resolve(expr: str, consts):
         return lit.group(1), None
     ref = _CONST_REF.match(expr) or _INTERPOLATION.match(expr)
     if ref:
+        # A bare identifier in Kotlin resolves to the declaration in its OWN FILE before anything
+        # else, and a `private const val` is file-private besides — so a same-named constant in a
+        # sibling file cannot be what this line reads. Resolving module-wide first reported two
+        # live sites as ambiguous while both were correct: kyc-service declares SERVICE both as a
+        # metric label ("kyc", in OrphanedPartyGauge) and as its event source ("kyc-service", in
+        # KycEvent), and domestic-payment declares SOURCE_SERVICE both for the inbound producer it
+        # VALIDATES ("delegation-service", in DelegatedSpendBinding) and for its own outbound event
+        # ("domestic-payment"). Neither is a naming defect; both were this resolver guessing.
+        #
+        # This preference cannot launder a wrong value: the file's own declaration is what the code
+        # actually emits, so a file declaring the wrong spelling is still flagged even when a
+        # correct constant of the same name exists elsewhere in the module. `openbank-samefile-bad-
+        # service` in the self-test is that negative control.
+        own = (own_file_consts or {}).get(ref.group(1))
+        if own and len(own) == 1:
+            return next(iter(own)), None
         values = consts.get(ref.group(1))
         if not values:
             return None, f"references {ref.group(1)}, which no `const val` in this module declares"
@@ -261,6 +289,7 @@ def scan(root):
         expected = module.name[len(MODULE_PREFIX):]
         consts = None
         for f in sorted((module / "src" / "main").rglob("*.kt")):
+            own_consts = None
             for lineno, line in enumerate(f.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
                 if _COMMENT_LINE.match(line) or "sourceService" not in line:
                     continue
@@ -269,11 +298,13 @@ def scan(root):
                 for expr, already_quoted in exprs:
                     if consts is None:
                         consts = module_consts(module)
+                    if own_consts is None:
+                        own_consts = file_consts(f)
                     if already_quoted:
                         interp = _INTERPOLATION.match(expr.strip())
-                        value, why = _resolve(expr, consts) if interp else (expr, None)
+                        value, why = _resolve(expr, consts, own_consts) if interp else (expr, None)
                     else:
-                        value, why = _resolve(expr, consts)
+                        value, why = _resolve(expr, consts, own_consts)
                     where = f"{f.relative_to(root)}:{lineno}"
                     if value is None:
                         if why is None:
@@ -341,11 +372,33 @@ SELF_TEST_MODULES = {
             "class X { val notTheField = 1 }\n"
         ),
     },
-    # Ambiguous const: two declarations, one value each, same simple name. Must be UNRESOLVED, not
-    # a coin flip — the shape that exists live (fx-service's SERVICE="fx" vs SOURCE_SERVICE).
+    # Ambiguous const: two declarations, one value each, same simple name, and the USE is in a
+    # third file that declares neither. Must be UNRESOLVED, not a coin flip. The use deliberately
+    # sits away from both declarations — once the resolver prefers the referencing file's own
+    # constant, a use next to one of them is no longer ambiguous, and this case must keep testing
+    # the ambiguity rather than quietly becoming a duplicate of the same-file case below.
     "openbank-ambiguous-service": {
-        "A.kt": 'private const val SERVICE = "ambiguous-service"\nval m = mapOf("sourceService" to SERVICE)\n',
+        "A.kt": 'private const val SERVICE = "ambiguous-service"\n',
         "B.kt": 'private const val SERVICE = "something-else"\n',
+        "C.kt": 'val m = mapOf("sourceService" to SERVICE)\n',
+    },
+    # Same simple name declared twice in one module, and the USE sits beside the RIGHT one. This is
+    # the live shape that reddened `main`: kyc-service declares SERVICE as a metric label ("kyc")
+    # in one file and as its event source ("kyc-service") in another, and domestic-payment does the
+    # same with SOURCE_SERVICE for an inbound producer it validates versus its own outbound event.
+    # Kotlin resolves the reference to the declaration in its own file, so both were correct code
+    # and the module-wide lookup was guessing. Must NOT be flagged.
+    "openbank-samefile-service": {
+        "A.kt": 'private const val SERVICE = "samefile-service"\nval m = mapOf("sourceService" to SERVICE)\n',
+        "B.kt": 'private const val SERVICE = "a-metric-label"\n',
+    },
+    # The negative control for that preference, and the reason it is safe. The use sits beside the
+    # WRONG value while a correct constant of the same name exists elsewhere in the module. If
+    # file-scope resolution could be used to launder a wrong spelling, this would pass. It must be
+    # flagged.
+    "openbank-samefile-bad-service": {
+        "A.kt": 'private const val SERVICE = "wrong-spelling"\nval m = mapOf("sourceService" to SERVICE)\n',
+        "B.kt": 'private const val SERVICE = "samefile-bad-service"\n',
     },
     # THE TWO NEGATIVE CONTROLS THAT REPRODUCED THE PASS-THROUGH HOLE.
     # Before the fix each of these produced 0 findings AND 0 producers: the value was unparseable,
@@ -395,6 +448,8 @@ SELF_TEST_EXPECT = {
     "openbank-passthrough-service": False,
     "openbank-prose-only-service": False,
     "openbank-ambiguous-service": True,
+    "openbank-samefile-service": False,
+    "openbank-samefile-bad-service": True,
     "openbank-configprop-service": True,
     "openbank-lowercaseval-service": True,
     "openbank-comparison-service": False,


### PR DESCRIPTION
## Summary

`source-service-convention` is failing on `origin/main`, so every open pull request is red on it. The two sites it names are correct code: the resolver looks a bare constant up across the whole module, finds the same simple name declared twice, and gives up. This teaches it to resolve the reference in its own file first, which is what Kotlin does.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #5902 (the sourceService convention this gate enforces), Refs #8791 (found while an unrelated pull request was red on it)

## What was actually wrong

A bare identifier in Kotlin resolves to the declaration in its own file before anything else, and a `private const val` is file-private besides, so a same-named constant in a sibling file cannot be what the line reads.

| module | constant | one value | the other |
|---|---|---|---|
| `openbank-kyc-service` | `SERVICE` | `"kyc"` — a metric label in `OrphanedPartyGauge` | `"kyc-service"` — the event source in `KycEvent` |
| `openbank-domestic-payment` | `SOURCE_SERVICE` | `"delegation-service"` — the **inbound** producer `DelegatedSpendBinding` validates | `"domestic-payment"` — its own outbound event |

In both, the file that emits the value declares the correct one beside it, and the other constant means something else entirely. Neither is a naming defect. A gate that cries wolf about correct code is worth less than nothing, so this fixes the resolver rather than renaming a constant in a money-path service or declaring the gate blind through its acknowledgement list.

## The preference cannot launder a wrong value

That is the obvious objection, so the self-test proves it rather than the comment asserting it. Three fixtures, three verdicts:

| fixture | shape | verdict |
|---|---|---|
| `openbank-samefile-service` | use beside the **right** value, wrong one elsewhere in the module | allowed |
| `openbank-samefile-bad-service` | use beside the **wrong** value, right one elsewhere | flagged |
| `openbank-ambiguous-service` | use in a file declaring **neither** | flagged |

The third fixture was edited: its use moved into a third file. Left beside one of the declarations it would have stopped testing ambiguity the moment the resolver improved, and quietly become a duplicate of the first case — a test that passes for a reason it was not written for.

## Verification

```
python3 .github/scripts/check-source-service-convention.py --root .
python3 .github/scripts/check-source-service-convention.py --self-test
```

Gate: exit 1 with two findings before, exit 0 after. Self-test: 27 passed, 0 failed.

Falsified: removing the three-line preference returns the gate to exit 1 naming exactly those two sites, and restoring it returns exit 0. The producer count is unchanged at 28, so the fix did not buy its green by measuring less.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — N/A, a CI script
- [x] Unit tests added/updated. — three self-test fixtures, one of them the negative control
- [x] Integration tests added/updated (if service boundary involved). — N/A
- [x] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Kotlin changed
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — N/A
- [x] Flyway migration added + rollback note (if DB changed). — N/A
- [x] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — the reasoning is in the resolver, where the next person meets it

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR). — none
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — none
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no. No service code changes; `openbank-domestic-payment` is named in the analysis but not edited.
- [x] PII path changed? → tag `gdpr-review-required`. — no
- [x] Cardholder data path changed? → tag `pci-review-required`. — no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

The gate protects audit attribution, and this change makes it strictly more accurate: two correct producers stop being reported as unresolvable, and no incorrect value becomes resolvable.

## Rollout / Rollback

- Deployment strategy: N/A, a CI script.
- Rollback plan: revert the PR; the gate returns to failing on `main` as it does today.
- Data migration reversible: N/A.

## Reviewer notes

`main` is red on a second enforced gate at the same time, fixed separately in #8821: five gates landed without `budget_seconds`, so `gate-observability-declarations` fails too. Both are needed before anything can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
