### PR TITLE
fix(account): render security-abort 401/403 as JSON + replay the anonymous pact

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -96,6 +96,26 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-09-05** — **Inbound REST error surface on the authentication boundary**, no new route,
+  caller, edge or privilege. A security abort (anonymous or under-roled caller hitting a
+  `@RolesAllowed` route) was rendered by Quarkus REST's built-in handling as the raw exception
+  message in a plain-text body under the resource's negotiated `application/json` content-type —
+  a 401 whose body was the literal text `Not Authenticated` while declaring itself JSON, which any
+  JSON-parsing client (and the VoP consumer pact's anonymous-IBAN-lookup replay, #8803) breaks on.
+  Three service-local mappers (`io.quarkus.security` Unauthorized / AuthenticationFailed → 401
+  `UNAUTHORIZED`, Forbidden → 403 `FORBIDDEN`) now answer with the standard `ApiError` envelope and
+  fixed messages. **Security-relevant half:** the fixed message names neither the failure detail
+  nor the underlying mechanism, so the abort leaks strictly less than the raw exception text did;
+  status codes are unchanged, so no client-visible signaling about account or authorization
+  existence moves. The mappers live in the service rather than libs-runtime because a
+  shared-library `@Provider` naming an `io.quarkus.security` type is the #6240 ArC boot-failure
+  class (enforced by the `provider-type-classpath` gate). The anonymous 401 itself is now covered
+  by contract: the VoP pact interaction is replayed with the `@TestSecurity` identity cleared
+  (TestIdentityAssociation), so "no caller identity → 401" is verified, not assumed. RBAC, OPA and
+  authentication itself are untouched. **Risk class:** availability/observability plus disclosure
+  hardening; no money mutation and no new principal. Rollback: delete the three mappers and the
+  aborts fall back to Quarkus' built-in text rendering. (#8803)
+
 - **2026-09-04** — **Inbound REST error surface on account opening**, no new route, caller, edge
   or privilege. Two sanctions-screening outcomes rendered 500 INTERNAL_ERROR through the generic
   mapper: an unreachable screening service (the gate fails closed, ADR-0032 §C) and a policy

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
@@ -13,6 +13,9 @@ import com.openbank.account.application.usecase.AuthorizationNotFoundException
 import com.openbank.account.application.usecase.AuthorizationNotOnAccountException
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.domain.identifiers.Ids
+import io.quarkus.security.AuthenticationFailedException
+import io.quarkus.security.ForbiddenException
+import io.quarkus.security.UnauthorizedException
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
@@ -202,6 +205,64 @@ class AccountScreeningUnavailableExceptionMapper : ExceptionMapper<AccountScreen
             )
             .build()
     }
+}
+
+// Security-abort responses must be the JSON error envelope like every other error here.
+// Without these mappers Quarkus REST's built-in handling writes the exception MESSAGE as a
+// plain-text entity while the response keeps the resource's negotiated application/json
+// content-type — a 401 whose body is the literal text "Not Authenticated" under a JSON
+// content-type. Any client parsing the error as JSON (and Pact-JVM's matching engine, which
+// plans the body comparison from the content-type) chokes on it: measured on the anonymous
+// IBAN-lookup pact replay (#8803). A user @Provider mapper wins over Quarkus' built-in.
+// These live in the SERVICE, not libs-runtime, on purpose: a shared-library @Provider naming
+// an `io.quarkus.security` type would be loaded by ArC in every consumer, including services
+// without quarkus-security on the classpath — the #6240 boot-failure class, enforced by the
+// provider-type-classpath gate. Fleet-wide registration is tracked as a follow-up (#8875 is
+// the party-service instance of the same latent defect).
+@Provider
+class QuarkusUnauthorizedExceptionMapper : ExceptionMapper<UnauthorizedException> {
+    override fun toResponse(exception: UnauthorizedException): Response = Response.status(Response.Status.UNAUTHORIZED)
+        .entity(
+            ApiError(
+                traceId = Ids.randomId().toString(),
+                status = Response.Status.UNAUTHORIZED.statusCode,
+                code = "UNAUTHORIZED",
+                message = "Unauthorized",
+                timestamp = Instant.now(),
+            ),
+        )
+        .build()
+}
+
+@Provider
+class QuarkusAuthenticationFailedExceptionMapper : ExceptionMapper<AuthenticationFailedException> {
+    override fun toResponse(exception: AuthenticationFailedException): Response =
+        Response.status(Response.Status.UNAUTHORIZED)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = Response.Status.UNAUTHORIZED.statusCode,
+                    code = "UNAUTHORIZED",
+                    message = "Unauthorized",
+                    timestamp = Instant.now(),
+                ),
+            )
+            .build()
+}
+
+@Provider
+class QuarkusForbiddenExceptionMapper : ExceptionMapper<ForbiddenException> {
+    override fun toResponse(exception: ForbiddenException): Response = Response.status(Response.Status.FORBIDDEN)
+        .entity(
+            ApiError(
+                traceId = Ids.randomId().toString(),
+                status = Response.Status.FORBIDDEN.statusCode,
+                code = "FORBIDDEN",
+                message = "Forbidden",
+                timestamp = Instant.now(),
+            ),
+        )
+        .build()
 }
 
 private const val UNPROCESSABLE_ENTITY = 422

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
@@ -27,6 +27,7 @@ import com.openbank.libs.domain.account.Iban
 import com.openbank.libs.domain.money.CurrencyCode
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestIdentityAssociation
 import io.quarkus.test.security.TestSecurity
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
 import io.vertx.core.Vertx
@@ -122,6 +123,9 @@ class AccountPactFolderProviderVerificationTest {
     @Inject
     lateinit var vertx: Vertx
 
+    @Inject
+    lateinit var testIdentityAssociation: TestIdentityAssociation
+
     /**
      * Bridges reactive Panache into Pact-JVM's synchronous `@State` callback — Pact-JVM invokes
      * `@State` by reflection on the JUnit thread, which has no Vert.x context, so a bare
@@ -162,6 +166,14 @@ class AccountPactFolderProviderVerificationTest {
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider::class)
     fun verifyPacts(context: PactVerificationContext?) {
+        // #8803: the vop pact's anonymous interaction expects 401, but the class-level
+        // @TestSecurity makes Quarkus' test auth mechanism authenticate EVERY replay as
+        // pact-verifier — an anonymous replay is impossible while a test identity is installed.
+        // Clear it for just this interaction so the replay reaches the endpoint unauthenticated;
+        // QuarkusSecurityTestExtension re-applies @TestSecurity before the next invocation.
+        if (context != null && context.interaction.description.endsWith("no caller identity")) {
+            testIdentityAssociation.setTestIdentity(null)
+        }
         context?.verifyInteraction()
     }
 

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/SecurityAbortExceptionMapperTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/SecurityAbortExceptionMapperTest.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import io.quarkus.security.AuthenticationFailedException
+import io.quarkus.security.ForbiddenException
+import io.quarkus.security.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * #8803: security aborts must render the JSON ApiError envelope — the built-in Quarkus
+ * handling writes the exception message as plain text under the resource's negotiated
+ * application/json content-type, which breaks any JSON-parsing client (and the anonymous
+ * IBAN-lookup pact replay).
+ */
+class SecurityAbortExceptionMapperTest {
+
+    @Test
+    fun `maps UnauthorizedException to a 401 UNAUTHORIZED ApiError`() {
+        val response = QuarkusUnauthorizedExceptionMapper()
+            .toResponse(UnauthorizedException("Not Authenticated"))
+
+        assertThat(response.status).isEqualTo(401)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(401)
+        assertThat(error.code).isEqualTo("UNAUTHORIZED")
+        // fixed message — the raw exception text is not leaked into the response
+        assertThat(error.message).isEqualTo("Unauthorized")
+        assertThat(error.traceId).isNotBlank()
+    }
+
+    @Test
+    fun `maps AuthenticationFailedException to the same 401 envelope`() {
+        val response = QuarkusAuthenticationFailedExceptionMapper()
+            .toResponse(AuthenticationFailedException("bad token"))
+
+        assertThat(response.status).isEqualTo(401)
+        val error = response.entity as ApiError
+        assertThat(error.code).isEqualTo("UNAUTHORIZED")
+        assertThat(error.message).isEqualTo("Unauthorized")
+    }
+
+    @Test
+    fun `maps ForbiddenException to a 403 FORBIDDEN ApiError`() {
+        val response = QuarkusForbiddenExceptionMapper()
+            .toResponse(ForbiddenException("wrong role"))
+
+        assertThat(response.status).isEqualTo(403)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(403)
+        assertThat(error.code).isEqualTo("FORBIDDEN")
+        assertThat(error.message).isEqualTo("Forbidden")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the account-service main-red from #8803 (every account-service build failed since #8552 added the vop pact's anonymous interaction) by fixing the two stacked defects behind it:

1. **`AccountPactFolderProviderVerificationTest` could never replay the anonymous interaction anonymously** — class-level `@TestSecurity` makes Quarkus' test auth mechanism authenticate every Pact-JVM replay as `pact-verifier`, so "GET the account behind the payee IBAN, with no caller identity" (expects 401) always saw 200.
2. **The real 401 response was itself broken** — replayed truly anonymously, the endpoint returns `401` with `Content-Type: application/json` but a plain-text body `Not Authenticated` (Quarkus REST's built-in security-abort handling writes the exception message as text under the resource's negotiated JSON content-type). Any JSON-parsing client breaks on that; Pact-JVM's matching engine died with `Invalid JSON, found unexpected character 'N'`.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8803
Refs #8875 (party-service has the same latent anonymous-pact defect)

## Changes

- `AccountPactFolderProviderVerificationTest` — clears the test identity via injected `TestIdentityAssociation` for just the anonymous interaction; `QuarkusSecurityTestExtension` (BeforeEach/AfterEach) re-applies `@TestSecurity` before the next invocation.
- `ExceptionMappers.kt` — new `@Provider` mappers for `io.quarkus.security.UnauthorizedException` / `AuthenticationFailedException` (→ 401 `UNAUTHORIZED`) and `ForbiddenException` (→ 403 `FORBIDDEN`) returning the standard `ApiError` JSON envelope with fixed messages (no exception-text leakage).
- New `SecurityAbortExceptionMapperTest` covering all three mappers.

The mappers deliberately live in the SERVICE, not libs-runtime: a shared-library `@Provider` naming an `io.quarkus.security` type would be loaded by ArC in every consumer — including services without quarkus-security on the classpath — the #6240 boot-failure class, enforced by the `provider-type-classpath` gate (which correctly rejected the libs-runtime placement in an earlier revision of this PR). Fleet-wide registration is a follow-up.

## Verification (local)

- `:openbank-account-service:test --tests AccountPactFolderProviderVerificationTest` — all 6 folder interactions pass; before this PR the same run reproduced the CI failure exactly.
- A temporary probe confirmed the pre-fix anonymous response: `status=401 contentType=application/json body="Not Authenticated"`.
- `SecurityAbortExceptionMapperTest` (3 tests), ktlint, detekt — green.

## Definition of Done

- [x] Hexagonal layering preserved (mappers sit in infrastructure/rest with the existing ones).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (the pact provider verification is the IT; now actually exercising the anonymous path).
- [ ] Contract tests updated (N/A — pact file unchanged; this makes its verification pass).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (scoped modules locally; full build via CI).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (N/A — error schema already declares ApiError; the 401 body now matches it).
- [ ] Flyway migration added + rollback note (N/A).
- [ ] Avro schema versioned backward-compatibly (N/A).
- [ ] Docs updated (N/A).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). (None — `io.quarkus.security` exceptions are already on the service classpath.)
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (Yes — error mapping on the auth failure path; the change STRENGTHENS it: anonymous access now verifiably returns a well-formed 401 and fixed messages leak less than raw exception text.)
- [x] PII path changed? → tag `gdpr-review-required`. (No.)
- [x] Cardholder data path changed? → tag `pci-review-required`. (No.)

## Compliance impact

- [ ] PCI DSS
- [x] DORA (error-handling robustness on the auth boundary)
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting

The 401/403 bodies change shape (text → JSON `ApiError`) for account-service. That is the documented envelope already used for every other error class; clients relying on the text body of a security abort were relying on a content-type lie.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

- Unblocks every account-service PR (main-red since #8552) and is a prerequisite for #8796 (fleet-wide build).
- The text-body-under-JSON-content-type defect on security aborts exists in EVERY service (built-in Quarkus handling); this PR fixes account-service (the one blocking CI) and the pattern is ready to sweep — see Reviewer notes in #8875.
