### PR TITLE
feat(campaign): HasAccount works — the reason it was disabled was already stale

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
@@ -84,19 +84,39 @@ sealed class SegmentRule {
     }
 
     /**
-     * Holds at least one account.
+     * Has ever held an account.
      *
-     * UNSUPPORTED: no ACCOUNT event in analytics carries a partyId (0 of 59 bronze rows, measured
-     * 2026-07-31), so the party↔account link does not exist in this layer at all. Supporting this
-     * needs account events to carry the owning party — not a cleverer query.
+     * SUPPORTED SINCE 2026-09-05 (#8792). The reason recorded here previously — "no ACCOUNT event
+     * carries a partyId (0 of 59 bronze rows, measured 2026-07-31)" — was already stale when it
+     * was written. `AccountCreatedEvent` has carried `partyId` since 2026-06-26, five weeks
+     * earlier; `KafkaAccountEventPublisher` serialises the whole event with
+     * `objectMapper.writeValueAsString`, so the field reaches the wire; and analytics-sink's
+     * `PayloadMasker` does not list `partyId` among its PII keys, so it survives into bronze
+     * unmasked. The 59 rows behind that measurement predate the field. A claim about data is a
+     * claim with a shelf life, and nothing re-checked this one.
+     *
+     * READS BRONZE, NOT SILVER, AND THAT IS THE WHOLE CARE IN THIS RULE. Silver keeps only the
+     * LATEST event per (aggregate_type, aggregate_id), and of the four account events only
+     * `AccountCreatedEvent` carries `partyId` — `AccountStatusChanged`, `AccountClosed` and
+     * `SavingsWithdrawalApproved` do not. So an account that has ever changed status has a silver
+     * row with no `partyId` at all, and a silver-based subquery would silently omit exactly the
+     * parties with the most account activity. That is the under-counting failure this rule's own
+     * neighbourhood already records: a fail-closed evaluator renders a missing party as "did not
+     * match", which is indistinguishable from a correct answer. `TenureAtLeastDays` reaches into
+     * bronze for the same reason and says so.
+     *
+     * WHAT IT DOES NOT MEAN: "currently holds an OPEN account". Excluding closed accounts is
+     * expressible — the terminal signals are `event_type = 'AccountClosed'` and a payload
+     * `newStatus` of `CLOSED` — but it is a different predicate and it can only shrink a cohort,
+     * so it belongs in its own rule, verified against a live warehouse rather than reasoned about
+     * from here (#8792).
      */
     data object HasAccount : SegmentRule() {
-        override val unsupportedReason: String =
-            "ACCOUNT events in the analytics layer carry no partyId, so account ownership " +
-                "cannot be resolved (issue #2891)"
-
         override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String =
-            throw UnsupportedOperationException(unsupportedReason)
+            "(upper(aggregate_type) = 'PARTY' AND aggregate_id IN (" +
+                "SELECT JSONExtractString(payload, 'partyId') FROM openbank_analytics.bronze_events " +
+                "WHERE upper(aggregate_type) = 'ACCOUNT' " +
+                "AND JSONExtractString(payload, 'partyId') != ''))"
     }
 
     /**

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasAccountProducerPinTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasAccountProducerPinTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRule
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * `SegmentRule.HasAccount` reads a JSON key by name out of an event another service produces, and
+ * that coupling fails in the worst direction: rename `partyId` in account-service and this rule
+ * stops matching anyone, silently. The evaluator is fail-closed, so a party it can no longer
+ * resolve renders as "did not match" — indistinguishable from a correct answer, which is the exact
+ * shape of #2891.
+ *
+ * Nothing else pins the two together. There is no schema registry for these topics, and the JSON
+ * key exists only as a Kotlin property name on one side and a string literal on the other. So this
+ * test reads the producer's source and asserts the name the rule depends on is still there.
+ *
+ * ON THE ASSUMPTION, stated rather than hidden: a per-service container build copies only its own
+ * module, so the sibling source is legitimately absent there and the test cannot run. It is skipped
+ * in that case, and this repository is right to distrust a skip — a skipped test reads as a pass.
+ * The mitigation is that the full-fleet build, which is where this coupling can actually break,
+ * always has both modules present. If that stops being true, this test stops being evidence.
+ */
+class HasAccountProducerPinTest {
+
+    private val producer =
+        File("../openbank-account-service/src/main/kotlin/com/openbank/account/domain/event/AccountEvents.kt")
+
+    @Test
+    fun `the account event still carries the party link this rule reads by name`() {
+        assumeTrue(producer.isFile, "sibling module not in this checkout (per-service build) — nothing to pin against")
+        val source = producer.readText()
+
+        val created = source.substringAfter("data class AccountCreatedEvent(").substringBefore(") : DomainEvent")
+        assertTrue(
+            created.contains("val partyId:"),
+            "AccountCreatedEvent no longer declares partyId, so SegmentRule.HasAccount now matches nobody — " +
+                "and it would do so silently. Rename the key in the rule, or restore the field.",
+        )
+    }
+
+    /**
+     * The other half of the same coupling: the rule reads the key out of the payload of an event
+     * whose OTHER variants do not carry it. If a future account event starts carrying `partyId`,
+     * this test does not break — the rule simply gets more rows, which is correct. It breaks only
+     * on the direction that matters.
+     */
+    @Test
+    fun `the rule reads exactly the key the producer writes`() {
+        assumeTrue(producer.isFile, "sibling module not in this checkout (per-service build)")
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        val keyInRule = Regex("JSONExtractString\\(payload, '([A-Za-z]+)'\\)").find(where)?.groupValues?.get(1)
+        assertTrue(keyInRule == "partyId", "the rule reads '$keyInRule' — actual SQL: $where")
+        assertTrue(
+            producer.readText().contains("val $keyInRule:"),
+            "the rule reads '$keyInRule', which AccountEvents.kt does not declare",
+        )
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
@@ -115,21 +115,57 @@ class SegmentEvaluationTest {
     }
 
     /**
-     * The two rules whose data does not exist anywhere in analytics are rejected where the segment is
-     * DEFINED. Rendering them into SQL that ClickHouse refuses is what made #2891 look like an empty
+     * A rule whose data does not exist anywhere in analytics is rejected where the segment is
+     * DEFINED. Rendering it into SQL that ClickHouse refuses is what made #2891 look like an empty
      * cohort instead of a broken query.
+     *
+     * `HasAccount` used to be in this list and no longer is (#8792): the reason it carried was
+     * already stale when it was written. Consent is still genuinely absent from the layer.
      */
     @Test
-    fun `rules whose data the analytics layer does not carry are rejected at construction`() {
-        val noAccountLink = assertThrows<IllegalArgumentException> {
-            Segment("has-account", 1, listOf(SegmentRule.HasAccount))
-        }
-        assertTrue(noAccountLink.message!!.contains("partyId"), "actual: ${noAccountLink.message}")
-
+    fun `a rule whose data the analytics layer does not carry is rejected at construction`() {
         val noConsentEvents = assertThrows<IllegalArgumentException> {
             Segment("consented", 1, listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_EMAIL")))
         }
         assertTrue(noConsentEvents.message!!.contains("consent events"), "actual: ${noConsentEvents.message}")
+    }
+
+    @Test
+    fun `HasAccount is constructible now that the party link exists in the layer`() {
+        val segment = Segment("has-account", 1, listOf(SegmentRule.HasAccount))
+        val (where, params) = segment.toWhereClause()
+        assertTrue(where.contains("JSONExtractString(payload, 'partyId')"), "actual: $where")
+        // No bind values: the rule carries no caller-supplied value, so there is nothing to
+        // parameterise and nothing that could become SQL.
+        assertTrue(params.isEmpty(), "actual: $params")
+    }
+
+    /**
+     * The load-bearing property of this rule, and the one worth a test of its own.
+     *
+     * Silver keeps only the LATEST event per aggregate, and of the four account events only
+     * `AccountCreatedEvent` carries `partyId`. So an account that has ever changed status has a
+     * silver row without the link, and a silver-based subquery would omit exactly the parties with
+     * the most account activity — while a fail-closed evaluator renders that as "did not match",
+     * which is indistinguishable from a correct answer. Reading bronze is what avoids it.
+     */
+    @Test
+    fun `HasAccount resolves the party link from bronze, never from the latest-state view`() {
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        assertTrue(where.contains("openbank_analytics.bronze_events"), "actual: $where")
+        assertFalse(where.contains("silver_current_state"), "reads the latest-state view — actual: $where")
+    }
+
+    /**
+     * An ACCOUNT row whose payload has no `partyId` must not contribute an empty string to the
+     * IN-list: `aggregate_id IN ('')` matches nothing, but it also costs nothing to exclude, and
+     * leaving it in makes the query's intent unreadable. Every account event other than
+     * `AccountCreated` produces exactly such a row.
+     */
+    @Test
+    fun `HasAccount excludes account rows that carry no party link`() {
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        assertTrue(where.contains("JSONExtractString(payload, 'partyId') != ''"), "actual: $where")
     }
 
     @Test


### PR DESCRIPTION
## Summary

ADR-0282 phase 1 (#8792) opens with "ACCOUNT events carry no partyId (#2891)". That is not true, and it was not true when the rule recorded it either. `SegmentRule.HasAccount` now works, and the segment DSL goes from two usable rules to three.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8792 (ADR-0282 phase 1), Refs #2891 (the issue the stale reason cited)

## The premise was stale, and here is the evidence

| fact | established by |
|---|---|
| `AccountCreatedEvent` declares `partyId` | its source, since 2026-06-26 |
| the whole event reaches the wire | `KafkaAccountEventPublisher` calls `objectMapper.writeValueAsString(event)` |
| the field survives ingest | `PayloadMasker.PII_KEYS` does not list `partyId`, so it passes through unmasked |
| bronze keeps it | `bronze_events.payload` is the masked event body as JSON |
| the layer exposes it | `silver_current_state` selects `payload` |

The rule's note was written on 2026-07-31 — five weeks after the field landed — and cites a measurement of 59 bronze rows that predate it. Nothing re-checked it, and the DSL has been one rule poorer ever since. Worth noting for its own sake: `accountNumber` **is** masked (IBAN strategy), so keying account ownership on the party is not merely the better choice, it is the only one that survives the sink.

## Reads bronze, not silver, and that is the whole care in this change

Silver keeps only the latest event per aggregate. Of the four account events, only `AccountCreated` carries `partyId` — `AccountStatusChanged`, `AccountClosed` and `SavingsWithdrawalApproved` do not. So an account that has ever changed status has a silver row with no party link, and a silver-based subquery would omit exactly the parties with the most account activity.

The evaluator is fail-closed, so those parties would render as "did not match" — indistinguishable from a correct answer. That is the shape of #2891 itself, which is why `TenureAtLeastDays` already reaches into bronze and says so.

## What it deliberately does not mean

"Currently holds an **open** account." The terminal signals exist and I read them (`event_type = 'AccountClosed'`, and a payload `newStatus` of `CLOSED`), but that predicate can only shrink a cohort and I have no live warehouse here to verify it against. Reasoning it out from a laptop and shipping it is how a segment quietly starts under-counting. It belongs in its own rule, named for what it means, verified where the data is.

## Verification

```
./gradlew :openbank-campaign-service:test --tests '*SegmentEvaluationTest*' --tests '*HasAccountProducerPinTest*' \
          :openbank-campaign-service:detekt :openbank-campaign-service:ktlintCheck
```

14 tests, 0 failures, **0 skipped** — the skip count matters here because the cross-module pin skips itself when the sibling module is absent, and a skip reads as a pass.

**Both properties are falsified, not asserted:**

| sabotage | what goes red |
|---|---|
| subquery points at `silver_current_state` | `HasAccount resolves the party link from bronze, never from the latest-state view` |
| JSON key renamed to `ownerId` | the cross-module pin, plus the two SQL-shape tests |

The pin reads account-service's own source and fails when the field the rule depends on is no longer declared. That coupling is otherwise invisible: no schema registry covers these topics, and the key exists as a Kotlin property on one side and a string literal on the other, so a rename would silently empty every cohort using this rule.

The pin's `assumeTrue` is stated in its own KDoc rather than hidden: a per-service container build copies only its own module, so the sibling source is legitimately absent there. The full-fleet build, which is where this coupling can actually break, always has both.

**What I could not verify:** the issue's acceptance asks for a non-empty cohort against real data, and explicitly says an empty result is not a pass. That needs a live ClickHouse, which this session does not reach. The SQL shape is tested; the cohort is not. Someone with warehouse access should run one segment carrying this rule before it is trusted for a send.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — the rule is pure domain, `java.*` only
- [x] Unit tests added/updated. — 3 new cases plus a new pin test; the stale "HasAccount is rejected" case corrected
- [x] Integration tests added/updated (if service boundary involved). — N/A; the boundary is a SQL string, and the live half is called out above
- [x] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — test, detekt and ktlintCheck run green on the module
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — N/A
- [x] Flyway migration added + rollback note (if DB changed). — N/A
- [x] Avro schema versioned backward-compatibly (if event changed). — N/A, read-side only
- [x] Docs updated (README, ADR if architectural). — the reasoning is in the rule's KDoc, where the next person meets it

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR). — none
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — none
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no; account-service is read about, not modified
- [x] PII path changed? → tag `gdpr-review-required`. — the rule reads a pseudonymous party UUID that the sink already stores unmasked; it adds no new field and no new store
- [x] Cardholder data path changed? → tag `pci-review-required`. — no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

A segment rule is a targeting predicate, so it is in GDPR scope by nature. It reads only the party identifier the analytics layer already holds, adds no new data and no new store, and per-send consent remains the binding check in `LiveConsentCheckAdapter` (ADR-0198) — a cohort rule never substitutes for it.

## Rollout / Rollback

- Deployment strategy: rolling, with campaign-service.
- Rollback plan: revert; the rule returns to being rejected at construction, and any segment using it fails where it is defined rather than at enrolment.
- Data migration reversible: N/A, read-side only.

## Reviewer notes

The one judgement call worth a second opinion is the semantics: this is "has ever held an account", not "currently holds an open one". If the marketing intent is the latter, say so and it should be a separate, differently named rule rather than a quiet tightening of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
