### PR TITLE
fix(ci): remove five duplicate budget_seconds keys that turn main red

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -200,7 +200,6 @@ gates:
   # it deliberately does not check REACHABILITY — a script invoked from a workflow that
   # never runs still counts as wired. Registering here is what puts them on a PR lane.
   - id: alert-rca-ledger-guards
-    budget_seconds: 15   # one script self-test run
     selftest_exempt: "is-a-test-suite — the run: IS alert-rca-ledger.py --self-test"
     name: "alert-RCA ledger guards (MTTR granularity, recurrence, observation coverage)"
     group: lint
@@ -212,7 +211,6 @@ gates:
       python3 .github/scripts/alert-rca-ledger.py --self-test
 
   - id: standing-critical-digest-guards
-    budget_seconds: 15   # one script self-test run
     selftest_exempt: "is-a-test-suite — the run: IS standing-critical-digest.py --self-test"
     name: "standing-critical digest guards (severity filter, observation envelope)"
     group: lint
@@ -1923,7 +1921,6 @@ gates:
   # 2026-08-20: a money-path prefix, an added `PUT /pulls/{n}/merge`, and a deleted bound each make
   # it exit 1; removing either half of `evaluate` makes the self-test go red.
   - id: agent-bounded-write-surface
-    budget_seconds: 20   # rules.yaml + agent charter scan
     min_subjects: 20   # the money_path_services entries the bound is checked against; 23 today
                         # (2026-08-20). A gate that resolves an empty list would pass everything,
                         # so the floor moves with the list rather than tracking it exactly.
@@ -2569,7 +2566,6 @@ gates:
   # baseline entry pins the (module, value) pair, so lending drifting to a third spelling still
   # fails. ENFORCED.
   - id: source-service-convention
-    budget_seconds: 30   # whole-fleet Kotlin scan
     name: "sourceService == module directory name (issues #5256/#5902, enforced)"
     group: kotlin
     mode: enforced
@@ -4822,7 +4818,6 @@ gates:
   # live admin actor is reported undeclared, and with its bypass_mode pinned to `always`
   # both directions report — red both ways, green only on the shipped declaration.
   - id: ruleset-bypass-actors
-    budget_seconds: 20   # one GitHub API read + compare
     name: "who may bypass main-protection is pinned, and widening it fails a PR (Refs #4828, enforced)"
     group: lint
     mode: enforced


### PR DESCRIPTION
## Summary

`yamllint` fails on a clean `origin/main` checkout: five gates declare `budget_seconds` twice, `key-duplicates` fires, and every open PR inherits the failure through its merge commit. This removes the duplicates.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Found while watching CI on the ADR-0283 stack (#8819, #8840), both of which went red on it without touching the file.

## What happened

Two changes declared a budget for the same gates independently. That is the duplicate-mapping-key shape this repo already documents: SnakeYAML and PyYAML keep only the **last** of a repeated key and drop the rest silently, so the file reads as saying one thing and parses as another.

## Which one was removed, and why it changes nothing

The **first** of each pair, never the second. PyYAML already keeps the last, so the effective budget today is the second value — this removes the ambiguity, not the setting. The surviving values are also the ones carrying a measurement.

| Gate | Surviving budget | Basis |
|---|---|---|
| alert-rca-ledger-guards | 30 s | 4.1 s measured under load |
| standing-critical-digest-guards | 30 s | 4.2 s measured under load |
| agent-bounded-write-surface | 30 s | 5.0 s measured under load |
| source-service-convention | 60 s | 14.1 s measured under load |
| ruleset-bypass-actors | 60 s | network-bound GitHub API read |

## Definition of Done

- [x] Hexagonal layering preserved — n/a, one manifest file.
- [ ] Unit tests — n/a. The gates below are the test, and they were red before and green after.
- [ ] Integration tests — n/a.
- [ ] Contract tests — n/a.
- [x] Verified after the change: `yamllint`, `duplicate-yaml-key-guard`, `gate-observability-declarations`, `gate-subject-floor`, `gate-lifecycle-metadata`, `gate-selftest-declaration`, `gate-script-registration` all pass. Verified before it too — `yamllint` fails on a detached checkout of `origin/main` with no local changes.
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / event schema — n/a.
- [x] Docs updated — the removed lines were duplicates; every surviving comment is the one with the measurement in it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `as Any` / `@Suppress`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No. One of the five gates is `ruleset-bypass-actors`, which watches who may bypass main-protection; its budget is unchanged in effect and its logic is untouched.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: none. A CI manifest, no runtime effect.
- Rollback plan: revert; `yamllint` returns to failing on main, which is the state before this PR.
- Data migration reversible: N/A.

## Reviewer notes

Worth confirming you agree the first of each pair is the right one to drop. My reasoning is that the parser already ignores it, so removing it cannot change behaviour, while removing the second would silently shorten four budgets and one network-bound one. If you would rather keep the shorter values, that is a deliberate tightening and belongs in its own change with its own measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
