### PR TITLE
fix(infra): accept cosign's buildInvocationID casing in the SLSA verify binding

### DIFF
--- a/openbank-infra/scripts/lib/cosign-attest.sh
+++ b/openbank-infra/scripts/lib/cosign-attest.sh
@@ -244,8 +244,14 @@ cosign_attest_slsa_provenance() {
 
   # Bind the verify to THIS run: require our buildInvocationId among the verified envelopes
   # (same append-only .att trap as the SBOM binding above — any-match is not proof).
+  # CASING TRAP (measured against cosign v2.4.3, run 33984244416 + local repro): cosign does
+  # NOT embed the predicate verbatim — it parses it into its Go struct and re-marshals, and
+  # the struct's json tag is `buildInvocationID` (capital D), not the SLSA v0.2 spec spelling
+  # `buildInvocationId`. The envelope therefore carries `buildInvocationID` and a binding on
+  # the spec spelling matches nothing. Accept both spellings.
   if ! printf '%s\n' "$envelopes" | jq -e -s --arg id "$invocation_id" \
-       '[ .[] | try (.payload | @base64d | fromjson | .predicate.metadata.buildInvocationId) catch empty ]
+       '[ .[] | try (.payload | @base64d | fromjson
+          | .predicate.metadata | (.buildInvocationId // .buildInvocationID)) catch empty ]
         | index($id) != null' >/dev/null 2>&1; then
     echo "ERROR: cosign verify-attestation for ${image} verified no envelope carrying this" >&2
     echo "       run's provenance (buildInvocationId=${invocation_id})." >&2


### PR DESCRIPTION
## Summary
- First auto-deploy run after #8847 (run 33984244416) failed: `cosign attest --type slsaprovenance` succeeded but the post-attest binding reported "verified no envelope carrying this run's provenance" for every image.
- Root cause, reproduced locally against the pinned cosign v2.4.3 and a throwaway registry: cosign does NOT embed the predicate verbatim — it parses it into its Go struct and re-marshals, and the struct's json tag is `buildInvocationID` (capital D), not the SLSA v0.2 spec spelling `buildInvocationId` our binding matched on.
- Fix: the jq binding accepts both spellings. Verified end-to-end in the local repro (attest → verify-attestation → binding passes).
- Also documents the casing trap in place so the next reader does not "simplify" it back.

Refs #8590 (#14)
