### PR TITLE
feat(campaign): refuse credit enrolment without CREDIT_OFFERS consent (#8770)

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/CampaignMetricsPort.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/CampaignMetricsPort.kt
@@ -126,4 +126,14 @@ enum class EnrolmentAttempt {
 
     /** The attempt threw. The sweep counts it per party and moves on rather than aborting the batch. */
     FAILED,
+
+    /**
+     * ADR-0269 rule 1: a credit campaign, and this party has not switched `CREDIT_OFFERS` on.
+     *
+     * Its own value rather than folding into FAILED or a generic consent bucket. "How many people
+     * did we decline to offer credit to, and why" has to be answerable from the metrics — the
+     * ADR's own success measure is the share of offers shown without a prior customer action, and
+     * that cannot be computed from a counter that also holds database errors and marketing opt-outs.
+     */
+    SUPPRESSED_CREDIT_CONSENT,
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -7,6 +7,7 @@ package com.openbank.campaign.application.usecase
 import com.openbank.campaign.application.port.out.CampaignMetricsPort
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignScheduler
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentAttempt
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.IncentiveOfferRegistry
@@ -18,6 +19,7 @@ import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignProductKind
+import com.openbank.campaign.domain.model.CampaignProductKind.Companion.CREDIT_OFFERS_SCOPE
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -34,6 +36,7 @@ import com.openbank.campaign.domain.model.TriggerCatalog
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import kotlinx.coroutines.CancellationException
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Duration
@@ -61,7 +64,11 @@ class CampaignReferenceNotFoundException(message: String) : NoSuchElementExcepti
  * [Campaign.activate] — a domain rule, not a UI convention.
  */
 @ApplicationScoped
-@Suppress("TooManyFunctions") // Lifecycle actions are separate authenticated use cases, not helpers.
+// LongParameterList: nine collaborators, each a distinct outbound port this service genuinely
+// drives (repositories, segments, journeys, scheduler, metrics, consent). Bundling them into a
+// holder would hide which ones a given use case touches and make the CDI graph less honest, for
+// no reduction in real coupling.
+@Suppress("TooManyFunctions", "LongParameterList") // Lifecycle actions are separate use cases, not helpers.
 class CampaignService @Inject constructor(
     private val campaigns: CampaignRepository,
     private val enrolments: EnrolmentRepository,
@@ -70,6 +77,12 @@ class CampaignService @Inject constructor(
     private val journeys: JourneySignaller,
     private val scheduler: CampaignScheduler,
     private val metrics: CampaignMetricsPort,
+    /**
+     * ADR-0269 rule 1. A live per-call check, never cached (ADR-0195): a cached credit consent
+     * outlives its own revocation, and the whole point of this consent is that switching it off
+     * takes effect at once rather than at the next sweep.
+     */
+    private val consentCheck: ConsentCheckPort,
     /**
      * Explicit graphs remain off until their isolated Temporal worker queue is deployed and proven
      * healthy. Their workflow type never shares a queue with legacy journeys, so a rollback pauses
@@ -169,6 +182,49 @@ class CampaignService @Inject constructor(
             decisions = source.decisions,
             incentiveOfferRef = source.incentiveOfferRef,
         )
+    }
+
+    /**
+     * Whether this sweep passes [partyId] over: already enrolled, or a credit campaign they never
+     * opted into.
+     *
+     * One guard rather than two `continue`s in the loop, and the reasoning lives here rather than
+     * inline. ADR-0269 rule 1 is checked PER PARTY, not once for the campaign, because consent is
+     * a property of the person and not of the journey — a campaign-level check would enrol
+     * everyone or no one.
+     *
+     * Fails CLOSED: an unreadable consent answers "no". The alternative offers credit to someone
+     * whose consent the bank could not read, which is the one outcome this rule exists to prevent,
+     * and a marketing act cannot be taken back once sent.
+     */
+    private suspend fun skipParty(campaign: Campaign, partyId: UUID): Boolean {
+        if (enrolments.findByCampaignAndParty(campaign.id, partyId) != null) return true
+        if (campaign.productKind.isCredit && !hasCreditOffersConsent(partyId)) {
+            metrics.enrolmentRecorded(EnrolmentAttempt.SUPPRESSED_CREDIT_CONSENT)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Whether [partyId] has switched credit offers on, answering `false` on any failure.
+     *
+     * `runCatching` with cancellation rethrown: swallowing a `CancellationException` here would
+     * turn a cancelled sweep into a business decision that the party has no consent, which is the
+     * safe direction but a lie in the metrics.
+     */
+    // TooGenericExceptionCaught: the point IS every failure — a timeout, a 500, a parse error all
+    // mean the same thing here, that the bank does not know whether it may offer credit, and the
+    // answer to that is always "no". Narrowing this would let some unknown class of fault through
+    // as a grant.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun hasCreditOffersConsent(partyId: UUID): Boolean = try {
+        consentCheck.hasActiveConsent(partyId, CREDIT_OFFERS_SCOPE)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log.warnf(e, "credit consent unreadable for party %s; treating as absent", partyId)
+        false
     }
 
     /** Keeps create and draft revision tied to the same reviewed catalogue boundary. */
@@ -298,7 +354,7 @@ class CampaignService @Inject constructor(
         var started = 0
         var failed = 0
         for (partyId in partyIds) {
-            if (enrolments.findByCampaignAndParty(id, partyId) != null) continue
+            if (skipParty(campaign, partyId)) continue
             try {
                 val cohort = ExperimentCohort.assign(campaign.id, partyId, campaign.holdoutPercent)
                 if (cohort == ExperimentCohort.HOLDOUT) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
@@ -6,17 +6,20 @@ package com.openbank.campaign.application.usecase
 
 import com.openbank.campaign.application.port.out.CampaignMetricsPort
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentAttempt
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.JourneyType
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort
 import com.openbank.campaign.application.port.out.SegmentRegistry
+import com.openbank.campaign.domain.model.CampaignProductKind.Companion.CREDIT_OFFERS_SCOPE
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CancellationException
 import org.jboss.logging.Logger
 import java.time.Instant
 import java.util.UUID
@@ -38,6 +41,8 @@ class TriggeredEnrolmentService(
     private val segmentEvaluation: SegmentEvaluationPort,
     private val journeys: JourneySignaller,
     private val metrics: CampaignMetricsPort,
+    /** ADR-0269 rule 1: live, uncached credit consent (ADR-0195), same as the scheduled sweep. */
+    private val consentCheck: ConsentCheckPort,
 ) {
 
     private val log = Logger.getLogger(TriggeredEnrolmentService::class.java)
@@ -49,6 +54,18 @@ class TriggeredEnrolmentService(
      * make a trigger a way around the versioned-segment rule (ADR-0201 D1) that nobody reviewing
      * the campaign definition would see.
      */
+    // TooGenericExceptionCaught: see CampaignService.hasCreditOffersConsent — every failure means
+    // the same thing, that the bank cannot tell whether it may offer credit, and that answer is "no".
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun hasCreditOffersConsent(partyId: UUID): Boolean = try {
+        consentCheck.hasActiveConsent(partyId, CREDIT_OFFERS_SCOPE)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log.warnf(e, "credit consent unreadable for party %s; treating as absent", partyId)
+        false
+    }
+
     suspend fun enrol(campaignId: UUID, partyId: UUID): TriggeredEnrolment {
         val campaign = campaigns.findById(campaignId) ?: return TriggeredEnrolment.CAMPAIGN_GONE
         if (campaign.state != CampaignState.ACTIVE) return TriggeredEnrolment.NOT_ACTIVE
@@ -61,6 +78,14 @@ class TriggeredEnrolmentService(
         val segment = segments.load(campaign.segmentRef.name, campaign.segmentRef.version)
             ?: return TriggeredEnrolment.SEGMENT_GONE
         if (!segmentEvaluation.matches(segment, partyId)) return TriggeredEnrolment.NOT_IN_SEGMENT
+
+        // ADR-0269 rule 1, the same gate the scheduled sweep applies. Both doors or neither: a
+        // trigger is just a different reason to enrol, and a credit campaign that refused the
+        // sweep while accepting a product event would deliver credit marketing to someone who
+        // never asked to see it. Fails closed — an unreadable consent answers "no".
+        if (campaign.productKind.isCredit && !hasCreditOffersConsent(partyId)) {
+            return TriggeredEnrolment.NO_CREDIT_CONSENT
+        }
 
         // Same order as the sweep, for the same reason (#2953): start the journey first, persist on
         // success. The reverse order costs the party forever, because the committed row makes
@@ -112,6 +137,12 @@ private fun com.openbank.campaign.domain.model.Campaign.journeyType(): JourneyTy
  */
 enum class TriggeredEnrolment {
     ENROLLED,
+
+    /**
+     * ADR-0269 rule 1: a credit campaign, and this party has not switched credit offers on.
+     * Distinct from NOT_IN_SEGMENT — the party qualifies, the bank is simply not allowed to say so.
+     */
+    NO_CREDIT_CONSENT,
     ALREADY_ENROLLED,
     NOT_IN_SEGMENT,
     NOT_ACTIVE,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -349,6 +349,17 @@ enum class CampaignProductKind {
 
     /** Whether ADR-0269's credit consent and suppression floor govern this campaign. */
     val isCredit: Boolean get() = this != NONE
+
+    companion object {
+        /**
+         * The consent-service scope a credit campaign requires, named once.
+         *
+         * Two enrolment paths ask this question — the scheduled sweep and the trigger consumer —
+         * and a second spelling of the string would let one of them silently ask about a scope
+         * nobody grants, which reads as "no consent" and looks like the gate working.
+         */
+        const val CREDIT_OFFERS_SCOPE: String = "CREDIT_OFFERS"
+    }
 }
 
 /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
@@ -153,6 +153,12 @@ class EnrolmentTriggerConsumer(
             TriggeredEnrolment.NOT_IN_SEGMENT,
             TriggeredEnrolment.ALREADY_ENROLLED,
             TriggeredEnrolment.NOT_ACTIVE,
+            // ADR-0269 rule 1. A settled answer, not a fault: the party qualified and the bank is
+            // not allowed to say so. Logged at the same level as the other ordinary outcomes and
+            // ACKED — a nack would redeliver the record forever against a consent that only the
+            // customer can change, and retrying a refusal is not how it becomes an enrolment. The
+            // count lives in the SUPPRESSED_CREDIT_CONSENT metric, not in this log line.
+            TriggeredEnrolment.NO_CREDIT_CONSENT,
             ->
                 log.debugf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
             // These two mean the definition is broken rather than the party unqualified.

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
@@ -5,6 +5,7 @@ package com.openbank.campaign.application
 
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignScheduler
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort
@@ -143,6 +144,9 @@ class CampaignDraftRevisionTest {
             journeys = mockk<JourneySignaller>(),
             scheduler = mockk<CampaignScheduler>(),
             metrics = mockk(relaxed = true),
+            consentCheck = object : ConsentCheckPort {
+                override suspend fun hasActiveConsent(partyId: java.util.UUID, scope: String) = true
+            },
             explicitGraphActivationEnabled = false,
         )
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -7,6 +7,7 @@ package com.openbank.campaign.application
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignScheduler
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.JourneyType
@@ -120,6 +121,7 @@ class CampaignEnrolmentFailureTest {
         journeys: JourneySignaller,
         selectedCampaign: Campaign = campaign,
         audience: List<UUID> = parties,
+        creditConsent: (UUID) -> Boolean = { true },
     ) = CampaignService(
         campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID): Campaign? = selectedCampaign.takeIf { it.id == id }
@@ -142,6 +144,10 @@ class CampaignEnrolmentFailureTest {
         // loudly if a future change started scheduling from inside the enrol path.
         scheduler = ThrowingScheduler,
         metrics = metrics,
+        consentCheck = object : ConsentCheckPort {
+            override suspend fun hasActiveConsent(partyId: java.util.UUID, scope: String) =
+                if (scope == CampaignProductKind.CREDIT_OFFERS_SCOPE) creditConsent(partyId) else true
+        },
         explicitGraphActivationEnabled = false,
     )
 
@@ -233,4 +239,58 @@ class CampaignEnrolmentFailureTest {
     private fun partyIn(cohort: ExperimentCohort): UUID = generateSequence(1L) { it + 1 }
         .map { UUID(0, it) }
         .first { ExperimentCohort.assign(campaignId, it, 50) == cohort }
+
+    // ── ADR-0269 rule 1 on the scheduled sweep ──────────────────────────────────────────────
+
+    @Test
+    fun `a credit sweep enrols only the parties who switched credit offers on`(): Unit = runBlocking {
+        val enrolments = RecordingEnrolments()
+        val journeys = FlakyJourneys(emptySet())
+        val consenting = parties.first()
+        val credit = campaign.copy(productKind = CampaignProductKind.UNSECURED)
+
+        service(enrolments, journeys, selectedCampaign = credit, creditConsent = { it == consenting })
+            .enrol(campaignId)
+
+        // Per party, not per campaign: consent belongs to the person. The others qualified for the
+        // segment and are simply not people the bank may offer credit to.
+        assertThat(enrolments.saved.map { it.partyId }).containsExactly(consenting)
+        assertThat(journeys.started).containsExactly(consenting)
+    }
+
+    @Test
+    fun `a credit sweep with no consenting party starts nothing at all`(): Unit = runBlocking {
+        val enrolments = RecordingEnrolments()
+        val journeys = FlakyJourneys(emptySet())
+        val credit = campaign.copy(productKind = CampaignProductKind.UNSECURED)
+
+        service(enrolments, journeys, selectedCampaign = credit, creditConsent = { false }).enrol(campaignId)
+
+        assertThat(enrolments.saved).isEmpty()
+        assertThat(journeys.started).isEmpty()
+    }
+
+    @Test
+    fun `a non-credit sweep ignores credit consent entirely`(): Unit = runBlocking {
+        val enrolments = RecordingEnrolments()
+        val journeys = FlakyJourneys(emptySet())
+
+        // campaign is NONE. If this refused, the credit consent would have become a general
+        // marketing switch — the thing ADR-0269 says it is not.
+        service(enrolments, journeys, creditConsent = { false }).enrol(campaignId)
+
+        assertThat(enrolments.saved.map { it.partyId }).containsExactlyElementsOf(parties)
+    }
+
+    @Test
+    fun `an unreadable consent skips the party rather than enrolling them`(): Unit = runBlocking {
+        val enrolments = RecordingEnrolments()
+        val journeys = FlakyJourneys(emptySet())
+        val credit = campaign.copy(productKind = CampaignProductKind.UNSECURED)
+
+        service(enrolments, journeys, selectedCampaign = credit, creditConsent = { error("consent down") })
+            .enrol(campaignId)
+
+        assertThat(enrolments.saved).isEmpty()
+    }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
@@ -7,6 +7,7 @@ package com.openbank.campaign.application
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignScheduler
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.JourneyType
@@ -145,6 +146,9 @@ class CampaignScheduleLifecycleTest {
             journeys = journeys,
             scheduler = scheduler,
             metrics = mockk(relaxed = true),
+            consentCheck = object : ConsentCheckPort {
+                override suspend fun hasActiveConsent(partyId: java.util.UUID, scope: String) = true
+            },
             explicitGraphActivationEnabled = false,
         )
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.application
 
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.JourneyType
@@ -98,6 +99,7 @@ class TriggeredEnrolmentTest {
         journeys: JourneySignaller,
         members: Set<UUID> = setOf(inSegment),
         segmentPresent: Boolean = true,
+        creditConsent: (UUID) -> Boolean = { true },
     ) = TriggeredEnrolmentService(
         campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID) = stored?.takeIf { it.id == id }
@@ -118,6 +120,10 @@ class TriggeredEnrolmentTest {
         },
         journeys = journeys,
         metrics = metrics,
+        consentCheck = object : ConsentCheckPort {
+            override suspend fun hasActiveConsent(partyId: UUID, scope: String): Boolean =
+                if (scope == CampaignProductKind.CREDIT_OFFERS_SCOPE) creditConsent(partyId) else true
+        },
     )
 
     @Test
@@ -234,5 +240,67 @@ class TriggeredEnrolmentTest {
         val outcome = service(null, Enrolments(), Journeys()).enrol(campaignId, inSegment)
 
         assertThat(outcome).isEqualTo(TriggeredEnrolment.CAMPAIGN_GONE)
+    }
+
+    // ── ADR-0269 rule 1 on the trigger path ─────────────────────────────────────────────────
+
+    @Test
+    fun `a credit campaign does not enrol a party who never switched credit offers on`() {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+        val credit = campaign().copy(productKind = CampaignProductKind.UNSECURED)
+
+        val outcome = runBlocking {
+            service(credit, enrolments, journeys, creditConsent = { false }).enrol(campaignId, inSegment)
+        }
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.NO_CREDIT_CONSENT)
+        // The refusal has to reach the journey, not merely the return value: an enrolment row or a
+        // started workflow would mean the party is in the campaign regardless of what we answered.
+        assertThat(enrolments.saved).isEmpty()
+        assertThat(journeys.started).isEmpty()
+    }
+
+    @Test
+    fun `a credit campaign enrols a party who did switch credit offers on`() {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+        val credit = campaign().copy(productKind = CampaignProductKind.UNSECURED)
+
+        val outcome = runBlocking {
+            service(credit, enrolments, journeys, creditConsent = { true }).enrol(campaignId, inSegment)
+        }
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.ENROLLED)
+        assertThat(enrolments.saved).hasSize(1)
+    }
+
+    @Test
+    fun `a non-credit campaign is not gated on credit consent`() {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+
+        // campaign is NONE. Refusing here would make the credit consent a general marketing switch,
+        // which is exactly what ADR-0269 says it is not.
+        val outcome = runBlocking {
+            service(campaign(), enrolments, journeys, creditConsent = { false }).enrol(campaignId, inSegment)
+        }
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.ENROLLED)
+    }
+
+    @Test
+    fun `an unreadable consent refuses the credit enrolment rather than assuming it`() {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+        val credit = campaign().copy(productKind = CampaignProductKind.UNSECURED)
+
+        val outcome = runBlocking {
+            service(credit, enrolments, journeys, creditConsent = { error("consent-service down") })
+                .enrol(campaignId, inSegment)
+        }
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.NO_CREDIT_CONSENT)
+        assertThat(enrolments.saved).isEmpty()
     }
 }


### PR DESCRIPTION
Closes #8770. The product-kind field this gate keys on merged as #8862, so this targets `main`
directly now and is a single commit.

## What was actually wrong

ADR-0269 rule 1 says the check "lives at the edge and in the campaign step gate". The campaign half
did not exist.

`campaign-service` **did** gate delivery on consent — a live, uncached pull (ADR-0195). But the
scope came from the **channel alone**:

```kotlin
private fun marketingScopeFor(channel: Channel): String = when (channel) {
    Channel.EMAIL -> "MARKETING_COMMS_EMAIL"
    Channel.PUSH -> "MARKETING_COMMS_PUSH"
    Channel.BANNER -> "MARKETING_COMMS_INAPP"
}
```

So a campaign whose content was a loan offer reached anyone holding the marketing consent for that
channel. The gate was not missing — it was well built, correctly uncached, and asking a different
question than the ADR requires.

## What this adds

Both enrolment doors refuse a credit campaign for a party who has not switched `CREDIT_OFFERS` on:
the scheduled sweep (`CampaignService.enrol`) and the trigger path
(`TriggeredEnrolmentService.enrol`). Both or neither — a trigger is just a different reason to
enrol, and gating one while leaving the other open would look shipped while a product event still
delivered credit marketing to someone who never asked.

## Decisions worth review

- **Per party, not per campaign.** Consent belongs to the person. A campaign-level check would
  enrol everyone or no one; the mixed-audience test pins that one party consents and only that
  party is enrolled.
- **Fails closed.** An unreadable consent answers "no". Offering credit to someone whose consent
  the bank could not read is the one outcome this rule exists to prevent, and a marketing act
  cannot be taken back once sent.
- **Its own metric**, `SUPPRESSED_CREDIT_CONSENT`, not folded into `FAILED` or a generic consent
  bucket. "How many people did we decline to offer credit to, and why" has to be answerable — the
  ADR's own success measure is the share of offers shown without a prior customer action, and that
  cannot be computed from a counter that also holds database errors and marketing opt-outs.
- **The trigger consumer ACKs a refusal** rather than nacking. Redelivering the record forever
  against a consent only the customer can change does not turn a refusal into an enrolment.
- **One scope constant.** Two spellings of `"CREDIT_OFFERS"` would let one path ask about a scope
  nobody grants — which reads as "no consent" and looks exactly like the gate working.

## Verification

**265 tests, 0 failures**, read from the JUnit XML rather than the Gradle exit code.

Falsified: neutering **both** gates fails exactly the five tests that assert the gating — the mixed
sweep, the all-refused sweep, both unreadable-consent cases, and the trigger refusal. The
"consent present" and "non-credit campaign" tests stay green, as they must, since they do not
exercise the gate. If those had also failed it would mean the tests measure something other than
what they claim.

The refusal is asserted against the **journey and the enrolment row**, not only the return value —
a return value can say `NO_CREDIT_CONSENT` while a workflow starts anyway.

`detekt` (not just `ktlint`) flagged five findings. Two are fixed structurally rather than
suppressed: the two `continue`s collapse into one `skipParty` guard, which also brings `enrol` back
under the length limit and moves the reasoning into KDoc where it belongs. The broad catches are
suppressed with the reason stated — every failure means the same thing there.

## Still not done by this PR

Rule 2, the distress suppression floor, is separate: this gate answers "may the bank offer at all",
not "is this person in financial distress right now". That is
`CreditOfferEligibilityService.evaluate(partyId, OfferSurface.PUSH)` and still has no caller —
worth its own issue once this lands, since campaign delivery is exactly the surface rule 2 was
written about.
