### PR TITLE
feat(analytics-sink): give party scoping one definition and materialise the per-party profile

### DIFF
--- a/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
@@ -80,32 +80,28 @@ async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
  * which is ADR-0210 D2's account→party resolution — owned by the `silver_party_accounts` view, not
  * by this route.
  *
- * ISOLATION IS THE LOAD-BEARING PROPERTY. Both arms filter on this party: the direct arm on
- * JSONExtractString(payload,'partyId'), the indirect arm on aggregate_id IN (that party's account
- * ids). If the indirect arm were ever widened, this route would show another customer's
- * transactions — which is why `customer-360.test.ts` asserts isolation, not just assembly.
+ * ISOLATION IS THE LOAD-BEARING PROPERTY, AND IT IS NO LONGER SPELLED OUT HERE. Both arms — the
+ * direct one on JSONExtractString(payload,'partyId') and the indirect one through the party's
+ * account ids — now live in `silver_party_events` (V12__party_event_profile.sql), which carries the
+ * party key on every row. This route filters that view to one party and nothing else. V5 collapsed
+ * the account→party resolution to one definition and this route's own comment recorded why; the
+ * scoping AROUND that resolution stayed behind in the caller, and this is the same collapse one
+ * level up. `customer-360.test.ts` still asserts isolation, now against a single WHERE.
  */
 function scopedRowsSql(partyId: string): string {
-  // Ownership resolution is NOT restated here. `silver_party_accounts` (V5__party_accounts.sql) is
-  // the ADR-0210 D2 view — "materialises as a ClickHouse view alongside the existing silver views"
-  // — and this route reads it rather than re-deriving it, for the same reason the ADR rejects
-  // querying bronze directly: a resolution with two definitions has two answers, and this one IS
-  // the isolation boundary. It carries the `upper()` fold and the empty-partyId guard, and it reads
-  // bronze rather than silver because an account's latest event is typically BALANCE_UPDATED, which
-  // carries no partyId. The CTE that used to live here shipped the whole of that reasoning inside
-  // one caller (issue #4511).
+  // Neither the ownership resolution NOR the scoping around it is restated here. V5's
+  // `silver_party_accounts` owns the account→party key; `silver_party_events` (V12) owns which rows
+  // belong to a party, applying both arms and de-duplicating a row that satisfies both. The two
+  // arms used to be an OR written out in this string, which made this caller a second definition of
+  // the isolation boundary — the exact hazard V5's header names, one level up (issues #4511, #8792).
   //
-  // What stays here is only the party scoping: every reference to the view is filtered to THIS
-  // party, which is what `customer-360.test.ts` asserts. A reference without that WHERE is the leak.
+  // Measured against the sandbox warehouse before the swap: the view and this route's former OR
+  // agree for all 20 parties, max |delta| 0. Dropping the view's de-duplication guard inflates one
+  // party by one event, so the agreement is a property of the guard and not of thin data.
   return `
     SELECT aggregate_type, aggregate_id, event_type, occurred_at, payload
-    FROM ${DB}.silver_current_state
-    WHERE JSONExtractString(payload, 'partyId') = '${partyId}'
-       OR (upper(aggregate_type) IN ('TRANSACTION', 'ACCOUNT')
-           AND aggregate_id IN (
-             SELECT account_id FROM ${DB}.silver_party_accounts
-             WHERE party_id = '${partyId}'
-           ))
+    FROM ${DB}.silver_party_events
+    WHERE party_id = '${partyId}'
     ORDER BY occurred_at DESC
     LIMIT 5000
   `

--- a/openbank-admin-ui/src/test/customer-360.test.ts
+++ b/openbank-admin-ui/src/test/customer-360.test.ts
@@ -82,7 +82,7 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
     await expect(res.json()).resolves.toMatchObject({ available: false, partyId: PARTY })
   })
 
-  it('scopes BOTH resolution arms to the requested party', async () => {
+  it('scopes the query to exactly one party, with no arm written out here', async () => {
     const seen = stubClickHouse([])
     const { GET } = await import('@/app/api/customer-360/[partyId]/route')
     await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
@@ -90,18 +90,20 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
     expect(seen).toHaveLength(1)
     const sql = seen[0]
 
-    // Direct arm: events that carry partyId.
-    expect(sql).toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
-    // Indirect arm: transactions and accounts, reached ONLY through this party's accounts.
-    expect(sql).toContain('silver_party_accounts')
-    expect(sql).toMatch(/upper\(aggregate_type\) IN \('TRANSACTION', 'ACCOUNT'\)/)
+    // One view carries both arms and the party key. This route's only job is the WHERE.
+    expect(sql).toContain('silver_party_events')
     // EVERY reference to the view must be party-scoped — an unscoped one is the leak. Asserted over
-    // all occurrences rather than the first, so adding a second (unscoped) join goes red.
-    const refs = sql.split('silver_party_accounts').slice(1)
+    // all occurrences rather than the first, so adding a second (unscoped) read goes red.
+    const refs = sql.split('silver_party_events').slice(1)
     expect(refs.length).toBeGreaterThan(0)
     for (const after of refs) {
       expect(after.slice(0, 80)).toMatch(new RegExp(`WHERE party_id = '${PARTY}'`))
     }
+    // The arms themselves must NOT be restated here — that is what made this route a second
+    // definition of the isolation boundary.
+    expect(sql).not.toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
+    expect(sql).not.toContain('silver_party_accounts')
+    expect(sql).not.toMatch(/IN \('TRANSACTION', 'ACCOUNT'\)/)
     // Type comparisons must be case-folded: bronze stores PARTY/ACCOUNT uppercase, and comparing
     // against lowercase literals matched nothing while looking like "this party has no accounts".
     expect(sql).not.toMatch(/aggregate_type = '[a-z]+'/)
@@ -114,16 +116,18 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
   // inline CTE in this route instead (#4511) — a definition living in one caller, which is what the
   // ADR rejects for the silver reduction and matters more here, because this resolution IS the
   // isolation boundary. Nothing could see that drift: the route was correct, tested and green.
-  it('resolves ownership through the shared view, never by re-deriving it (D2)', async () => {
+  it('resolves ownership through the shared views, never by re-deriving them (D2)', async () => {
     const seen = stubClickHouse([])
     const { GET } = await import('@/app/api/customer-360/[partyId]/route')
     await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
     const sql = seen[0]
 
-    // The route reads the view and does NOT restate the ownership filter — no second definition.
+    // No second definition of anything: not the log, not the account key, not the scoping.
     expect(sql).not.toContain('bronze_events')
+    expect(sql).not.toContain('silver_current_state')
     expect(sql).not.toMatch(/aggregate_type\) = 'ACCOUNT'/)
     expect(sql).not.toContain('WITH ')
+    expect(sql).not.toContain('JSONExtractString')
   })
 
   it('the D2 view exists in the DDL of record and carries the guards the route relies on', () => {
@@ -154,6 +158,39 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
     // The columns the route selects on.
     expect(ddl).toMatch(/AS party_id/)
     expect(ddl).toMatch(/AS account_id/)
+  })
+
+  it('the V12 scoping view exists in the DDL of record and keeps both arms disjoint', () => {
+    // Same reason as the V5 pin above: this route's correctness now rests on an object defined in
+    // another module, and that dependency has no compiler behind it.
+    const file = readFileSync(
+      path.join(
+        process.cwd(),
+        '../openbank-analytics-sink/src/main/resources/clickhouse/V12__party_event_profile.sql',
+      ),
+      'utf-8',
+    )
+    const ddl = file.split('\n').filter((l) => !l.trimStart().startsWith('--')).join('\n')
+
+    expect(ddl).toContain('openbank_analytics.silver_party_events')
+    // The columns this route selects. A view that dropped one would fail at request time only.
+    for (const col of ['party_id', 'aggregate_type', 'aggregate_id', 'event_type', 'occurred_at', 'payload']) {
+      expect(ddl).toContain(col)
+    }
+    // Both arms are present: the payload key, and the account join through V5.
+    expect(ddl).toMatch(/JSONExtractString\(s\.payload, 'partyId'\) != ''/)
+    expect(ddl).toContain('openbank_analytics.silver_party_accounts')
+    // THE DISJOINTNESS GUARD. Without it a row carrying both a partyId and an owned account id is
+    // counted twice, and every downstream count inflates for exactly the best-instrumented events.
+    // Measured on the sandbox: removing this line inflates one party of twenty by one event, so the
+    // guard is doing work on real data rather than being defensive about a case that cannot arise.
+    expect(ddl).toMatch(/JSONExtractString\(s\.payload, 'partyId'\) = ''/)
+    // CREATE OR REPLACE, not IF NOT EXISTS: the latter is a no-op on a warehouse that already has
+    // the object, which is how an edit looks applied in git and does nothing in ClickHouse.
+    expect(ddl).toContain('CREATE OR REPLACE VIEW')
+    // It reduces silver, not bronze: this is a current-state view, and the history questions belong
+    // to V10's monthly flows. A view reading both would answer neither question consistently.
+    expect(ddl).toContain('openbank_analytics.silver_current_state')
   })
 
   it('rejects a non-UUID partyId before it reaches ClickHouse (injection boundary)', async () => {

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V12__party_event_profile.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V12__party_event_profile.sql
@@ -86,7 +86,10 @@ SELECT
     party_id,
     count()                                    AS events_observed,
     uniqExact(aggregate_id)                    AS aggregates_observed,
-    uniqExactIf(aggregate_id, aggregate_type = 'ACCOUNT')            AS accounts_observed,
+    -- upper() restated at the comparison even though silver_party_events folds it: inheriting a
+    -- fold is an assumption that breaks silently the day the source view changes, which is what the
+    -- aggregate-type-case-fold gate exists to prevent. upper() of an already-folded value is free.
+    uniqExactIf(aggregate_id, upper(aggregate_type) = 'ACCOUNT')      AS accounts_observed,
     uniqExact(aggregate_type)                  AS domains_observed,
     min(occurred_at)                           AS first_seen_at,
     max(occurred_at)                           AS last_seen_at,

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V12__party_event_profile.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V12__party_event_profile.sql
@@ -1,0 +1,113 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The per-party event profile ADR-0282 phase 1 asks for (issue #8792).
+--
+-- WHAT WAS ACTUALLY MISSING. ADR-0210 put Customer 360 in the silver layer, and V5 gave the
+-- account-to-party key one definition. What no object gave one definition to is the question one
+-- level up: WHICH ROWS BELONG TO A PARTY. The Customer 360 BFF answers it inline, in TypeScript,
+-- on every request — `payload.partyId = P` OR an ACCOUNT/TRANSACTION row whose aggregate_id is one
+-- of P's accounts — then pulls up to 5000 rows and folds them in the route handler.
+--
+-- That predicate IS the isolation boundary, in the same sense V5's header means it: a caller that
+-- widens its own copy shows another customer's events. V5 collapsed one such copy and the route's
+-- own comment records the lesson ("a resolution with two definitions has two answers"), but the
+-- scoping around the view stayed behind in the caller. `silver_party_events` is that scoping, named
+-- once, so a second consumer — the Lipa earn evaluation, the segment DSL, the AI advisor — inherits
+-- the boundary instead of re-deriving it.
+--
+-- WHY silver_current_state AND NOT bronze. Deliberately the same source the Customer 360 route
+-- reads today, so this view is a refactor of an existing answer rather than a new one with a
+-- different meaning. Silver is the latest event per (aggregate_type, aggregate_id): a profile built
+-- on it describes current state, which is what a 360 view is for. Anything needing the full history
+-- (cash-flow medians, cadence) must read bronze, and V10's monthly-flows view already does exactly
+-- that — the two are different questions, not two answers to one.
+--
+-- THE ACCOUNT LEG READS V5, WHICH READS BRONZE, AND THAT ASYMMETRY IS LOAD-BEARING. An account's
+-- latest silver row is typically a status or balance event carrying no partyId, so resolving the
+-- account key from silver would drop exactly the parties with the most account activity. V5 already
+-- makes that choice and states it; this view inherits it by delegating rather than repeating it.
+--
+-- WHAT IT DELIBERATELY DOES NOT DO. It computes no financial-health measure, no segment membership
+-- and no score. ADR-0220 D5's rule applies to this phase: a rewards programme rendered from
+-- fabricated profiles is worse than a missing feature. Every column below is a count or a timestamp
+-- that is directly observable in the rows; nothing is imputed for a party with thin data, and a
+-- party with no events has no row here rather than a row of zeros.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_party_events AS
+SELECT
+    JSONExtractString(s.payload, 'partyId') AS party_id,
+    -- Folded once here so no downstream view repeats it. silver_current_state already upper()s its
+    -- output; the fold is restated rather than assumed, because a caller that inherits case-folding
+    -- by accident breaks the day the source view changes and nothing says why.
+    upper(s.aggregate_type)                 AS aggregate_type,
+    s.aggregate_id,
+    s.event_id,
+    s.event_type,
+    s.occurred_at,
+    s.source_service,
+    s.payload
+FROM openbank_analytics.silver_current_state AS s
+WHERE JSONExtractString(s.payload, 'partyId') != ''
+
+UNION ALL
+
+-- The account leg: rows the party owns through an account rather than through a payload key. The
+-- `NOT IN` on the payload key is what keeps the union disjoint — without it a TRANSACTION row that
+-- carries BOTH a partyId and an owned account id appears twice, and every count below doubles for
+-- exactly the best-instrumented events.
+SELECT
+    pa.party_id                             AS party_id,
+    upper(s.aggregate_type)                 AS aggregate_type,
+    s.aggregate_id,
+    s.event_id,
+    s.event_type,
+    s.occurred_at,
+    s.source_service,
+    s.payload
+FROM openbank_analytics.silver_current_state AS s
+INNER JOIN openbank_analytics.silver_party_accounts AS pa
+    ON pa.account_id = s.aggregate_id
+WHERE upper(s.aggregate_type) IN ('ACCOUNT', 'TRANSACTION')
+  AND JSONExtractString(s.payload, 'partyId') = '';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The profile itself: the fold the Customer 360 route performs per request, computed once.
+--
+-- The per-domain breakdown is a SECOND view (one row per party per domain) rather than a column per
+-- domain, because the domain set is open: a newly ingested topic must widen the profile without a
+-- migration, and a fixed column list would report zero for a domain that merely had no column yet.
+-- That is the sentinel-default failure shape — indistinguishable from a real zero.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_event_profile AS
+SELECT
+    party_id,
+    count()                                    AS events_observed,
+    uniqExact(aggregate_id)                    AS aggregates_observed,
+    uniqExactIf(aggregate_id, aggregate_type = 'ACCOUNT')            AS accounts_observed,
+    uniqExact(aggregate_type)                  AS domains_observed,
+    min(occurred_at)                           AS first_seen_at,
+    max(occurred_at)                           AS last_seen_at,
+    -- Recency in days, computed here so every consumer agrees on the clock. NOT seeded from a
+    -- sentinel: a party with no events has no row at all, so there is no boot-time value that could
+    -- read as decades of staleness the way a registration-time gauge does.
+    dateDiff('day', max(occurred_at), now())   AS days_since_last_event,
+    arraySort(groupUniqArray(aggregate_type))  AS domains
+FROM openbank_analytics.silver_party_events
+GROUP BY party_id;
+
+-- One row per (party, domain): the `byDomain` map the Customer 360 route builds in the handler,
+-- including the latest event per domain that the route derives from row order. argMax rather than
+-- "the first row of a DESC scan", because the ordering guarantee is a property of the query the
+-- caller happens to write, and this must hold for every caller.
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_domain_activity AS
+SELECT
+    party_id,
+    aggregate_type,
+    count()                                                   AS events_observed,
+    argMax(event_type, occurred_at)                           AS last_event_type,
+    max(occurred_at)                                          AS last_occurred_at
+FROM openbank_analytics.silver_party_events
+GROUP BY party_id, aggregate_type;

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V13__settled_transactions.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V13__settled_transactions.sql
@@ -1,0 +1,101 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The post-settlement transaction fact ADR-0282 phase 1 asks for (issue #8792).
+--
+-- WHAT THE ISSUE SAID, AND WHAT THE WAREHOUSE SAYS. #8792 states that the only transaction fact in
+-- analytics is the initiated event, that it carries no rail, and that it is emitted before the money
+-- moves. Measured 2026-09-05, two of those three are no longer true: THREE transaction event kinds
+-- are ingested — TransactionInitiated (63), TransactionCompleted (47), TransactionFailed (13) — and
+-- the initiated payload does carry `rail`, alongside amount, currencyCode, instructionType, type,
+-- source/target account and initiatedByPartyId.
+--
+-- WHAT IS ACTUALLY MISSING IS THE OPPOSITE SHAPE. The post-settlement event EXISTS and is
+-- content-free: TransactionCompleted carries only a referenceNumber. So "did it settle" and "what
+-- settled" live in two different events, and every consumer that wants a settled amount has to know
+-- to join them. Nothing did, which is why the fact read as absent.
+--
+-- Both events are keyed by the transaction's own aggregate_id, so the join is exact rather than
+-- heuristic. Verified before writing this: all 47 completed transactions join back to an initiated
+-- event carrying an amount, 47 of 47.
+--
+-- SETTLEMENT TIME COMES FROM THE COMPLETED EVENT, THE ECONOMICS FROM THE INITIATED ONE. Mixing them
+-- is the whole point: a fact stamped with the initiation time would put a payment in the wrong day
+-- and, for a month-boundary settlement, the wrong reporting period. occurred_at throughout, never
+-- ingested_at — a backfill must land in the period it happened.
+--
+-- WHAT IS STILL GENUINELY MISSING, AND IS NOT PAPERED OVER HERE. Category, MCC and merchant are
+-- absent from every transaction payload and cannot be derived: no view can invent them, and this one
+-- does not try. `rail` is present but reads UNKNOWN for 55 of 63 initiated events, so it is a
+-- declared field with no producer filling it — a column that exists and lies is worse than one that
+-- is missing, so `rail` is surfaced verbatim rather than defaulted, and a consumer can see UNKNOWN
+-- for what it is. Those three fields plus a populated rail are the producer change that remains.
+--
+-- NEVER THE COUNTERPARTY NAME AND NEVER THE FREE-TEXT MESSAGE. #8792 requires the enrichment to be
+-- designed minimal rather than filtered afterwards, and this view selects a closed column list: no
+-- `payload` passthrough, so a field added to the event later cannot arrive here by accident.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_settled_transactions AS
+SELECT
+    c.aggregate_id                                          AS transaction_id,
+    c.occurred_at                                           AS settled_at,
+    toStartOfMonth(c.occurred_at)                           AS settled_month,
+    toDecimal64OrNull(JSONExtractString(i.payload, 'amount'), 2) AS amount,
+    JSONExtractString(i.payload, 'currencyCode')            AS currency_code,
+    JSONExtractString(i.payload, 'type')                    AS transaction_type,
+    JSONExtractString(i.payload, 'instructionType')         AS instruction_type,
+    -- Surfaced verbatim. UNKNOWN is what the producer wrote, and it must stay distinguishable from
+    -- a rail this view failed to read.
+    JSONExtractString(i.payload, 'rail')                    AS rail,
+    JSONExtractString(i.payload, 'sourceAccountId')         AS source_account_id,
+    JSONExtractString(i.payload, 'targetAccountId')         AS target_account_id,
+    JSONExtractString(i.payload, 'initiatedByPartyId')      AS initiated_by_party_id,
+    i.occurred_at                                           AS initiated_at
+FROM
+(
+    SELECT aggregate_id, occurred_at
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionCompleted'
+) AS c
+INNER JOIN
+(
+    SELECT aggregate_id, occurred_at, payload
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionInitiated'
+) AS i
+    ON i.aggregate_id = c.aggregate_id;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Per-party settled spend, from the account side rather than the initiator side.
+--
+-- WHY NOT initiated_by_party_id. It is populated on 50 of 63 initiated events, so keying on it
+-- silently drops a fifth of the traffic — and drops it as "this party spent less", which is the
+-- flattering direction and therefore the dangerous one for anything that rewards behaviour.
+-- Ownership through V5's account key covers every transaction with a known account, and both legs
+-- are unioned so an internal transfer between two of the customer's own accounts appears as both,
+-- exactly as V10's monthly flows already treats it.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_settled_spend AS
+SELECT
+    party_id,
+    settled_month,
+    countIf(direction = 'OUT')                 AS outbound_count,
+    sumIf(amount, direction = 'OUT')           AS outbound_amount,
+    countIf(direction = 'IN')                  AS inbound_count,
+    sumIf(amount, direction = 'IN')            AS inbound_amount,
+    uniqExact(transaction_id)                  AS settled_transactions
+FROM
+(
+    SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'OUT' AS direction
+    FROM openbank_analytics.silver_settled_transactions AS t
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.source_account_id
+
+    UNION ALL
+
+    SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'IN' AS direction
+    FROM openbank_analytics.silver_settled_transactions AS t
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.target_account_id
+)
+GROUP BY party_id, settled_month;

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -1059,7 +1059,10 @@ data:
         party_id,
         count()                                    AS events_observed,
         uniqExact(aggregate_id)                    AS aggregates_observed,
-        uniqExactIf(aggregate_id, aggregate_type = 'ACCOUNT')            AS accounts_observed,
+        -- upper() restated at the comparison even though silver_party_events folds it: inheriting a
+        -- fold is an assumption that breaks silently the day the source view changes, which is what the
+        -- aggregate-type-case-fold gate exists to prevent. upper() of an already-folded value is free.
+        uniqExactIf(aggregate_id, upper(aggregate_type) = 'ACCOUNT')      AS accounts_observed,
         uniqExact(aggregate_type)                  AS domains_observed,
         min(occurred_at)                           AS first_seen_at,
         max(occurred_at)                           AS last_seen_at,

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -1087,6 +1087,108 @@ data:
         max(occurred_at)                                          AS last_occurred_at
     FROM openbank_analytics.silver_party_events
     GROUP BY party_id, aggregate_type;
+  13-settled-transactions.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- The post-settlement transaction fact ADR-0282 phase 1 asks for (issue #8792).
+    --
+    -- WHAT THE ISSUE SAID, AND WHAT THE WAREHOUSE SAYS. #8792 states that the only transaction fact in
+    -- analytics is the initiated event, that it carries no rail, and that it is emitted before the money
+    -- moves. Measured 2026-09-05, two of those three are no longer true: THREE transaction event kinds
+    -- are ingested — TransactionInitiated (63), TransactionCompleted (47), TransactionFailed (13) — and
+    -- the initiated payload does carry `rail`, alongside amount, currencyCode, instructionType, type,
+    -- source/target account and initiatedByPartyId.
+    --
+    -- WHAT IS ACTUALLY MISSING IS THE OPPOSITE SHAPE. The post-settlement event EXISTS and is
+    -- content-free: TransactionCompleted carries only a referenceNumber. So "did it settle" and "what
+    -- settled" live in two different events, and every consumer that wants a settled amount has to know
+    -- to join them. Nothing did, which is why the fact read as absent.
+    --
+    -- Both events are keyed by the transaction's own aggregate_id, so the join is exact rather than
+    -- heuristic. Verified before writing this: all 47 completed transactions join back to an initiated
+    -- event carrying an amount, 47 of 47.
+    --
+    -- SETTLEMENT TIME COMES FROM THE COMPLETED EVENT, THE ECONOMICS FROM THE INITIATED ONE. Mixing them
+    -- is the whole point: a fact stamped with the initiation time would put a payment in the wrong day
+    -- and, for a month-boundary settlement, the wrong reporting period. occurred_at throughout, never
+    -- ingested_at — a backfill must land in the period it happened.
+    --
+    -- WHAT IS STILL GENUINELY MISSING, AND IS NOT PAPERED OVER HERE. Category, MCC and merchant are
+    -- absent from every transaction payload and cannot be derived: no view can invent them, and this one
+    -- does not try. `rail` is present but reads UNKNOWN for 55 of 63 initiated events, so it is a
+    -- declared field with no producer filling it — a column that exists and lies is worse than one that
+    -- is missing, so `rail` is surfaced verbatim rather than defaulted, and a consumer can see UNKNOWN
+    -- for what it is. Those three fields plus a populated rail are the producer change that remains.
+    --
+    -- NEVER THE COUNTERPARTY NAME AND NEVER THE FREE-TEXT MESSAGE. #8792 requires the enrichment to be
+    -- designed minimal rather than filtered afterwards, and this view selects a closed column list: no
+    -- `payload` passthrough, so a field added to the event later cannot arrive here by accident.
+    -- ─────────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_settled_transactions AS
+    SELECT
+        c.aggregate_id                                          AS transaction_id,
+        c.occurred_at                                           AS settled_at,
+        toStartOfMonth(c.occurred_at)                           AS settled_month,
+        toDecimal64OrNull(JSONExtractString(i.payload, 'amount'), 2) AS amount,
+        JSONExtractString(i.payload, 'currencyCode')            AS currency_code,
+        JSONExtractString(i.payload, 'type')                    AS transaction_type,
+        JSONExtractString(i.payload, 'instructionType')         AS instruction_type,
+        -- Surfaced verbatim. UNKNOWN is what the producer wrote, and it must stay distinguishable from
+        -- a rail this view failed to read.
+        JSONExtractString(i.payload, 'rail')                    AS rail,
+        JSONExtractString(i.payload, 'sourceAccountId')         AS source_account_id,
+        JSONExtractString(i.payload, 'targetAccountId')         AS target_account_id,
+        JSONExtractString(i.payload, 'initiatedByPartyId')      AS initiated_by_party_id,
+        i.occurred_at                                           AS initiated_at
+    FROM
+    (
+        SELECT aggregate_id, occurred_at
+        FROM openbank_analytics.bronze_events
+        WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionCompleted'
+    ) AS c
+    INNER JOIN
+    (
+        SELECT aggregate_id, occurred_at, payload
+        FROM openbank_analytics.bronze_events
+        WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionInitiated'
+    ) AS i
+        ON i.aggregate_id = c.aggregate_id;
+
+    -- ─────────────────────────────────────────────────────────────────────────────
+    -- Per-party settled spend, from the account side rather than the initiator side.
+    --
+    -- WHY NOT initiated_by_party_id. It is populated on 50 of 63 initiated events, so keying on it
+    -- silently drops a fifth of the traffic — and drops it as "this party spent less", which is the
+    -- flattering direction and therefore the dangerous one for anything that rewards behaviour.
+    -- Ownership through V5's account key covers every transaction with a known account, and both legs
+    -- are unioned so an internal transfer between two of the customer's own accounts appears as both,
+    -- exactly as V10's monthly flows already treats it.
+    -- ─────────────────────────────────────────────────────────────────────────────
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_settled_spend AS
+    SELECT
+        party_id,
+        settled_month,
+        countIf(direction = 'OUT')                 AS outbound_count,
+        sumIf(amount, direction = 'OUT')           AS outbound_amount,
+        countIf(direction = 'IN')                  AS inbound_count,
+        sumIf(amount, direction = 'IN')            AS inbound_amount,
+        uniqExact(transaction_id)                  AS settled_transactions
+    FROM
+    (
+        SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'OUT' AS direction
+        FROM openbank_analytics.silver_settled_transactions AS t
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.source_account_id
+
+        UNION ALL
+
+        SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'IN' AS direction
+        FROM openbank_analytics.silver_settled_transactions AS t
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.target_account_id
+    )
+    GROUP BY party_id, settled_month;
 kind: ConfigMap
 metadata:
   name: clickhouse-init

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -970,6 +970,120 @@ data:
     WHERE b.synthetic = 0
       AND b.occurred_at <= {t:DateTime64(3, 'UTC')}
     GROUP BY upper(b.aggregate_type), b.aggregate_id;
+  12-party-event-profile.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- The per-party event profile ADR-0282 phase 1 asks for (issue #8792).
+    --
+    -- WHAT WAS ACTUALLY MISSING. ADR-0210 put Customer 360 in the silver layer, and V5 gave the
+    -- account-to-party key one definition. What no object gave one definition to is the question one
+    -- level up: WHICH ROWS BELONG TO A PARTY. The Customer 360 BFF answers it inline, in TypeScript,
+    -- on every request — `payload.partyId = P` OR an ACCOUNT/TRANSACTION row whose aggregate_id is one
+    -- of P's accounts — then pulls up to 5000 rows and folds them in the route handler.
+    --
+    -- That predicate IS the isolation boundary, in the same sense V5's header means it: a caller that
+    -- widens its own copy shows another customer's events. V5 collapsed one such copy and the route's
+    -- own comment records the lesson ("a resolution with two definitions has two answers"), but the
+    -- scoping around the view stayed behind in the caller. `silver_party_events` is that scoping, named
+    -- once, so a second consumer — the Lipa earn evaluation, the segment DSL, the AI advisor — inherits
+    -- the boundary instead of re-deriving it.
+    --
+    -- WHY silver_current_state AND NOT bronze. Deliberately the same source the Customer 360 route
+    -- reads today, so this view is a refactor of an existing answer rather than a new one with a
+    -- different meaning. Silver is the latest event per (aggregate_type, aggregate_id): a profile built
+    -- on it describes current state, which is what a 360 view is for. Anything needing the full history
+    -- (cash-flow medians, cadence) must read bronze, and V10's monthly-flows view already does exactly
+    -- that — the two are different questions, not two answers to one.
+    --
+    -- THE ACCOUNT LEG READS V5, WHICH READS BRONZE, AND THAT ASYMMETRY IS LOAD-BEARING. An account's
+    -- latest silver row is typically a status or balance event carrying no partyId, so resolving the
+    -- account key from silver would drop exactly the parties with the most account activity. V5 already
+    -- makes that choice and states it; this view inherits it by delegating rather than repeating it.
+    --
+    -- WHAT IT DELIBERATELY DOES NOT DO. It computes no financial-health measure, no segment membership
+    -- and no score. ADR-0220 D5's rule applies to this phase: a rewards programme rendered from
+    -- fabricated profiles is worse than a missing feature. Every column below is a count or a timestamp
+    -- that is directly observable in the rows; nothing is imputed for a party with thin data, and a
+    -- party with no events has no row here rather than a row of zeros.
+    -- ─────────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_party_events AS
+    SELECT
+        JSONExtractString(s.payload, 'partyId') AS party_id,
+        -- Folded once here so no downstream view repeats it. silver_current_state already upper()s its
+        -- output; the fold is restated rather than assumed, because a caller that inherits case-folding
+        -- by accident breaks the day the source view changes and nothing says why.
+        upper(s.aggregate_type)                 AS aggregate_type,
+        s.aggregate_id,
+        s.event_id,
+        s.event_type,
+        s.occurred_at,
+        s.source_service,
+        s.payload
+    FROM openbank_analytics.silver_current_state AS s
+    WHERE JSONExtractString(s.payload, 'partyId') != ''
+
+    UNION ALL
+
+    -- The account leg: rows the party owns through an account rather than through a payload key. The
+    -- `NOT IN` on the payload key is what keeps the union disjoint — without it a TRANSACTION row that
+    -- carries BOTH a partyId and an owned account id appears twice, and every count below doubles for
+    -- exactly the best-instrumented events.
+    SELECT
+        pa.party_id                             AS party_id,
+        upper(s.aggregate_type)                 AS aggregate_type,
+        s.aggregate_id,
+        s.event_id,
+        s.event_type,
+        s.occurred_at,
+        s.source_service,
+        s.payload
+    FROM openbank_analytics.silver_current_state AS s
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = s.aggregate_id
+    WHERE upper(s.aggregate_type) IN ('ACCOUNT', 'TRANSACTION')
+      AND JSONExtractString(s.payload, 'partyId') = '';
+
+    -- ─────────────────────────────────────────────────────────────────────────────
+    -- The profile itself: the fold the Customer 360 route performs per request, computed once.
+    --
+    -- The per-domain breakdown is a SECOND view (one row per party per domain) rather than a column per
+    -- domain, because the domain set is open: a newly ingested topic must widen the profile without a
+    -- migration, and a fixed column list would report zero for a domain that merely had no column yet.
+    -- That is the sentinel-default failure shape — indistinguishable from a real zero.
+    -- ─────────────────────────────────────────────────────────────────────────────
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_event_profile AS
+    SELECT
+        party_id,
+        count()                                    AS events_observed,
+        uniqExact(aggregate_id)                    AS aggregates_observed,
+        uniqExactIf(aggregate_id, aggregate_type = 'ACCOUNT')            AS accounts_observed,
+        uniqExact(aggregate_type)                  AS domains_observed,
+        min(occurred_at)                           AS first_seen_at,
+        max(occurred_at)                           AS last_seen_at,
+        -- Recency in days, computed here so every consumer agrees on the clock. NOT seeded from a
+        -- sentinel: a party with no events has no row at all, so there is no boot-time value that could
+        -- read as decades of staleness the way a registration-time gauge does.
+        dateDiff('day', max(occurred_at), now())   AS days_since_last_event,
+        arraySort(groupUniqArray(aggregate_type))  AS domains
+    FROM openbank_analytics.silver_party_events
+    GROUP BY party_id;
+
+    -- One row per (party, domain): the `byDomain` map the Customer 360 route builds in the handler,
+    -- including the latest event per domain that the route derives from row order. argMax rather than
+    -- "the first row of a DESC scan", because the ordering guarantee is a property of the query the
+    -- caller happens to write, and this must hold for every caller.
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_domain_activity AS
+    SELECT
+        party_id,
+        aggregate_type,
+        count()                                                   AS events_observed,
+        argMax(event_type, occurred_at)                           AS last_event_type,
+        max(occurred_at)                                          AS last_occurred_at
+    FROM openbank_analytics.silver_party_events
+    GROUP BY party_id, aggregate_type;
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
## Summary

ADR-0282 phase 1 asks for a materialised per-party profile so Customer 360 stops re-deriving what it needs on every request. Building it surfaced the more important half: the party **scoping** had no definition anywhere except inside one caller. V5 gave the account-to-party key one definition; the question one level up — which rows belong to a party — stayed in the Customer 360 route as an inline OR, folded in TypeScript over up to 5000 rows per request.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8792 · ADR-0282 phase 1 · ADR-0210 D2 · ADR-0220 D5

## Changes

- `V12__party_event_profile.sql` adds three views, all reducing silver. The history questions stay with V10's monthly flows, which reads bronze on purpose.
  - `silver_party_events` — the party key on every row, both arms, disjoint.
  - `gold_party_event_profile` — one row per party: counts, first/last seen, domains.
  - `gold_party_domain_activity` — one row per (party, domain), with its latest event.
- The boot ConfigMap gains the matching `12-party-event-profile.sql` key. Nothing applies migrations to a running warehouse, so a key missing here is invisible until a rebuild.
- The Customer 360 route reads `silver_party_events` filtered to one party, and states no arm of its own.
- Its cross-tree pin is extended to V12, alongside the existing V5 pin.

## Measured, not argued

Applied to a scratch database on the sandbox warehouse and compared with the route's former OR semantics, per party:

| parties | max abs delta | parties disagreeing |
|---|---|---|
| 20 | 0 | 0 |

The naive check was vacuous and is recorded as such: every party in the sandbox holds an account, so a count that matches everything proves nothing. The sets were compared instead.

## Falsified three ways

Each against a build that must fail, and does.

1. Drop the disjointness guard on the account arm: one party of twenty inflates by one event, so parties disagreeing goes 0 to 1. The guard does work on real data.
2. Remove the ConfigMap key: `clickhouse-migration-configmap-sync` names V12 exactly, saying a freshly booted cluster will never apply it.
3. Remove the route's `WHERE party_id`: the isolation test fails, and only it. 1 failed, 31 passed.

Also measured: no event is attributed to two parties, and the profile counts reconcile with the per-domain view.

The sandbox warehouse is unchanged by this work. Three views were created there by mistake when a BSD `sed` alternation silently failed to rewrite the database name; they were additive, nothing pre-existing was touched, and they were dropped. The warehouse is back to its 24 objects with nothing modified in the last hour.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

The ClickHouse migration is not Flyway and has no runner: an operator applies `clickhouse/V*.sql` by hand, and the boot ConfigMap covers a fresh cluster. Rollback is `DROP VIEW` on the three names, which removes no data because all three are views.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. Verified against the diff: zero added.
- [x] No new third-party dependency. Verified: no build or lock file in the diff.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

Erasure: this adds no store. All three objects are views, so a crypto-shredded bronze row disappears from them with no separate anonymisation step. What they inherit rather than introduce is V5's account arm, which resolves a party through account rows; whether erasing a party also reaches its account rows is a property of `ErasureService` and `RetentionPolicies`, unchanged here and worth confirming separately.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
