### PR TITLE
refactor: drop the unproducible KYC_DOCUMENT_REQUIRED template and its dead cockpit column

### DIFF
--- a/docs/adr/0068-onboarding-operations-cockpit.md
+++ b/docs/adr/0068-onboarding-operations-cockpit.md
@@ -31,6 +31,15 @@ choreographed across three services, each owning one slice of the truth:
 - **sca-service** — passkey/SCA device enrollment, which happens *after* KYC approval
   (ADR-0066), and is what makes a party fully operational.
 
+> **Correction, 2026-09-05 (issue #8535).** The `DOCUMENTS_REQUIRED` stage described above, and the
+> `KYC_DOCUMENTS_REQUIRED` funnel column in §4.2, were never implemented: no kyc-service operation
+> ever set that status, so the cockpit column could only ever read zero — which reads as "nobody is
+> stuck on documents" rather than "this is not built". The column has been removed from the cockpit.
+> The status itself is still declared in the enums and contracts: removing it there is blocked by
+> two mutually exclusive CI gates (#8618). The decision recorded below is preserved as written;
+> collecting documents from a customer needs an operator endpoint, an upload path and storage, and
+> would be a new ADR.
+
 There is no operational view over this. An operator cannot answer "how many applicants
 are stuck waiting on documents", "who failed sanctions screening", or "which approved
 customers never finished passkey enrollment". Concretely:

--- a/docs/adr/0116-kyc-engine-risk-checks-and-four-eyes-gate.md
+++ b/docs/adr/0116-kyc-engine-risk-checks-and-four-eyes-gate.md
@@ -64,6 +64,21 @@ OPEN → DOCUMENTS_REQUIRED → UNDER_REVIEW → APPROVED (terminal)
 OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW → EXPIRED   (terminal, time-driven)
 ```
 
+> **Correction, 2026-09-05.** Three gaps between this lifecycle and the code, found together:
+>
+> - **`DOCUMENTS_REQUIRED` was never implemented** (#8535). No operation in `KycService` sets it,
+>   and the service has no concept of a document type or any upload path. Removing it from the
+>   enums and contracts is blocked by two mutually exclusive CI gates (#8618); the dead cockpit
+>   column it fed has been removed, and the `KYC_DOCUMENT_REQUIRED` notification template with it.
+> - **`ESCALATED` was never a KYC case status at all.** The lifecycle diagram drew it with four
+>   transitions; it is not in `KycCaseStatus`. Escalation here is a check in `MANUAL_REVIEW` plus
+>   `due_diligence_level = EDD`, with the case staying `UNDER_REVIEW`; MLRO escalation is a state
+>   of the *AML* case in aml-service (ADR-0032).
+> - **`EXPIRED` was declared and nothing set it** (#8548). `expires_at` was written on every case
+>   and never acted on, and because `uq_kyc_cases_active_party` treats only
+>   `APPROVED`/`REJECTED`/`EXPIRED` as terminal, an abandoned case blocked that party from ever
+>   opening another. Fixed by the daily sweep in #8562.
+
 Terminal states: `APPROVED`, `REJECTED`, `EXPIRED`. A party with an active (non-terminal) case
 cannot have a second case opened (409 Conflict from the operator-facing path; idempotent reuse
 on the event-driven path).

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -47,7 +47,6 @@ type FunnelCounts = Record<string, number>
 const STAGES = [
   'REGISTERED',
   'KYC_OPEN',
-  'KYC_DOCUMENTS_REQUIRED',
   'KYC_UNDER_REVIEW',
   'SCA_PENDING',
   'ACTIVE',
@@ -59,7 +58,6 @@ type Stage = typeof STAGES[number]
 const STAGE_LABEL_CS: Record<Stage, string> = {
   REGISTERED:               'Registrován',
   KYC_OPEN:                 'KYC otevřeno',
-  KYC_DOCUMENTS_REQUIRED:   'KYC — dokumenty',
   KYC_UNDER_REVIEW:         'KYC — přezkoumání',
   SCA_PENDING:              'SCA čeká',
   ACTIVE:                   'Aktivní',
@@ -69,7 +67,6 @@ const STAGE_LABEL_CS: Record<Stage, string> = {
 const STAGE_LABEL_EN: Record<Stage, string> = {
   REGISTERED:               'Registered',
   KYC_OPEN:                 'KYC Open',
-  KYC_DOCUMENTS_REQUIRED:   'KYC — Docs Needed',
   KYC_UNDER_REVIEW:         'KYC Under Review',
   SCA_PENDING:              'SCA Pending',
   ACTIVE:                   'Active',
@@ -79,7 +76,6 @@ const STAGE_LABEL_EN: Record<Stage, string> = {
 const STAGE_COLOR: Record<Stage, string> = {
   REGISTERED:               'var(--text-muted)',
   KYC_OPEN:                 'var(--yellow)',
-  KYC_DOCUMENTS_REQUIRED:   'var(--yellow)',
   KYC_UNDER_REVIEW:         'var(--accent)',
   SCA_PENDING:              '#a855f7',
   ACTIVE:                   'var(--green)',

--- a/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import OnboardingPage from '@/app/onboarding/page'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 
-const FUNNEL = { REGISTERED: 12, KYC_OPEN: 4, KYC_DOCUMENTS_REQUIRED: 2, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
+const FUNNEL = { REGISTERED: 12, KYC_OPEN: 4, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
 const RECORDS = { items: [], total: 0, page: 0, size: 20 }
 
 function response(status: number, body: unknown) {

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -100,13 +100,13 @@ spec:
             (
               (
                 sum by (template) (increase(openbank_notification_push_fanouts_total{
-                  devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                  devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|TRANSACTION_FAILED"
                 }[15m]))
                 or on (template) (
                   sum by (template) (openbank_notification_push_fanouts_total{
-                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|TRANSACTION_FAILED"
                   }) unless on (template) sum by (template) (openbank_notification_push_fanouts_total{
-                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|TRANSACTION_FAILED"
                   } offset 15m)
                 )
               )
@@ -120,7 +120,7 @@ spec:
                   )
                 ) or on (template) (
                   sum by (template) (openbank_notification_push_fanouts_total{
-                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|TRANSACTION_FAILED"
                   }) * 0
                 )
               )

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -1053,10 +1053,6 @@ class NotificationConsumer @Inject constructor(
                     "<h2>KYC Rejected</h2><p>We could not verify your identity. Reason: ${vars.v(
                         "reason",
                     )}. Please contact support.</p>"
-            NotificationTemplate.KYC_DOCUMENT_REQUIRED ->
-                "We need a document from you" to
-                    "<h2>Document Required</h2><p>To finish verifying your identity we need your " +
-                    "<b>${vars.v("documentType")}</b>. You can upload it in the OpenBank app.</p>"
             NotificationTemplate.CONSENT_GRANTED ->
                 "Access to your account data was granted" to
                     "<h2>Consent Granted</h2><p>You granted access to your account data " +

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -40,7 +40,6 @@ enum class NotificationTemplate(val variables: Set<String>) {
     TRANSACTION_FAILED(setOf("amount", "currency", "reason")),
     KYC_APPROVED(emptySet()),
     KYC_REJECTED(setOf("reason")),
-    KYC_DOCUMENT_REQUIRED(setOf("documentType")),
     CONSENT_GRANTED(setOf("scope")),
     CONSENT_REVOKED(setOf("scope")),
     OTP_CODE(setOf("code")),
@@ -106,7 +105,6 @@ enum class NotificationTemplate(val variables: Set<String>) {
         get() = when (this) {
             ACCOUNT_FROZEN,
             KYC_REJECTED,
-            KYC_DOCUMENT_REQUIRED,
             TRANSACTION_FAILED,
             -> NotificationChannel.EMAIL
             ACCOUNT_OPENED,
@@ -139,7 +137,7 @@ enum class NotificationTemplate(val variables: Set<String>) {
     val category: NotificationCategory
         get() = when (this) {
             OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN, SCA_APPROVAL,
-            KYC_APPROVED, KYC_REJECTED, KYC_DOCUMENT_REQUIRED,
+            KYC_APPROVED, KYC_REJECTED,
             CONSENT_GRANTED, CONSENT_REVOKED,
             DELEGATION_OFFERED, DELEGATION_ACCEPTED, DELEGATION_DECLINED,
             DELEGATION_REVOKED, DELEGATION_SUSPENDED, DELEGATION_REINSTATED,

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -31,7 +31,9 @@ class NotificationModelTest {
 
     @Test
     fun `NotificationTemplate has all expected templates`() {
-        assertThat(NotificationTemplate.values()).hasSize(23)
+        // 22 since #8535 removed KYC_DOCUMENT_REQUIRED: nothing could produce it, because
+        // kyc-service had no transition into DOCUMENTS_REQUIRED and no concept of a document type.
+        assertThat(NotificationTemplate.values()).hasSize(22)
         assertThat(NotificationTemplate.values()).contains(
             NotificationTemplate.ACCOUNT_OPENED,
             NotificationTemplate.OTP_CODE,
@@ -125,7 +127,6 @@ class NotificationModelTest {
         ).containsExactlyInAnyOrder(
             NotificationTemplate.ACCOUNT_FROZEN,
             NotificationTemplate.KYC_REJECTED,
-            NotificationTemplate.KYC_DOCUMENT_REQUIRED,
             NotificationTemplate.TRANSACTION_FAILED,
         )
         assertThat(NotificationTemplate.SCA_APPROVAL.noDeviceFallbackChannel).isNull()


### PR DESCRIPTION
The part of #8544 that **no gate objects to**, split out so it can land while the enum question waits on #8618.

## What lands here

`KYC_DOCUMENT_REQUIRED` could never be produced (#8535): kyc-service has no transition into `DOCUMENTS_REQUIRED`, no concept of a document type, and `grep -i upload` over kyc-service and onboarding-service main Kotlin returns zero hits.

Crucially, **`NotificationTemplate` has no OpenAPI counterpart** — notification-service publishes no spec listing it — so removing a value from it does not trip `openapi-enum-domain-drift`, which is what blocks the same removal from `KycCaseStatus` and `FunnelStage`.

| | |
|---|---|
| `NotificationTemplate.KYC_DOCUMENT_REQUIRED` | removed, with its renderer branch and its `noDeviceFallbackChannel` / `category` entries |
| `NotificationModelTest` | template count 23 → 22, with the reason |
| ADR-0068 cockpit column | removed — it could only ever read zero, which reads as *"nobody is stuck on documents"* rather than *"this is not built"* |
| `PushDeliveryNoDevices` alert regex | the template dropped from it |
| ADRs 0068 / 0116 | decision text untouched; dated correction notes added |

ADR-0116's note also records the two neighbouring findings from the same pass: **`ESCALATED` was never a `KycCaseStatus` at all** (the diagram drew it with four transitions; escalation here is a check in `MANUAL_REVIEW` plus `due_diligence_level = EDD`, while MLRO escalation belongs to the *AML* case), and **`EXPIRED` was declared with nothing setting it** until the sweep in #8562.

## What is deliberately NOT here

The kyc and onboarding **enums**, their **docs**, and the **lifecycle diagram**. Those documents describe the enum, so removing the value from them while it remains in the enum would trade one inconsistency for another — the drift gate exists precisely to stop that. They stay in #8544, blocked on #8618.

The ADR notes are therefore worded to say what is true **today**: the state is still declared in the enums and contracts, and why.

## Verification

- The identical notification-service edit ran green in #8544 on 2026-09-03 (module suite 107 tests, 0 failures), and the count assertion is correct against current main, which carries 23 templates.
- **Local verification has since completed**: `openbank-notification-service:test` — **209 tests, 0 failures**, `BUILD SUCCESSFUL`. It took 50 minutes on a loaded host, which is why the PR was opened before it finished; the description then said the run was cut short, and this corrects it. `ktlintCheck` also ran clean. `detekt` was not run locally — `:openbank-libs-detekt-rules:compileKotlin`, a module this PR does not touch, fails in my worktree — so CI remains the gate for that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
