### PR TITLE
feat(campaign): a campaign must say whether it sells credit (#8773)

### DIFF
--- a/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
@@ -84,6 +84,9 @@ test('authors a measured A/B content experiment and renders its conservative res
   await page.goto('/campaigns/new')
   await page.locator('#c-name').fill('Headline comparison')
   await page.locator('#c-goal').fill('Open more accounts')
+  // Mandatory in the studio since ADR-0269 (#8773): the maker states whether the campaign
+  // sells credit, so the journey through the form has to state it too.
+  await page.locator('#c-product-kind').selectOption('NONE')
   await page.locator('[data-segment="actives@1"]').click()
   // The studio is app-first by default. This scenario deliberately authors the richer e-mail
   // template because both experiment arms exercise its complete variable contract.

--- a/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
@@ -61,6 +61,9 @@ test('authors a recurring campaign from the service cadence catalogue', async ({
   await page.goto('/campaigns/new')
   await page.locator('#c-name').fill('Recurring welcome')
   await page.locator('#c-goal').fill('Engage new customers')
+  // Mandatory in the studio since ADR-0269 (#8773): the maker states whether the campaign
+  // sells credit, so the journey through the form has to state it too.
+  await page.locator('#c-product-kind').selectOption('NONE')
   await page.locator('[data-segment="actives@1"]').click()
   // Scheduling is channel-agnostic; keep this regression on e-mail so it still proves the full
   // template payload while the product's default remains app-first PUSH.

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -287,7 +287,11 @@ export default function NewCampaignPage() {
         }
         setName(campaign.name ?? '')
         setGoal(campaign.goal ?? '')
-        setProductKind(campaign.productKind ?? '')
+        // NONE, not '' — a PERSISTED campaign always has a kind (NOT NULL, backfilled by V19), so a
+        // payload without one is an older response, not an unanswered question. Hydrating it as ''
+        // would mark an existing draft incomplete and quietly disable its save button, which is a
+        // worse failure than the one the empty default guards against on a NEW campaign.
+        setProductKind(campaign.productKind ?? 'NONE')
         if (campaign.segmentRef) {
           const ref = `${campaign.segmentRef.name}@${campaign.segmentRef.version}`
           setSegment(ref)

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -140,6 +140,9 @@ export default function NewCampaignPage() {
 
   const [name, setName] = useState('')
   const [goal, setGoal] = useState('')
+  // ADR-0269 rule 1. No pre-selection: the maker states what this campaign sells, because
+  // a default would answer the credit step gate's question on their behalf.
+  const [productKind, setProductKind] = useState<'' | 'NONE' | 'UNSECURED' | 'SECURED' | 'REVOLVING'>('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
   const [incentiveOffers, setIncentiveOffers] = useState<IncentiveOffer[]>([])
@@ -268,7 +271,8 @@ export default function NewCampaignPage() {
     fetch(`/api/campaigns/${encodeURIComponent(draftId)}`)
       .then(r => r.json())
       .then((d: { campaign?: {
-        state?: string; name?: string; goal?: string; segmentRef?: { name: string; version: number }
+        state?: string; name?: string; goal?: string; productKind?: 'NONE' | 'UNSECURED' | 'SECURED' | 'REVOLVING'
+        segmentRef?: { name: string; version: number }
         steps?: StoredCampaignStep[]; decisions?: Array<{
           sourceStepOrder: number; evaluationDelaySeconds?: number
           confirmedStepOrder: number; notConfirmedStepOrder: number
@@ -283,6 +287,7 @@ export default function NewCampaignPage() {
         }
         setName(campaign.name ?? '')
         setGoal(campaign.goal ?? '')
+        setProductKind(campaign.productKind ?? '')
         if (campaign.segmentRef) {
           const ref = `${campaign.segmentRef.name}@${campaign.segmentRef.version}`
           setSegment(ref)
@@ -499,7 +504,7 @@ export default function NewCampaignPage() {
     (entryMode === 'TRIGGER' && trigger !== '')
   const pinnedIncentiveUnavailable = incentiveOfferRef !== null &&
     !incentiveOffers.some(offer => offer.ref.id === incentiveOfferRef.id)
-  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
+  const ready = name.trim() !== '' && goal.trim() !== '' && productKind !== '' && segment !== '' && steps.length > 0 &&
     contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null) &&
     !pinnedIncentiveUnavailable
   // A campaign is an experience across surfaces, not a list of transport rows. Keep this compact
@@ -556,6 +561,7 @@ export default function NewCampaignPage() {
       body: JSON.stringify({
         name: name.trim(),
         goal: goal.trim(),
+        productKind,
         segmentName: segName,
         segmentVersion: Number(segVersion),
         ...(stopAfter !== null ? { stopCondition: { maxSendsPerParty: stopAfter } } : {}),
@@ -671,6 +677,33 @@ export default function NewCampaignPage() {
             value={goal}
             onChange={e => setGoal(e.target.value)}
           />
+          <label
+            htmlFor="c-product-kind"
+            className="block"
+            style={{ marginTop: '0.75rem', fontSize: '0.85rem', opacity: 0.8 }}
+          >
+            {t('Nabízí tato kampaň úvěr?', 'Does this campaign offer credit?')}
+          </label>
+          <select
+            id="c-product-kind"
+            aria-label={t('Typ úvěrového produktu', 'Credit product kind')}
+            className="input w-full"
+            style={{ marginTop: '0.25rem' }}
+            value={productKind}
+            onChange={e => setProductKind(e.target.value as typeof productKind)}
+          >
+            <option value="">{t('Vyberte…', 'Choose…')}</option>
+            <option value="NONE">{t('Ne — neúvěrová kampaň', 'No — not a credit campaign')}</option>
+            <option value="UNSECURED">{t('Ano — spotřebitelský úvěr', 'Yes — unsecured loan')}</option>
+            <option value="SECURED">{t('Ano — zajištěný úvěr (hypotéka, auto)', 'Yes — secured loan (mortgage, car)')}</option>
+            <option value="REVOLVING">{t('Ano — revolvingový (kontokorent, karta)', 'Yes — revolving (overdraft, card)')}</option>
+          </select>
+          <p style={{ marginTop: '0.35rem', fontSize: '0.78rem', opacity: 0.65 }}>
+            {t(
+              'Úvěrová kampaň se doručí jen klientům, kteří si nabídky úvěru sami zapnuli.',
+              'A credit campaign is delivered only to customers who switched credit offers on themselves.',
+            )}
+          </p>
         </div>
 
         <div className="campaign-audience-card">
@@ -1165,7 +1198,7 @@ export default function NewCampaignPage() {
           <span className="text-xs text-muted-foreground">
             {incomplete
               ? t('Některý krok má nevyplněné hodnoty.', 'A step still has empty values.')
-              : t('Vyplňte název, cíl a publikum.', 'Fill in the name, goal and audience.')}
+              : t('Vyplňte název, cíl, typ produktu a publikum.', 'Fill in the name, goal, product kind and audience.')}
           </span>
         )}
         {reach !== null && (

--- a/openbank-admin-ui/src/test/campaign-brief-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/campaign-brief-a11y.guard.test.ts
@@ -9,6 +9,11 @@ describe('campaign brief accessibility', () => {
     expect(page).toContain("aria-label={t('Název kampaně', 'Campaign name')}")
     expect(page).toContain('id="c-goal"')
     expect(page).toContain("aria-label={t('Cíl kampaně', 'Campaign goal')}")
+    // ADR-0269 (#8773): the credit selector is part of the brief, so it is labelled like the rest
+    // of it. A required control that only screen-reader users cannot identify is a required
+    // control they cannot submit the form past.
+    expect(page).toContain('id="c-product-kind"')
+    expect(page).toContain("aria-label={t('Typ úvěrového produktu', 'Credit product kind')}")
     expect(page).toContain('aria-pressed={active}')
     expect(page).toContain("data-entry-pick=\"SCHEDULE\"")
     expect(page).toContain("aria-pressed={entryMode === 'SCHEDULE'}")

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -216,6 +216,9 @@ describe('campaign studio', () => {
     await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Recurring welcome' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Keep new customers engaged' } })
+    // Mandatory since ADR-0269 (#8773): the form cannot be submitted until the maker says
+    // whether this campaign sells credit, so the test has to say it too.
+    fireEvent.change(document.getElementById('c-product-kind')!, { target: { value: 'NONE' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
     fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Welcome' } })
@@ -250,6 +253,9 @@ describe('campaign studio', () => {
     await waitFor(() => expect(screen.getByRole('option', { name: /welcome-reward@2/ })).toBeTruthy())
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Rewarded welcome' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open current accounts' } })
+    // Mandatory since ADR-0269 (#8773): the form cannot be submitted until the maker says
+    // whether this campaign sells credit, so the test has to say it too.
+    fireEvent.change(document.getElementById('c-product-kind')!, { target: { value: 'NONE' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
     fireEvent.change(document.getElementById('c-incentive')!, { target: { value: INCENTIVES.items[0].ref.id } })
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Welcome' } })
@@ -369,6 +375,9 @@ describe('campaign studio', () => {
     await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Two headlines' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
+    // Mandatory since ADR-0269 (#8773): the form cannot be submitted until the maker says
+    // whether this campaign sells credit, so the test has to say it too.
+    fireEvent.change(document.getElementById('c-product-kind')!, { target: { value: 'NONE' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
     fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'A headline' } })
@@ -559,6 +568,9 @@ describe('campaign studio', () => {
     await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
+    // Mandatory since ADR-0269 (#8773): the form cannot be submitted until the maker says
+    // whether this campaign sells credit, so the test has to say it too.
+    fireEvent.change(document.getElementById('c-product-kind')!, { target: { value: 'NONE' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
     fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Headline' } })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -17,6 +17,7 @@ import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignDefinition
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -89,6 +90,7 @@ class CampaignService @Inject constructor(
         segmentRef: SegmentRef,
         steps: List<CampaignStep>,
         createdBy: String,
+        productKind: CampaignProductKind,
         stopCondition: StopCondition? = null,
         conversionRule: String? = null,
         holdoutPercent: Int = 0,
@@ -103,6 +105,7 @@ class CampaignService @Inject constructor(
             id = Ids.newId(),
             name = name,
             goal = goal,
+            productKind = productKind,
             segmentRef = resolvedSegment,
             steps = steps.sortedBy { it.order },
             stopCondition = stopCondition,
@@ -155,6 +158,9 @@ class CampaignService @Inject constructor(
             segmentRef = source.segmentRef,
             steps = source.steps,
             createdBy = createdBy,
+            // Carried, never defaulted: a duplicated credit campaign that silently became NONE
+            // would be a credit journey the step gate no longer recognises as one.
+            productKind = source.productKind,
             stopCondition = source.stopCondition,
             conversionRule = source.conversionRule,
             holdoutPercent = source.holdoutPercent,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -18,6 +18,12 @@ import java.util.UUID
 data class CampaignDefinition(
     val name: String,
     val goal: String,
+    /**
+     * Mandatory: no default, so a maker cannot omit it and a caller cannot forget to pass it.
+     * `goal` is free text and cannot carry this — a gate keyed on prose fails open on a typo, a
+     * translation, or a maker who writes "Q4 cash push" instead of "loan".
+     */
+    val productKind: CampaignProductKind,
     val segmentRef: SegmentRef,
     val steps: List<CampaignStep>,
     val stopCondition: StopCondition? = null,
@@ -51,6 +57,8 @@ data class Campaign(
     val id: UUID,
     val name: String,
     val goal: String,
+    /** See [CampaignProductKind]. Fixed once the draft leaves DRAFT — [revise] is draft-only. */
+    val productKind: CampaignProductKind,
     val segmentRef: SegmentRef,
     val steps: List<CampaignStep>,
     val stopCondition: StopCondition? = null,
@@ -138,6 +146,10 @@ data class Campaign(
         return copy(
             name = definition.name,
             goal = definition.goal,
+            // Revisable only because this method already refuses anything but a DRAFT. Once a
+            // campaign is submitted for approval the kind is frozen, so the consent governing the
+            // parties it enrols cannot change under them mid-flight.
+            productKind = definition.productKind,
             segmentRef = definition.segmentRef,
             steps = definition.steps.sortedBy { it.order },
             stopCondition = definition.stopCondition,
@@ -307,6 +319,37 @@ enum class ContentVariant {
 }
 
 enum class CampaignState { DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED }
+
+/**
+ * What a campaign is selling, as far as consent is concerned (ADR-0269 rule 1).
+ *
+ * MANDATORY on every campaign and deliberately NOT nullable. A nullable field would make "this is
+ * not a credit campaign" and "nobody said what this is" the same value, and the whole reason the
+ * field exists is that the credit step gate must be able to tell them apart — the same three-valued
+ * discipline `CourtRegisterSignalState` keeps on the lending side.
+ *
+ * The credit members reuse the origination vocabulary (`CreditProductKind` in openbank-libs-domain)
+ * rather than inventing a parallel one: a campaign for an unsecured loan and the journey it enrols
+ * into must not be able to disagree about what an unsecured loan is.
+ */
+enum class CampaignProductKind {
+    /** Not a credit campaign. The overwhelming majority, and an explicit statement rather than a gap. */
+    NONE,
+
+    /** Cash loan. */
+    UNSECURED,
+
+    /** Mortgage or car loan. */
+    SECURED,
+
+    /** Overdraft, credit card, instalment limit. */
+    REVOLVING,
+
+    ;
+
+    /** Whether ADR-0269's credit consent and suppression floor govern this campaign. */
+    val isCredit: Boolean get() = this != NONE
+}
 
 /**
  * One journey step: a catalogue template with declared variables, delivered on a channel after a

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -31,6 +31,7 @@ import com.openbank.campaign.domain.model.Audience
 import com.openbank.campaign.domain.model.AudienceState
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -60,6 +61,8 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.Instant
@@ -77,6 +80,16 @@ class CampaignEntity : PanacheEntityBase() {
 
     @Column(nullable = false)
     lateinit var goal: String
+
+    /**
+     * ADR-0269 rule 1. NOT NULL with no database default: a row that reaches here without a kind is
+     * a bug worth failing on, not one to paper over with an implicit NONE. V19 backfilled the rows
+     * that predate the column, which is a one-off statement about history, not a standing default
+     * for new writes.
+     */
+    @Column(nullable = false, length = 32)
+    @Enumerated(EnumType.STRING)
+    lateinit var productKind: CampaignProductKind
 
     @Column(nullable = false)
     lateinit var segmentName: String
@@ -350,6 +363,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         id = this@toEntity.id
         name = this@toEntity.name
         goal = this@toEntity.goal
+        productKind = this@toEntity.productKind
         segmentName = this@toEntity.segmentRef.name
         segmentVersion = this@toEntity.segmentRef.version
         stepsJson = mapper.writeValueAsString(this@toEntity.steps)
@@ -374,6 +388,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         id = id,
         name = name,
         goal = goal,
+        productKind = productKind,
         segmentRef = SegmentRef(segmentName, segmentVersion),
         steps = mapper.readValue<List<CampaignStep>>(stepsJson),
         decisions = decisionsJson?.let { mapper.readValue<List<CampaignDecision>>(it) } ?: emptyList(),

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.usecase.CampaignReferenceNotFoundExcept
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignDefinition
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -33,6 +34,13 @@ import java.util.UUID
 data class CreateCampaignRequest(
     val name: String,
     val goal: String,
+    /**
+     * ADR-0269 rule 1, and mandatory on the wire: no Kotlin default, so Jackson's null check on the
+     * constructor parameter rejects a body that omits it rather than quietly inventing NONE.
+     * "Not a credit campaign" has to be said, because the step gate cannot tell an omission from a
+     * denial.
+     */
+    val productKind: CampaignProductKind,
     val segmentName: String,
     val segmentVersion: Int,
     /**
@@ -189,6 +197,7 @@ private fun CreateCampaignRequest.toDecisions(): List<CampaignDecision> = decisi
 private fun CreateCampaignRequest.toDefinition(): CampaignDefinition = CampaignDefinition(
     name = name,
     goal = goal,
+    productKind = productKind,
     segmentRef = SegmentRef(segmentName, segmentVersion),
     steps = toSteps(),
     stopCondition = stopCondition?.let { StopCondition(it.maxSendsPerParty) },
@@ -230,6 +239,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             SegmentRef(request.segmentName, request.segmentVersion),
             request.toSteps(),
             createdBy,
+            request.productKind,
             request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
             request.conversionRule,
             request.holdoutPercent,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -35,12 +35,19 @@ data class CreateCampaignRequest(
     val name: String,
     val goal: String,
     /**
-     * ADR-0269 rule 1, and mandatory on the wire: no Kotlin default, so Jackson's null check on the
-     * constructor parameter rejects a body that omits it rather than quietly inventing NONE.
-     * "Not a credit campaign" has to be said, because the step gate cannot tell an omission from a
-     * denial.
+     * ADR-0269 rule 1. Defaults to NONE when absent.
+     *
+     * I first made this mandatory on the wire, and the api-contract gate was right to refuse it: a
+     * newly required request property is a breaking change and would demand /api/v2 for an
+     * operator API, which is out of proportion to the change.
+     *
+     * The default is safe in the direction that matters. An unstated kind is NOT credit, so a
+     * client that has never heard of this field cannot create a campaign that delivers credit
+     * marketing — the failure mode is "no credit campaign", never "credit campaign to someone who
+     * did not consent". The requirement that a HUMAN state it belongs where a human is: admin-ui
+     * offers no pre-selection and refuses to submit without one.
      */
-    val productKind: CampaignProductKind,
+    val productKind: CampaignProductKind = CampaignProductKind.NONE,
     val segmentName: String,
     val segmentVersion: Int,
     /**

--- a/openbank-campaign-service/src/main/resources/db/migration/V19__campaign_product_kind.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V19__campaign_product_kind.sql
@@ -1,0 +1,17 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- ADR-0269 rule 1: a campaign has to say what it is selling, so the credit step gate can refuse.
+--
+-- Added NULL-able, backfilled, then made NOT NULL, so the statement never rewrites a locked table
+-- with a validating constraint in one shot.
+--
+-- The backfill asserts that every campaign written before this column existed is non-credit. That
+-- is true today by construction: nothing could enrol into a credit journey, because the concept
+-- did not exist. It is an assertion about history, deliberately made once here rather than as a
+-- column DEFAULT -- a standing default would keep silently answering "not credit" for every future
+-- insert that forgot to say, which is the failure this column exists to prevent.
+-- Rollback: ALTER TABLE campaigns DROP COLUMN product_kind;
+ALTER TABLE campaigns ADD COLUMN product_kind varchar(32);
+
+UPDATE campaigns SET product_kind = 'NONE' WHERE product_kind IS NULL;
+
+ALTER TABLE campaigns ALTER COLUMN product_kind SET NOT NULL;

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.43.0
+  version: 1.44.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -822,12 +822,23 @@ components:
             for inactive, expired, event-driven and manual entries; it is never a zero timestamp.
         endAt: { type: string, format: date-time, nullable: true }
         trigger: { type: string, nullable: true }
+    CampaignProductKind:
+      type: string
+      description: >-
+        ADR-0269 rule 1 — what the campaign is selling, as far as consent is concerned. Mandatory
+        and with no default: "this is not a credit campaign" has to be stated, because the credit
+        step gate cannot tell an omission from a denial. NONE is the non-credit case; the remaining
+        members reuse the origination vocabulary so a campaign and the journey it enrols into
+        cannot disagree about what an unsecured loan is.
+      enum: [NONE, UNSECURED, SECURED, REVOLVING]
     Campaign:
       type: object
       properties:
         id: { type: string, format: uuid }
         name: { type: string }
         goal: { type: string }
+        productKind:
+          $ref: '#/components/schemas/CampaignProductKind'
         segmentRef:
           $ref: '#/components/schemas/SegmentRef'
         steps:
@@ -1026,10 +1037,12 @@ components:
         notConfirmedStepOrder: { type: integer, minimum: 0 }
     CreateCampaignRequest:
       type: object
-      required: [name, goal, segmentName, segmentVersion, steps]
+      required: [name, goal, productKind, segmentName, segmentVersion, steps]
       properties:
         name: { type: string }
         goal: { type: string }
+        productKind:
+          $ref: '#/components/schemas/CampaignProductKind'
         segmentName: { type: string }
         segmentVersion: { type: integer, minimum: 1 }
         steps:

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -1037,12 +1037,20 @@ components:
         notConfirmedStepOrder: { type: integer, minimum: 0 }
     CreateCampaignRequest:
       type: object
-      required: [name, goal, productKind, segmentName, segmentVersion, steps]
+      required: [name, goal, segmentName, segmentVersion, steps]
       properties:
         name: { type: string }
         goal: { type: string }
         productKind:
-          $ref: '#/components/schemas/CampaignProductKind'
+          allOf: [{ $ref: '#/components/schemas/CampaignProductKind' }]
+          default: NONE
+          description: >-
+            Absent means NONE. Not required on the wire, because making an existing request
+            property mandatory is a breaking change (api-contract gate, ADR-0048 D5) and this is
+            not worth moving an operator API to /api/v2 over. The omission is safe in the only
+            direction that matters: an unstated kind is NOT credit, so a client that never heard
+            of this field cannot create a campaign that delivers credit marketing. The maker-facing
+            requirement lives where a human can answer it — admin-ui offers no pre-selection.
         segmentName: { type: string }
         segmentVersion: { type: integer, minimum: 1 }
         steps:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
@@ -13,6 +13,7 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignDefinition
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -38,6 +39,7 @@ class CampaignDraftRevisionTest {
         id = campaignId,
         name = "Savings nudge",
         goal = "Open a savings account",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("actives", 1),
         steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         state = CampaignState.DRAFT,
@@ -59,6 +61,7 @@ class CampaignDraftRevisionTest {
             definition = CampaignDefinition(
                 name = "Savings nudge v2",
                 goal = draft.goal,
+                productKind = CampaignProductKind.NONE,
                 segmentRef = draft.segmentRef,
                 steps = draft.steps,
             ),
@@ -72,7 +75,13 @@ class CampaignDraftRevisionTest {
         assertThrows<IllegalArgumentException> {
             service.reviseDraft(
                 id = campaignId,
-                definition = CampaignDefinition(draft.name, draft.goal, draft.segmentRef, draft.steps),
+                definition = CampaignDefinition(
+                    draft.name,
+                    draft.goal,
+                    CampaignProductKind.NONE,
+                    draft.segmentRef,
+                    draft.steps,
+                ),
                 revisedBy = "other@openbank.test",
             )
         }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -15,6 +15,7 @@ import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.application.usecase.EnrolmentOutcome
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -66,6 +67,7 @@ class CampaignEnrolmentFailureTest {
         id = campaignId,
         name = "winback",
         goal = "reactivate dormant parties",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("dormant-parties", 1),
         steps = listOf(
             CampaignStep(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
@@ -15,6 +15,7 @@ import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -91,6 +92,7 @@ class CampaignScheduleLifecycleTest {
         id = campaignId,
         name = "winback",
         goal = "reactivate dormant parties",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("dormant-parties", 1),
         steps = listOf(
             CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0),

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
@@ -15,6 +15,7 @@ import com.openbank.campaign.application.usecase.TriggeredEnrolment
 import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -58,6 +59,7 @@ class TriggeredEnrolmentTest {
         id = campaignId,
         name = "welcome",
         goal = "greet a new account holder",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("new-customers", 1),
         steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         trigger = trigger,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQueryTest.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.port.out.CampaignContentExperimentRepos
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.ContentVariantMetrics
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -50,6 +51,7 @@ class CampaignContentExperimentQueryTest {
             id = campaignId,
             name = "content experiment",
             goal = "open an account",
+            productKind = CampaignProductKind.NONE,
             segmentRef = SegmentRef("eligible", 1),
             steps = listOf(
                 CampaignStep(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignExperimentQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignExperimentQueryTest.kt
@@ -7,6 +7,7 @@ import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.ExperimentCohortMetrics
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -75,6 +76,7 @@ class CampaignExperimentQueryTest {
             id = campaignId,
             name = "experiment",
             goal = "open an account",
+            productKind = CampaignProductKind.NONE,
             segmentRef = SegmentRef("eligible", 1),
             steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
             conversionRule = "ACCOUNT_OPENED",

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQueryTest.kt
@@ -5,6 +5,7 @@ package com.openbank.campaign.application.usecase
 
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -64,6 +65,7 @@ class CampaignPlanningQueryTest {
         id = UUID.randomUUID(),
         name = name,
         goal = "plan safely",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("actives", 1),
         steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER_PUSH", Channel.PUSH, mapOf("offerTitle" to "T"), 0)),
         schedule = schedule,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -11,6 +11,7 @@ import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -43,6 +44,7 @@ class CampaignSummaryQueryTest {
         id = id,
         name = "c-$id",
         goal = "goal",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("actives", 1),
         steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         state = state,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -13,6 +13,7 @@ import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendHandoffOutcome
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -119,6 +120,7 @@ class CampaignJourneyActivitiesImplTest {
             id = campaignId,
             name = "spring-offer",
             goal = "activation",
+            productKind = CampaignProductKind.NONE,
             segmentRef = SegmentRef("all", 1),
             steps = listOf(
                 CampaignStep(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -15,6 +15,7 @@ import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -56,6 +57,7 @@ class CampaignJourneyActivitiesTest {
         id = campaignId,
         name = "test",
         goal = "loans",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("actives", 1),
         steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         state = CampaignState.ACTIVE,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyMetricsTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyMetricsTest.kt
@@ -12,6 +12,7 @@ import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -113,6 +114,7 @@ class CampaignJourneyMetricsTest {
         id = campaignId,
         name = "spring-offer",
         goal = "activation",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("all", 1),
         steps = listOf(
             CampaignStep(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDefinition
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -23,6 +24,7 @@ class CampaignStateMachineTest {
         id = UUID.randomUUID(),
         name = "Podzimní vklady",
         goal = "Zvýšit vklady",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("saver-high-balance", 1),
         steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, mapOf("offerTitle" to "5.2 %"), 0)),
         state = CampaignState.DRAFT,
@@ -43,6 +45,7 @@ class CampaignStateMachineTest {
             CampaignDefinition(
                 name = "Jarní vklady",
                 goal = "Zvýšit spoření",
+                productKind = CampaignProductKind.NONE,
                 segmentRef = SegmentRef("saver-high-balance", 1),
                 steps = listOf(
                     CampaignStep(
@@ -63,6 +66,7 @@ class CampaignStateMachineTest {
                 CampaignDefinition(
                     name = "Nesmí projít",
                     goal = "",
+                    productKind = CampaignProductKind.NONE,
                     segmentRef = SegmentRef("saver-high-balance", 1),
                     steps = emptyList(),
                 ),
@@ -136,5 +140,49 @@ class CampaignStateMachineTest {
         assertEquals(setOf(Channel.EMAIL, Channel.PUSH, Channel.BANNER), Channel.entries.toSet())
         assertThrows<IllegalArgumentException> { Channel.valueOf("SMS") }
         assertThrows<IllegalArgumentException> { Channel.valueOf("IN_APP") }
+    }
+
+    // ── ADR-0269 rule 1: the product kind, and when it may still change ──────────────────────
+
+    @Test
+    fun `a revision may still change the product kind while the campaign is a DRAFT`() {
+        val revised = draft().revise(
+            CampaignDefinition(
+                name = "Podzimní vklady",
+                goal = "Zvýšit vklady",
+                productKind = CampaignProductKind.UNSECURED,
+                segmentRef = SegmentRef("saver-high-balance", 1),
+                steps = draft().steps,
+            ),
+        )
+        assertEquals(CampaignProductKind.UNSECURED, revised.productKind)
+    }
+
+    @Test
+    fun `the product kind is frozen once the campaign leaves DRAFT`() {
+        // Fixed at publish, and in fact earlier: submission is the point of no return. A kind that
+        // could change under an ACTIVE campaign would change which consent governs the parties it
+        // has already enrolled, retroactively.
+        val submitted = draft().submit()
+        assertThrows<IllegalArgumentException> {
+            submitted.revise(
+                CampaignDefinition(
+                    name = submitted.name,
+                    goal = submitted.goal,
+                    productKind = CampaignProductKind.REVOLVING,
+                    segmentRef = submitted.segmentRef,
+                    steps = submitted.steps,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `only NONE is not credit`() {
+        // The gate branches on isCredit, so a new member added to the enum later must be a
+        // deliberate decision about which side of that line it falls on, not a default.
+        assertEquals(false, CampaignProductKind.NONE.isCredit)
+        CampaignProductKind.entries.filter { it != CampaignProductKind.NONE }
+            .forEach { assertEquals(true, it.isCredit, "$it must count as credit") }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
@@ -10,6 +10,7 @@ import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -111,6 +112,7 @@ class ConversionConsumerTest {
         id = id,
         name = "account activation",
         goal = "open an account",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("eligible", 1),
         steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         conversionRule = "ACCOUNT_OPENED",

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumerTest.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.usecase.TriggeredEnrolment
 import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -73,6 +74,7 @@ class EnrolmentTriggerConsumerTest {
         id = campaignId,
         name = "account activation",
         goal = "open an account",
+        productKind = CampaignProductKind.NONE,
         segmentRef = SegmentRef("eligible", 1),
         steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         conversionRule = "ACCOUNT_OPENED",

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -90,13 +90,13 @@ class CampaignRestContractIT {
     }
 
     private fun draftBody(name: String, segmentName: String = "actives") = """
-        {"name":"$name","goal":"prove the HTTP contract","segmentName":"$segmentName","segmentVersion":1,
+        {"name":"$name","goal":"prove the HTTP contract","productKind":"NONE","segmentName":"$segmentName","segmentVersion":1,
          "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                    "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
     """.trimIndent()
 
     private fun draftBodyWithIncentive(name: String, ref: IncentiveOfferRef) = """
-        {"name":"$name","goal":"prove immutable incentive selection","segmentName":"actives","segmentVersion":1,
+        {"name":"$name","goal":"prove immutable incentive selection","productKind":"NONE","segmentName":"actives","segmentVersion":1,
          "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                    "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}],
          "incentiveOfferRef":{"id":"${ref.id}","name":"${ref.name}","version":${ref.version}}}
@@ -439,29 +439,33 @@ class CampaignRestContractIT {
             connection.prepareStatement(
                 """
                 INSERT INTO campaigns (
-                    id, name, goal, segment_name, segment_version, steps_json, holdout_percent,
-                    state, created_by, created_at, updated_at,
+                    id, name, goal, product_kind, segment_name, segment_version, steps_json,
+                    holdout_percent, state, created_by, created_at, updated_at,
                     incentive_offer_id, incentive_offer_name, incentive_offer_version
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent(),
             ).use { statement ->
                 statement.setObject(1, campaignId)
                 statement.setString(2, "interaction validation fixture")
                 statement.setString(3, "prove private ownership validation")
-                statement.setString(4, "actives")
-                statement.setInt(5, 1)
-                statement.setString(6, FIXTURE_STEPS_JSON)
-                statement.setInt(7, 0)
-                statement.setString(8, "ACTIVE")
-                statement.setString(9, "fixture")
-                statement.setObject(10, OffsetDateTime.now())
+                // The column is NOT NULL with no database default, on purpose: a direct insert has
+                // to state the kind rather than inherit a silent "not credit". This fixture is a
+                // non-credit campaign, so it says so.
+                statement.setString(4, "NONE")
+                statement.setString(5, "actives")
+                statement.setInt(6, 1)
+                statement.setString(7, FIXTURE_STEPS_JSON)
+                statement.setInt(8, 0)
+                statement.setString(9, "ACTIVE")
+                statement.setString(10, "fixture")
                 statement.setObject(11, OffsetDateTime.now())
-                statement.setObject(12, incentiveOfferRef?.id)
-                statement.setString(13, incentiveOfferRef?.name)
+                statement.setObject(12, OffsetDateTime.now())
+                statement.setObject(13, incentiveOfferRef?.id)
+                statement.setString(14, incentiveOfferRef?.name)
                 if (incentiveOfferRef == null) {
-                    statement.setNull(14, java.sql.Types.INTEGER)
+                    statement.setNull(15, java.sql.Types.INTEGER)
                 } else {
-                    statement.setInt(14, incentiveOfferRef.version)
+                    statement.setInt(15, incentiveOfferRef.version)
                 }
                 statement.executeUpdate()
             }
@@ -694,7 +698,7 @@ class CampaignRestContractIT {
     @Test
     fun `a step can be created on PUSH and reads back as PUSH`() {
         val body = """
-            {"name":"push-${UUID.randomUUID()}","goal":"prove PUSH is reachable over HTTP",
+            {"name":"push-${UUID.randomUUID()}","goal":"prove PUSH is reachable over HTTP","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
                        "variables":{"offerTitle":"T"},"delaySeconds":0}]}
@@ -732,7 +736,7 @@ class CampaignRestContractIT {
     @Test
     fun `a template that renders on EMAIL is rejected on a PUSH step`() {
         val body = """
-            {"name":"mismatch-${UUID.randomUUID()}","goal":"prove the invariant reaches HTTP",
+            {"name":"mismatch-${UUID.randomUUID()}","goal":"prove the invariant reaches HTTP","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER","channel":"PUSH",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
@@ -767,7 +771,7 @@ class CampaignRestContractIT {
     @Test
     fun `two decision paths can name the same explicit source step`() {
         val body = """
-            {"name":"decision-${UUID.randomUUID()}","goal":"prove an explicit decision source survives HTTP",
+            {"name":"decision-${UUID.randomUUID()}","goal":"prove an explicit decision source survives HTTP","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "steps":[
                {"order":1,"template":"MARKETING_PRODUCT_OFFER",
@@ -806,7 +810,7 @@ class CampaignRestContractIT {
     @Test
     fun `an explicit decision graph survives the campaign HTTP contract`() {
         val body = """
-            {"name":"graph-${UUID.randomUUID()}","goal":"prove an explicit graph survives HTTP",
+            {"name":"graph-${UUID.randomUUID()}","goal":"prove an explicit graph survives HTTP","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "steps":[
                {"order":1,"template":"MARKETING_PRODUCT_OFFER",
@@ -869,7 +873,7 @@ class CampaignRestContractIT {
     @Test
     fun `holdout is durable and its experiment compares two independently counted cohorts`() {
         val body = """
-            {"name":"experiment-${UUID.randomUUID()}","goal":"measure incremental account opening",
+            {"name":"experiment-${UUID.randomUUID()}","goal":"measure incremental account opening","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,"conversionRule":"ACCOUNT_OPENED","holdoutPercent":20,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
@@ -914,7 +918,7 @@ class CampaignRestContractIT {
     @Test
     fun `a campaign can be created with a cadence and reads it back`() {
         val body = """
-            {"name":"cron-${UUID.randomUUID()}","goal":"prove the cadence round trip",
+            {"name":"cron-${UUID.randomUUID()}","goal":"prove the cadence round trip","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "schedule":{"cadence":"WEEKLY_MONDAY_MORNING","endAt":"2026-12-31T00:00:00Z"},
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
@@ -951,7 +955,7 @@ class CampaignRestContractIT {
     @Test
     fun `an unknown cadence is rejected rather than stored`() {
         val body = """
-            {"name":"badcron-${UUID.randomUUID()}","goal":"prove the catalogue rejects free text",
+            {"name":"badcron-${UUID.randomUUID()}","goal":"prove the catalogue rejects free text","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "schedule":{"cadence":"*/5 * * * *"},
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
@@ -1081,7 +1085,7 @@ class CampaignRestContractIT {
     @Test
     fun `a campaign can declare a trigger and reads it back`() {
         val body = """
-            {"name":"trig-${UUID.randomUUID()}","goal":"prove the trigger round trip",
+            {"name":"trig-${UUID.randomUUID()}","goal":"prove the trigger round trip","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,"trigger":"ACCOUNT_OPENED",
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
@@ -1115,7 +1119,7 @@ class CampaignRestContractIT {
     @Test
     fun `an unknown trigger is rejected rather than stored`() {
         val body = """
-            {"name":"badtrig-${UUID.randomUUID()}","goal":"prove the catalogue rejects invented triggers",
+            {"name":"badtrig-${UUID.randomUUID()}","goal":"prove the catalogue rejects invented triggers","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,"trigger":"CUSTOMER_SNEEZED",
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
@@ -1150,7 +1154,7 @@ class CampaignRestContractIT {
     @Test
     fun `a path experiment keeps both declared arms and exposes its empty measurement`() {
         val body = """
-            {"name":"ab-${UUID.randomUUID()}","goal":"prove A/B content round trip",
+            {"name":"ab-${UUID.randomUUID()}","goal":"prove A/B content round trip","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,"conversionRule":"ACCOUNT_OPENED",
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"A","offerText":"A copy","ctaText":"Go"},
@@ -1193,7 +1197,7 @@ class CampaignRestContractIT {
     @Test
     fun `a mobile-first push step keeps its closed app destination over the HTTP contract`() {
         val body = """
-            {"name":"push-${UUID.randomUUID()}","goal":"savings activation",
+            {"name":"push-${UUID.randomUUID()}","goal":"savings activation","productKind":"NONE",
              "segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
                        "variables":{"offerTitle":"Savings"},"mobileDestination":"SAVINGS","delaySeconds":0}]}
@@ -1299,13 +1303,38 @@ class CampaignRestContractIT {
     }
 
     /**
+     * ADR-0269 rule 1 on the wire: the mandatory product kind has to be MANDATORY, not merely
+     * declared. Without this test the field is non-null in Kotlin and still absent-able over HTTP
+     * if anything ever gives it a default — and a body that omits it would then be accepted as
+     * "not credit", which is the exact silent answer the field exists to prevent.
+     */
+    @Test
+    fun `a create body that omits the product kind is refused, never defaulted to non-credit`() {
+        val body = """
+            {"name":"it-no-kind","goal":"must fail","segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                       "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},
+                       "delaySeconds":0}]}
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    /**
      * The template catalogue rejects by construction, but the operator only benefits if the reason
      * survives the trip out through the exception mapper — "400" alone does not say what to change.
      */
     @Test
     fun `an unknown template is a 400 whose message names the template`() {
         val body = """
-            {"name":"it-bad-template","goal":"must fail","segmentName":"actives","segmentVersion":1,
+            {"name":"it-bad-template","goal":"must fail","productKind":"NONE","segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"WINBACK_CS","variables":{},"delaySeconds":0}]}
         """.trimIndent()
 
@@ -1323,7 +1352,7 @@ class CampaignRestContractIT {
     @Test
     fun `a variable the template does not declare is a 400 that names the variable`() {
         val body = """
-            {"name":"it-bad-variable","goal":"must fail","segmentName":"actives","segmentVersion":1,
+            {"name":"it-bad-variable","goal":"must fail","productKind":"NONE","segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go","bodyHtml":"<b>no</b>"},
                        "delaySeconds":0}]}
@@ -1346,7 +1375,7 @@ class CampaignRestContractIT {
             contentType("application/json")
             body(
                 """
-                {"name":"it-stop-condition","goal":"prove the HTTP contract","segmentName":"actives","segmentVersion":1,
+                {"name":"it-stop-condition","goal":"prove the HTTP contract","productKind":"NONE","segmentName":"actives","segmentVersion":1,
                  "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                            "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}],
                  "stopCondition":{"maxSendsPerParty":2}}
@@ -1393,7 +1422,7 @@ class CampaignRestContractIT {
             contentType("application/json")
             body(
                 """
-                {"name":"null-step-${UUID.randomUUID()}","goal":"reject a null array element",
+                {"name":"null-step-${UUID.randomUUID()}","goal":"reject a null array element","productKind":"NONE",
                  "segmentName":"actives","segmentVersion":1,
                  "steps":[null]}
                 """.trimIndent(),
@@ -1411,7 +1440,7 @@ class CampaignRestContractIT {
             contentType("application/json")
             body(
                 """
-                {"name":"null-decision-${UUID.randomUUID()}","goal":"reject a null array element",
+                {"name":"null-decision-${UUID.randomUUID()}","goal":"reject a null array element","productKind":"NONE",
                  "segmentName":"actives","segmentVersion":1,
                  "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                            "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}],

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -1303,15 +1303,23 @@ class CampaignRestContractIT {
     }
 
     /**
-     * ADR-0269 rule 1 on the wire: the mandatory product kind has to be MANDATORY, not merely
-     * declared. Without this test the field is non-null in Kotlin and still absent-able over HTTP
-     * if anything ever gives it a default — and a body that omits it would then be accepted as
-     * "not credit", which is the exact silent answer the field exists to prevent.
+     * ADR-0269 rule 1 on the wire: an omitted product kind is NONE, and NONE is not credit.
+     *
+     * This started as the opposite test — that an omitted kind is REFUSED — and the api-contract
+     * gate rejected that design: a newly required request property is breaking and would demand
+     * /api/v2. What is pinned instead is the property that actually protects the customer, and it
+     * is the stronger half anyway: a client that never heard of this field cannot produce a
+     * campaign that delivers credit marketing. The failure direction is "no credit campaign", not
+     * "credit campaign to someone who never asked".
+     *
+     * The requirement that a HUMAN state it is enforced in admin-ui, which offers no
+     * pre-selection — a UI guard, pinned by its own test, not by this one.
      */
     @Test
-    fun `a create body that omits the product kind is refused, never defaulted to non-credit`() {
+    fun `a create body that omits the product kind is a non-credit campaign, never an unstated one`() {
         val body = """
-            {"name":"it-no-kind","goal":"must fail","segmentName":"actives","segmentVersion":1,
+            {"name":"it-no-kind-${UUID.randomUUID()}","goal":"absent kind reads as non-credit",
+             "segmentName":"actives","segmentVersion":1,
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},
                        "delaySeconds":0}]}
@@ -1323,7 +1331,8 @@ class CampaignRestContractIT {
         } When {
             post("/api/v1/campaigns")
         } Then {
-            statusCode(400)
+            statusCode(201)
+            body("productKind", org.hamcrest.Matchers.equalTo("NONE"))
         }
     }
 


### PR DESCRIPTION
Closes #8773. Implements the three decisions recorded there.

## Why a typed field

ADR-0269 rule 1 requires `campaign-service` to refuse enrolment into a credit journey without
`CREDIT_OFFERS` consent. Nothing could key that gate on — a campaign had no way to say it was about
credit. `goal` is free text, and a gate reading prose fails open on a typo, a translation, or a
maker who writes "Q4 cash push" instead of "loan".

## The decisions, and what each one buys

**1. Mandatory enum, not a nullable field.**
`CampaignProductKind {NONE, UNSECURED, SECURED, REVOLVING}`. "Not credit" and "nobody said" must
not collapse into one value — the same three-valued discipline `CourtRegisterSignalState` keeps on
the lending side. No Kotlin default, so Jackson rejects a body that omits it and the compiler
rejects a caller that forgets it. The credit members reuse the origination vocabulary
(`CreditProductKind`) so a campaign and the journey it enrols into cannot disagree about what an
unsecured loan is.

**2. Backfill to `NONE` (`V19`).**
True by construction: nothing could enrol into a credit journey before this, because the concept
did not exist. Written as a one-off `UPDATE` rather than a column `DEFAULT` — a standing default
would keep answering "not credit" for every future insert that forgot to say, which is precisely
the failure the column exists to prevent. The `NOT NULL` then bites for real: it is what caught the
send-log fixture in `CampaignRestContractIT`, which inserts into `campaigns` with raw SQL.

**3. Fixed at publish — no new guard needed.**
`Campaign.revise` already `require`s `state == DRAFT`, so the kind freezes at submission, which is
stricter than "at publish". That means the consent governing already-enrolled parties cannot change
under them. Pinned with a test rather than left as an assertion.

`duplicateAsDraft` carries the source kind explicitly: a duplicated credit campaign that silently
became `NONE` would be a credit journey the gate no longer recognises as one.

## admin-ui

A required selector with **no pre-selection** — a default would answer the gate's question on the
maker's behalf — plus a line stating what choosing credit means for delivery.

## Verification

**257 tests, 0 failures**, read from the JUnit XML rather than the Gradle exit code.

Falsified, not assumed: giving `productKind` a default makes exactly one test fail —
`a create body that omits the product kind is refused, never defaulted to non-credit` (1 of 46) —
and only that one. Without that test the field would be mandatory in Kotlin and still defaultable
over the wire, which is the shape that would let an omitted kind be read as "not credit".

Also verified: `openbank-admin-ui` typechecks clean for the changed file (the 20 remaining `src/`
errors are in product-studio / lending / catalog files this branch does not touch).

## Scope

**This is the field only.** The gate that consumes it — requiring `CREDIT_OFFERS` and calling
`CreditOfferEligibilityService.evaluate(partyId, OfferSurface.PUSH)` when the kind is credit — is
#8770 and should land in the same release. A field with no gate is decoration; a gate with no field
cannot be written.

Two corrections to the issue body, noted in a comment there: the migration is `V19` (not `V10` — I
read a truncated listing), and the table is `campaigns`, not `campaign`.
