### PR TITLE
feat(campaign): HasActiveConsentScope works — and it is still not the consent control

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
@@ -22,6 +22,13 @@ data class Segment(val name: String, val version: Int, val rules: List<SegmentRu
         // Fail where the segment is DEFINED, not at enrolment. An unsupported rule used to render
         // SQL that ClickHouse rejected, which the fail-closed evaluator turned into an empty cohort
         // — indistinguishable from "nobody matched" (#2891).
+        //
+        // CURRENTLY UNEXERCISED, and that is worth knowing rather than discovering: since #8792
+        // every rule in the sealed catalogue is supported, so no input can reach this branch and no
+        // test can construct one — `SegmentRule` is sealed precisely so a stand-in cannot be
+        // conjured in a test. The guard is not dead code; it is the landing pad for the next rule
+        // written ahead of its data, and it re-arms the moment one declares `unsupportedReason`.
+        // Nobody should delete it for being green.
         rules.forEach { rule ->
             require(rule.unsupportedReason == null) {
                 "segment rule ${rule::class.simpleName} cannot be evaluated: ${rule.unsupportedReason}"
@@ -122,17 +129,49 @@ sealed class SegmentRule {
     /**
      * An ACTIVE consent carrying [scope] exists.
      *
-     * UNSUPPORTED: consent events are not ingested into analytics at all — neither silver nor bronze
-     * holds a CONSENT aggregate. This rule was only ever a cohort-narrowing optimisation: the binding
-     * consent check is the live per-send call in LiveConsentCheckAdapter (ADR-0198), which is
-     * unaffected. A campaign without this rule is not less consent-gated.
+     * **THIS IS NOT THE CONSENT CONTROL, AND MUST NEVER BE TREATED AS ONE.** The binding check is
+     * the live per-send call in `LiveConsentCheckAdapter` (ADR-0198). This rule narrows a cohort so
+     * a send is not attempted against parties who will be refused anyway; a campaign without it is
+     * not one bit less consent-gated, and a campaign WITH it is not one bit more. The distinction
+     * matters concretely: the silver row this reads is a projection with its own lag, so a party
+     * who revoked consent seconds ago can still appear here — and the live check is what stops the
+     * message, not this.
+     *
+     * SUPPORTED SINCE 2026-09-05 (#8792). The reason recorded here previously — "consent events are
+     * not ingested into analytics at all" — was stale when it was written, in the same commit and
+     * the same way as `HasAccount`'s. `openbank.consent.events` has been in analytics-sink's
+     * ingest list since 2026-06-26, five weeks before that claim; `ConsentGranted` and its siblings
+     * declare `aggregateType = "Consent"` and carry `partyId` and `scopes`; and `PayloadMasker`
+     * lists neither, so both survive into bronze unmasked.
+     *
+     * READS SILVER, and that is the opposite choice from [HasAccount] one rule up — deliberately.
+     * "Is a consent active" is a question about CURRENT state, which is exactly what
+     * `silver_current_state` answers: it keeps the latest event per aggregate, so a consent that
+     * was revoked, superseded or expired has a latest row whose `event_type` is no longer
+     * `ConsentGranted` and drops out by construction. `HasAccount` reads bronze because its own
+     * question is historical and its later events drop the field it needs. The two rules differ
+     * because their questions differ, not by accident.
      */
     data class HasActiveConsentScope(val scope: String) : SegmentRule() {
-        override val unsupportedReason: String =
-            "consent events are not ingested into the analytics layer, so consent scopes cannot be " +
-                "resolved there; per-send consent is still enforced live (issue #2891)"
+        init {
+            // Fail where the segment is DEFINED, as the class's other rules do. This catches a
+            // mis-shaped scope (lower case, a space, an empty string); it cannot catch a
+            // well-formed name that consent-service has never heard of, and such a value matches
+            // nobody rather than erroring. `HasActiveConsentScopeProducerPinTest` is what keeps
+            // the two vocabularies honest.
+            require(scope.matches(Regex("[A-Z][A-Z0-9_]*"))) {
+                "consent scope must be a SCREAMING_SNAKE_CASE ConsentScope name, was '$scope'"
+            }
+        }
 
-        override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String =
-            throw UnsupportedOperationException(unsupportedReason)
+        override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String {
+            params["${paramPrefix}_scope"] = scope
+            return "(upper(aggregate_type) = 'PARTY' AND aggregate_id IN (" +
+                "SELECT JSONExtractString(payload, 'partyId') " +
+                "FROM openbank_analytics.silver_current_state " +
+                "WHERE upper(aggregate_type) = 'CONSENT' AND event_type = 'ConsentGranted' " +
+                "AND has(JSONExtract(payload, 'scopes', 'Array(String)'), " +
+                "{${paramPrefix}_scope:String})))"
+        }
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
@@ -84,19 +84,39 @@ sealed class SegmentRule {
     }
 
     /**
-     * Holds at least one account.
+     * Has ever held an account.
      *
-     * UNSUPPORTED: no ACCOUNT event in analytics carries a partyId (0 of 59 bronze rows, measured
-     * 2026-07-31), so the party↔account link does not exist in this layer at all. Supporting this
-     * needs account events to carry the owning party — not a cleverer query.
+     * SUPPORTED SINCE 2026-09-05 (#8792). The reason recorded here previously — "no ACCOUNT event
+     * carries a partyId (0 of 59 bronze rows, measured 2026-07-31)" — was already stale when it
+     * was written. `AccountCreatedEvent` has carried `partyId` since 2026-06-26, five weeks
+     * earlier; `KafkaAccountEventPublisher` serialises the whole event with
+     * `objectMapper.writeValueAsString`, so the field reaches the wire; and analytics-sink's
+     * `PayloadMasker` does not list `partyId` among its PII keys, so it survives into bronze
+     * unmasked. The 59 rows behind that measurement predate the field. A claim about data is a
+     * claim with a shelf life, and nothing re-checked this one.
+     *
+     * READS BRONZE, NOT SILVER, AND THAT IS THE WHOLE CARE IN THIS RULE. Silver keeps only the
+     * LATEST event per (aggregate_type, aggregate_id), and of the four account events only
+     * `AccountCreatedEvent` carries `partyId` — `AccountStatusChanged`, `AccountClosed` and
+     * `SavingsWithdrawalApproved` do not. So an account that has ever changed status has a silver
+     * row with no `partyId` at all, and a silver-based subquery would silently omit exactly the
+     * parties with the most account activity. That is the under-counting failure this rule's own
+     * neighbourhood already records: a fail-closed evaluator renders a missing party as "did not
+     * match", which is indistinguishable from a correct answer. `TenureAtLeastDays` reaches into
+     * bronze for the same reason and says so.
+     *
+     * WHAT IT DOES NOT MEAN: "currently holds an OPEN account". Excluding closed accounts is
+     * expressible — the terminal signals are `event_type = 'AccountClosed'` and a payload
+     * `newStatus` of `CLOSED` — but it is a different predicate and it can only shrink a cohort,
+     * so it belongs in its own rule, verified against a live warehouse rather than reasoned about
+     * from here (#8792).
      */
     data object HasAccount : SegmentRule() {
-        override val unsupportedReason: String =
-            "ACCOUNT events in the analytics layer carry no partyId, so account ownership " +
-                "cannot be resolved (issue #2891)"
-
         override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String =
-            throw UnsupportedOperationException(unsupportedReason)
+            "(upper(aggregate_type) = 'PARTY' AND aggregate_id IN (" +
+                "SELECT JSONExtractString(payload, 'partyId') FROM openbank_analytics.bronze_events " +
+                "WHERE upper(aggregate_type) = 'ACCOUNT' " +
+                "AND JSONExtractString(payload, 'partyId') != ''))"
     }
 
     /**

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasAccountProducerPinTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasAccountProducerPinTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRule
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * `SegmentRule.HasAccount` reads a JSON key by name out of an event another service produces, and
+ * that coupling fails in the worst direction: rename `partyId` in account-service and this rule
+ * stops matching anyone, silently. The evaluator is fail-closed, so a party it can no longer
+ * resolve renders as "did not match" — indistinguishable from a correct answer, which is the exact
+ * shape of #2891.
+ *
+ * Nothing else pins the two together. There is no schema registry for these topics, and the JSON
+ * key exists only as a Kotlin property name on one side and a string literal on the other. So this
+ * test reads the producer's source and asserts the name the rule depends on is still there.
+ *
+ * ON THE ASSUMPTION, stated rather than hidden: a per-service container build copies only its own
+ * module, so the sibling source is legitimately absent there and the test cannot run. It is skipped
+ * in that case, and this repository is right to distrust a skip — a skipped test reads as a pass.
+ * The mitigation is that the full-fleet build, which is where this coupling can actually break,
+ * always has both modules present. If that stops being true, this test stops being evidence.
+ */
+class HasAccountProducerPinTest {
+
+    private val producer =
+        File("../openbank-account-service/src/main/kotlin/com/openbank/account/domain/event/AccountEvents.kt")
+
+    @Test
+    fun `the account event still carries the party link this rule reads by name`() {
+        assumeTrue(producer.isFile, "sibling module not in this checkout (per-service build) — nothing to pin against")
+        val source = producer.readText()
+
+        val created = source.substringAfter("data class AccountCreatedEvent(").substringBefore(") : DomainEvent")
+        assertTrue(
+            created.contains("val partyId:"),
+            "AccountCreatedEvent no longer declares partyId, so SegmentRule.HasAccount now matches nobody — " +
+                "and it would do so silently. Rename the key in the rule, or restore the field.",
+        )
+    }
+
+    /**
+     * The other half of the same coupling: the rule reads the key out of the payload of an event
+     * whose OTHER variants do not carry it. If a future account event starts carrying `partyId`,
+     * this test does not break — the rule simply gets more rows, which is correct. It breaks only
+     * on the direction that matters.
+     */
+    @Test
+    fun `the rule reads exactly the key the producer writes`() {
+        assumeTrue(producer.isFile, "sibling module not in this checkout (per-service build)")
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        val keyInRule = Regex("JSONExtractString\\(payload, '([A-Za-z]+)'\\)").find(where)?.groupValues?.get(1)
+        assertTrue(keyInRule == "partyId", "the rule reads '$keyInRule' — actual SQL: $where")
+        assertTrue(
+            producer.readText().contains("val $keyInRule:"),
+            "the rule reads '$keyInRule', which AccountEvents.kt does not declare",
+        )
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasActiveConsentScopeProducerPinTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/HasActiveConsentScopeProducerPinTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRule
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * `SegmentRule.HasActiveConsentScope` depends on three literals that consent-service owns and this
+ * module only quotes: the event-type discriminator `ConsentGranted`, the payload key `partyId`, and
+ * the payload key `scopes`. Rename any of them there and this rule matches nobody — silently,
+ * because the evaluator is fail-closed and an unresolvable party renders as "did not match".
+ *
+ * For this rule the silence is worse than for `HasAccount`. An empty cohort here reads as
+ * "nobody has consented", which is a plausible and unalarming answer, so it can sit for months. The
+ * same coupling exists for the scope VOCABULARY, which is why a caller passing a name
+ * `ConsentScope` does not contain gets an empty cohort rather than an error — the rule can check
+ * the shape of a scope but not its existence, and that limit is stated on the rule itself.
+ *
+ * ON THE ASSUMPTION, stated rather than hidden: a per-service container build copies only its own
+ * module, so the sibling source is legitimately absent there and this test skips. This repository
+ * is right to distrust a skip — a skipped test reads as a pass — and the mitigation is that the
+ * full-fleet build, where this coupling can actually break, always has both modules.
+ */
+class HasActiveConsentScopeProducerPinTest {
+
+    private val events =
+        File("../openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/event/ConsentEvents.kt")
+    private val model = File("../openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt")
+
+    @Test
+    fun `the grant event still declares the discriminator and payload keys this rule reads`() {
+        assumeTrue(events.isFile, "sibling module not in this checkout (per-service build)")
+        val source = events.readText()
+        val granted = source.substringAfter("data class ConsentGranted(").substringBefore(") : DomainEvent")
+
+        assertTrue(
+            source.contains("""override val eventType = "ConsentGranted""""),
+            "consent-service no longer emits the event type this rule filters on, so the rule now " +
+                "matches nobody — and it would do so silently.",
+        )
+        assertTrue(granted.contains("val partyId:"), "ConsentGranted no longer carries partyId")
+        assertTrue(granted.contains("val scopes:"), "ConsentGranted no longer carries scopes")
+    }
+
+    /**
+     * The vocabulary half. A scope this module names in a segment must exist in consent-service's
+     * enum, or the segment silently enrols nobody. Only the marketing scopes are asserted, because
+     * they are the ones a campaign has any business targeting on — an AISP account-access scope is
+     * not a marketing basis (ADR-0198).
+     */
+    @Test
+    fun `the marketing scopes a campaign may target still exist in the producer's vocabulary`() {
+        assumeTrue(model.isFile, "sibling module not in this checkout (per-service build)")
+        val source = model.readText()
+        for (scope in listOf("MARKETING_COMMS_EMAIL", "MARKETING_COMMS_PUSH", "MARKETING_COMMS_INAPP")) {
+            assertTrue(source.contains("$scope,"), "ConsentScope no longer declares $scope")
+            // And the rule accepts it: shape check and vocabulary agree, so a name that exists
+            // upstream is never rejected here for the wrong reason.
+            Segment("c", 1, listOf(SegmentRule.HasActiveConsentScope(scope)))
+        }
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
@@ -114,20 +114,49 @@ class SegmentEvaluationTest {
         assertFalse(where.contains("aggregate_type = 'PARTY'"), "unfolded literal reintroduced — actual: $where")
     }
 
+    @Test
+    fun `HasActiveConsentScope renders a parameterised scope, never interpolated`() {
+        val (where, params) = Segment(
+            "consented",
+            1,
+            listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_EMAIL")),
+        ).toWhereClause()
+
+        assertEquals("MARKETING_COMMS_EMAIL", params["p0_scope"])
+        assertFalse(where.contains("MARKETING_COMMS_EMAIL"), "scope interpolated into SQL — actual: $where")
+        assertTrue(where.contains("{p0_scope:String}"), "actual: $where")
+    }
+
     /**
-     * A rule whose data does not exist anywhere in analytics is rejected where the segment is
-     * DEFINED. Rendering it into SQL that ClickHouse refuses is what made #2891 look like an empty
-     * cohort instead of a broken query.
-     *
-     * `HasAccount` used to be in this list and no longer is (#8792): the reason it carried was
-     * already stale when it was written. Consent is still genuinely absent from the layer.
+     * The opposite source choice from `HasAccount`, and the reason is the question, not a habit.
+     * "Is a consent active" is about CURRENT state, and silver keeps the latest event per
+     * aggregate — so a revoked, superseded or expired consent drops out by construction because
+     * its latest row is no longer a grant. Reading bronze here would match every consent ever
+     * granted, including the ones the customer has since withdrawn.
      */
     @Test
-    fun `a rule whose data the analytics layer does not carry is rejected at construction`() {
-        val noConsentEvents = assertThrows<IllegalArgumentException> {
-            Segment("consented", 1, listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_EMAIL")))
+    fun `HasActiveConsentScope reads current state, and only a live grant counts`() {
+        val (where, _) = Segment(
+            "consented",
+            1,
+            listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_PUSH")),
+        ).toWhereClause()
+
+        assertTrue(where.contains("silver_current_state"), "actual: $where")
+        assertFalse(
+            where.contains("bronze_events"),
+            "reads the log, so a revoked consent still matches — actual: $where",
+        )
+        assertTrue(where.contains("event_type = 'ConsentGranted'"), "actual: $where")
+    }
+
+    @Test
+    fun `a mis-shaped consent scope is rejected where the segment is defined`() {
+        for (bad in listOf("marketing_comms_email", "MARKETING COMMS", "", "1MARKETING")) {
+            assertThrows<IllegalArgumentException>("expected '$bad' to be rejected") {
+                SegmentRule.HasActiveConsentScope(bad)
+            }
         }
-        assertTrue(noConsentEvents.message!!.contains("consent events"), "actual: ${noConsentEvents.message}")
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
@@ -115,21 +115,57 @@ class SegmentEvaluationTest {
     }
 
     /**
-     * The two rules whose data does not exist anywhere in analytics are rejected where the segment is
-     * DEFINED. Rendering them into SQL that ClickHouse refuses is what made #2891 look like an empty
+     * A rule whose data does not exist anywhere in analytics is rejected where the segment is
+     * DEFINED. Rendering it into SQL that ClickHouse refuses is what made #2891 look like an empty
      * cohort instead of a broken query.
+     *
+     * `HasAccount` used to be in this list and no longer is (#8792): the reason it carried was
+     * already stale when it was written. Consent is still genuinely absent from the layer.
      */
     @Test
-    fun `rules whose data the analytics layer does not carry are rejected at construction`() {
-        val noAccountLink = assertThrows<IllegalArgumentException> {
-            Segment("has-account", 1, listOf(SegmentRule.HasAccount))
-        }
-        assertTrue(noAccountLink.message!!.contains("partyId"), "actual: ${noAccountLink.message}")
-
+    fun `a rule whose data the analytics layer does not carry is rejected at construction`() {
         val noConsentEvents = assertThrows<IllegalArgumentException> {
             Segment("consented", 1, listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_EMAIL")))
         }
         assertTrue(noConsentEvents.message!!.contains("consent events"), "actual: ${noConsentEvents.message}")
+    }
+
+    @Test
+    fun `HasAccount is constructible now that the party link exists in the layer`() {
+        val segment = Segment("has-account", 1, listOf(SegmentRule.HasAccount))
+        val (where, params) = segment.toWhereClause()
+        assertTrue(where.contains("JSONExtractString(payload, 'partyId')"), "actual: $where")
+        // No bind values: the rule carries no caller-supplied value, so there is nothing to
+        // parameterise and nothing that could become SQL.
+        assertTrue(params.isEmpty(), "actual: $params")
+    }
+
+    /**
+     * The load-bearing property of this rule, and the one worth a test of its own.
+     *
+     * Silver keeps only the LATEST event per aggregate, and of the four account events only
+     * `AccountCreatedEvent` carries `partyId`. So an account that has ever changed status has a
+     * silver row without the link, and a silver-based subquery would omit exactly the parties with
+     * the most account activity — while a fail-closed evaluator renders that as "did not match",
+     * which is indistinguishable from a correct answer. Reading bronze is what avoids it.
+     */
+    @Test
+    fun `HasAccount resolves the party link from bronze, never from the latest-state view`() {
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        assertTrue(where.contains("openbank_analytics.bronze_events"), "actual: $where")
+        assertFalse(where.contains("silver_current_state"), "reads the latest-state view — actual: $where")
+    }
+
+    /**
+     * An ACCOUNT row whose payload has no `partyId` must not contribute an empty string to the
+     * IN-list: `aggregate_id IN ('')` matches nothing, but it also costs nothing to exclude, and
+     * leaving it in makes the query's intent unreadable. Every account event other than
+     * `AccountCreated` produces exactly such a row.
+     */
+    @Test
+    fun `HasAccount excludes account rows that carry no party link`() {
+        val (where, _) = Segment("has-account", 1, listOf(SegmentRule.HasAccount)).toWhereClause()
+        assertTrue(where.contains("JSONExtractString(payload, 'partyId') != ''"), "actual: $where")
     }
 
     @Test


### PR DESCRIPTION
## Summary

The second segment rule disabled by a stale reason. `openbank.consent.events` has been ingested since 2026-06-26; the claim that consent events "are not ingested into the analytics layer at all" was written on 2026-07-31, in the same commit that disabled `HasAccount`. With this, every rule in the segment DSL is usable.

**Stacked on #8885** — it builds on that branch, so review that one first. The shared files drop out of this diff once it lands.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8792 (ADR-0282 phase 1), Refs #2891

## This is not the consent control, and the KDoc says so first

The binding check is the live per-send call in `LiveConsentCheckAdapter` (ADR-0198). This rule narrows a cohort so a send is not attempted against parties who would be refused anyway. A campaign without it is not one bit less consent-gated, and a campaign with it is not one bit more.

That distinction is concrete rather than ceremonial: silver is a projection with its own lag, so a party who revoked consent seconds ago can still appear in this cohort. The live check is what stops the message. Anyone reading a green cohort here as "these people have consented" is reading it wrong, which is why the warning is the first paragraph of the rule's documentation and not a footnote.

## Why this one reads silver when the previous one reads bronze

The two rules make opposite source choices one after the other, and the reason is the question, not a habit.

| rule | question | source | why |
|---|---|---|---|
| `HasAccount` | historical: has ever held an account | bronze | only `AccountCreated` carries `partyId`; a silver row for an account that changed status has lost it |
| `HasActiveConsentScope` | current: is a consent live now | silver | silver keeps the latest event, so a revoked, superseded or expired consent drops out by construction |

Reading bronze here would match every consent ever granted, including the ones the customer has since withdrawn. Reading silver in `HasAccount` would omit exactly the parties with the most account activity.

## Evidence the premise was stale

| fact | established by |
|---|---|
| the topic is ingested | `openbank.consent.events` in analytics-sink's `application.yaml` since 2026-06-26 |
| a CONSENT aggregate exists | `ConsentGranted` and siblings declare `aggregateType = "Consent"` |
| the party link is there | `ConsentGranted.partyId` |
| the scopes are there | `ConsentGranted.scopes: Set<ConsentScope>` |
| both survive ingest | `PayloadMasker.PII_KEYS` lists neither |

## What the rule can and cannot check

A mis-shaped scope (lower case, a space, empty) is rejected where the segment is **defined**, as the rest of the DSL does. A well-formed name that `ConsentScope` has never heard of cannot be rejected — campaign-service does not depend on consent-service — and it matches nobody rather than erroring. That limit is stated on the rule, and the vocabulary is pinned by a test that reads consent-service's own enum.

## A test was removed rather than made to pass

With both rules now supported, no input can reach `Segment.init`'s unsupported-rule branch, and `SegmentRule` is sealed precisely so a stand-in cannot be conjured in a test — the compiler refuses it. Faking one would have produced a test that proves nothing.

So the test is gone and the guard is documented in place instead: it is the landing pad for the next rule written ahead of its data, it re-arms the moment one declares `unsupportedReason`, and nobody should delete it for being green. Saying that in the code beats a test that cannot fail.

## Verification

```
./gradlew :openbank-campaign-service:test --tests '*SegmentEvaluationTest*' --tests '*ProducerPinTest*' \
          :openbank-campaign-service:detekt :openbank-campaign-service:ktlintCheck
```

18 tests, 0 failures, **0 skipped** — the skip count matters because both pin tests skip themselves when the sibling module is absent, and a skip reads as a pass.

**Falsified, not asserted:**

| sabotage | what goes red |
|---|---|
| drop the `event_type = 'ConsentGranted'` filter, so a revoked consent matches | `HasActiveConsentScope reads current state, and only a live grant counts` |
| interpolate the scope instead of binding it | `HasActiveConsentScope renders a parameterised scope, never interpolated` |

**What I could not verify:** the same limit as #8885. Cohort behaviour against real data needs a live ClickHouse this session does not reach. The SQL shape and the cross-module couplings are tested; the cohort is not.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — pure domain
- [x] Unit tests added/updated. — 3 new cases plus a second pin test
- [x] Integration tests added/updated (if service boundary involved). — N/A; the live half is called out above
- [x] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — test, detekt, ktlintCheck green on the module
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — N/A
- [x] Flyway migration added + rollback note (if DB changed). — N/A
- [x] Avro schema versioned backward-compatibly (if event changed). — N/A, read-side only
- [x] Docs updated (README, ADR if architectural). — the reasoning is in the rule's KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR). — none
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — none
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no; consent-service is read about, not modified
- [x] PII path changed? → tag `gdpr-review-required`. — reads a party UUID and a scope name the sink already stores unmasked; adds no field and no store
- [x] Cardholder data path changed? → tag `pci-review-required`. — no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

Consent is the Art. 7 basis for marketing, so this is squarely in scope — and the important compliance statement is the negative one: this rule does not become the consent gate, and the live per-send check remains the only thing that decides whether a message may be sent.

## Rollout / Rollback

- Deployment strategy: rolling, with campaign-service.
- Rollback plan: revert; the rule returns to being rejected at construction.
- Data migration reversible: N/A, read-side only.

## Reviewer notes

The judgement worth a second opinion: a consent that expired is excluded because its latest event is `ConsentExpired`, which relies on consent-service actually emitting that event when the clock passes the expiry rather than only computing expiry at read time. If expiry is lazily evaluated there, this cohort will include expired consents until something writes the event — and the live check would still refuse the send, so the failure is a wasted enrolment rather than an unlawful message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
