### PR TITLE
fix(domestic-payment,kyc): rename same-named consts colliding with sourceService

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DelegatedSpendBinding.kt
@@ -49,7 +49,7 @@ data class DelegatedSpendReservationSnapshot(
     init {
         require(schemaVersion == SCHEMA_VERSION) { "Unsupported reservation schema version: $schemaVersion" }
         require(aggregateType == AGGREGATE_TYPE) { "Unexpected aggregateType: $aggregateType" }
-        require(sourceService == SOURCE_SERVICE) { "Unexpected sourceService: $sourceService" }
+        require(sourceService == EXPECTED_SOURCE_SERVICE) { "Unexpected sourceService: $sourceService" }
         require(resourceType == ACCOUNT_RESOURCE_TYPE) { "Domestic payment reservation must target ACCOUNT" }
         require(operationType == OPERATION_TYPE) { "Unexpected reservation operationType: $operationType" }
         require(amount > BigDecimal.ZERO) { "Reservation amount must be positive" }
@@ -106,7 +106,7 @@ data class DelegatedSpendReservationSnapshot(
         /** Producer-owned discriminator accepted by the projection; this service does not emit it. */
         const val SOURCE_EVENT_TYPE = "DelegationSpendReservationStateChanged"
         const val AGGREGATE_TYPE = "DelegationSpendReservation"
-        const val SOURCE_SERVICE = "delegation-service"
+        const val EXPECTED_SOURCE_SERVICE = "delegation-service"
         const val ACCOUNT_RESOURCE_TYPE = "ACCOUNT"
         const val OPERATION_TYPE = "DOMESTIC_PAYMENT"
         const val SCHEMA_VERSION = 1L

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
@@ -117,7 +117,7 @@ class OrphanedPartyGauge(
 
     private fun gauge(r: MeterRegistry, name: String, holder: AtomicLong) {
         Gauge.builder(name, holder) { it.get().toDouble() }
-            .tag("service", SERVICE)
+            .tag("service", METRIC_SERVICE_TAG)
             .strongReference(true)
             .register(r)
     }
@@ -173,7 +173,7 @@ class OrphanedPartyGauge(
     }
 
     private companion object {
-        const val SERVICE = "kyc"
+        const val METRIC_SERVICE_TAG = "kyc"
         const val WORKFLOW_NAME = "kyc-orphaned-party-detection"
         val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }


### PR DESCRIPTION
## Summary
`gates (registry-kotlin-data)` fails fleet-wide on every PR touching `openbank-domestic-payment`
or `openbank-kyc-service`: `source-service-convention` reports both as UNRESOLVED/ambiguous.

That's the gate's designed-in caution working correctly, not a bug in the check — both modules
genuinely declare two constants under the same simple name, and the gate deliberately refuses
to guess which one a write site's reference means (see the script's own header, which cites the
identical fx-service `SERVICE` vs `SOURCE_SERVICE` shape as the reason this ambiguity path
exists). The fix is in the modules, not the gate: rename the constant that ISN'T the real
`sourceService` write site so the collision goes away.

- **domestic-payment**: `DelegatedSpendBinding.SOURCE_SERVICE = "delegation-service"` documents
  the *upstream* producer's value for a `require(...)` validation, not this module's own
  emission — `DelegatedSpendFinalizedAbsentEvent.SOURCE_SERVICE = "domestic-payment"` is the
  real write site. Renamed the former to `EXPECTED_SOURCE_SERVICE`.
- **kyc-service**: `OrphanedPartyGauge.SERVICE = "kyc"` is an unrelated Micrometer tag, not the
  audit `sourceService` — `KycEvent.kt`'s `SERVICE = "kyc-service"` (assigned via
  `"sourceService" to SERVICE`) is the real write site. Renamed the gauge's constant to
  `METRIC_SERVICE_TAG`.

No values changed, no external callers of either renamed constant.

(Originally filed as #8827 diagnosing this as a gate false positive — on closer reading of the
gate's own design comments this is intentional ambiguity detection, so closing that issue with
this PR instead.)

## Linked issues
Closes #8827

## Test plan
- [x] `python3 .github/scripts/check-source-service-convention.py --root . --self-test` — `25 passed, 0 failed`
- [x] `python3 .github/scripts/check-source-service-convention.py --root .` — `OK — 28 producer(s) checked`
- [x] `./gradlew :openbank-kyc-service:compileKotlin :openbank-domestic-payment:compileKotlin` — `BUILD SUCCESSFUL`
