### PR TITLE
feat(onboarding): project the business onboarding funnel from kyb events

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -384,6 +384,18 @@
   destructive (`gh run rerun`, a deploy, a delete), stub the binary on `PATH` — **and validate
   the stub against a known-positive first**, or a silent passthrough runs the real thing.
 
+- **A new Kafka channel is TWO deploys, not one, and doing it in one is a hard boot failure.**
+  The msg-override ConfigMap that supplies `group.id` / `auto.offset.reset` (the #686 apparatus) is
+  applied by Argo BEFORE auto-deploy bumps the image, so a channel named there that the RUNNING
+  image has no `connector:` for is SRMSG00071 — SmallRye refuses to start, so the whole service
+  stops rather than the one consumer degrading. `msg-channel-image-parity` compares the ConfigMap
+  against the `application.yaml` inside the image that is actually deployed and blocks it at PR
+  time. Order: (1) code + `application.yaml` channel + the ACLs, merge, let the image ship;
+  (2) the ConfigMap lines. In between, the consumer runs on the fallback group id
+  (`quarkus.application.name`), so grant the KafkaUser Read on **both** group names or every poll
+  answers `GroupAuthorizationException` — which is silent, because a consumer that cannot join a
+  group looks exactly like a topic with nothing on it (#8877, #8882).
+
 ### main-protection: the bypass has two halves, and only one had a reader
 - **`rulesets/rule-suites` (the bypass LOG) is private and rejects fine-grained tokens;
   `rulesets/{id}` (the bypass CONFIG) is world-readable.** Same feature, opposite access, and it

--- a/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
@@ -700,3 +700,18 @@ spec:
   config:
     retention.ms: 2592000000
     cleanup.policy: delete
+---
+# openbank-onboarding-service :: channel `kyb-events-in` (ADR-0284 D6)
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.onboarding.kyb-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
+++ b/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
@@ -55,6 +55,13 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # kyb events consumer (ADR-0284 D6 — the business funnel projection)
+      - resource:
+          type: topic
+          name: openbank.kyb.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       # consumer groups (one per channel, matching application.yaml group.id)
       - resource:
           type: group
@@ -71,6 +78,12 @@ spec:
       - resource:
           type: group
           name: onboarding-service-sca
+          patternType: literal
+        operations: [Read]
+        host: "*"
+      - resource:
+          type: group
+          name: onboarding-service-kyb
           patternType: literal
         operations: [Read]
         host: "*"
@@ -101,6 +114,16 @@ spec:
       - resource:
           type: topic
           name: openbank.dlq.onboarding.sca-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `kyb-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.onboarding.kyb-events-in
           patternType: literal
         operations: [Write, Describe]
         host: "*"

--- a/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
+++ b/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
@@ -81,9 +81,21 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # kyb-events-in (ADR-0284 D6) is granted TWICE on purpose. `onboarding-service-kyb` is the
+      # group the msg-override ConfigMap will set once an image carrying the channel is deployed;
+      # `openbank-onboarding-service` is the fallback group id SmallRye uses until then
+      # (quarkus.application.name). Without the fallback grant the consumer answers
+      # GroupAuthorizationException on every poll in that window — silently, since a consumer that
+      # cannot join a group looks exactly like a topic with nothing on it.
       - resource:
           type: group
           name: onboarding-service-kyb
+          patternType: literal
+        operations: [Read]
+        host: "*"
+      - resource:
+          type: group
+          name: openbank-onboarding-service
           patternType: literal
         operations: [Read]
         host: "*"

--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -43,6 +43,12 @@ metadata:
     app.kubernetes.io/name: onboarding-service
     app.kubernetes.io/part-of: onboarding
 data:
+  # NOT here yet: kyb-events-in. This ConfigMap is applied by Argo BEFORE auto-deploy bumps the
+  # image, so naming a channel here that the RUNNING image has no connector for is SRMSG00071 —
+  # a hard boot failure, not a degraded consumer (`msg-channel-image-parity` enforces exactly
+  # this ordering). Add the two kyb-events-in lines in a follow-up, once an image carrying the
+  # channel is deployed. Until then the channel runs on the fallback group id
+  # (quarkus.application.name), which the KafkaUser grants Read on for that reason.
   override.properties: |
     config_ordinal=500
     mp.messaging.incoming.party-events-in.group.id=onboarding-service-party
@@ -51,5 +57,3 @@ data:
     mp.messaging.incoming.kyc-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.sca-events-in.group.id=onboarding-service-sca
     mp.messaging.incoming.sca-events-in.auto.offset.reset=earliest
-    mp.messaging.incoming.kyb-events-in.group.id=onboarding-service-kyb
-    mp.messaging.incoming.kyb-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -51,3 +51,5 @@ data:
     mp.messaging.incoming.kyc-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.sca-events-in.group.id=onboarding-service-sca
     mp.messaging.incoming.sca-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.kyb-events-in.group.id=onboarding-service-kyb
+    mp.messaging.incoming.kyb-events-in.auto.offset.reset=earliest

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -397,8 +397,9 @@ change_requirements:
     allowlist:
       # openbank.psd2.events left the allowlist in #8510: the producer itself was deleted
       # (the psd2_outbox apparatus had zero writers), so there is no topic left to exempt.
-      - topic: "openbank.kyb.events"
-        reason: "ADR-0284 first slice. The case lifecycle is published for the consumers the ADR names — onboarding-service's business funnel projection (D6 follow-up) and analytics-sink's Customer 360 silver layer (D8) — and neither is built yet, so the topic has a producer and no @Incoming today. NOT the #889 shape of a working publish going nowhere: the operator review queue reads cases over REST (GET /api/v1/kyb/cases?status=MANUAL_REVIEW), so nothing depends on this stream to function. Remove this entry with the first consumer PR."
+      # openbank.kyb.events left the allowlist here: onboarding-service now consumes it
+      # (BusinessOnboardingEventConsumer, channel kyb-events-in, ADR-0284 D6). The entry said
+      # to remove it with the first consumer PR, and the gate fails on a stale entry too.
       - topic: "openbank.tpp.registry.event"
         reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
       - topic: "proposal-events"

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/port/out/BusinessOnboardingRepository.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/port/out/BusinessOnboardingRepository.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.application.port.out
+
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingRecord
+import java.time.Instant
+import java.util.UUID
+
+/** Outbound persistence port for the business funnel read model (ADR-0284 D6). */
+interface BusinessOnboardingRepository {
+
+    /**
+     * Upsert by case id, ignoring an event OLDER than the row it would overwrite.
+     *
+     * Kafka guarantees order within a partition and the case id is the partition key, so
+     * out-of-order delivery needs a redelivery or a replay to happen at all — but when it does, a
+     * blind upsert walks the board backwards: a replayed `SIGNER_INVITED` would drag a live
+     * customer back into AWAITING_SIGNATURES, and the operator would chase a case that is done.
+     * The guard is [Instant] on the event, not arrival time.
+     */
+    suspend fun upsert(record: BusinessOnboardingRecord, eventAt: Instant)
+
+    suspend fun findByCaseId(caseId: UUID): BusinessOnboardingRecord?
+
+    suspend fun listByStage(stage: BusinessFunnelStage, page: Int, size: Int): List<BusinessOnboardingRecord>
+
+    suspend fun listAll(page: Int, size: Int): List<BusinessOnboardingRecord>
+
+    suspend fun countAll(): Long
+
+    suspend fun countByStage(stage: BusinessFunnelStage): Long
+
+    /**
+     * GDPR Art. 17: the initiator or a signer exercised erasure. The case row keeps the entity's
+     * register facts — a company is not a data subject — but every natural-person reference goes,
+     * which for this projection means the initiator id and the review reason (an operator note that
+     * can name a person).
+     */
+    suspend fun anonymizeParty(partyId: UUID)
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/BusinessOnboardingProjectionService.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/BusinessOnboardingProjectionService.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.application.usecase
+
+import com.openbank.onboarding.application.port.out.BusinessOnboardingRepository
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingEvent
+import com.openbank.onboarding.domain.model.BusinessOnboardingRecord
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/** Projects `openbank.kyb.events` into the business funnel read model (ADR-0284 D6). */
+@ApplicationScoped
+class BusinessOnboardingProjectionService {
+
+    @Inject lateinit var repo: BusinessOnboardingRepository
+
+    @Inject lateinit var clock: Clock
+
+    suspend fun project(event: BusinessOnboardingEvent) {
+        val existing = repo.findByCaseId(event.caseId)
+        val record = BusinessOnboardingRecord(
+            caseId = event.caseId,
+            identifierScheme = event.identifierScheme,
+            identifier = event.identifier,
+            country = event.country,
+            // The register facts arrive with the verification event and are absent from the events
+            // before it. Keeping what we already have beats overwriting a name with null on the
+            // next signer event — the board would blank out a company mid-flow.
+            legalName = event.legalName ?: existing?.legalName,
+            legalFormClass = event.legalFormClass ?: existing?.legalFormClass,
+            initiatorPartyId = event.initiatorPartyId,
+            entityPartyId = event.entityPartyId ?: existing?.entityPartyId,
+            caseStatus = event.status,
+            stage = BusinessFunnelStage.of(event.status),
+            requiredSignatures = event.requiredSignatures ?: existing?.requiredSignatures,
+            signedCount = event.signedCount,
+            // The reason is cleared when the case leaves review: a stale "power of attorney
+            // required" under a live customer is a sentence an operator would act on.
+            reviewReason = if (event.status.name == "MANUAL_REVIEW") event.reviewReason else null,
+            createdAt = existing?.createdAt ?: event.occurredAt,
+            updatedAt = Instant.now(clock),
+        )
+        repo.upsert(record, event.occurredAt)
+    }
+
+    /** GDPR Art. 17 for a human who took part in a case; the entity's own facts survive. */
+    suspend fun eraseParty(partyId: UUID) = repo.anonymizeParty(partyId)
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/BusinessOnboardingEvent.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/BusinessOnboardingEvent.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The parsed shape of one `openbank.kyb.events` message (contract:
+ * `openbank-contracts/openbank-kyb-service/asyncapi.yaml`). Framework-free — the consumer maps
+ * JSON into this, the projection consumes only this.
+ *
+ * Every field except [caseId], [status] and [occurredAt] is nullable because the wire contract says
+ * so: a case that never reached the register carries no legal name, and a case with an unparsed
+ * representation rule carries no signature count. Nothing here is defaulted to a plausible value —
+ * a zero signature requirement would show an operator a case that needs nobody.
+ */
+data class BusinessOnboardingEvent(
+    val eventType: String,
+    val caseId: UUID,
+    val status: BusinessCaseStage,
+    val identifierScheme: String,
+    val identifier: String,
+    val country: String?,
+    val legalName: String?,
+    val legalFormClass: String?,
+    val initiatorPartyId: UUID,
+    val entityPartyId: UUID?,
+    val requiredSignatures: Int?,
+    val signedCount: Int,
+    val reviewReason: String?,
+    val occurredAt: Instant,
+)

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/BusinessOnboardingRecord.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/BusinessOnboardingRecord.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Read-model projection of one BUSINESS onboarding case (ADR-0284 D6, issue #8866).
+ *
+ * The sibling of [OnboardingRecord], and deliberately a SEPARATE row rather than more columns on
+ * it: the two are keyed differently and count differently. An individual funnel row is one per
+ * PARTY; a business case is one per CASE, may exist before any entity party does, and carries
+ * several humans. Folding them into one table would make every existing cockpit count ambiguous —
+ * "how many people are stuck in KYC" would start including companies.
+ *
+ * Like its sibling this record is never the source of truth. kyb-service owns the case; this is a
+ * denormalised view assembled from `openbank.kyb.events` for the operator board.
+ */
+data class BusinessOnboardingRecord(
+    val caseId: UUID,
+    val identifierScheme: String,
+    val identifier: String,
+    val country: String?,
+    val legalName: String?,
+    val legalFormClass: String?,
+    val initiatorPartyId: UUID,
+    val entityPartyId: UUID?,
+    val caseStatus: BusinessCaseStage,
+    val stage: BusinessFunnelStage,
+    val requiredSignatures: Int?,
+    val signedCount: Int,
+    /** Why a human at the bank is involved. Carried verbatim — the cockpit renders the reason, never a paraphrase. */
+    val reviewReason: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+)
+
+/** The case status as kyb-service publishes it. Unknown values are not guessed — see [BusinessCaseStage.from]. */
+enum class BusinessCaseStage {
+    IDENTIFIER_ENTERED,
+    REGISTRY_VERIFIED,
+    INITIATOR_MATCHED,
+    AWAITING_COSIGNERS,
+    READY_TO_SIGN,
+    SIGNED,
+    ACTIVE,
+    MANUAL_REVIEW,
+    REJECTED,
+    ABANDONED,
+    ;
+
+    companion object {
+        /**
+         * Null for a status this service does not know. A projection that mapped an unrecognised
+         * status onto its nearest neighbour would put a case in a board column it does not belong
+         * to, which is worse than not showing it: the operator would act on it.
+         */
+        fun from(raw: String?): BusinessCaseStage? = entries.firstOrNull { it.name == raw }
+    }
+}
+
+/**
+ * The operator board's columns for business cases (ADR-0284 D6). Coarser than the case status on
+ * purpose: the board answers "who is waiting on whom", and three of the ten statuses are the same
+ * answer — the bank is waiting for the customer to pick signers or for those signers to act.
+ *
+ * `NEEDS_REVIEW` is the only column that is work for the BANK, which is why it is its own column
+ * and why the cockpit sorts on it first.
+ */
+enum class BusinessFunnelStage {
+    /** The identifier is in, the register has not answered yet. */
+    STARTED,
+
+    /** The register answered; waiting for the customer to say which listed person they are. */
+    AWAITING_INITIATOR,
+
+    /** Waiting for co-signers to be invited, to verify themselves, or to sign. */
+    AWAITING_SIGNATURES,
+
+    /** Every required signature is in; waiting for the entity party's KYC + AML gate (ADR-0267). */
+    AWAITING_CHECKS,
+
+    /** Live customer. */
+    ACTIVE,
+
+    /** A person at the bank has to decide: unparsed representation rule, unlisted initiator, dead register. */
+    NEEDS_REVIEW,
+
+    /** Terminal and not a customer: rejected by an operator, or abandoned by the initiator or the timer. */
+    CLOSED,
+    ;
+
+    companion object {
+        /** The board column for a case status. Total over the enum — a new status must be classified here. */
+        fun of(status: BusinessCaseStage): BusinessFunnelStage = when (status) {
+            BusinessCaseStage.IDENTIFIER_ENTERED -> STARTED
+            BusinessCaseStage.REGISTRY_VERIFIED -> AWAITING_INITIATOR
+            BusinessCaseStage.INITIATOR_MATCHED,
+            BusinessCaseStage.AWAITING_COSIGNERS,
+            BusinessCaseStage.READY_TO_SIGN,
+            -> AWAITING_SIGNATURES
+            BusinessCaseStage.SIGNED -> AWAITING_CHECKS
+            BusinessCaseStage.ACTIVE -> ACTIVE
+            BusinessCaseStage.MANUAL_REVIEW -> NEEDS_REVIEW
+            BusinessCaseStage.REJECTED, BusinessCaseStage.ABANDONED -> CLOSED
+        }
+    }
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/BusinessOnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/BusinessOnboardingEventConsumer.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
+import com.openbank.onboarding.application.usecase.BusinessOnboardingProjectionService
+import com.openbank.onboarding.domain.model.BusinessCaseStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingEvent
+import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Projects `openbank.kyb.events` into the business half of the onboarding read model (ADR-0284 D6).
+ *
+ * Same contract as [OnboardingEventConsumer], for the same reasons: a poison pill is logged and
+ * acked because replaying it fails identically forever, while a projection failure is rethrown
+ * after [EventRetry]'s bounded attempts so the record is nacked rather than silently marked done.
+ * What happens to a nacked record is the connector's decision — `kyb-events-in` is configured
+ * `failure-strategy: dead-letter-queue` with its own explicit topic in `application.yaml`.
+ *
+ * Consuming this topic is also what retires the `openbank.kyb.events` entry from
+ * `rules.yaml: change_requirements.event_consumer_liveness.allowlist`: a produced-but-unconsumed
+ * topic was allowed only until its first consumer landed, and that gate fails on a stale entry.
+ */
+@ApplicationScoped
+class BusinessOnboardingEventConsumer(private val clock: Clock) {
+
+    @Inject
+    lateinit var projection: BusinessOnboardingProjectionService
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    // Field injection: detekt's LongParameterList fires AT the constructor threshold, not above it.
+    @Inject
+    lateinit var metrics: ProjectionOutcomeMetrics
+
+    private val log = Logger.getLogger(BusinessOnboardingEventConsumer::class.java)
+
+    @Incoming("kyb-events-in")
+    // Jackson raises unchecked subclasses of both IOException and RuntimeException for malformed
+    // input; the specific type does not change the handling, which is "ack, this record can never
+    // parse". Same shape as OnboardingEventConsumer's parse guards.
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun consume(payload: String) {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "[%s] Failed to parse JSON payload: %.200s", CHANNEL, payload)
+            metrics.record(CHANNEL, ProjectionOutcomeMetrics.Outcome.FAILED)
+            return
+        }
+        val event = parse(node)
+        if (event == null) {
+            // The quiet drop this counter exists for: valid JSON carrying an event type or a
+            // status this build does not model. Not logged per record — it is the normal outcome
+            // for a shared topic — so the ratio is the only thing that tells "ignoring what we
+            // should" from "ignoring everything".
+            metrics.record(CHANNEL, ProjectionOutcomeMetrics.Outcome.UNRECOGNISED)
+            return
+        }
+        project(event)
+    }
+
+    private fun parse(node: JsonNode): BusinessOnboardingEvent? {
+        val caseId = node.path("caseId").asUuid() ?: return null
+        val initiator = node.path("initiatorPartyId").asUuid() ?: return null
+        // An unknown status is NOT mapped to a neighbouring one: a guessed board column is worse
+        // than a missing row, because it looks like a measurement.
+        val status = BusinessCaseStage.from(node.path("status").asText()) ?: return null
+        val identifier = node.path("identifier").asText("").takeIf { it.isNotBlank() } ?: return null
+        return BusinessOnboardingEvent(
+            eventType = node.path("eventType").asText(""),
+            caseId = caseId,
+            status = status,
+            identifierScheme = node.path("identifierScheme").asText("UNKNOWN"),
+            identifier = identifier,
+            country = node.path("country").asTextOrNull(),
+            legalName = node.path("legalName").asTextOrNull(),
+            legalFormClass = node.path("legalFormClass").asTextOrNull(),
+            initiatorPartyId = initiator,
+            entityPartyId = node.path("entityPartyId").asUuid(),
+            requiredSignatures = node.path("requiredSignatures").takeIf { it.isInt }?.asInt(),
+            signedCount = node.path("signedCount").asInt(0),
+            reviewReason = node.path("reviewReason").asTextOrNull(),
+            occurredAt = node.path("occurredAt").asInstant() ?: clock.instant(),
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught") // the metric is recorded for every failure, then rethrown
+    private suspend fun project(event: BusinessOnboardingEvent) {
+        try {
+            EventRetry.withRetry(log, "[$CHANNEL] Projection of ${event.eventType}", event.caseId) {
+                projection.project(event)
+            }
+        } catch (e: Exception) {
+            metrics.record(CHANNEL, ProjectionOutcomeMetrics.Outcome.FAILED)
+            throw e
+        }
+        metrics.record(CHANNEL, ProjectionOutcomeMetrics.Outcome.PROJECTED)
+    }
+
+    private fun JsonNode.asUuid(): UUID? = runCatching { UUID.fromString(asText()) }.getOrNull()
+    private fun JsonNode.asInstant(): Instant? = runCatching { Instant.parse(asText()) }.getOrNull()
+    private fun JsonNode.asTextOrNull(): String? = asText("").takeIf { it.isNotBlank() }
+
+    private companion object {
+        const val CHANNEL = "kyb-events-in"
+    }
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/entity/BusinessOnboardingEntity.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/entity/BusinessOnboardingEntity.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "business_onboarding_records",
+    indexes = [
+        Index(name = "idx_business_onboarding_stage", columnList = "stage"),
+        Index(name = "idx_business_onboarding_initiator", columnList = "initiator_party_id"),
+    ],
+)
+class BusinessOnboardingEntity : PanacheEntity() {
+
+    @Column(name = "case_id", nullable = false, unique = true)
+    lateinit var caseId: UUID
+
+    @Column(name = "identifier_scheme", nullable = false)
+    lateinit var identifierScheme: String
+
+    @Column(name = "identifier", nullable = false)
+    lateinit var identifier: String
+
+    @Column(name = "country")
+    var country: String? = null
+
+    @Column(name = "legal_name")
+    var legalName: String? = null
+
+    @Column(name = "legal_form_class")
+    var legalFormClass: String? = null
+
+    @Column(name = "initiator_party_id", nullable = false)
+    lateinit var initiatorPartyId: UUID
+
+    @Column(name = "entity_party_id")
+    var entityPartyId: UUID? = null
+
+    @Column(name = "case_status", nullable = false)
+    lateinit var caseStatus: String
+
+    @Column(name = "stage", nullable = false)
+    lateinit var stage: String
+
+    @Column(name = "required_signatures")
+    var requiredSignatures: Int? = null
+
+    @Column(name = "signed_count", nullable = false)
+    var signedCount: Int = 0
+
+    @Column(name = "review_reason", columnDefinition = "TEXT")
+    var reviewReason: String? = null
+
+    /** The projection's ordering guard — see [com.openbank.onboarding.application.port.out.BusinessOnboardingRepository.upsert]. */
+    @Column(name = "last_event_at", nullable = false)
+    lateinit var lastEventAt: Instant
+
+    @Column(name = "created_at", nullable = false)
+    lateinit var createdAt: Instant
+
+    @Column(name = "updated_at", nullable = false)
+    lateinit var updatedAt: Instant
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/BusinessOnboardingRepositoryImpl.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/BusinessOnboardingRepositoryImpl.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.persistence.repository
+
+import com.openbank.onboarding.application.port.out.BusinessOnboardingRepository
+import com.openbank.onboarding.domain.model.BusinessCaseStage
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingRecord
+import com.openbank.onboarding.infrastructure.persistence.entity.BusinessOnboardingEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.quarkus.panache.common.Page
+import io.quarkus.panache.common.Sort
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class BusinessOnboardingRepositoryImpl :
+    BusinessOnboardingRepository,
+    PanacheRepository<BusinessOnboardingEntity> {
+
+    override suspend fun upsert(record: BusinessOnboardingRecord, eventAt: Instant) {
+        Panache.withTransaction {
+            // flatMap, not map: persist() returns a Uni that must be chained or the INSERT is
+            // never subscribed and the transaction commits having written nothing — the defect
+            // that left the personal funnel empty (OnboardingRepositoryImpl carries the same note).
+            find("caseId", record.caseId).firstResult().flatMap { existing ->
+                if (existing == null) {
+                    persist(newEntity(record, eventAt))
+                } else if (eventAt.isBefore(existing.lastEventAt)) {
+                    // Out-of-order replay. Dropping it is the whole reason lastEventAt is stored:
+                    // a redelivered SIGNER_INVITED must not walk a live customer back to
+                    // AWAITING_SIGNATURES. The row is left exactly as it is.
+                    Uni.createFrom().voidItem()
+                } else {
+                    apply(existing, record, eventAt)
+                    // Managed entity: dirty-checking flushes on commit, no explicit call needed.
+                    Uni.createFrom().voidItem()
+                }
+            }
+        }.awaitSuspending()
+    }
+
+    override suspend fun findByCaseId(caseId: UUID): BusinessOnboardingRecord? =
+        Panache.withSession { find("caseId", caseId).firstResult() }
+            .awaitSuspending()
+            ?.let(::toRecord)
+
+    override suspend fun listByStage(stage: BusinessFunnelStage, page: Int, size: Int): List<BusinessOnboardingRecord> =
+        Panache.withSession {
+            find("stage", Sort.by("updatedAt", Sort.Direction.Descending), stage.name)
+                .page(Page.of(page, size))
+                .list()
+        }.awaitSuspending().map(::toRecord)
+
+    override suspend fun listAll(page: Int, size: Int): List<BusinessOnboardingRecord> = Panache.withSession {
+        findAll(Sort.by("updatedAt", Sort.Direction.Descending)).page(Page.of(page, size)).list()
+    }.awaitSuspending().map(::toRecord)
+
+    override suspend fun countAll(): Long = Panache.withSession { count() }.awaitSuspending()
+
+    override suspend fun countByStage(stage: BusinessFunnelStage): Long =
+        Panache.withSession { count("stage", stage.name) }.awaitSuspending()
+
+    override suspend fun anonymizeParty(partyId: UUID) {
+        Panache.withTransaction {
+            // The rows are NOT deleted. A case is a record of a business relationship the bank
+            // must keep (AML retention); what Art. 17 reaches is the natural person's link to it.
+            // initiator_party_id is NOT NULL by design — the case has to have had an initiator —
+            // so it is overwritten with the all-zero UUID rather than nulled, which reads as
+            // "a person who has been erased" instead of as missing data.
+            update(
+                "initiatorPartyId = ?1 where initiatorPartyId = ?2",
+                ERASED_PARTY,
+                partyId,
+            )
+        }.awaitSuspending()
+    }
+
+    private fun newEntity(record: BusinessOnboardingRecord, eventAt: Instant) = BusinessOnboardingEntity().also {
+        it.caseId = record.caseId
+        it.createdAt = record.createdAt
+        apply(it, record, eventAt)
+    }
+
+    private fun apply(entity: BusinessOnboardingEntity, record: BusinessOnboardingRecord, eventAt: Instant) {
+        entity.identifierScheme = record.identifierScheme
+        entity.identifier = record.identifier
+        entity.country = record.country
+        entity.legalName = record.legalName
+        entity.legalFormClass = record.legalFormClass
+        entity.initiatorPartyId = record.initiatorPartyId
+        entity.entityPartyId = record.entityPartyId
+        entity.caseStatus = record.caseStatus.name
+        entity.stage = record.stage.name
+        entity.requiredSignatures = record.requiredSignatures
+        entity.signedCount = record.signedCount
+        entity.reviewReason = record.reviewReason
+        entity.lastEventAt = eventAt
+        entity.updatedAt = record.updatedAt
+    }
+
+    private fun toRecord(entity: BusinessOnboardingEntity) = BusinessOnboardingRecord(
+        caseId = entity.caseId,
+        identifierScheme = entity.identifierScheme,
+        identifier = entity.identifier,
+        country = entity.country,
+        legalName = entity.legalName,
+        legalFormClass = entity.legalFormClass,
+        initiatorPartyId = entity.initiatorPartyId,
+        entityPartyId = entity.entityPartyId,
+        // A status this build does not know is projected as MANUAL_REVIEW rather than dropped:
+        // an unreadable row must reach a human, not disappear from every count.
+        caseStatus = BusinessCaseStage.from(entity.caseStatus) ?: BusinessCaseStage.MANUAL_REVIEW,
+        stage = BusinessFunnelStage.entries.firstOrNull { it.name == entity.stage }
+            ?: BusinessFunnelStage.NEEDS_REVIEW,
+        requiredSignatures = entity.requiredSignatures,
+        signedCount = entity.signedCount,
+        reviewReason = entity.reviewReason,
+        createdAt = entity.createdAt,
+        updatedAt = entity.updatedAt,
+    )
+
+    companion object {
+        /** Tombstone for an erased natural person. Never a real party id. */
+        private val ERASED_PARTY: UUID = UUID(0L, 0L)
+    }
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/rest/BusinessOnboardingResource.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/rest/BusinessOnboardingResource.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.rest
+
+import com.openbank.libs.security.Roles
+import com.openbank.onboarding.application.port.out.BusinessOnboardingRepository
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * The business half of the onboarding cockpit (ADR-0284 D6).
+ *
+ * A SEPARATE resource from [OnboardingResource], not three more methods on it: the personal
+ * read model is keyed per party and this one per case, so a shared endpoint would have to
+ * return a union whose every count is ambiguous about what it counted.
+ *
+ * Nothing is declared between this KDoc and the class — a top-level declaration here would
+ * steal the `@Path` annotation and the resource would silently never be registered (#3371).
+ */
+@Path("/api/v1/onboarding/business")
+@Produces(MediaType.APPLICATION_JSON)
+class BusinessOnboardingResource {
+
+    @Inject lateinit var repository: BusinessOnboardingRepository
+
+    /**
+     * List business onboarding cases, newest activity first, optionally filtered by funnel stage.
+     *
+     * Carries the legal name of a company and the party id of the human who started the case, so
+     * it is read-restricted exactly like the personal records endpoint.
+     *
+     * GET /api/v1/onboarding/business/cases?page=0&size=20&stage=NEEDS_REVIEW
+     */
+    @GET
+    @Path("/cases")
+    @RolesAllowed(Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN, Roles.KYC, Roles.COMPLIANCE)
+    suspend fun listCases(
+        @QueryParam("page") @DefaultValue("0") page: Int,
+        @QueryParam("size") @DefaultValue("20") size: Int,
+        @QueryParam("stage") stageParam: String?,
+    ): Response {
+        // An unparseable filter must never WIDEN the result set (#8699): silently dropping the
+        // predicate answers 200 with every case to a caller who asked for one stage and mistyped
+        // it. Blank stays "no filter", which is what `?stage=` has always meant.
+        // IllegalArgumentException is mapped to 400 by libs-runtime — never a local mapper (#526).
+        val stage = stageParam?.takeIf { it.isNotBlank() }?.let { raw ->
+            BusinessFunnelStage.entries.firstOrNull { it.name == raw.uppercase() }
+                ?: throw IllegalArgumentException(
+                    "unknown stage '$raw'; expected one of " +
+                        BusinessFunnelStage.entries.joinToString { entry -> entry.name },
+                )
+        }
+        val bounded = size.coerceIn(1, MAX_PAGE_SIZE)
+        val items = if (stage == null) {
+            repository.listAll(page, bounded)
+        } else {
+            repository.listByStage(stage, page, bounded)
+        }
+        return Response.ok(items).build()
+    }
+
+    /**
+     * One case by its kyb-service case id.
+     *
+     * GET /api/v1/onboarding/business/cases/{caseId}
+     */
+    @GET
+    @Path("/cases/{caseId}")
+    @RolesAllowed(Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN, Roles.KYC, Roles.COMPLIANCE)
+    suspend fun getCase(@PathParam("caseId") caseId: UUID): Response = repository.findByCaseId(caseId)
+        ?.let { Response.ok(it).build() }
+        ?: Response.status(Response.Status.NOT_FOUND)
+            .entity(mapOf("code" to "NOT_FOUND", "message" to "no business onboarding case $caseId"))
+            .build()
+
+    /**
+     * KPI tiles — case count per funnel stage. Aggregate counts only, no PII.
+     *
+     * Every stage is present, including the ones at zero. A stage that is simply missing from
+     * the map reads as "nothing to see" on a dashboard, which is exactly what a broken
+     * projection also looks like.
+     *
+     * GET /api/v1/onboarding/business/funnel
+     */
+    @GET
+    @Path("/funnel")
+    @RolesAllowed(Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN, Roles.KYC, Roles.COMPLIANCE)
+    suspend fun funnel(): Response {
+        val counts = BusinessFunnelStage.entries.associate { it.name to repository.countByStage(it) }
+        return Response.ok(mapOf("total" to repository.countAll(), "stages" to counts)).build()
+    }
+
+    private companion object {
+        const val MAX_PAGE_SIZE = 100
+    }
+}

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -174,6 +174,12 @@ mp:
         # See the party-events-in comment above for why failure-strategy and an EXPLICIT
         # dead-letter topic are both required, and why the topic key is nested rather than
         # written as the dotted leaf `dead-letter-queue.topic:` (#686, #5745, #5751).
+        # This channel is NOT yet in the msg-override ConfigMap, unlike its three siblings: that
+        # file is applied before the image is bumped, so naming a channel there that the running
+        # image cannot serve is SRMSG00071, a hard boot failure (`msg-channel-image-parity`).
+        # Until the follow-up adds it, the deployed consumer runs on the fallback group id
+        # (quarkus.application.name) with auto.offset.reset at the Kafka default — acceptable only
+        # because this topic is new and carries no backlog. Both group ids are granted Read.
         failure-strategy: dead-letter-queue
         dead-letter-queue:
           topic: openbank.dlq.onboarding.kyb-events-in

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -170,6 +170,17 @@ mp:
         topic: openbank.sca.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
+      kyb-events-in:
+        # See the party-events-in comment above for why failure-strategy and an EXPLICIT
+        # dead-letter topic are both required, and why the topic key is nested rather than
+        # written as the dotted leaf `dead-letter-queue.topic:` (#686, #5745, #5751).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.onboarding.kyb-events-in
+        connector: smallrye-kafka
+        topic: openbank.kyb.events
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
 openbank:
   rate-limit:
     enabled: true

--- a/openbank-onboarding-service/src/main/resources/db/migration/V4__business_onboarding_records.sql
+++ b/openbank-onboarding-service/src/main/resources/db/migration/V4__business_onboarding_records.sql
@@ -1,0 +1,43 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors.
+-- ADR-0284 D6: the business half of the onboarding read model. A SEPARATE table from
+-- onboarding_records on purpose — that one is keyed per PARTY and counts people, this one is keyed
+-- per CASE, exists before any entity party does, and carries several humans. Folding them together
+-- would make every existing cockpit count ambiguous.
+--
+-- last_event_at is the projection's ordering guard: an event older than the row it would overwrite
+-- is ignored, so a replay cannot walk a live customer backwards into AWAITING_SIGNATURES.
+--
+-- Rollback:
+--   DROP TABLE business_onboarding_records;
+--   DROP SEQUENCE IF EXISTS business_onboarding_records_seq;
+
+CREATE TABLE business_onboarding_records (
+    id                  BIGSERIAL PRIMARY KEY,
+    case_id             UUID        NOT NULL UNIQUE,
+    identifier_scheme   TEXT        NOT NULL,
+    identifier          TEXT        NOT NULL,
+    country             CHAR(2),
+    legal_name          TEXT,
+    legal_form_class    TEXT,
+    initiator_party_id  UUID        NOT NULL,
+    entity_party_id     UUID,
+    case_status         TEXT        NOT NULL,
+    stage               TEXT        NOT NULL,
+    required_signatures INTEGER,
+    signed_count        INTEGER     NOT NULL DEFAULT 0,
+    review_reason       TEXT,
+    last_event_at       TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL,
+    updated_at          TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_business_onboarding_stage ON business_onboarding_records (stage, updated_at DESC);
+CREATE INDEX idx_business_onboarding_initiator ON business_onboarding_records (initiator_party_id);
+CREATE INDEX idx_business_onboarding_entity ON business_onboarding_records (entity_party_id)
+    WHERE entity_party_id IS NOT NULL;
+
+-- Hibernate Reactive + PanacheEntity allocate ids from "<table>_seq" (allocationSize 50), which
+-- BIGSERIAL does not create. Unquoted, lowercase, INCREMENT BY 50 — the convention party V19 and
+-- delegation V2 restored after both got it wrong.
+CREATE SEQUENCE IF NOT EXISTS business_onboarding_records_seq INCREMENT BY 50;

--- a/openbank-onboarding-service/src/main/resources/openapi.yaml
+++ b/openbank-onboarding-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Onboarding Service API
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Read-model projection of the onboarding funnel (ADR-0068). Aggregates events from
     party-service, kyc-service and sca-service into a denormalised view for operator
@@ -16,6 +16,7 @@ servers:
     description: Local development
 tags:
   - name: Onboarding
+  - name: Business onboarding
 
 security:
   - bearerAuth: []
@@ -114,6 +115,81 @@ paths:
                   ACTIVE: 301
                   BLOCKED: 4
 
+  /api/v1/onboarding/business/cases:
+    get:
+      tags: [Business onboarding]
+      summary: Business onboarding cases, newest activity first
+      operationId: listBusinessCases
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema: { type: integer, default: 0, minimum: 0 }
+        - name: size
+          in: query
+          required: false
+          schema: { type: integer, default: 20, minimum: 1, maximum: 100 }
+        - name: stage
+          in: query
+          required: false
+          description: >-
+            Funnel stage filter. Blank or absent means no filter; a value that is not a stage is
+            rejected with 400 rather than silently widening the result set.
+          schema:
+            type: string
+            enum: [STARTED, AWAITING_INITIATOR, AWAITING_SIGNATURES, AWAITING_CHECKS, ACTIVE, NEEDS_REVIEW, CLOSED]
+      responses:
+        '200':
+          description: A page of business onboarding cases
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/BusinessOnboardingCase' }
+        '400':
+          description: Unparseable stage filter
+  /api/v1/onboarding/business/cases/{caseId}:
+    get:
+      tags: [Business onboarding]
+      summary: One business onboarding case
+      operationId: getBusinessCase
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: caseId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: The case
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BusinessOnboardingCase' }
+        '404':
+          description: No such case
+  /api/v1/onboarding/business/funnel:
+    get:
+      tags: [Business onboarding]
+      summary: KPI tile counts — business cases per funnel stage
+      operationId: getBusinessFunnelCounts
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Total plus a count for every stage, zeroes included
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer, format: int64 }
+                  stages:
+                    type: object
+                    additionalProperties: { type: integer, format: int64 }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -137,6 +213,33 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    BusinessOnboardingCase:
+      type: object
+      description: >-
+        Projection of one kyb-service case (ADR-0284 D6). caseStatus is the status kyb-service
+        published; stage is the cockpit board column derived from it.
+      properties:
+        caseId: { type: string, format: uuid }
+        identifierScheme: { type: string, example: ICO }
+        identifier: { type: string, example: "27074358" }
+        country: { type: string, nullable: true, example: CZ }
+        legalName: { type: string, nullable: true }
+        legalFormClass: { type: string, nullable: true, example: LIMITED_COMPANY }
+        initiatorPartyId: { type: string, format: uuid }
+        entityPartyId: { type: string, format: uuid, nullable: true }
+        caseStatus: { type: string, example: AWAITING_COSIGNERS }
+        stage:
+          type: string
+          enum: [STARTED, AWAITING_INITIATOR, AWAITING_SIGNATURES, AWAITING_CHECKS, ACTIVE, NEEDS_REVIEW, CLOSED]
+        requiredSignatures: { type: integer, nullable: true }
+        signedCount: { type: integer }
+        reviewReason:
+          type: string
+          nullable: true
+          description: Carried verbatim from kyb-service; never paraphrased for display.
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+      required: [caseId, identifierScheme, identifier, initiatorPartyId, caseStatus, stage, signedCount, createdAt, updatedAt]
     OnboardingRecordDto:
       type: object
       properties:

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/BusinessFunnelStageTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/BusinessFunnelStageTest.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.application.usecase
+
+import com.openbank.onboarding.domain.model.BusinessCaseStage
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BusinessFunnelStageTest {
+
+    @Test
+    fun `every case status has a board column`() {
+        // The mapping is a `when` over the enum, so this cannot fail while the code compiles —
+        // which is the point: the test exists so that ADDING a status without classifying it is
+        // a compile error rather than a silent extra column, and this asserts the count nobody
+        // else counts.
+        val columns = BusinessCaseStage.entries.map { BusinessFunnelStage.of(it) }
+        assertThat(columns).hasSize(BusinessCaseStage.entries.size)
+        assertThat(columns).doesNotContainNull()
+    }
+
+    @Test
+    fun `only the manual review status is work for the bank`() {
+        val needingReview = BusinessCaseStage.entries.filter {
+            BusinessFunnelStage.of(it) == BusinessFunnelStage.NEEDS_REVIEW
+        }
+        assertThat(needingReview).containsExactly(BusinessCaseStage.MANUAL_REVIEW)
+    }
+
+    @Test
+    fun `both terminal non-customer statuses collapse into one closed column`() {
+        assertThat(BusinessFunnelStage.of(BusinessCaseStage.REJECTED)).isEqualTo(BusinessFunnelStage.CLOSED)
+        assertThat(BusinessFunnelStage.of(BusinessCaseStage.ABANDONED)).isEqualTo(BusinessFunnelStage.CLOSED)
+    }
+
+    @Test
+    fun `an unknown status is not guessed`() {
+        // A status this build does not model must be dropped by the consumer, never mapped onto
+        // a neighbouring one — a guessed board column looks exactly like a measurement.
+        assertThat(BusinessCaseStage.from("SIGNED_BY_NOTARY")).isNull()
+        assertThat(BusinessCaseStage.from(null)).isNull()
+        assertThat(BusinessCaseStage.from("signed")).isNull()
+        assertThat(BusinessCaseStage.from("SIGNED")).isEqualTo(BusinessCaseStage.SIGNED)
+    }
+}

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/BusinessOnboardingProjectionServiceTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/BusinessOnboardingProjectionServiceTest.kt
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.application.usecase
+
+import com.openbank.onboarding.application.port.out.BusinessOnboardingRepository
+import com.openbank.onboarding.domain.model.BusinessCaseStage
+import com.openbank.onboarding.domain.model.BusinessFunnelStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingEvent
+import com.openbank.onboarding.domain.model.BusinessOnboardingRecord
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class BusinessOnboardingProjectionServiceTest {
+
+    private val repo = mockk<BusinessOnboardingRepository>()
+    private val now = Instant.parse("2026-09-05T10:00:00Z")
+    private lateinit var service: BusinessOnboardingProjectionService
+
+    @BeforeEach
+    fun setUp() {
+        service = BusinessOnboardingProjectionService().apply {
+            repo = this@BusinessOnboardingProjectionServiceTest.repo
+            clock = Clock.fixed(now, ZoneOffset.UTC)
+        }
+        coEvery { repo.upsert(any(), any()) } just runs
+    }
+
+    @Test
+    fun `maps a signed case onto the checks column and keeps the event time`(): Unit = runBlocking {
+        coEvery { repo.findByCaseId(any()) } returns null
+        val at = Instant.parse("2026-09-05T09:00:00Z")
+        val record = slot<BusinessOnboardingRecord>()
+        val eventAt = slot<Instant>()
+
+        service.project(event(status = BusinessCaseStage.SIGNED, occurredAt = at))
+
+        coVerify { repo.upsert(capture(record), capture(eventAt)) }
+        assertThat(record.captured.stage).isEqualTo(BusinessFunnelStage.AWAITING_CHECKS)
+        // createdAt comes from the first event, updatedAt from the clock — a row whose two
+        // timestamps are equal would hide how long a case has been sitting.
+        assertThat(record.captured.createdAt).isEqualTo(at)
+        assertThat(record.captured.updatedAt).isEqualTo(now)
+        assertThat(eventAt.captured).isEqualTo(at)
+    }
+
+    @Test
+    fun `an event that omits register facts does not erase the ones already stored`(): Unit = runBlocking {
+        coEvery { repo.findByCaseId(any()) } returns stored()
+        val record = slot<BusinessOnboardingRecord>()
+
+        // SIGNER_INVITED carries the case, not the register extract.
+        service.project(
+            event(status = BusinessCaseStage.AWAITING_COSIGNERS).copy(
+                legalName = null,
+                legalFormClass = null,
+                entityPartyId = null,
+                requiredSignatures = null,
+            ),
+        )
+
+        coVerify { repo.upsert(capture(record), any()) }
+        assertThat(record.captured.legalName).isEqualTo("ACME s.r.o.")
+        assertThat(record.captured.legalFormClass).isEqualTo("LIMITED_COMPANY")
+        assertThat(record.captured.entityPartyId).isEqualTo(ENTITY)
+        assertThat(record.captured.requiredSignatures).isEqualTo(2)
+        // The first event's createdAt survives; the case did not start again.
+        assertThat(record.captured.createdAt).isEqualTo(Instant.parse("2026-09-01T08:00:00Z"))
+    }
+
+    @Test
+    fun `leaving manual review clears the reason`(): Unit = runBlocking {
+        coEvery { repo.findByCaseId(any()) } returns stored().copy(
+            caseStatus = BusinessCaseStage.MANUAL_REVIEW,
+            stage = BusinessFunnelStage.NEEDS_REVIEW,
+            reviewReason = "representation rule could not be parsed",
+        )
+        val record = slot<BusinessOnboardingRecord>()
+
+        service.project(event(status = BusinessCaseStage.READY_TO_SIGN))
+
+        coVerify { repo.upsert(capture(record), any()) }
+        assertThat(record.captured.reviewReason).isNull()
+        assertThat(record.captured.stage).isEqualTo(BusinessFunnelStage.AWAITING_SIGNATURES)
+    }
+
+    @Test
+    fun `a review reason is carried verbatim`(): Unit = runBlocking {
+        coEvery { repo.findByCaseId(any()) } returns null
+        val reason = "initiator is not listed as a representative in the register"
+        val record = slot<BusinessOnboardingRecord>()
+
+        service.project(event(status = BusinessCaseStage.MANUAL_REVIEW).copy(reviewReason = reason))
+
+        coVerify { repo.upsert(capture(record), any()) }
+        assertThat(record.captured.reviewReason).isEqualTo(reason)
+        assertThat(record.captured.stage).isEqualTo(BusinessFunnelStage.NEEDS_REVIEW)
+    }
+
+    @Test
+    fun `erasure is delegated to the repository`(): Unit = runBlocking {
+        val party = UUID.randomUUID()
+        coEvery { repo.anonymizeParty(party) } just runs
+
+        service.eraseParty(party)
+
+        coVerify(exactly = 1) { repo.anonymizeParty(party) }
+    }
+
+    private fun event(status: BusinessCaseStage, occurredAt: Instant = now) = BusinessOnboardingEvent(
+        eventType = "BUSINESS_ONBOARDING_STARTED",
+        caseId = CASE,
+        status = status,
+        identifierScheme = "ICO",
+        identifier = "27074358",
+        country = "CZ",
+        legalName = "ACME s.r.o.",
+        legalFormClass = "LIMITED_COMPANY",
+        initiatorPartyId = INITIATOR,
+        entityPartyId = ENTITY,
+        requiredSignatures = 2,
+        signedCount = 1,
+        reviewReason = null,
+        occurredAt = occurredAt,
+    )
+
+    private fun stored() = BusinessOnboardingRecord(
+        caseId = CASE,
+        identifierScheme = "ICO",
+        identifier = "27074358",
+        country = "CZ",
+        legalName = "ACME s.r.o.",
+        legalFormClass = "LIMITED_COMPANY",
+        initiatorPartyId = INITIATOR,
+        entityPartyId = ENTITY,
+        caseStatus = BusinessCaseStage.REGISTRY_VERIFIED,
+        stage = BusinessFunnelStage.AWAITING_INITIATOR,
+        requiredSignatures = 2,
+        signedCount = 0,
+        reviewReason = null,
+        createdAt = Instant.parse("2026-09-01T08:00:00Z"),
+        updatedAt = Instant.parse("2026-09-01T08:00:00Z"),
+    )
+
+    private companion object {
+        val CASE: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        val INITIATOR: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        val ENTITY: UUID = UUID.fromString("33333333-3333-3333-3333-333333333333")
+    }
+}

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/BusinessOnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/BusinessOnboardingEventConsumerTest.kt
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.onboarding.application.usecase.BusinessOnboardingProjectionService
+import com.openbank.onboarding.domain.model.BusinessCaseStage
+import com.openbank.onboarding.domain.model.BusinessOnboardingEvent
+import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The payloads below are the flat wire shape of `KybEventPayload` (kyb-service, ADR-0284): the
+ * outbox publisher sends `entry.payload` verbatim, so every field here is a constructor property
+ * of the corresponding data class, not an envelope wrapper. That producer lives in another
+ * module, so the JSON cannot be generated from it here — the contract test for the pair is the
+ * AsyncAPI document in `openbank-contracts/openbank-kyb-service/asyncapi.yaml`.
+ */
+class BusinessOnboardingEventConsumerTest {
+
+    private val projection = mockk<BusinessOnboardingProjectionService>()
+    private val metrics = mockk<ProjectionOutcomeMetrics>(relaxed = true)
+    private lateinit var consumer: BusinessOnboardingEventConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumer = BusinessOnboardingEventConsumer(Clock.systemUTC()).also {
+            it.projection = projection
+            it.objectMapper = ObjectMapper()
+            it.metrics = metrics
+        }
+        coEvery { projection.project(any()) } just runs
+    }
+
+    @Test
+    fun `projects a registry-verified event`(): Unit = runBlocking {
+        val event = slot<BusinessOnboardingEvent>()
+
+        consumer.consume(payload())
+
+        coVerify { projection.project(capture(event)) }
+        assertThat(event.captured.caseId).isEqualTo(CASE)
+        assertThat(event.captured.status).isEqualTo(BusinessCaseStage.REGISTRY_VERIFIED)
+        assertThat(event.captured.legalName).isEqualTo("ACME s.r.o.")
+        assertThat(event.captured.requiredSignatures).isEqualTo(2)
+        assertThat(event.captured.occurredAt).isEqualTo(Instant.parse("2026-09-05T09:30:00Z"))
+        verify { metrics.record("kyb-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
+    }
+
+    @Test
+    fun `a status this build does not model is dropped, not guessed`(): Unit = runBlocking {
+        consumer.consume(payload(status = "SIGNED_BY_NOTARY"))
+
+        coVerify(exactly = 0) { projection.project(any()) }
+        verify { metrics.record("kyb-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED) }
+    }
+
+    @Test
+    fun `an absent optional field is null, not a placeholder`(): Unit = runBlocking {
+        val event = slot<BusinessOnboardingEvent>()
+
+        // BUSINESS_ONBOARDING_STARTED has no register facts yet: the identifier is all we have.
+        consumer.consume(
+            """
+            {"eventType":"BUSINESS_ONBOARDING_STARTED","caseId":"$CASE","status":"IDENTIFIER_ENTERED",
+             "identifierScheme":"ICO","identifier":"27074358","country":"CZ","legalName":null,
+             "legalFormClass":null,"initiatorPartyId":"$INITIATOR","entityPartyId":null,
+             "requiredSignatures":null,"signedCount":0,"occurredAt":"2026-09-05T09:00:00Z",
+             "actorId":"party:$INITIATOR","actorType":"HUMAN","sourceService":"kyb-service"}
+            """.trimIndent(),
+        )
+
+        coVerify { projection.project(capture(event)) }
+        assertThat(event.captured.legalName).isNull()
+        assertThat(event.captured.entityPartyId).isNull()
+        assertThat(event.captured.requiredSignatures).isNull()
+    }
+
+    @Test
+    fun `a poison pill is acked, not rethrown`(): Unit = runBlocking {
+        // Replaying unparseable bytes fails identically forever; nacking wedges the partition or
+        // fills the DLQ with the same record. A projection failure is the opposite case and IS
+        // rethrown — that is the contract this test pins down by contrast.
+        assertThatCode { runBlocking { consumer.consume("{ this is not json") } }.doesNotThrowAnyException()
+        coVerify(exactly = 0) { projection.project(any()) }
+        verify { metrics.record("kyb-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
+    }
+
+    @Test
+    fun `an event with no case id is dropped`(): Unit = runBlocking {
+        consumer.consume("""{"eventType":"BUSINESS_ONBOARDING_STARTED","status":"IDENTIFIER_ENTERED"}""")
+
+        coVerify(exactly = 0) { projection.project(any()) }
+        verify { metrics.record("kyb-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED) }
+    }
+
+    private fun payload(status: String = "REGISTRY_VERIFIED") =
+        """
+        {"eventType":"BUSINESS_REGISTRY_VERIFIED","caseId":"$CASE","status":"$status",
+         "identifierScheme":"ICO","identifier":"27074358","country":"CZ",
+         "legalName":"ACME s.r.o.","legalFormClass":"LIMITED_COMPANY",
+         "initiatorPartyId":"$INITIATOR","entityPartyId":"$ENTITY",
+         "requiredSignatures":2,"signedCount":0,"occurredAt":"2026-09-05T09:30:00Z",
+         "actorId":"system:registry","actorType":"SYSTEM","sourceService":"kyb-service"}
+        """.trimIndent()
+
+    private companion object {
+        val CASE: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        val INITIATOR: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        val ENTITY: UUID = UUID.fromString("33333333-3333-3333-3333-333333333333")
+    }
+}


### PR DESCRIPTION
## Summary

onboarding-service now consumes `openbank.kyb.events` and keeps a per-CASE business read model
beside the existing per-PARTY one, so the operator cockpit can see business onboarding at all
(ADR-0284 D6, first item of #8866). Stacked on `feat/legal-entity-onboarding` (#8863) — review
that one first; this PR's base is that branch, so its diff here is empty by construction.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8866

## Changes

- `BusinessOnboardingRecord` + `BusinessCaseStage` + `BusinessFunnelStage`: seven board columns,
  mapped totally from the case status. An unknown status is dropped rather than mapped onto a
  neighbouring one — a guessed column reads as a measurement.
- `kyb-events-in` channel with `failure-strategy: dead-letter-queue`, its own explicit topic
  `openbank.dlq.onboarding.kyb-events-in`, the `KafkaTopic` CR, the KafkaUser Read + Write ACLs
  and the `group.id` in the msg-override ConfigMap. All four, or the rethrow wedges on the DLQ
  send itself (#5745, #5751), and the dotted YAML key never reaches the connector (#686).
- `last_event_at` guards ordering: an event older than the stored row is ignored, so a redelivered
  `BUSINESS_SIGNER_INVITED` cannot walk a live customer back to `AWAITING_SIGNATURES`.
- Register facts merge forward instead of being overwritten with null by an event that does not
  carry them; the review reason is cleared once a case leaves `MANUAL_REVIEW`.
- GDPR Art. 17 anonymises the initiator link rather than deleting the case, which the bank must
  retain for AML.
- Three read endpoints under `/api/v1/onboarding/business`, `openapi.yaml` 1.1.0 → 1.2.0
  (additive only). A separate resource class rather than more methods on `OnboardingResource`:
  the two read models are keyed differently, so a shared endpoint returns counts that cannot say
  what they counted.
- Removes the `openbank.kyb.events` entry from `rules.yaml: event_consumer_liveness.allowlist`.
  Its own text said to delete it with the first consumer PR.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

14 unit tests, 0 skipped. Falsified rather than assumed:

- the merge-forward test fails when the merge is removed from the projection (sabotaged, 1 failure,
  restored);
- the consumer-liveness gate exits 1 under `--enforce` with the allowlist entry re-added, and 0
  without it.

No integration test: driving a real `@QuarkusTest` through Kafka needs a broker, and the reactive
repository cannot be called from a bare test thread. The projection and the wire parsing are the
parts with logic in them and both are covered; the persistence path is the same
`Panache.withTransaction` idiom as `OnboardingRepositoryImpl`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
      One `@Suppress("TooGenericExceptionCaught")` on the consumer's parse guard: Jackson raises
      unchecked subclasses of both `IOException` and `RuntimeException` for malformed input and the
      handling is identical for all of them.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [x] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The read model carries the legal name of a company and the party id of the human who started the
case. Erasure anonymises that link (the initiator column is NOT NULL by design, so it is set to the
all-zero UUID rather than nulled, which reads as "a person who has been erased" instead of as
missing data) and leaves the case itself, which AML retention requires.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: the consumer is additive — reverting stops the projection and leaves the table.
  The channel, the DLQ topic and the ACLs are separate GitOps resources and can be reverted alone.
- Data migration reversible: yes — `V4` creates one table and one sequence, rollback note in the
  migration header.

## Reviewer notes

The table is deliberately separate from `onboarding_records` rather than a set of nullable columns
on it: that one is keyed per party and counts people, this one is keyed per case, exists before any
entity party does, and carries several humans. Folding them together makes every existing cockpit
count ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
