### PR TITLE
fix(balance,ledger): fuzz-found 500s on date query params become 400/default

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -321,3 +321,10 @@ also be deleted (nothing else in balance-service depends on it).
   added `assertj` test dep for the guard. Additive DDL only — no new flow/surface/boundary.
   Risk class = **availability** (missing sequence breaks all balance writes), mitigated by
   `HibernateSequenceGuardTest`. Rollback: `DROP SEQUENCE`.
+- **2026-09-05** — Input validation hardened on the reconciliation trigger
+  (`POST /api/v1/balances/reconciliation`): a blank `asOf` now means "omitted" and a malformed one
+  is rejected as 400 (`IllegalArgumentException` via libs-runtime `CommonExceptionMappers`) where a
+  raw `DateTimeParseException` previously surfaced as 500. Found by the api-fuzz lane (#8832).
+  No new surface, role, or data flow — same endpoint, same authz, tighter input handling.
+  Risk class = **availability/information disclosure** (500s on an operator control endpoint).
+  Rollback: revert the guard; no stored data or schema changes.

--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -422,3 +422,11 @@ set) apply equally to the new `ledger.approval.decide` action.
   translated into a financial success; an application failure remains an error span and propagates
   unchanged. Rollback: revert the instrumentation and its contract test; no stored financial data,
   schema, caller, endpoint, role, or policy changes.
+- **2026-09-05** — Input validation hardened on the FX revaluation ops trigger
+  (`POST /api/v1/ledger/fx-revaluation`): a malformed `date` is rejected as 400
+  (`IllegalArgumentException` via libs-runtime `CommonExceptionMappers`) where a raw
+  `DateTimeParseException` previously surfaced as 500; a blank date still defaults to today
+  (Europe/Prague). Found by the api-fuzz lane (#8832). No new surface, role, or data flow — same
+  endpoint, same authz (`ROLE_OPERATOR`), tighter input handling. The blank-date 500 the fuzzer saw
+  was harness-environment-only (no fx-service in the single-service lane); loud failure on a down
+  ČNB rate dependency stays by design. Risk class = **availability**. Rollback: revert the guard.

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResource.kt
@@ -45,7 +45,18 @@ class ReconciliationResource(private val reconcile: ReconcileBalancesUseCase, pr
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.reconciliation.run")
     suspend fun run(@QueryParam("asOf") asOf: String?): Response {
-        val date = asOf?.let { LocalDate.parse(it) } ?: LocalDate.now(clock)
+        // Blank means "omitted" (the fuzzer found `?asOf=` 500ing, #8832); a malformed value is a
+        // client error — IllegalArgumentException maps to 400 via libs-runtime CommonExceptionMappers,
+        // where a raw DateTimeParseException would surface as a 500.
+        val date = asOf?.takeIf { it.isNotBlank() }?.let {
+            try {
+                LocalDate.parse(it)
+            } catch (ex: java.time.format.DateTimeParseException) {
+                throw IllegalArgumentException(
+                    "query parameter 'asOf' must be an ISO-8601 date (yyyy-MM-dd), got '$it'",
+                )
+            }
+        } ?: LocalDate.now(clock)
         val report = reconcile.reconcile(date)
         return Response.status(Response.Status.CREATED).entity(report).build()
     }

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResourceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResourceTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.rest
+
+import com.openbank.balance.application.port.`in`.ReconcileBalancesUseCase
+import com.openbank.balance.domain.reconciliation.ReconciliationReport
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * Regression for #8832: the api-fuzz lane found `POST /api/v1/balances/reconciliation?asOf=`
+ * answering 500 — a blank value reached `LocalDate.parse`, and a malformed one would have too. A
+ * blank `asOf` means "omitted" (default today); a malformed one is a client error and must surface
+ * as [IllegalArgumentException] so libs-runtime renders 400, never a raw [java.time.format.DateTimeParseException].
+ */
+class ReconciliationResourceTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-09-05T00:00:00Z"), ZoneOffset.UTC)
+
+    private class FakeUseCase : ReconcileBalancesUseCase {
+        var seenAsOf: LocalDate? = null
+
+        override suspend fun reconcile(asOf: LocalDate): ReconciliationReport {
+            seenAsOf = asOf
+            return ReconciliationReport(
+                asOf = asOf,
+                generatedAt = OffsetDateTime.parse("2026-09-05T00:00:00Z"),
+                tolerance = BigDecimal.ZERO,
+                currencies = emptyList(),
+            )
+        }
+
+        override suspend fun latest(): ReconciliationReport? = null
+    }
+
+    @Test
+    fun `a blank asOf falls back to today instead of throwing`(): Unit = runBlocking {
+        val useCase = FakeUseCase()
+        val response = ReconciliationResource(useCase, clock).run("")
+
+        assertEquals(201, response.status)
+        assertEquals(LocalDate.of(2026, 9, 5), useCase.seenAsOf)
+    }
+
+    @Test
+    fun `a malformed asOf is an IllegalArgumentException, not a DateTimeParseException`(): Unit = runBlocking {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { ReconciliationResource(FakeUseCase(), clock).run("not-a-date") }
+        }
+        assertEquals(true, ex.message?.contains("asOf"))
+    }
+
+    @Test
+    fun `a well-formed asOf is parsed and passed through`(): Unit = runBlocking {
+        val useCase = FakeUseCase()
+        ReconciliationResource(useCase, clock).run("2026-08-31")
+
+        assertEquals(LocalDate.of(2026, 8, 31), useCase.seenAsOf)
+    }
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/FxRevaluationResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/FxRevaluationResource.kt
@@ -36,7 +36,18 @@ class FxRevaluationResource(private val useCase: FxRevaluationUseCase) {
     @Authorize(action = "ledger.trigger", resource = "")
     @Operation(summary = "Run the daily FX revaluation for a business day (default: today, Europe/Prague)")
     suspend fun revalue(@QueryParam("date") date: String?): Response {
-        val day = date?.takeIf { it.isNotBlank() }?.let { LocalDate.parse(it) }
+        // Blank means "omitted"; a malformed value is a client error — IllegalArgumentException maps
+        // to 400 via libs-runtime CommonExceptionMappers, where a raw DateTimeParseException would
+        // surface as a 500 (#8832).
+        val day = date?.takeIf { it.isNotBlank() }?.let {
+            try {
+                LocalDate.parse(it)
+            } catch (ex: java.time.format.DateTimeParseException) {
+                throw IllegalArgumentException(
+                    "query parameter 'date' must be an ISO-8601 date (yyyy-MM-dd), got '$it'",
+                )
+            }
+        }
             ?: LocalDate.now(ZoneId.of("Europe/Prague"))
         return Response.ok(useCase.revalue(RevalueFxCommand(day))).build()
     }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/FxRevaluationResourceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/FxRevaluationResourceTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.rest
+
+import com.openbank.ledger.application.port.`in`.FxRevaluationResult
+import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
+import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+/**
+ * Regression for #8832: the api-fuzz lane found `POST /api/v1/ledger/fx-revaluation?date=…`
+ * variants answering 500. A blank `date` must mean "today (Europe/Prague)", and a malformed one is
+ * a client error — [IllegalArgumentException] so libs-runtime renders 400, never a raw
+ * [java.time.format.DateTimeParseException] surfacing as a 500.
+ */
+class FxRevaluationResourceTest {
+
+    private class FakeUseCase : FxRevaluationUseCase {
+        var seenDate: LocalDate? = null
+
+        override suspend fun revalue(command: RevalueFxCommand): FxRevaluationResult {
+            seenDate = command.date
+            return FxRevaluationResult(command.date, posted = false, journalId = null, movements = emptyMap())
+        }
+    }
+
+    @Test
+    fun `a blank date falls back to today instead of throwing`(): Unit = runBlocking {
+        val useCase = FakeUseCase()
+        val response = FxRevaluationResource(useCase).revalue("")
+
+        assertEquals(200, response.status)
+        assertEquals(LocalDate.now(java.time.ZoneId.of("Europe/Prague")), useCase.seenDate)
+    }
+
+    @Test
+    fun `a malformed date is an IllegalArgumentException, not a DateTimeParseException`(): Unit = runBlocking {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { FxRevaluationResource(FakeUseCase()).revalue("32.13._2026") }
+        }
+        assertEquals(true, ex.message?.contains("date"))
+    }
+
+    @Test
+    fun `a well-formed date is parsed and passed through`(): Unit = runBlocking {
+        val useCase = FakeUseCase()
+        FxRevaluationResource(useCase).revalue("2026-08-31")
+
+        assertEquals(LocalDate.of(2026, 8, 31), useCase.seenDate)
+    }
+}


### PR DESCRIPTION
## Summary

DAST api-fuzz (run 33954836043) found two money-path 500s on date query params:

- **balance-service** `POST /api/v1/balances/reconciliation?asOf=` — a blank value reached `LocalDate.parse` and `DateTimeParseException` fell through to the generic 500 mapper. Blank now means "omitted" (default today); a malformed value throws `IllegalArgumentException` → 400 via libs-runtime `CommonExceptionMappers`.
- **ledger-service** `POST /api/v1/ledger/fx-revaluation?date=abc` — same malformed-date class fixed the same way. The blank-date 500 the fuzzer also saw was harness-environment-only (no fx-service in the single-service lane; loud failure on a down ČNB rate dependency stays by design — freshness metric + WARN, see `FxRevaluationService` KDoc).

Both endpoints keep their existing happy-path behaviour; regression tests cover blank → default, malformed → `IllegalArgumentException`, and well-formed pass-through. Threat-model change logs for both services are updated in this diff (ADR-0030 D2).

## Test plan

- [x] `:openbank-balance-service:test --tests "*ReconciliationResourceTest*"` — 3/3
- [x] `:openbank-ledger-service:test --tests "*FxRevaluationResourceTest*"` — 3/3
- [x] `ktlintCheck` + `detekt` on both modules
- [x] `check-threat-model-diff.py --enforce` — PASS locally

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (Not applicable: input-validation only, no auth/crypto/payment logic touched — both endpoints keep their existing `@RolesAllowed`/`@Authorize`.)
- [x] PII path changed? → tag `gdpr-review-required`. (Not applicable: no PII handled.)
- [x] Cardholder data path changed? → tag `pci-review-required`. (Not applicable: no cardholder data.)

Closes #8832
Refs #8590
