### PR TITLE
fix(notification): remove the unproducible PASSWORD_RESET template

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-email.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-email.yaml
@@ -93,11 +93,11 @@ spec:
         - alert: SecurityEmailNotDelivered
           expr: |
             (sum(openbank_notification_email_sends_total{
-              template=~"OTP_CODE|SCA_APPROVAL|PASSWORD_RESET", outcome!="ACCEPTED"
+              template=~"OTP_CODE|SCA_APPROVAL", outcome!="ACCEPTED"
             }) or vector(0))
             -
             (sum(openbank_notification_email_sends_total{
-              template=~"OTP_CODE|SCA_APPROVAL|PASSWORD_RESET", outcome!="ACCEPTED"
+              template=~"OTP_CODE|SCA_APPROVAL", outcome!="ACCEPTED"
             } offset 15m) or vector(0)) > 0
           for: 0m
           labels:

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -1064,11 +1064,6 @@ class NotificationConsumer @Inject constructor(
             NotificationTemplate.OTP_CODE ->
                 "Your OpenBank verification code" to
                     "<h2>Verification Code</h2><p>Your code is: <b>${vars.v("code")}</b>. Valid for 5 minutes.</p>"
-            NotificationTemplate.PASSWORD_RESET ->
-                "Reset your OpenBank password" to
-                    "<h2>Password Reset</h2><p>Use the link below to set a new password. It expires in 15 minutes " +
-                    "and can be used once. If you did not ask for this, ignore this message and your password stays " +
-                    "unchanged.</p><p><a href=\"${vars.v("resetLink")}\">Reset your password</a></p>"
             NotificationTemplate.WELCOME ->
                 "Welcome to OpenBank" to
                     "<h2>Welcome!</h2><p>Thank you for joining OpenBank, ${vars.v("name")}.</p>"
@@ -1124,11 +1119,13 @@ class NotificationConsumer @Inject constructor(
  * message, since poison payloads are acked. An omitted variable renders empty, as it always has.
  *
  * Escaping happens HERE, not per call site (issue #1382): every one of [renderTemplate]'s ~16
- * reads interpolates straight into an HTML body (or, for `PASSWORD_RESET`'s `resetLink`, an
- * `href="..."` attribute) with zero escaping between a domain-event-supplied variable and the
- * mail actually sent — a `reason`, `documentType`, or `scope` containing markup rendered verbatim
- * in the customer's mail client. Escaping the shared accessor closes every call site in one place
- * instead of relying on each of the 16 to remember it.
+ * reads interpolates straight into an HTML body with zero escaping between a domain-event-supplied
+ * variable and the mail actually sent — a `reason`, `documentType`, or `scope` containing markup
+ * rendered verbatim in the customer's mail client. Escaping the shared accessor closes every call
+ * site in one place instead of relying on each of the 16 to remember it. (The escaper also covers
+ * the attribute-value context: `"` and `'` are escaped, so a variable remains safe if a template
+ * ever interpolates one into an `href="..."` attribute again — the removed PASSWORD_RESET's
+ * `resetLink` was the case that originally forced that, #8568.)
  *
  * Top-level rather than a member so `renderTemplate` reads as copy instead of null-handling — the
  * 16 inline `?: ""` reads it replaces were most of that function's cyclomatic complexity.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/HtmlEscape.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/HtmlEscape.kt
@@ -12,9 +12,10 @@ package com.openbank.notification.domain
  * [com.openbank.notification.application.OperatorMessageService.render] ran any escaping between
  * a caller-supplied variable and the HTML body handed to `Mail.withHtml` — an operator (or, for
  * the system templates, an upstream domain event) could inject arbitrary markup that a customer's
- * mail client would render, including `<img onerror=...>`/`<script>`-style payloads and, for
- * `PASSWORD_RESET`'s `resetLink` (interpolated into an `href="..."` attribute), an attribute
- * breakout via an embedded `"`.
+ * mail client would render, including `<img onerror=...>`/`<script>`-style payloads and an
+ * attribute breakout via an embedded `"` if a variable is ever interpolated into an
+ * `href="..."` attribute (the removed PASSWORD_RESET's `resetLink` was that case, #8568 — the
+ * quote escaping stays so a future attribute-context variable is safe by default).
  *
  * Deliberately not a general-purpose sanitizer: every call site here treats its variables as
  * plain text that must render literally, never as markup the caller is allowed to inject, so

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -43,7 +43,10 @@ enum class NotificationTemplate(val variables: Set<String>) {
     CONSENT_GRANTED(setOf("scope")),
     CONSENT_REVOKED(setOf("scope")),
     OTP_CODE(setOf("code")),
-    PASSWORD_RESET(setOf("resetLink")),
+
+    // No PASSWORD_RESET template (#8568): no password flow exists anywhere in the system —
+    // the app authenticates with passkeys/biometrics and Keycloak runs with
+    // resetPasswordAllowed=false and no SMTP, so nothing could ever produce one.
     WELCOME(setOf("name")),
 
     /** Decoupled/push SCA — "you have a payment to approve" (#4). [detail] = the human summary. */
@@ -114,7 +117,6 @@ enum class NotificationTemplate(val variables: Set<String>) {
             CONSENT_GRANTED,
             CONSENT_REVOKED,
             OTP_CODE,
-            PASSWORD_RESET,
             WELCOME,
             SCA_APPROVAL,
             MARKETING_PRODUCT_OFFER,
@@ -136,7 +138,7 @@ enum class NotificationTemplate(val variables: Set<String>) {
      */
     val category: NotificationCategory
         get() = when (this) {
-            OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN, SCA_APPROVAL,
+            OTP_CODE, ACCOUNT_FROZEN, SCA_APPROVAL,
             KYC_APPROVED, KYC_REJECTED,
             CONSENT_GRANTED, CONSENT_REVOKED,
             DELEGATION_OFFERED, DELEGATION_ACCEPTED, DELEGATION_DECLINED,

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
@@ -48,7 +48,6 @@ object TemplateSensitivity {
      */
     val SECRET_TEMPLATES: Set<NotificationTemplate> = setOf(
         NotificationTemplate.OTP_CODE,
-        NotificationTemplate.PASSWORD_RESET,
     )
 
     /** True when [template]'s rendered body embeds an authentication secret. */

--- a/openbank-notification-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/04-data.cs.md
@@ -45,7 +45,7 @@ Každý soubor migrace nese inline **poznámku k rollbacku** (např. V6: `DROP T
 
 #### Šablony nesoucí tajemství
 
-`OTP_CODE` a `PASSWORD_RESET` renderují do těla zprávy autentizační tajemství. To se doručí
+`OTP_CODE` renderuje do těla zprávy autentizační tajemství. To se doručí
 zákazníkovi, ale **nikdy se neukládá**: `NotificationConsumer` uloží místo něj
 `TemplateSensitivity.REDACTED_BODY` a `NotificationResource` redaguje ještě jednou při čtení
 (dvě nezávislé kontroly, stejný tvar jako ADR-0059 D3). V9 vyčistila řádky zapsané předtím.
@@ -94,7 +94,7 @@ Unique `(platform, token)` → opětovná registrace provede upsert; index `(par
 | Pole | Klasifikace | Kontrola |
 |---|---|---|
 | `notifications.recipient` | přímé PII (e-mail / telefon) | maskováno v logu (PiiMask); nevystaveno v oversight signálech |
-| `notifications.body` / `subject` | možné PII | šablony s tajemstvím (OTP_CODE, PASSWORD_RESET) se doručí, ale neukládají — redakce při zápisu i při čtení; do oversightu neegrešuje žádná šablona |
+| `notifications.body` / `subject` | možné PII | šablony s tajemstvím (OTP_CODE) se doručí, ale neukládají — redakce při zápisu i při čtení; do oversightu neegrešuje žádná šablona |
 | `notifications.party_id`, `device_tokens.party_id` | pseudonymní identifikátor | vazba na party-service |
 | `device_tokens.token` | PII-adjacentní token poskytovatele | jen pro zápis přes REST, maskovaný v logu |
 | `dispatch_control_log.actor` / `dispatch_resume_proposal.*_by` | identita operátora | audit-logováno, jen interní |

--- a/openbank-notification-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-notification-service/src/main/resources/docs/04-data.en.md
@@ -45,7 +45,7 @@ Each migration file carries an inline **rollback note** (e.g. V6: `DROP TABLE de
 
 #### Secret-bearing templates
 
-`OTP_CODE` and `PASSWORD_RESET` render an authentication secret into the message body. The
+`OTP_CODE` renders an authentication secret into the message body. The
 secret is delivered to the customer but **never persisted**: `NotificationConsumer` stores
 `TemplateSensitivity.REDACTED_BODY` in its place, and `NotificationResource` redacts again on
 read (two independent controls, the ADR-0059 D3 shape). V9 cleared the rows written before this.
@@ -93,7 +93,7 @@ Unique `(platform, token)` → re-registration upserts; index `(party_id, status
 | Field | Classification | Control |
 |---|---|---|
 | `notifications.recipient` | direct PII (email / phone) | masked in logs (PiiMask); not exposed in oversight signals |
-| `notifications.body` / `subject` | possible PII | secret-bearing templates (OTP_CODE, PASSWORD_RESET) are delivered but never stored — redacted on write and again on read; no template egresses to oversight |
+| `notifications.body` / `subject` | possible PII | secret-bearing templates (OTP_CODE) are delivered but never stored — redacted on write and again on read; no template egresses to oversight |
 | `notifications.party_id`, `device_tokens.party_id` | pseudonymous identifier | links to party-service |
 | `device_tokens.token` | PII-adjacent provider token | write-only over REST, masked in logs |
 | `dispatch_control_log.actor` / `dispatch_resume_proposal.*_by` | operator identity | audit-logged, internal only |

--- a/openbank-notification-service/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/06-compliance.cs.md
@@ -87,7 +87,7 @@ Zastavení odchozích notifikací je bezpečný směr, takže **halt** je break-
 - ✅ AuthZ: `@RolesAllowed` per endpoint; aktér řízení výpravy z JWT subjektu (ne z těla)
 - ✅ Prevence IDOR: device `partyId` injektováno edgem ze zákaznického JWT
 - ✅ Důvěrnost tokenu: push token jen pro zápis přes REST, maskovaný v logu
-- ✅ Důvěrnost tajemství: těla OTP_CODE / PASSWORD_RESET se doručí, ale neukládají — redakce při zápisu i při čtení (GDPR čl. 5 odst. 1 písm. c); uložené OTP by operátorovi umožnilo dokončit zákazníkovo SCA, ADR-0021)
+- ✅ Důvěrnost tajemství: těla OTP_CODE se doručí, ale neukládají — redakce při zápisu i při čtení (GDPR čl. 5 odst. 1 písm. c); uložené OTP by operátorovi umožnilo dokončit zákazníkovo SCA, ADR-0021)
 - ✅ Minimalizace egresu: push + oversight ve výchozím stavu vypnuté; oversight bez PII z principu
 - ✅ Odolnost: outbox circuit-breaker/retry/bulkhead/timeout; break-glass halt
 - ✅ Bezpečnostní hlavičky: CSP, HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy

--- a/openbank-notification-service/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-notification-service/src/main/resources/docs/06-compliance.en.md
@@ -87,7 +87,7 @@ Stopping outbound notifications is the fail-safe direction, so **halt** is a sin
 - ✅ AuthZ: `@RolesAllowed` per endpoint; dispatch-control actor from JWT subject (not body)
 - ✅ IDOR prevention: device `partyId` injected by the edge from the customer JWT
 - ✅ Token confidentiality: push token write-only over REST, masked in logs
-- ✅ Secret confidentiality: OTP_CODE / PASSWORD_RESET bodies delivered but never stored — redacted on write and again on read (GDPR Art. 5(1)(c); a stored OTP would let an operator complete the customer's SCA, ADR-0021)
+- ✅ Secret confidentiality: OTP_CODE bodies delivered but never stored — redacted on write and again on read (GDPR Art. 5(1)(c); a stored OTP would let an operator complete the customer's SCA, ADR-0021)
 - ✅ Egress minimisation: push + oversight off by default; oversight PII-free by construction
 - ✅ Resilience: outbox circuit-breaker/retry/bulkhead/timeout; break-glass halt
 - ✅ Security headers: CSP, HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy

--- a/openbank-notification-service/src/main/resources/openapi.yaml
+++ b/openbank-notification-service/src/main/resources/openapi.yaml
@@ -536,8 +536,8 @@ components:
         body:
           type: string
           description: |
-            The rendered message body. For secret-bearing templates (OTP_CODE,
-            PASSWORD_RESET) this is a redaction placeholder, never the delivered
+            The rendered message body. For secret-bearing templates (OTP_CODE)
+            this is a redaction placeholder, never the delivered
             secret — the secret is sent to the customer but never stored.
         status:
           $ref: '#/components/schemas/NotificationStatus'

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/application/OversightWebhookTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/application/OversightWebhookTest.kt
@@ -39,7 +39,6 @@ class OversightWebhookTest {
         assertThat(OversightWebhook.isOversight(NotificationTemplate.TRANSACTION_COMPLETED)).isFalse()
         assertThat(OversightWebhook.isOversight(NotificationTemplate.ACCOUNT_OPENED)).isFalse()
         assertThat(OversightWebhook.isOversight(NotificationTemplate.KYC_APPROVED)).isFalse()
-        assertThat(OversightWebhook.isOversight(NotificationTemplate.PASSWORD_RESET)).isFalse()
     }
 
     @Test

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/HtmlEscapeTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/HtmlEscapeTest.kt
@@ -24,9 +24,9 @@ class HtmlEscapeTest {
 
     @Test
     fun `an attribute-breakout payload can no longer close the surrounding quote`() {
-        // The PASSWORD_RESET template interpolates resetLink into href="...". A raw double quote
-        // in the value would close the attribute early and let the rest of the string inject a
-        // new attribute or element; escaped, the quote is inert text.
+        // A variable interpolated into an href="..." attribute (the removed PASSWORD_RESET's
+        // resetLink was that case, #8568): a raw double quote would close the attribute early and
+        // let the rest of the string inject a new attribute or element; escaped, it is inert text.
         val payload = "https://example.com/reset?t=abc\" onmouseover=\"alert(1)"
         val escaped = HtmlEscape.escape(payload)
         assertThat(escaped).doesNotContain("\"")

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -33,7 +33,9 @@ class NotificationModelTest {
     fun `NotificationTemplate has all expected templates`() {
         // 22 since #8535 removed KYC_DOCUMENT_REQUIRED: nothing could produce it, because
         // kyc-service had no transition into DOCUMENTS_REQUIRED and no concept of a document type.
-        assertThat(NotificationTemplate.values()).hasSize(22)
+        // 21 since #8568 removed PASSWORD_RESET: no password flow exists (passkeys/biometrics only;
+        // Keycloak has resetPasswordAllowed=false and no SMTP), so nothing could produce it either.
+        assertThat(NotificationTemplate.values()).hasSize(21)
         assertThat(NotificationTemplate.values()).contains(
             NotificationTemplate.ACCOUNT_OPENED,
             NotificationTemplate.OTP_CODE,
@@ -131,7 +133,6 @@ class NotificationModelTest {
         )
         assertThat(NotificationTemplate.SCA_APPROVAL.noDeviceFallbackChannel).isNull()
         assertThat(NotificationTemplate.OTP_CODE.noDeviceFallbackChannel).isNull()
-        assertThat(NotificationTemplate.PASSWORD_RESET.noDeviceFallbackChannel).isNull()
         assertThat(NotificationTemplate.MARKETING_PRODUCT_OFFER.noDeviceFallbackChannel).isNull()
         assertThat(NotificationTemplate.TRANSACTION_COMPLETED.noDeviceFallbackChannel).isNull()
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateSensitivityTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateSensitivityTest.kt
@@ -18,7 +18,6 @@ class TemplateSensitivityTest {
     @Test
     fun `secret-bearing templates are classified (allow-list, not block-list)`() {
         assertThat(TemplateSensitivity.isSecret(NotificationTemplate.OTP_CODE)).isTrue()
-        assertThat(TemplateSensitivity.isSecret(NotificationTemplate.PASSWORD_RESET)).isTrue()
     }
 
     @Test
@@ -58,7 +57,6 @@ class TemplateSensitivityTest {
         // enum rather than in the consumer.
         assertThat(TemplateSensitivity.SECRET_TEMPLATES).containsExactlyInAnyOrder(
             NotificationTemplate.OTP_CODE,
-            NotificationTemplate.PASSWORD_RESET,
         )
     }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateVariableSchemaTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateVariableSchemaTest.kt
@@ -57,13 +57,11 @@ class TemplateVariableSchemaTest {
     @Test
     fun `secret templates declare exactly the variable that carries the secret`() {
         assertThat(NotificationTemplate.OTP_CODE.variables).containsExactly("code")
-        assertThat(NotificationTemplate.PASSWORD_RESET.variables).containsExactly("resetLink")
-        // Both are also classified SECRET, so their rendered body is delivered but never stored.
+        // It is also classified SECRET, so its rendered body is delivered but never stored.
         // Two independent controls: the schema stops the secret arriving on the WRONG template,
         // TemplateSensitivity stops it being stored on the RIGHT one.
         assertThat(TemplateSensitivity.SECRET_TEMPLATES).contains(
             NotificationTemplate.OTP_CODE,
-            NotificationTemplate.PASSWORD_RESET,
         )
     }
 


### PR DESCRIPTION
Refs #8568 (kept open: OTP_CODE second-channel decision and the WELCOME product gap remain).

**Why:** no password flow exists — the app authenticates with passkeys/biometrics and Keycloak runs with `resetPasswordAllowed=false` and no SMTP, so nothing could ever produce this template. Same class as `KYC_DOCUMENT_REQUIRED` (#8535).

**What:** enum entry, renderer branch, `SECRET_TEMPLATES`/fallback memberships, alert selector, docs. `HtmlEscape` quote-escaping stays (documented as covering future attribute-context variables).

**Verified locally:** compile + targeted tests + ktlint green.

## Security checklist
- [x] No new endpoint, role, or data flow — template removal only
- [x] No stored secret or PII handling change beyond narrowing SECRET_TEMPLATES
- [x] Alert selector narrowed to producible templates only