### PR TITLE
fix(ci): unblock main — declare five gate budgets, disambiguate two sourceService constants

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -203,6 +203,7 @@ gates:
     selftest_exempt: "is-a-test-suite — the run: IS alert-rca-ledger.py --self-test"
     name: "alert-RCA ledger guards (MTTR granularity, recurrence, observation coverage)"
     group: lint
+    budget_seconds: 20   # 0.2s in CI (run 33956518443), 7.3s through the local runner
     mode: enforced
     rationale: "The MTTR granularity refusal and the recurrence guard are the only things stopping ADR-0241 D1/D3 from publishing a number nobody measured, and the coverage outcome is what stops an empty week reporting as a clean one. They were wired only inside a scheduled workflow that has never once succeeded, so they had never run on any lane. Recheck for removal when a durable alert open/close feed exists (#5869) and the MTTR half is no longer a refusal."
     review_after: "2027-02-21"
@@ -213,6 +214,7 @@ gates:
     selftest_exempt: "is-a-test-suite — the run: IS standing-critical-digest.py --self-test"
     name: "standing-critical digest guards (severity filter, observation envelope)"
     group: lint
+    budget_seconds: 20   # 0.1s in CI (run 33956518443), 3.5s locally
     mode: enforced
     rationale: "The digest's severity filter and observation envelope are the producer half of the same control; if the envelope shape drifts, the weekly review silently folds nothing and reports a clean week. Same lane gap as its consumer above. Recheck when the digest stops being the ledger's only observation source."
     review_after: "2027-02-21"
@@ -1924,6 +1926,7 @@ gates:
                         # so the floor moves with the list rather than tracking it exactly.
     name: "agent bounded GitHub write surface (ADR-0031 D9 phase 3, enforced)"
     group: registry
+    budget_seconds: 20   # 0.8s in CI (run 33956518443), 3.6s locally
     mode: enforced
     rationale: "flaky-test-hunter is the only agent with a real GitHub write path; its non-money-path confinement and its inability to merge or approve held only because a human read a Kotlin constant, and money_path_services grows over time."
     review_after: "2027-02-20"
@@ -2565,6 +2568,7 @@ gates:
   - id: source-service-convention
     name: "sourceService == module directory name (issues #5256/#5902, enforced)"
     group: kotlin
+    budget_seconds: 30   # 0.8s in CI (run 33956518443), 2.7s locally; it walks every module src tree
     mode: enforced
     min_subjects: 20
     rationale: >-
@@ -4790,6 +4794,7 @@ gates:
   - id: ruleset-bypass-actors
     name: "who may bypass main-protection is pinned, and widening it fails a PR (Refs #4828, enforced)"
     group: lint
+    budget_seconds: 30   # 0.7s in CI (run 33956518443); it makes GitHub API calls, so the ceiling covers a slow response
     mode: enforced
     rationale: >
       The bypass surface of main-protection is a repository SETTING, not a file: it is edited

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
@@ -49,7 +49,7 @@ data class DelegatedSpendReservationSnapshot(
     init {
         require(schemaVersion == SCHEMA_VERSION) { "Unsupported reservation schema version: $schemaVersion" }
         require(aggregateType == AGGREGATE_TYPE) { "Unexpected aggregateType: $aggregateType" }
-        require(sourceService == SOURCE_SERVICE) { "Unexpected sourceService: $sourceService" }
+        require(sourceService == EXPECTED_PRODUCER_SERVICE) { "Unexpected sourceService: $sourceService" }
         require(resourceType == ACCOUNT_RESOURCE_TYPE) { "Domestic payment reservation must target ACCOUNT" }
         require(operationType == OPERATION_TYPE) { "Unexpected reservation operationType: $operationType" }
         require(amount > BigDecimal.ZERO) { "Reservation amount must be positive" }
@@ -106,7 +106,15 @@ data class DelegatedSpendReservationSnapshot(
         /** Producer-owned discriminator accepted by the projection; this service does not emit it. */
         const val SOURCE_EVENT_TYPE = "DelegationSpendReservationStateChanged"
         const val AGGREGATE_TYPE = "DelegationSpendReservation"
-        const val SOURCE_SERVICE = "delegation-service"
+        /**
+         * The service that PRODUCES the snapshot this projection accepts — delegation-service —
+         * not what this module emits as its own `sourceService`. The two are different facts and
+         * used to share the name `SOURCE_SERVICE` inside one module, which made every reference
+         * to that simple name ambiguous: `check-source-service-convention.py` reports such a
+         * module UNRESOLVED rather than guessing, and guessing is exactly what would produce a
+         * confident wrong verdict in either direction.
+         */
+        const val EXPECTED_PRODUCER_SERVICE = "delegation-service"
         const val ACCOUNT_RESOURCE_TYPE = "ACCOUNT"
         const val OPERATION_TYPE = "DOMESTIC_PAYMENT"
         const val SCHEMA_VERSION = 1L

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DelegatedSpendFinalizedAbsentPactFixture.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DelegatedSpendFinalizedAbsentPactFixture.kt
@@ -48,7 +48,7 @@ object DelegatedSpendFinalizedAbsentPactFixture {
             reservationVersion = DelegatedSpendReservationSnapshot.RESERVED_VERSION,
             schemaVersion = DelegatedSpendReservationSnapshot.SCHEMA_VERSION,
             aggregateType = DelegatedSpendReservationSnapshot.AGGREGATE_TYPE,
-            sourceService = DelegatedSpendReservationSnapshot.SOURCE_SERVICE,
+            sourceService = DelegatedSpendReservationSnapshot.EXPECTED_PRODUCER_SERVICE,
             createdAt = Instant.parse("2026-09-01T12:00:00Z"),
             settledAt = null,
             occurredAt = Instant.parse("2026-09-01T12:00:00Z"),

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/domain/model/KycEvent.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/domain/model/KycEvent.kt
@@ -65,8 +65,8 @@ object KycEvents {
             // so it is safe to add net-new. Value matches the fleet's audit convention: the
             // module directory without the `openbank-` prefix, the same spelling
             // `TopicAttribution` already maps `openbank.kyc.events` to and this file's own
-            // `actorId`/`SERVICE` constant already uses for the SYSTEM actor id.
-            "sourceService" to SERVICE,
+            // `actorId`/`SOURCE_SERVICE` constant already uses for the SYSTEM actor id.
+            "sourceService" to SOURCE_SERVICE,
         ),
     )
 
@@ -90,12 +90,19 @@ object KycEvents {
      * person, which is the property that matters.
      */
     private fun actorId(case: KycCase): String = case.reviewedBy?.takeIf { it.isNotBlank() }
-        ?: EventActor.system(SERVICE, "case-lifecycle")
+        ?: EventActor.system(SOURCE_SERVICE, "case-lifecycle")
 
     private fun actorType(case: KycCase): String =
         if (case.reviewedBy.isNullOrBlank()) EventActor.TYPE_SYSTEM else ACTOR_TYPE_REVIEWER
 
-    private const val SERVICE = "kyc-service"
+    /**
+     * This module's own `sourceService`, and the SYSTEM actor id. Named `SOURCE_SERVICE` rather
+     * than `SERVICE` because `OrphanedPartyGauge` declares a metrics-tag `const val SERVICE =
+     * "kyc"` in the same module: two different values behind one simple name make every
+     * reference ambiguous to `check-source-service-convention.py`, which then reports UNRESOLVED
+     * instead of guessing. The VALUE is unchanged — the module directory without the prefix.
+     */
+    private const val SOURCE_SERVICE = "kyc-service"
 
     /**
      * A named human reviewer. Not `OPERATOR`: the audit trail's existing `actorType` vocabulary uses


### PR DESCRIPTION
## Summary

Two enforced gates fail on a clean `origin/main` checkout, so every open PR is red on them regardless of its own content. This fixes both. Reproduced by running the gate manifest in a detached worktree at `origin/main` with no local changes.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8808 (found while running the full manifest for the card-platform phase-0 PR, #8819)

## Changes

**`gate-observability-declarations`** — five gates were added without `budget_seconds`, taking the undeclared count from 159 to 164 against a baseline that allows 159. The baseline is a ratchet whose whole purpose is that a new gate arrives declared, so the fix is to declare the five, not to raise the number. Each budget is set from the seconds measured in CI run 33956518443 with headroom, and the measurement is stated inline next to the value.

| Gate | Measured in CI | Declared |
|---|---|---|
| alert-rca-ledger-guards | 0.2 s | 20 s |
| standing-critical-digest-guards | 0.1 s | 20 s |
| ruleset-bypass-actors | 0.7 s | 30 s |
| agent-bounded-write-surface | 0.8 s | 20 s |
| source-service-convention | 0.8 s | 30 s |

**`source-service-convention`** — two modules each declare one constant name with two different values, so every reference to that simple name is ambiguous. The checker reports such a module UNRESOLVED rather than guessing, which is the right call: guessing would produce a confident wrong verdict in either direction.

- `openbank-domestic-payment` used `SOURCE_SERVICE` both for what it emits (`domestic-payment`) and for the producer whose snapshots it accepts (`delegation-service`). The second is a different fact and is renamed `EXPECTED_PRODUCER_SERVICE`.
- `openbank-kyc-service` had a metrics-tag `SERVICE = "kyc"` in the orphaned-party gauge and an event `SERVICE = "kyc-service"`. The event one is renamed `SOURCE_SERVICE`.

No emitted value changes in either module. Both compile, including the domestic-payment test tree that referenced the renamed constant.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated — n/a, this is a rename plus a manifest declaration; the two gates are themselves the tests and both now pass.
- [ ] Integration tests added/updated — n/a.
- [ ] Contract tests updated — n/a; the Pact fixture reference was updated as part of the rename.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — the two touched modules compile (`compileKotlin`, `compileTestKotlin`).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — n/a.
- [ ] Flyway migration added — n/a.
- [ ] Avro schema versioned backward-compatibly — n/a; no wire value changes.
- [x] Docs updated — the reason for each rename is written where the constant is.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. Verified against the diff.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`. Verified: `git diff origin/main...HEAD | grep -E '^\+.*(@Suppress|as Any)'` is empty.
- [x] No new third-party dependency. No `build.gradle*`, `libs.versions.toml` or `package.json` in the file list.
- [x] Auth / crypto / payment code changed? A constant in domestic-payment's delegated-spend projection was renamed; the value it compares against is unchanged, so the guard accepts and rejects exactly what it did before.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

The kyc event's `sourceService` value is unchanged (`kyc-service`), so audit attribution and the record-hash chain are untouched.

## Rollout / Rollback

- Deployment strategy: rolling. No behaviour change to deploy.
- Rollback plan: revert. The gates return to failing on main, which is the state before this PR.
- Data migration reversible: N/A.

## Reviewer notes

The thing worth checking is that neither rename changes a value that reaches the wire or the audit chain. `domestic-payment` emits `domestic-payment` and accepts `delegation-service`, both unchanged; `kyc-service` emits `kyc-service`, unchanged. Only the Kotlin identifiers moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
