### PR TITLE
fix(clearing): announce an empty cycle instead of settling it silently

### DIFF
--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/port/out/ClearingPorts.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/port/out/ClearingPorts.kt
@@ -28,6 +28,14 @@ interface ClearingBatchRepository {
     fun update(batch: ClearingBatch): Uni<ClearingBatch>
 
     /**
+     * INSERT a batch and its outbox message in one transaction. The settle* methods above cannot
+     * serve this: both `s.find` the batch first and fail with "Batch not found", because they exist
+     * to move an EXISTING batch to SETTLED. An empty clearing cycle has no such prior row -- its
+     * batch is born SETTLED -- so announcing it needs an insert-and-emit, not an update-and-emit.
+     */
+    fun saveWithEvent(batch: ClearingBatch, event: OutboxMessage): Uni<ClearingBatch>
+
+    /**
      * Settle atomically (#8509): the batch state change, the item status flips and the outbox
      * row for `event` commit in ONE transaction. Before this, `ClearingService.settleBatch`
      * composed `update` + `saveAll` + `publishBatchSettled`, each opening its own transaction

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/usecase/ClearingService.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/usecase/ClearingService.kt
@@ -100,7 +100,16 @@ class ClearingService(
                     createdAt = now,
                     updatedAt = now,
                 )
-                batchRepo.save(emptyBatch)
+                // An empty cycle still RAN, and a consumer that receives nothing cannot tell
+                // "the cycle ran and had nothing to settle" from "the cycle did not run" -- the
+                // two states are the reason this event exists. So the batch is born SETTLED *and*
+                // announced, atomically, exactly as a populated one is.
+                //
+                // `batch.settled` only: NOT the net_settlement.post command the populated path
+                // also emits, because there is no journal to post. Emitting a zero-amount
+                // settlement command would give NetSettlementPostingConsumer work that must not
+                // happen.
+                batchRepo.saveWithEvent(emptyBatch, eventPublisher.batchSettledMessage(emptyBatch))
             } else {
                 val now = OffsetDateTime.now(clock)
                 // For GROSS settlement: every item is a debit from our participant's perspective.

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingRepositories.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingRepositories.kt
@@ -41,6 +41,17 @@ class ClearingBatchRepositoryImpl @Inject constructor(
     }
         .flatMap { findById(batch.id).map { it!! } }
 
+    /**
+     * Insert a batch and its outbox message in one transaction — the born-SETTLED empty cycle.
+     * `settleWithEvent(s)` cannot serve it: both `s.find` the batch first and fail with
+     * "Batch not found", since they exist to move an EXISTING batch to SETTLED.
+     */
+    override fun saveWithEvent(batch: ClearingBatch, event: OutboxMessage): Uni<ClearingBatch> =
+        sf.withTransaction { s ->
+            s.persist(mapper.toEntity(batch).also { it.id = batch.id })
+                .flatMap { outboxRepo.persistInTransaction(event) }
+        }.flatMap { findById(batch.id).map { it!! } }
+
     @WithSession
     override fun findById(id: UUID): Uni<ClearingBatch?> =
         sf.withSession { s -> s.find(ClearingBatchEntity::class.java, id) }.map { it?.let(mapper::toDomain) }

--- a/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/application/usecase/ClearingServiceTest.kt
+++ b/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/application/usecase/ClearingServiceTest.kt
@@ -190,6 +190,33 @@ class ClearingServiceTest {
     }
 
     @Test
+    fun `an empty cycle announces its settlement`() {
+        val batchSlot: CapturingSlot<ClearingBatch> = slot()
+        val eventSlot: CapturingSlot<OutboxMessage> = slot()
+        val settledMessage = mockk<OutboxMessage>()
+
+        every { itemRepo.findPendingByRail(PaymentRail.SEPA_SCT, any()) } returns
+            Uni.createFrom().item(emptyList())
+        every { eventPublisher.batchSettledMessage(capture(batchSlot)) } returns settledMessage
+        every { batchRepo.saveWithEvent(any(), capture(eventSlot)) } answers {
+            Uni.createFrom().item(firstArg<ClearingBatch>())
+        }
+
+        val batch = service.triggerClearingCycle(PaymentRail.SEPA_SCT).await().indefinitely()
+
+        // The cycle RAN. Without an event a consumer cannot tell that from "the cycle did not
+        // run" -- distinguishing those two is why this event exists.
+        assertThat(batch.status).isEqualTo(ClearingStatus.SETTLED)
+        assertThat(batch.itemCount).isEqualTo(0)
+        assertThat(eventSlot.captured).isSameAs(settledMessage)
+        assertThat(batchSlot.captured.status).isEqualTo(ClearingStatus.SETTLED)
+
+        // Announced atomically with the insert, never through the bare save that wrote no event.
+        verify(exactly = 1) { batchRepo.saveWithEvent(any(), any()) }
+        verify(exactly = 0) { batchRepo.save(any()) }
+    }
+
+    @Test
     fun `triggerClearingCycle computes correct netPosition for bilateral settlement`() {
         val amount = BigDecimal("200.00")
         val items = listOf(


### PR DESCRIPTION
## The defect

`ClearingService.triggerClearingCycle` with no pending items builds a batch that is **born** `SETTLED` and persists it with a bare save:

```kotlin
if (items.isEmpty()) {
    val emptyBatch = ClearingBatch(status = ClearingStatus.SETTLED, ...)
    batchRepo.save(emptyBatch)          // no outbox row
}
```

A populated batch reaching the same state goes through `settleBatch` → `batchRepo.settleWithEvents` and emits `batch.settled`.

**The cost is the ambiguity, not the missing row.** With no event, a consumer cannot distinguish *"the cycle ran and had nothing to settle"* from *"the cycle did not run"* — and telling those apart is the reason the event exists. The quiet path is the harder one to notice, because nothing is wrong. Same family as the push adapter whose `PushResult.skipped()` carried `success = true`: a no-op and a real outcome producing identical evidence.

## Why a new repository method

`settleWithEvent` / `settleWithEvents` cannot serve this. Both `s.find` the batch first:

```kotlin
s.find(ClearingBatchEntity::class.java, batch.id).flatMap { e ->
    if (e == null) Uni.createFrom().failure(IllegalArgumentException("Batch not found"))
```

They exist to move an **existing** batch to `SETTLED`. An empty cycle has no prior row — its batch is born settled — so announcing it needs insert-and-emit, not update-and-emit. Hence `ClearingBatchRepository.saveWithEvent(batch, event)`: one `sf.withTransaction` persisting the batch and the outbox message together, mirroring the `save` above it.

## `batch.settled` only — deliberately not the settlement command

The populated path emits **two** messages: `batch.settled` and the ADR-0281 `net_settlement.post` command. The empty path emits only the first. There is no journal to post, and a zero-amount settlement command would hand `NetSettlementPostingConsumer` work that must not happen.

The new method takes a **single** `event`, not a list, so that is structural rather than a convention someone can drift from later.

## Blast radius of the new event

`openbank.clearing.batch.*` is consumed by **audit-service** (topic list) and by clearing-service itself. Nothing in the fleet branches on `batch.settled` in code — `git grep -rn "batch.settled" -- '*/src/main/kotlin/**/*.kt'` outside this service returns nothing — so the new occurrence adds an audit-trail record and changes no downstream behaviour. clearing's own consumer listens for `net_settlement.post`, which this path does not emit.

## Verification — falsified, not just observed green

| tree | `ClearingServiceTest` |
|---|---|
| fix in place | **7/7**, 0 failures, 0 errors, **0 skipped** (JUnit XML) |
| use case reverted to `batchRepo.save(emptyBatch)` | **exactly 1 red — the new test**; the other 6 green |

The second row is what makes the test worth having: it goes red for the defect and for nothing else. `ktlintCheck` + `detekt` green.

The assertion is on the **event actually handed to the repository** (`isSameAs(settledMessage)`), plus `verify(exactly = 0) { batchRepo.save(any()) }` — so an implementation that inserts silently and emits afterwards through some other path still fails, rather than passing on "an event exists somewhere".

## Scope

`openbank-clearing-service` **is** money-path, so this needs 2 approvals. No API surface change, no migration, no new event type — `batch.settled` already exists on this topic and the event-contract baseline pins the topic, not the payload. This adds an **occurrence** on a path that had none.

Third of the three findings in #8745; finding 2 landed as #8805, finding 1 was withdrawn (it was deliberate — the reversal is announced by the new REVERSAL transaction). Refs #8745

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [x] Cardholder data path changed? → tag `pci-review-required`.

Checked against the diff: four files, no `@Suppress`/`as Any` added, no dependency file touched, no secret-shaped line. The payload is `batchSettledPayload(batch)`, already used verbatim by the populated path — no new field and no new recipient, and it carries batch-level settlement totals rather than any party or instrument identifier. No auth or crypto path is touched; the money path is affected only in that a cycle which previously settled silently now says so.
