### PR TITLE
test(vop): give the VoP pacts a negative case the provider can actually serve

### DIFF
--- a/.github/scripts/check-adversarial-contract-tests.py
+++ b/.github/scripts/check-adversarial-contract-tests.py
@@ -33,13 +33,24 @@ CONTRACT_FILE = re.compile(r"(Pact|/contract/)[^/]*Test\.kt$")
 # A negative-auth signal anywhere in the file: an expected 401/403/404 status, or an
 # unauthorized marker in a provider-state/test name. 404 counts: for an id the caller may
 # not see, "not found" IS the correct negative contract (enumeration resistance).
+# 404 was in the comment above, in the error message this gate prints, and in NEITHER the pattern
+# nor the self-test — so a contract whose negative case is a 404 was reported as happy-path-only
+# and told to add the very thing it already had (#8889). A comment is not a control; the pattern
+# is. `NOT_FOUND` and `notFound` come with it because a provider replay expresses the same case as
+# a state name rather than a literal status.
 NEGATIVE = re.compile(
-    r"\b(401|403)\b|UNAUTHORIZED|FORBIDDEN|Unauthorized|unauthorized|"
-    r"rejectsUnauthenticated|missingToken|expiredToken"
+    r"\b(401|403|404)\b|UNAUTHORIZED|FORBIDDEN|NOT_FOUND|Unauthorized|unauthorized|"
+    r"notFound|rejectsUnauthenticated|missingToken|expiredToken"
 )
 
 SELFTEST_OK = '''class FooPactConsumerTest {
     fun `rejects when token is missing`() { /* expects 401 */ }
+}'''
+
+# The 404 half, which the pattern did not cover until #8889: an id the caller may not see is
+# correctly a "not found", and a provider replay states it as a case name rather than a status.
+SELFTEST_OK_404 = '''class FooPactConsumerTest {
+    fun `an id the bank does not hold is a 404`() { /* expects 404 */ }
 }'''
 SELFTEST_BAD = '''class FooPactConsumerTest {
     fun `returns the list`() { /* expects 200 */ }
@@ -77,6 +88,8 @@ def _self_test() -> int:
     bad = 0
     if not NEGATIVE.search(SELFTEST_OK):
         print("self-test FAIL: negative case not detected"); bad += 1
+    if not NEGATIVE.search(SELFTEST_OK_404):
+        print("self-test FAIL: a 404 negative case not detected"); bad += 1
     if NEGATIVE.search(SELFTEST_BAD):
         print("self-test FAIL: happy path misread as adversarial"); bad += 1
     for ok, name in [(True, "x/contract/FooPactConsumerTest.kt"), (True, "x/FooPactTest.kt"),

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
@@ -177,6 +177,18 @@ class AccountPactFolderProviderVerificationTest {
         context?.verifyInteraction()
     }
 
+    /**
+     * Serves the NEGATIVE interaction of the VoP pact: an IBAN the bank does not hold must answer
+     * 404, not an empty account. The absence IS the state — nothing is seeded, and the IBAN in the
+     * pact is one no other state creates — but a handler still has to exist, because pact-jvm fails
+     * the interaction on an unknown state string before it ever issues the request, which is what
+     * "GET the account behind an IBAN the bank does not hold FAILED" meant the first time (#8889).
+     */
+    @State("no account exists for the IBAN")
+    fun noAccountForIban() {
+        // Deliberately empty. Asserting emptiness here would test the fixture, not the provider.
+    }
+
     @State("an account has been created")
     fun accountHasBeenCreated() {
         // No setup: the message is produced deterministically by the @PactVerifyProvider method below.

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
@@ -152,6 +152,17 @@ class PartyPactFolderProviderVerificationTest {
         context.verifyInteraction()
     }
 
+    /**
+     * Serves the NEGATIVE interaction of the VoP pact: a party id the bank does not hold must
+     * answer 404, not an empty party. The absence IS the state — nothing is seeded, and the id in
+     * the pact is one no other state creates — but a handler still has to exist, because pact-jvm
+     * fails on an unknown state string before it issues the request at all (#8889).
+     */
+    @State("no party exists for the id")
+    fun noPartyForId() {
+        // Deliberately empty. Asserting emptiness here would test the fixture, not the provider.
+    }
+
     @State("a party has been created")
     fun partyHasBeenCreated() {
         // No setup: the message is produced deterministically by the @PactVerifyProvider method below.

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/AccountIbanLookupPactConsumerTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/AccountIbanLookupPactConsumerTest.kt
@@ -134,6 +134,41 @@ class AccountIbanLookupPactConsumerTest {
     // property, not a wire contract.
 
     /**
+     * The negative case (ADR-0279 #3), in the one shape the provider replay CAN serve. The comment
+     * above explains why a 401 cannot be recorded here; what it leaves is a contract with no
+     * negative interaction at all, which is the thing the adversarial-contract gate exists to
+     * prevent — and that gate is currently satisfied by the word "401" appearing in that comment.
+     *
+     * An IBAN the bank does not hold is a DIFFERENT PATH, so the provider distinguishes it from
+     * the 200 interaction and answers 404 under the same TestAuthMechanism that makes 401
+     * unreachable. Enumeration resistance is a real contract: "not found" must not become an empty
+     * account object.
+     */
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun unknownIbanPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("no account exists for the IBAN")
+        .uponReceiving("GET the account behind an IBAN the bank does not hold")
+        .path(UNKNOWN_ACCOUNT_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(404)
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "unknownIbanPact")
+    fun `an IBAN the bank does not hold is a 404, not an empty account`(mockServer: MockServer) {
+        assertClientPathMatchesContract()
+
+        given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .get("/api/v1/accounts/iban/$UNKNOWN_IBAN")
+            .then()
+            .statusCode(404)
+    }
+
+    /**
      * The asymmetry that makes this contract falsifiable at the consumer layer: the path the client
      * would really call, recomputed from [AccountServiceClient]'s own annotations, must equal the
      * literal this pact promises account-service. A `@Path` edit on the client reddens here.
@@ -168,6 +203,18 @@ class AccountIbanLookupPactConsumerTest {
          * client — see the class KDoc.
          */
         const val EXPECTED_ACCOUNT_PATH = "/api/v1/accounts/iban/$PACT_IBAN"
+
+        /**
+         * No state seeds this one — that IS the state. Two constraints shape it, each learned by
+         * tripping over it: the mod-97 check digits are REAL (a made-up IBAN makes account-service
+         * answer 400, not 404, because it never reaches the lookup, and a negative case must fail
+         * for the reason it claims to test), and it stays inside the demo range .gitleaks.toml
+         * safelists (CZ6508000000192000145\\d{3}) — gitleaks cannot tell a fixture from a customer
+         * account, which is why that safelist is a range. Of the eleven suffixes in the range with
+         * valid check digits, ...399 is the seeded account and this is not.
+         */
+        const val UNKNOWN_IBAN = "CZ6508000000192000145981"
+        const val UNKNOWN_ACCOUNT_PATH = "/api/v1/accounts/iban/$UNKNOWN_IBAN"
 
         fun clientDerivedAccountPath(): String {
             val base = AccountServiceClient::class.java.getAnnotation(Path::class.java).value

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/PartyNameLookupPactConsumerTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/PartyNameLookupPactConsumerTest.kt
@@ -111,6 +111,36 @@ class PartyNameLookupPactConsumerTest {
     // (no token, expect rejection) stays a client property, not a wire contract.
 
     /**
+     * The negative case (ADR-0279 #3), in the one shape the provider replay CAN serve: a party id
+     * nobody holds is a DIFFERENT PATH, so the provider distinguishes it from the 200 interaction
+     * and answers 404 under the same TestAuthMechanism that makes a recorded 401 unreachable.
+     * Enumeration resistance is a real contract — "not found" must not become an empty party.
+     */
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun unknownPartyPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("no party exists for the id")
+        .uponReceiving("GET a party id the bank does not hold")
+        .path(UNKNOWN_PARTY_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(404)
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "unknownPartyPact")
+    fun `a party id the bank does not hold is a 404, not an empty party`(mockServer: MockServer) {
+        assertClientPathMatchesContract()
+
+        given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .get("/api/v1/parties/$UNKNOWN_PARTY_ID")
+            .then()
+            .statusCode(404)
+    }
+
+    /**
      * The asymmetry that makes this contract falsifiable at the consumer layer: the path the client
      * would really call, recomputed from [PartyServiceClient]'s own annotations, must equal the
      * literal this pact promises party-service. A `@Path` edit on the client reddens here.
@@ -136,6 +166,10 @@ class PartyNameLookupPactConsumerTest {
          * + `@GET @Path("/{id}")`). Never derive this from the client — see the class KDoc.
          */
         const val EXPECTED_PARTY_PATH = "/api/v1/parties/$PACT_PARTY_ID"
+
+        /** No state seeds this one — that IS the state. A well-formed id no party carries. */
+        const val UNKNOWN_PARTY_ID = "00000000-0000-4000-8000-000000000001"
+        const val UNKNOWN_PARTY_PATH = "/api/v1/parties/$UNKNOWN_PARTY_ID"
 
         fun clientDerivedPartyPath(): String {
             val base = PartyServiceClient::class.java.getAnnotation(Path::class.java).value

--- a/pacts/openbank-vop-service-openbank-account-service.json
+++ b/pacts/openbank-vop-service-openbank-account-service.json
@@ -50,6 +50,24 @@
         },
         "status": 200
       }
+    },
+    {
+      "description": "GET the account behind an IBAN the bank does not hold",
+      "providerStates": [
+        {
+          "name": "no account exists for the IBAN"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/accounts/iban/CZ6508000000192000145981"
+      },
+      "response": {
+        "status": 404
+      }
     }
   ],
   "metadata": {

--- a/pacts/openbank-vop-service-openbank-party-service.json
+++ b/pacts/openbank-vop-service-openbank-party-service.json
@@ -47,6 +47,24 @@
         },
         "status": 200
       }
+    },
+    {
+      "description": "GET a party id the bank does not hold",
+      "providerStates": [
+        {
+          "name": "no party exists for the id"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/parties/00000000-0000-4000-8000-000000000001"
+      },
+      "response": {
+        "status": 404
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary

**Rewritten after #8876 landed the overlapping half.** That PR removed the 401 pact interactions no
provider replay could pass, and its diagnosis is the sharper one: the replay boots a
`TestAuthMechanism` that authenticates *every* replayed request as `pact-verifier/ROLE_OPERATOR`, so
a recorded 401 is unreachable by construction. This PR keeps only what `main` still lacks — a
negative case the provider **can** serve, and the gate fix that makes such a case recognisable.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8889

## Changes

- **A negative interaction that the replay can serve.** After #8876 both VoP pacts cover only the
  happy path. An unknown IBAN and an unknown party id are *different paths*, so the provider
  distinguishes them from the 200 interaction and answers 404 under the same `TestAuthMechanism`.
  Enumeration resistance is a real contract: "not found" must not become an empty account.
- **`adversarial-contract-test` now recognises a 404.** Its own comment says "404 counts: for an id
  the caller may not see, not found IS the correct negative contract" and its error message asks for
  "the 401/403/404 expectation" — while the pattern matched only 401 and 403. A file whose negative
  case is a 404 was told to add exactly what it already had. `NOT_FOUND`/`notFound` come with it,
  because a provider replay states the case as a state name rather than a literal status.
- **A self-test case for that half.** The existing self-test could not have caught the gap: it only
  ever fed the pattern a 401.
- **An (empty) `@State` handler in each provider.** pact-jvm fails an interaction on an unknown
  state string *before* it issues the request. The absence is the state; the handler still has to
  exist.

**Worth flagging for the reviewer:** on current `main` this gate reports the VoP contracts as
adversarial because the word "401" appears in the comment explaining why the 401 was removed. A gate
satisfied by prose is the shape it exists to prevent. This PR does not change that property — the
pattern is deliberately "a negative signal anywhere in the file" — but it does mean the contracts
now carry a real negative interaction rather than only a comment about one.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

Verified rather than assumed:

- consumer tests green and both pacts regenerated — each now carries a 200 and a 404 interaction;
- `check-adversarial-contract-tests --self-test` clean, and `--since` reports 0 findings;
- gitleaks clean over the branch history (the fixture IBAN sits inside the safelisted demo range and
  carries real mod-97 check digits — an invented one made account-service answer **400**, not 404,
  and a negative case must fail for the reason it claims to test);
- both provider replays run against the new interactions.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. (None added.)
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (Not applicable:
      test-only; no auth, crypto or payment logic is touched.)
- [x] PII path changed? → tag `gdpr-review-required`. (Not applicable.)
- [x] Cardholder data path changed? → tag `pci-review-required`. (Not applicable.)

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only change, no shipped code.
- Rollback plan: revert; the contracts return to happy-path-only.
- Data migration reversible: N/A

## Reviewer notes

The auth-rejection expectation stays where #8876 put it — each provider's own security test — and
that remains correct: it cannot be a wire contract while the replay authenticates every request.
What this PR adds is orthogonal, which is why the two coexist rather than compete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
