### PR TITLE
feat(lending): credit-risk & decisioning console — and the engine evidence that was never persisted

### DIFF
--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -1,0 +1,25 @@
+# Notebooks
+
+Analyst notebooks that read an **export**, never a live database. The bank's OLTP databases are
+not an analytics surface (ADR-0022): a notebook pointed at `lending` would hold a session against
+a money-path database, bypass every role gate the service applies, and read PII with no audit
+trail. So the flow is:
+
+1. A credit-risk analyst opens the console (`/lending/risk`) with their own role.
+2. They export the decision set they are entitled to see (JSON or CSV).
+3. The notebook reads that file from disk.
+
+The export is the audit boundary. What is in the file is what the analyst was allowed to read at
+the moment they read it, and the file carries the policy bundle that produced the decisions, so a
+notebook cell can always answer "against which rules?".
+
+| Notebook | Reads | Answers |
+|---|---|---|
+| [`credit-risk-decisioning.ipynb`](credit-risk-decisioning.ipynb) | the console's JSON export | Outcome and reason-code distribution, affordability against the policy's own thresholds, engine-vs-human overrides, IFRS 9 stage/ECL and vintage |
+
+Dependencies are `pandas` and `matplotlib` only — deliberately not a project environment: the
+notebook must open on an analyst's laptop without this repo being built.
+
+**What a notebook must not become.** These are exploratory. A number that has to be defensible to
+the regulator belongs in a service or a regulatory return, where it is versioned, tested and
+gated — never in a notebook cell that only one person has run.

--- a/docs/notebooks/credit-risk-decisioning.ipynb
+++ b/docs/notebooks/credit-risk-decisioning.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Credit risk & decisioning",
+    "",
+    "Reads a JSON export from the admin console (`/lending/risk` \u2192 **JSON**). Nothing here connects to a",
+    "database or a service: the export is the audit boundary, and it carries the policy bundle that",
+    "produced the decisions, so every threshold drawn below is the bank's own rule, not a constant",
+    "typed into this notebook.",
+    "",
+    "**What the data can and cannot say.** The decision fields are the ADR-0213 evidence the engine",
+    "pinned (outcome, reason codes, matched rule ids, table versions, input hash). There is no score",
+    "and no probability \u2014 the engine does not produce one. The IFRS 9 figures come from the scheduled",
+    "provisioning cycle; the PD/LGD behind them is a flat placeholder set (see the model version cell),",
+    "so an ECL here is arithmetic on assumed parameters, not a calibrated loss estimate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json",
+    "from pathlib import Path",
+    "",
+    "import pandas as pd",
+    "import matplotlib.pyplot as plt",
+    "",
+    "# The file the console downloaded. Point EXPORT at your own download.",
+    "EXPORT = Path(\"credit-decisions.json\")",
+    "",
+    "payload = json.loads(EXPORT.read_text())",
+    "policy = payload.get(\"policy\")",
+    "decisions = pd.json_normalize(payload.get(\"decisions\", []))",
+    "portfolio = pd.json_normalize(payload.get(\"portfolio\", []))",
+    "",
+    "print(f\"{len(decisions)} decisions, {len(portfolio)} loans\")",
+    "print(\"policy:\", (policy or {}).get(\"source\"), \"code-seeded:\", (policy or {}).get(\"codeSeeded\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. What the engine decides",
+    "",
+    "Outcome mix over the exported set. Remember this is the export, not the book: the console's own",
+    "tiles take book-wide totals from a database aggregate, and the export is capped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outcomes = decisions[\"engineOutcome\"].value_counts()",
+    "display(outcomes.rename(\"count\").to_frame().assign(share=lambda d: d[\"count\"] / d[\"count\"].sum()))",
+    "",
+    "ax = outcomes.reindex([\"APPROVE\", \"REFER\", \"DECLINE\"]).fillna(0).plot.bar(",
+    "    color=[\"#22c55e\", \"#f59e0b\", \"#ef4444\"], rot=0, figsize=(6, 3))",
+    "ax.set_title(\"Engine outcomes (exported sample)\")",
+    "ax.set_ylabel(\"applications\")",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Why \u2014 reason codes and the rule that fired",
+    "",
+    "`reasons` is the adverse-action contract: a machine-readable code plus the id of the rule that",
+    "produced it. A REFER with `INPUT_MISSING` is a data problem, not a credit judgement, and the two",
+    "should never be read as one number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reasons = decisions.explode(\"reasons\").dropna(subset=[\"reasons\"])",
+    "if len(reasons):",
+    "    reasons = pd.concat([",
+    "        reasons.drop(columns=[\"reasons\"]).reset_index(drop=True),",
+    "        pd.json_normalize(reasons[\"reasons\"]).reset_index(drop=True),",
+    "    ], axis=1)",
+    "    pareto = (reasons.groupby([\"code\", \"ruleId\"], dropna=False)",
+    "              .size().sort_values(ascending=False).rename(\"count\").to_frame())",
+    "    display(pareto.head(15))",
+    "else:",
+    "    print(\"No reasons in this export: every decision was a clean approve.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Against which policy",
+    "",
+    "The tables the engine evaluated, in evaluation order, with how often each rule matched in this",
+    "export. A rule with zero hits is either redundant or starved of its input \u2014 worth asking which."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rules = []",
+    "for table in (policy or {}).get(\"tables\", []):",
+    "    for rule in table[\"rules\"]:",
+    "        rules.append({",
+    "            \"kind\": table[\"kind\"], \"table\": table[\"name\"], \"version\": table[\"version\"],",
+    "            \"rule\": rule[\"id\"], \"attribute\": rule[\"attribute\"], \"operator\": rule[\"operator\"],",
+    "            \"threshold\": rule[\"threshold\"], \"values\": \",\".join(rule[\"values\"]), \"band\": rule[\"band\"],",
+    "        })",
+    "rules = pd.DataFrame(rules)",
+    "",
+    "hits = decisions.explode(\"matchedRuleIds\")[\"matchedRuleIds\"].value_counts()",
+    "rules[\"hits\"] = rules[\"rule\"].map(hits).fillna(0).astype(int)",
+    "order = {\"EXCLUSION\": 0, \"ELIGIBILITY\": 1, \"AFFORDABILITY\": 2, \"PRICING_BAND\": 3}",
+    "display(rules.sort_values(by=[\"kind\", \"rule\"], key=lambda c: c.map(order).fillna(99) if c.name == \"kind\" else c))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Affordability against the bank's own thresholds",
+    "",
+    "The lines are read from the policy above. Two DSTI definitions are plotted: the one the engine",
+    "evaluates (new installment / verified income) and the total-debt-service one (adding the",
+    "applicant's existing monthly debt service), which is the CNB/EBA definition. The gap between them",
+    "is the part of the borrower's obligations the current policy does not see."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def limit(kind: str, attribute: str):",
+    "    if rules.empty:",
+    "        return None",
+    "    row = rules[(rules[\"kind\"] == kind) & (rules[\"attribute\"] == attribute) & rules[\"threshold\"].notna()]",
+    "    return None if row.empty else float(row.iloc[0][\"threshold\"])",
+    "",
+    "dsti_limit, dti_limit = limit(\"AFFORDABILITY\", \"DSTI\"), limit(\"AFFORDABILITY\", \"DTI\")",
+    "aff = decisions.dropna(subset=[\"affordability.dsti\"])",
+    "",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4), sharey=True)",
+    "colour = {\"APPROVE\": \"#22c55e\", \"REFER\": \"#f59e0b\", \"DECLINE\": \"#ef4444\"}",
+    "for ax, column, title in [",
+    "    (axes[0], \"affordability.dsti\", \"DSTI as the engine reads it\"),",
+    "    (axes[1], \"affordability.dstiIncludingExistingDebt\", \"DSTI incl. existing debt service\"),",
+    "]:",
+    "    for outcome, group in aff.groupby(\"engineOutcome\"):",
+    "        ax.scatter(group[column], group[\"affordability.dti\"], s=22,",
+    "                   c=colour.get(outcome, \"#94a3b8\"), label=outcome, alpha=0.8)",
+    "    if dsti_limit is not None:",
+    "        ax.axvline(dsti_limit, ls=\"--\", c=\"#ef4444\")",
+    "    if dti_limit is not None:",
+    "        ax.axhline(dti_limit, ls=\"--\", c=\"#ef4444\")",
+    "    ax.set_xlabel(\"DSTI\"); ax.set_title(title)",
+    "axes[0].set_ylabel(\"DTI\"); axes[0].legend(fontsize=8)",
+    "plt.tight_layout()",
+    "",
+    "if dsti_limit is not None and len(aff):",
+    "    over = (aff[\"affordability.dstiIncludingExistingDebt\"] > dsti_limit).sum()",
+    "    within = (aff[\"affordability.dsti\"] <= dsti_limit).sum()",
+    "    print(f\"{over} of {len(aff)} applications breach the DSTI limit ONLY once existing debt service \"",
+    "          f\"is counted; {within} pass the limit the engine applies.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Engine versus human",
+    "",
+    "Where the four-eyes checker went the other way. A high override rate is not automatically a",
+    "problem \u2014 it can be a policy that is too tight \u2014 but it is always a question for the risk",
+    "committee, and it is the number a model-risk review asks for first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "APPROVED = {\"OFFERED\", \"AWAITING_SIGNATURE\", \"SIGNED\", \"REFLECTION_PERIOD\", \"READY_TO_DISBURSE\", \"DISBURSED\"}",
+    "LAPSED = {\"WITHDRAWN\", \"EXPIRED\"}",
+    "",
+    "def disposition(status: str) -> str:",
+    "    if status in APPROVED:",
+    "        return \"approved\"",
+    "    if status == \"DECLINED\":",
+    "        return \"declined\"",
+    "    if status in LAPSED:",
+    "        return \"lapsed\"",
+    "    return \"in flight\"",
+    "",
+    "decisions[\"disposition\"] = decisions[\"status\"].map(disposition)",
+    "matrix = pd.crosstab(decisions[\"engineOutcome\"], decisions[\"disposition\"])",
+    "display(matrix)",
+    "",
+    "disposed = matrix.reindex(columns=[\"approved\", \"declined\"]).fillna(0)",
+    "overridden = disposed.get(\"declined\", 0).get(\"APPROVE\", 0) + disposed.get(\"approved\", 0).get(\"DECLINE\", 0)",
+    "total = disposed.to_numpy().sum()",
+    "print(\"override rate:\", \"n/a (nothing disposed yet)\" if total == 0 else f\"{overridden / total:.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. The book \u2014 IFRS 9 staging, ECL coverage, vintage",
+    "",
+    "Money is per currency. Anything summed across currencies below is grouped first, because a single",
+    "figure adding CZK to EUR looks authoritative and means nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if portfolio.empty:",
+    "    print(\"No loans in this export.\")",
+    "else:",
+    "    assessed = portfolio.dropna(subset=[\"assessment.stage\"])",
+    "    print(f\"{len(assessed)} of {len(portfolio)} loans have a provisioning record; \"",
+    "          f\"PD/LGD model versions: {sorted(assessed['assessment.modelVersion'].unique())}\")",
+    "",
+    "    by_stage = (assessed.groupby([\"currency\", \"assessment.stage\"])",
+    "                .agg(loans=(\"loanId\", \"size\"),",
+    "                     outstanding=(\"assessment.outstandingBalance\", \"sum\"),",
+    "                     ecl=(\"assessment.expectedCreditLoss\", \"sum\")))",
+    "    by_stage[\"coverage\"] = by_stage[\"ecl\"] / by_stage[\"outstanding\"]",
+    "    display(by_stage)",
+    "",
+    "    buckets = (assessed.groupby([\"currency\", \"assessment.bucket\"])",
+    "               .agg(loans=(\"loanId\", \"size\"), outstanding=(\"assessment.outstandingBalance\", \"sum\")))",
+    "    display(buckets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not portfolio.empty:",
+    "    portfolio[\"vintage\"] = pd.to_datetime(portfolio[\"disbursedAt\"]).dt.to_period(\"M\").astype(str)",
+    "    stage = portfolio.get(\"assessment.stage\")",
+    "    vintage = pd.crosstab(portfolio[\"vintage\"], stage.fillna(\"NOT ASSESSED\") if stage is not None else \"NOT ASSESSED\")",
+    "    display(vintage)",
+    "    ax = vintage.plot.bar(stacked=True, figsize=(8, 3.5), rot=0,",
+    "                          color={\"STAGE_1\": \"#6366f1\", \"STAGE_2\": \"#f59e0b\", \"STAGE_3\": \"#ef4444\",",
+    "                                 \"NOT ASSESSED\": \"#cbd5e1\"})",
+    "    ax.set_title(\"Vintage: disbursement month \u00d7 current IFRS 9 stage\")",
+    "    ax.set_ylabel(\"loans\")",
+    "    plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Read this before quoting any number above",
+    "",
+    "- **The bureau port is a no-op.** `CUSTOMER_TYPE` is `STANDARD` for every applicant, so the",
+    "  exclusion table cannot fire. A decline rate near zero is a statement about the missing feed, not",
+    "  about the applicants.",
+    "- **PD/LGD are flat placeholders** (`noop-flat-v1` unless the model version above says otherwise).",
+    "  ECL and coverage are arithmetic on assumed parameters.",
+    "- **The policy may be code-seeded** (`codeSeeded: true`), meaning the tables can only change through",
+    "  a reviewed commit and a release \u2014 there is no four-eyes activation for them yet.",
+    "- **The export is capped.** Rates computed here are of the exported sample; book-wide totals come",
+    "  from the console's database aggregate."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -660,3 +660,21 @@ warning that the code cannot fire would itself never fire.
   impact of a candidate parameter set before it merges. No new endpoint, no authz change, no
   behavior change to computed values (the defaults themselves are untouched). Rollback: revert
   the commit; the `model_version` column is additive and unread by pre-change code.
+
+## 10. Credit-risk read surface (ADR-0230 D1, ADR-0213 D4) — STRIDE supplement
+
+`CreditRiskResource` adds four read-only endpoints under `/api/v1/lending/risk`
+(`decisions`, `decisions/summary`, `portfolio`, `policy`) for the admin-ui credit-risk console
+and notebook export. No mutation: the console renders decisions and never makes them
+(ADR-0227 D4 keeps disposal in the approval inbox). What changes the trust picture is the
+**breadth of one read**: a single call returns every evaluated applicant's affordability inputs
+(income, existing debt service, age, residency) and the book-wide stage/ECL picture.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **I**nfo disclosure | A role outside the credit desk reads every applicant's income and the whole book's impairment | Class-level `@RolesAllowed("ROLE_CREDIT_RISK","ROLE_COMPLIANCE","ROLE_LENDING_OFFICER","ROLE_ADMIN")` — the same set that may read the ADR-0214 evidence bundle, narrower than the class-level roles on `LendingResource`'s `GET /loans/{id}`; OPA `@Authorize(lending.list / lending.read)` on every method; `LendingSecurityTest` asserts no `@PermitAll` on this class too. `CreditRiskConsoleIT` refuses `ROLE_CUSTOMER` on all four paths. |
+| **I**nfo disclosure | Bulk export of PII via `limit` | Clamped server-side to 1..1000 (`CreditRiskInsightService.MAX_LIMIT`); the endpoint is a console read, not a data feed — the warehouse (ADR-0022) is the sanctioned bulk path once the lending topic is wired to the sink (tracked). |
+| **T**ampering | The console shows a ratio or outcome the engine did not evaluate | Views are decoded from the pinned evidence columns (`decision_*`, `policy_versions`, `decision_input_hash`) and from `loan_provisioning`, never recomputed; the affordability ratios call the ASSESSMENT leg's own `OriginationDecisionService.affordabilityRatios`, so a console figure and an engine figure cannot diverge. The total-DSTI figure (`dstiIncludingExistingDebt`) is labelled as **not** what the engine reads. |
+| **R**epudiation | "Which policy produced this?" | Every row carries the pinned table versions and input hash; `/policy` reports `codeSeeded=true` while `StarterCreditPolicy` is the binding, so a reader knows the tables cannot have been changed without a reviewed commit. |
+| **D**oS | Repeated book-wide reads | Two `GROUP BY` aggregates and two capped, indexed reads (`decided_engine_at`, `disbursed_at`, `(loan_id, period)`); no joins over installments. Same rate-limit posture as the other reads. |
+| **S**poofing / **E**oP | n/a | No write path; no identity is taken from the request. |

--- a/openbank-admin-ui/src/app/lending/risk/page.tsx
+++ b/openbank-admin-ui/src/app/lending/risk/page.tsx
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Credit risk & decisioning console (ADR-0230 D1 read view over ADR-0213 / ADR-0028 Phase 3).
+//
+// WHAT A RISK ANALYST OPENS THIS FOR
+//   - what the engine decides, how often, and WHY (reason codes, the rule that fired)
+//   - which policy it decided against, and whether anyone can change that policy
+//   - where the affordability floor actually sits against the applications it saw
+//   - how often the four-eyes checker went the other way
+//   - how the book is staged under IFRS 9, what the ECL coverage is, and which vintage is souring
+//
+// HONESTY RULES, SAME AS /lending
+//   - A number labelled a total comes from a DB-grouped summary; anything from the capped
+//     `/risk/decisions` list is labelled "of the loaded N".
+//   - Thresholds on the charts are READ from `/risk/policy`. The page never hard-codes 0.45.
+//   - `codeSeeded` policy, placeholder PD/LGD (model version), no bureau feed: all said on the page,
+//     because a chart that hides its provenance is what a risk committee later gets blamed for.
+//   - No mutation. Disposal stays in the approval inbox (ADR-0227 D4).
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { RefreshCw, ShieldAlert, Activity, Scale, AlertTriangle, Layers, FileText } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+import { AuthGuard } from '@/components/auth/AuthGuard'
+import { EntityChip } from '@/components/entities/EntityChip'
+import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
+import type { Tone } from '@/components/ui/tone'
+import {
+  type Decision, type LoanRisk, type OutcomeSummary, type Policy,
+  byJurisdiction, decisionsToCsv, outcomeTotals, overrideMatrix, overrideRate, portfolioMix,
+  priceBandTotals, reasonPareto, ruleHits, threshold, vintage, weeklyOutcomes,
+} from '@/components/lending/risk/model'
+import { PolicyTables } from '@/components/lending/risk/PolicyTables'
+import { AffordabilityScatter, BucketBars, C_STAGE, OutcomeTrend, ReasonPareto, StageMixPie } from '@/components/lending/risk/charts'
+
+const UNKNOWN = '—'
+/** The server clamps to 1000; ask for it so the cap is a known number on the labels. */
+const DECISION_LIMIT = 1000
+const PORTFOLIO_LIMIT = 1000
+
+const OUTCOME_TONE: Record<string, Tone> = { APPROVE: 'success', REFER: 'warning', DECLINE: 'danger' }
+
+type Loaded<T> = { data: T; ok: true } | { data: null; ok: false }
+
+async function getJson<T>(url: string): Promise<Loaded<T>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) return { data: null, ok: false }
+    return { data: (await res.json()) as T, ok: true }
+  } catch {
+    return { data: null, ok: false }
+  }
+}
+
+function pct(v: number | null, locale: string): string {
+  return v === null ? UNKNOWN : `${(v * 100).toLocaleString(locale, { maximumFractionDigits: 1 })} %`
+}
+
+function download(name: string, mime: string, body: string) {
+  const blob = new Blob([body], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = name
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export default function CreditRiskPage() {
+  return (
+    <AuthGuard permission="lending:risk:view">
+      <CreditRiskConsole />
+    </AuthGuard>
+  )
+}
+
+function CreditRiskConsole() {
+  const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = numberLocale
+  const [decisions, setDecisions] = useState<Loaded<Decision[]> | null>(null)
+  const [summary, setSummary] = useState<Loaded<OutcomeSummary[]> | null>(null)
+  const [portfolio, setPortfolio] = useState<Loaded<LoanRisk[]> | null>(null)
+  const [policy, setPolicy] = useState<Loaded<Policy> | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [jurisdiction, setJurisdiction] = useState<string>('')
+  const [totalDsti, setTotalDsti] = useState(false)
+  const [tab, setTab] = useState<'decisions' | 'policy' | 'portfolio'>('decisions')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const [d, s, p, pol] = await Promise.all([
+      getJson<Decision[]>(svcUrl('lending-service', '/api/v1/lending/risk/decisions', { limit: String(DECISION_LIMIT) })),
+      getJson<OutcomeSummary[]>(svcUrl('lending-service', '/api/v1/lending/risk/decisions/summary')),
+      getJson<LoanRisk[]>(svcUrl('lending-service', '/api/v1/lending/risk/portfolio', { limit: String(PORTFOLIO_LIMIT) })),
+      getJson<Policy>(svcUrl('lending-service', '/api/v1/lending/risk/policy')),
+    ])
+    setDecisions(d); setSummary(s); setPortfolio(p); setPolicy(pol)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  const allDecisions = useMemo(() => decisions?.data ?? [], [decisions])
+  const jurisdictions = useMemo(() => [...new Set(allDecisions.map(d => d.jurisdiction ?? '—'))].sort(), [allDecisions])
+  const visible = useMemo(
+    () => (jurisdiction ? allDecisions.filter(d => (d.jurisdiction ?? '—') === jurisdiction) : allDecisions),
+    [allDecisions, jurisdiction],
+  )
+
+  // Book-wide totals from the DB summary; a jurisdiction filter can only be applied to the loaded
+  // list, so the tiles switch source and SAY so in the hint.
+  const totals = useMemo(() => (summary?.data ? outcomeTotals(summary.data) : null), [summary])
+  const filteredTotals = useMemo(() => {
+    const acc = { APPROVE: 0, REFER: 0, DECLINE: 0, total: 0 }
+    for (const d of visible) { if (d.engineOutcome in acc) acc[d.engineOutcome as 'APPROVE'] += 1; acc.total += 1 }
+    return acc
+  }, [visible])
+  const kpiSource = jurisdiction ? filteredTotals : totals
+  const kpiHint = jurisdiction
+    ? t(`z ${visible.length} načtených (filtr ${jurisdiction})`, `of ${visible.length} loaded (filter ${jurisdiction})`)
+    : t('celá kniha (agregováno v DB)', 'whole book (DB-grouped)')
+
+  const weekly = useMemo(() => weeklyOutcomes(visible), [visible])
+  const pareto = useMemo(() => reasonPareto(visible), [visible])
+  const hits = useMemo(() => ruleHits(visible), [visible])
+  const matrix = useMemo(() => overrideMatrix(visible), [visible])
+  const overrides = useMemo(() => overrideRate(matrix), [matrix])
+  const bands = useMemo(() => (summary?.data ? priceBandTotals(summary.data) : []), [summary])
+  const perJurisdiction = useMemo(() => byJurisdiction(allDecisions), [allDecisions])
+  const dstiLimit = threshold(policy?.data ?? null, 'AFFORDABILITY', 'DSTI')
+  const dtiLimit = threshold(policy?.data ?? null, 'AFFORDABILITY', 'DTI')
+  const mixes = useMemo(() => portfolioMix(portfolio?.data ?? []), [portfolio])
+  const primary = mixes[0] ?? null
+  const vintages = useMemo(() => vintage(portfolio?.data ?? []), [portfolio])
+  const unavailable = useMemo(() => {
+    const parts: string[] = []
+    if (decisions && !decisions.ok) parts.push('/risk/decisions')
+    if (summary && !summary.ok) parts.push('/risk/decisions/summary')
+    if (portfolio && !portfolio.ok) parts.push('/risk/portfolio')
+    if (policy && !policy.ok) parts.push('/risk/policy')
+    return parts
+  }, [decisions, summary, portfolio, policy])
+
+  const rate = (n: number) => (kpiSource && kpiSource.total > 0 ? pct(n / kpiSource.total, numberLocale) : UNKNOWN)
+  const money = (v: number, ccy: string) => v.toLocaleString(numberLocale, { style: 'currency', currency: ccy, maximumFractionDigits: 0 })
+  const th = { padding: '8px 12px', fontSize: 11, color: 'var(--text-tertiary)', textAlign: 'left' } as const
+  const td = { padding: '8px 12px', fontSize: 13 } as const
+
+  return (
+    <div>
+      <PageHeader
+        title={t('Kreditní riziko a decisioning', 'Credit risk & decisioning')}
+        subtitle={t(
+          'Co engine rozhoduje a proč, proti jaké politice, kde sedí bonitní práh a jak je kniha stagovaná podle IFRS 9. Jen čtení — rozhodnutí se schvalují ve frontě schvalování (ADR-0227).',
+          'What the engine decides and why, against which policy, where the affordability floor sits, and how the book is staged under IFRS 9. Read-only — decisions are approved in the approval inbox (ADR-0227).',
+        )}
+        icon={<ShieldAlert size={18} style={{ color: 'var(--accent)' }} />}
+        actions={
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <select value={jurisdiction} onChange={e => setJurisdiction(e.target.value)} aria-label={t('Filtr jurisdikce', 'Jurisdiction filter')} className="btn btn-secondary" style={{ fontSize: 12 }}>
+              <option value="">{t('Všechny jurisdikce', 'All jurisdictions')}</option>
+              {jurisdictions.map(j => <option key={j} value={j}>{j}</option>)}
+            </select>
+            <button type="button" className="btn btn-secondary" style={{ fontSize: 12, display: 'flex', gap: 6, alignItems: 'center' }}
+              disabled={visible.length === 0}
+              aria-label={t('Exportovat rozhodnutí jako CSV', 'Export decisions as CSV')}
+              onClick={() => download(`credit-decisions-${new Date().toISOString().slice(0, 10)}.csv`, 'text/csv;charset=utf-8', decisionsToCsv(visible))}>
+              <FileText size={14} aria-hidden="true" /> CSV
+            </button>
+            <button type="button" className="btn btn-secondary" style={{ fontSize: 12, display: 'flex', gap: 6, alignItems: 'center' }}
+              disabled={visible.length === 0}
+              aria-label={t('Exportovat rozhodnutí jako JSON pro notebook', 'Export decisions as JSON for a notebook')}
+              onClick={() => download(`credit-decisions-${new Date().toISOString().slice(0, 10)}.json`, 'application/json', JSON.stringify({ policy: policy?.data ?? null, decisions: visible, portfolio: portfolio?.data ?? [] }, null, 2))}>
+              <FileText size={14} aria-hidden="true" /> JSON
+            </button>
+            <button onClick={load} disabled={loading} type="button" aria-busy={loading}
+              aria-label={t('Obnovit kreditní riziko', 'Refresh credit risk')} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+              <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+            </button>
+          </div>
+        }
+      />
+
+      {unavailable.length > 0 && (
+        <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 13 }}>
+          {t('lending-service neodpověděl na:', 'lending-service did not answer:')} {unavailable.join(', ')}
+        </div>
+      )}
+
+      {/* Provenance first. A risk committee reading a table must know whether anyone can change it. */}
+      {policy?.data && (
+        <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: `3px solid ${policy.data.codeSeeded ? 'var(--warning)' : 'var(--success)'}`, fontSize: 13, display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <AlertTriangle size={14} style={{ color: policy.data.codeSeeded ? 'var(--warning)' : 'var(--success)' }} aria-hidden="true" />
+          <span>
+            {policy.data.codeSeeded
+              ? t(`Politika je zadrátovaná v kódu (${policy.data.source}, ADR-0213 D3). Změna = PR + release, ne four-eyes aktivace v UI (D4 table store není postaven).`,
+                  `Policy is code-seeded (${policy.data.source}, ADR-0213 D3). Changing it is a PR + release, not a four-eyes activation here (the D4 table store is not built).`)
+              : t(`Politika z governovaného úložiště: ${policy.data.source}.`, `Policy from the governed store: ${policy.data.source}.`)}
+          </span>
+          <span style={{ color: 'var(--text-tertiary)' }}>
+            {t('Bureau port je no-op → EXCLUSION nikdy nezasáhne. PD/LGD jsou placeholder konstanty (viz model version v portfoliu). ML (ADR-0142) nenasazeno.',
+               'Bureau port is a no-op → EXCLUSION can never fire. PD/LGD are placeholder constants (see model version under portfolio). ML (ADR-0142) not deployed.')}
+          </span>
+        </div>
+      )}
+
+      <div className="grid-4" style={{ marginBottom: 12 }}>
+        <StatCard label={t('Schváleno enginem', 'Engine approve rate')} value={kpiSource ? rate(kpiSource.APPROVE) : UNKNOWN} tone={kpiSource ? 'success' : undefined} hint={kpiSource ? `${kpiSource.APPROVE.toLocaleString(numberLocale)} · ${kpiHint}` : t('čeká na data', 'waiting for data')} icon={<Activity size={13} />} />
+        <StatCard label={t('K lidskému posouzení', 'Engine refer rate')} value={kpiSource ? rate(kpiSource.REFER) : UNKNOWN} tone={kpiSource && kpiSource.REFER > 0 ? 'warning' : undefined} hint={kpiSource ? `${kpiSource.REFER.toLocaleString(numberLocale)} · ${kpiHint}` : t('čeká na data', 'waiting for data')} icon={<Scale size={13} />} />
+        <StatCard label={t('Zamítnuto enginem', 'Engine decline rate')} value={kpiSource ? rate(kpiSource.DECLINE) : UNKNOWN} tone={kpiSource && kpiSource.DECLINE > 0 ? 'danger' : undefined} hint={kpiSource ? `${kpiSource.DECLINE.toLocaleString(numberLocale)} · ${kpiHint}` : t('čeká na data', 'waiting for data')} icon={<AlertTriangle size={13} />} />
+        <StatCard label={t('Přebití člověkem', 'Human override rate')} value={decisions?.ok ? pct(overrides, numberLocale) : UNKNOWN} tone={overrides !== null && overrides > 0 ? 'warning' : undefined} hint={decisions?.ok ? t(`z ${visible.length} načtených, jen již rozhodnuté`, `of ${visible.length} loaded, disposed only`) : t('čeká na data', 'waiting for data')} icon={<Layers size={13} />} />
+      </div>
+      <div className="grid-4" style={{ marginBottom: 20 }}>
+        <StatCard label={t('Stage 2+3 z expozice', 'Stage 2+3 share of exposure')} value={primary ? pct(primary.stage23Share, numberLocale) : UNKNOWN} tone={primary && (primary.stage23Share ?? 0) > 0 ? 'warning' : undefined} hint={primary ? `${primary.currency} · ${t(`${primary.assessed} posouzených úvěrů`, `${primary.assessed} assessed loans`)}` : t('čeká na data', 'waiting for data')} />
+        <StatCard label={t('ECL krytí', 'ECL coverage')} value={primary ? pct(primary.coverage, numberLocale) : UNKNOWN} hint={primary ? `${money(primary.totalEcl, primary.currency)} / ${money(primary.totalOutstanding, primary.currency)}` : t('čeká na data', 'waiting for data')} />
+        <StatCard label={t('90+ DPD z expozice', '90+ DPD share of exposure')} value={primary ? pct(primary.npl90Share, numberLocale) : UNKNOWN} tone={primary && (primary.npl90Share ?? 0) > 0 ? 'danger' : undefined} hint={primary ? t('podle posledního provisioning cyklu', 'per the latest provisioning cycle') : t('čeká na data', 'waiting for data')} />
+        <StatCard label={t('Nikdy neposouzeno', 'Never assessed')} value={portfolio?.ok ? (primary?.unassessed ?? 0).toLocaleString(numberLocale) : UNKNOWN} tone={primary && primary.unassessed > 0 ? 'warning' : undefined} hint={portfolio?.ok ? t('úvěrů bez provisioning záznamu', 'loans with no provisioning record') : t('čeká na data', 'waiting for data')} />
+      </div>
+
+      <div style={{ display: 'flex', gap: 4, marginBottom: 12, flexWrap: 'wrap' }}>
+        {(['decisions', 'policy', 'portfolio'] as const).map(id => (
+          <button key={id} type="button" onClick={() => setTab(id)} aria-pressed={tab === id}
+            aria-label={id === 'decisions' ? t('Zobrazit rozhodnutí', 'Show decisions') : id === 'policy' ? t('Zobrazit politiku', 'Show policy') : t('Zobrazit portfolio', 'Show portfolio')}
+            style={{ padding: '6px 12px', fontSize: 12, fontWeight: 600, borderRadius: 6, border: 'none', cursor: 'pointer', background: tab === id ? 'var(--accent)' : 'var(--surface-3)', color: tab === id ? '#fff' : 'var(--text-secondary)' }}>
+            {id === 'decisions' ? t('Rozhodnutí', 'Decisions') : id === 'policy' ? t('Politika', 'Policy') : t('Portfolio IFRS 9', 'IFRS 9 portfolio')}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'decisions' && (
+        <div style={{ display: 'grid', gap: 16 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))', gap: 16 }}>
+            <section className="card" style={{ padding: 14 }} aria-label={t('Vývoj výsledků po týdnech', 'Outcome trend by week')}>
+              <h3 style={{ fontSize: 13, margin: '0 0 8px' }}>{t('Výsledky enginu po týdnech', 'Engine outcomes by week')}</h3>
+              {weekly.length ? <OutcomeTrend data={weekly} /> : <Empty />}
+            </section>
+            <section className="card" style={{ padding: 14 }} aria-label={t('Pareto důvodů', 'Reason Pareto')}>
+              <h3 style={{ fontSize: 13, margin: '0 0 8px' }}>{t('Důvody REFER/DECLINE (reason code · pravidlo)', 'REFER/DECLINE reasons (reason code · rule)')}</h3>
+              {pareto.length ? <ReasonPareto data={pareto} /> : <Empty />}
+            </section>
+          </div>
+          <section className="card" style={{ padding: 14 }} aria-label={t('Bonita proti politice', 'Affordability against policy')}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8 }}>
+              <h3 style={{ fontSize: 13, margin: 0 }}>
+                {t('DSTI × DTI, prahy čtené z politiky', 'DSTI × DTI, thresholds read from policy')}
+                {dstiLimit !== null && <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}> · DSTI ≤ {dstiLimit.toLocaleString(numberLocale)}</span>}
+                {dtiLimit !== null && <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}> · DTI ≤ {dtiLimit.toLocaleString(numberLocale)}</span>}
+              </h3>
+              <label style={{ fontSize: 12, display: 'flex', gap: 6, alignItems: 'center' }}>
+                <input type="checkbox" checked={totalDsti} onChange={e => setTotalDsti(e.target.checked)} />
+                {t('DSTI vč. stávající dluhové služby (ČNB definice; engine ji dnes NEČTE)', 'DSTI incl. existing debt service (CNB definition; the engine does NOT read it today)')}
+              </label>
+            </div>
+            {visible.some(d => d.affordability) ? <AffordabilityScatter decisions={visible} dstiLimit={dstiLimit} dtiLimit={dtiLimit} includeExistingDebt={totalDsti} /> : <Empty />}
+          </section>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))', gap: 16 }}>
+            <section className="card" style={{ padding: 0, overflow: 'hidden' }} aria-label={t('Engine versus člověk', 'Engine versus human')}>
+              <h3 style={{ fontSize: 13, margin: 0, padding: 14 }}>{t('Engine × konečný stav', 'Engine × final disposition')}</h3>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }} data-testid="override-matrix">
+                <thead><tr style={{ background: 'var(--surface-2)' }}>
+                  <th style={th}>{t('Engine', 'Engine')}</th><th style={th}>{t('Schváleno', 'Approved')}</th><th style={th}>{t('Zamítnuto', 'Declined')}</th><th style={th}>{t('Zaniklo', 'Lapsed')}</th><th style={th}>{t('V běhu', 'In flight')}</th><th style={th}>{t('Přebito', 'Overridden')}</th>
+                </tr></thead>
+                <tbody>{matrix.map(r => (
+                  <tr key={r.engine} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td style={td}><StatusBadge status={r.engine} tone={OUTCOME_TONE[r.engine]} /></td>
+                    <td style={td}>{r.approved}</td><td style={td}>{r.declined}</td><td style={td}>{r.lapsed}</td><td style={td}>{r.inFlight}</td>
+                    <td style={{ ...td, fontWeight: 700, color: r.overridden > 0 ? 'var(--warning-text)' : undefined }}>{r.overridden}</td>
+                  </tr>
+                ))}</tbody>
+              </table>
+            </section>
+            <section className="card" style={{ padding: 0, overflow: 'hidden' }} aria-label={t('Podle jurisdikce a pásma', 'By jurisdiction and band')}>
+              <h3 style={{ fontSize: 13, margin: 0, padding: 14 }}>{t('Jurisdikce a cenová pásma', 'Jurisdictions and price bands')}</h3>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead><tr style={{ background: 'var(--surface-2)' }}>
+                  <th style={th}>{t('Jurisdikce', 'Jurisdiction')}</th><th style={th}>APPROVE</th><th style={th}>REFER</th><th style={th}>DECLINE</th><th style={th}>{t('Celkem', 'Total')}</th>
+                </tr></thead>
+                <tbody>{perJurisdiction.map(r => (
+                  <tr key={r.jurisdiction} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td style={td}>{r.jurisdiction}</td><td style={td}>{r.APPROVE}</td><td style={td}>{r.REFER}</td><td style={td}>{r.DECLINE}</td><td style={td}>{r.total}</td>
+                  </tr>
+                ))}</tbody>
+              </table>
+              <div style={{ padding: 14, display: 'flex', gap: 8, flexWrap: 'wrap', fontSize: 12 }}>
+                {bands.length === 0 && <span style={{ color: 'var(--text-tertiary)' }}>{t('Žádné schválené pásmo', 'No approved band yet')}</span>}
+                {bands.map(b => <span key={b.band}><StatusBadge status={b.band} tone="accent" /> {b.count.toLocaleString(numberLocale)}</span>)}
+              </div>
+            </section>
+          </div>
+          <section className="card" style={{ padding: 0, overflow: 'hidden' }} aria-label={t('Poslední rozhodnutí', 'Latest decisions')}>
+            <h3 style={{ fontSize: 13, margin: 0, padding: 14 }}>{t(`Poslední rozhodnutí (${visible.length} z max. ${DECISION_LIMIT})`, `Latest decisions (${visible.length} of at most ${DECISION_LIMIT})`)}</h3>
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead><tr style={{ background: 'var(--surface-2)' }}>
+                  <th style={th}>{t('Klient', 'Party')}</th><th style={th}>{t('Částka', 'Amount')}</th><th style={th}>DSTI</th><th style={th}>DTI</th><th style={th}>{t('Engine', 'Engine')}</th><th style={th}>{t('Pásmo', 'Band')}</th><th style={th}>{t('Důvody', 'Reasons')}</th><th style={th}>{t('Stav', 'Status')}</th><th style={th}>{t('Vyhodnoceno', 'Evaluated')}</th><th style={th} />
+                </tr></thead>
+                <tbody>
+                  {visible.slice(0, 100).map(d => (
+                    <tr key={d.applicationId} style={{ borderTop: '1px solid var(--border)' }}>
+                      <td style={td}><EntityChip type="party" id={d.partyId} /></td>
+                      <td style={{ ...td, fontWeight: 600 }}>{money(d.requestedAmount, d.currency)}</td>
+                      <td style={td}>{d.affordability ? d.affordability.dsti.toLocaleString(numberLocale, { maximumFractionDigits: 3 }) : UNKNOWN}</td>
+                      <td style={td}>{d.affordability ? d.affordability.dti.toLocaleString(numberLocale, { maximumFractionDigits: 2 }) : UNKNOWN}</td>
+                      <td style={td}><StatusBadge status={d.engineOutcome} tone={OUTCOME_TONE[d.engineOutcome] ?? 'neutral'} /></td>
+                      <td style={td}>{d.priceBand ?? UNKNOWN}</td>
+                      <td style={{ ...td, fontSize: 11, color: 'var(--text-secondary)' }}>{d.reasons.length ? d.reasons.map(r => `${r.code}${r.ruleId ? ` (${r.ruleId})` : ''}`).join(', ') : UNKNOWN}</td>
+                      <td style={td}><StatusBadge status={d.status} /></td>
+                      <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>{d.decidedEngineAt ? new Date(d.decidedEngineAt).toLocaleString(dateLocale) : UNKNOWN}</td>
+                      <td style={td}><Link href={`/lending/applications/${d.applicationId}`} style={{ color: 'var(--accent)', fontSize: 12 }}>{t('Evidence', 'Evidence')} ›</Link></td>
+                    </tr>
+                  ))}
+                  {!loading && visible.length === 0 && <tr><td colSpan={10} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>{t('Engine zatím nic nevyhodnotil', 'The engine has evaluated nothing yet')}</td></tr>}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {tab === 'policy' && (
+        policy?.data
+          ? <PolicyTables policy={policy.data} hits={hits} sample={visible.length} />
+          : <div className="card" style={{ padding: 20, color: 'var(--text-tertiary)', fontSize: 13 }}>{t('Politika nenačtena', 'Policy not loaded')}</div>
+      )}
+
+      {tab === 'portfolio' && (
+        <div style={{ display: 'grid', gap: 16 }}>
+          {mixes.length === 0 && <div className="card" style={{ padding: 20, color: 'var(--text-tertiary)', fontSize: 13 }}>{portfolio?.ok ? t('Prázdná kniha', 'Empty book') : t('Portfolio nenačteno', 'Portfolio not loaded')}</div>}
+          {mixes.map(mix => (
+            <div key={mix.currency} style={{ display: 'grid', gap: 16 }}>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 16 }}>
+                <section className="card" style={{ padding: 14 }} aria-label={t(`Stage mix ${mix.currency}`, `Stage mix ${mix.currency}`)}>
+                  <h3 style={{ fontSize: 13, margin: '0 0 8px' }}>{t(`Expozice podle IFRS 9 stage (${mix.currency})`, `Exposure by IFRS 9 stage (${mix.currency})`)}</h3>
+                  {mix.assessed ? <StageMixPie stages={mix.stages} /> : <Empty />}
+                </section>
+                <section className="card" style={{ padding: 14 }} aria-label={t('DPD buckety', 'DPD buckets')}>
+                  <h3 style={{ fontSize: 13, margin: '0 0 8px' }}>{t('Úvěry podle dnů po splatnosti', 'Loans by days past due')}</h3>
+                  {mix.assessed ? <BucketBars buckets={mix.buckets} /> : <Empty />}
+                </section>
+                <section className="card" style={{ padding: 0, overflow: 'hidden' }} aria-label={t('ECL po stage', 'ECL by stage')}>
+                  <h3 style={{ fontSize: 13, margin: 0, padding: 14 }}>{t('ECL a krytí po stage', 'ECL and coverage by stage')}</h3>
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }} data-testid="stage-table">
+                    <thead><tr style={{ background: 'var(--surface-2)' }}><th style={th}>Stage</th><th style={th}>{t('Úvěry', 'Loans')}</th><th style={th}>{t('Expozice', 'Outstanding')}</th><th style={th}>ECL</th><th style={th}>{t('Krytí', 'Coverage')}</th></tr></thead>
+                    <tbody>{mix.stages.map(s => (
+                      <tr key={s.stage} style={{ borderTop: '1px solid var(--border)' }}>
+                        <td style={td}><span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: 4, background: C_STAGE[s.stage], marginRight: 6 }} />{s.stage.replace('_', ' ')}</td>
+                        <td style={td}>{s.count}</td><td style={td}>{money(s.outstanding, mix.currency)}</td><td style={td}>{money(s.ecl, mix.currency)}</td><td style={td}>{pct(s.coverage, numberLocale)}</td>
+                      </tr>
+                    ))}</tbody>
+                  </table>
+                  <div style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }}>
+                    {t('PD/LGD model:', 'PD/LGD model:')} <code>{mix.modelVersions.join(', ') || UNKNOWN}</code> · {t(`${mix.unassessed} úvěrů bez posouzení`, `${mix.unassessed} loans not assessed`)}
+                  </div>
+                </section>
+              </div>
+            </div>
+          ))}
+          {vintages.length > 0 && (
+            <section className="card" style={{ padding: 0, overflow: 'hidden' }} aria-label={t('Vintage', 'Vintage')}>
+              <h3 style={{ fontSize: 13, margin: 0, padding: 14 }}>{t('Vintage: měsíc čerpání × aktuální stage', 'Vintage: disbursement month × current stage')}</h3>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }} data-testid="vintage-table">
+                <thead><tr style={{ background: 'var(--surface-2)' }}><th style={th}>{t('Měsíc', 'Month')}</th><th style={th}>{t('Úvěry', 'Loans')}</th><th style={th}>Stage 1</th><th style={th}>Stage 2</th><th style={th}>Stage 3</th><th style={th}>{t('Neposouzeno', 'Unassessed')}</th></tr></thead>
+                <tbody>{vintages.map(v => (
+                  <tr key={v.month} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td style={td}>{v.month}</td><td style={td}>{v.loans}</td>
+                    {(['STAGE_1', 'STAGE_2', 'STAGE_3'] as const).map(s => (
+                      <td key={s} style={{ ...td, background: v[s] ? `${C_STAGE[s]}${Math.min(0.85, 0.15 + v[s] / v.loans).toString(16).slice(2, 4).padStart(2, '0')}` : undefined }}>{v[s]}</td>
+                    ))}
+                    <td style={{ ...td, color: v.unassessed ? 'var(--warning-text)' : undefined }}>{v.unassessed}</td>
+                  </tr>
+                ))}</tbody>
+              </table>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Empty() {
+  const { t } = useLanguage()
+  return <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>{t('Zatím žádná data', 'No data yet')}</div>
+}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -93,6 +93,7 @@ const coreNav: NavItem[] = [
 
 const revenueNav: NavItem[] = [
   { nameCs: 'Úvěry',        nameEn: 'Lending',      href: '/lending',      icon: TrendingUp,    permission: 'payments:view' },
+  { nameCs: 'Kreditní riziko', nameEn: 'Credit risk', href: '/lending/risk', icon: ShieldAlert, permission: 'lending:risk:view' },
   { nameCs: 'Poplatky',     nameEn: 'Fees',         href: '/fees',         icon: Receipt,         permission: 'payments:view' },
 ]
 

--- a/openbank-admin-ui/src/components/lending/risk/PolicyTables.tsx
+++ b/openbank-admin-ui/src/components/lending/risk/PolicyTables.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { StatusBadge } from '@/components/ui'
+import type { Policy, PolicyRule } from './model'
+
+const OPERATOR_GLYPH: Record<string, string> = {
+  GT: '>', GTE: '≥', LT: '<', LTE: '≤', EQ: '=', NEQ: '≠', IN: '∈', NOT_IN: '∉',
+}
+
+const KIND_LABEL_CS: Record<string, string> = {
+  EXCLUSION: 'Vyloučení', ELIGIBILITY: 'Způsobilost', AFFORDABILITY: 'Bonita', PRICING_BAND: 'Cenové pásmo',
+}
+const KIND_LABEL_EN: Record<string, string> = {
+  EXCLUSION: 'Exclusion', ELIGIBILITY: 'Eligibility', AFFORDABILITY: 'Affordability', PRICING_BAND: 'Pricing band',
+}
+
+/** The rule as a credit officer would read it: `DSTI ≤ 0.45`, `RESIDENCY ∈ {CZ, DE, SK}`. */
+export function ruleCondition(rule: PolicyRule, numberLocale: string): string {
+  const op = OPERATOR_GLYPH[rule.operator] ?? rule.operator
+  if (rule.threshold !== null) return `${rule.attribute} ${op} ${rule.threshold.toLocaleString(numberLocale, { maximumFractionDigits: 4 })}`
+  if (rule.values.length) return `${rule.attribute} ${op} {${rule.values.join(', ')}}`
+  return `${rule.attribute} ${op}`
+}
+
+type Props = {
+  policy: Policy
+  /** Matched-rule counts from the loaded decisions — how often each rule actually fired. */
+  hits: Map<string, number>
+  /** How many decisions the hit counts were taken from (so the column can say "of N"). */
+  sample: number
+}
+
+/**
+ * The decision tables themselves, in the order the engine evaluates them (ADR-0213 D2), with a
+ * hit count per rule. A table a risk committee cannot read is a policy nobody governs; a rule
+ * that never fires is either redundant or starved of data — both are things this column shows.
+ */
+export function PolicyTables({ policy, hits, sample }: Props) {
+  const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const kindLabel = (k: string) => (language === 'cs' ? KIND_LABEL_CS[k] : KIND_LABEL_EN[k]) ?? k
+  const order = ['EXCLUSION', 'ELIGIBILITY', 'AFFORDABILITY', 'PRICING_BAND']
+  const tables = [...policy.tables].sort((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind) || b.version - a.version)
+  const th = { padding: '8px 12px', fontSize: 11, color: 'var(--text-tertiary)', textAlign: 'left' } as const
+  const td = { padding: '8px 12px', fontSize: 13, verticalAlign: 'top' } as const
+
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {tables.map(table => (
+        <div key={`${table.kind}-${table.name}-${table.version}`} className="card" style={{ padding: 0, overflow: 'hidden' }} data-testid={`policy-table-${table.kind}`}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap' }}>
+            <strong style={{ fontSize: 13 }}>{kindLabel(table.kind)}</strong>
+            <code style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{table.name}</code>
+            <StatusBadge status={`v${table.version}`} tone="neutral" />
+            <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
+              {t('platné od', 'effective from')} {new Date(table.effectiveFrom).toLocaleDateString(numberLocale)}
+              {table.effectiveTo ? ` — ${new Date(table.effectiveTo).toLocaleDateString(numberLocale)}` : ''}
+            </span>
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: 'var(--surface-2)' }}>
+                <th style={th}>{t('Pravidlo', 'Rule')}</th>
+                <th style={th}>{t('Podmínka', 'Condition')}</th>
+                <th style={th}>{table.kind === 'PRICING_BAND' ? t('Pásmo', 'Band') : t('Důvod', 'Reason')}</th>
+                <th style={{ ...th, textAlign: 'right' }} title={t(`z ${sample} načtených rozhodnutí`, `of ${sample} loaded decisions`)}>
+                  {t('Zásahy', 'Hits')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {table.rules.map(rule => {
+                const n = hits.get(rule.id) ?? 0
+                return (
+                  <tr key={rule.id} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td style={td}><code style={{ fontSize: 12 }}>{rule.id}</code></td>
+                    <td style={{ ...td, fontWeight: 600 }}>{ruleCondition(rule, numberLocale)}</td>
+                    <td style={{ ...td, color: 'var(--text-secondary)' }}>
+                      {table.kind === 'PRICING_BAND' ? <StatusBadge status={rule.band ?? '—'} tone="accent" /> : (rule.detail || '—')}
+                    </td>
+                    <td style={{ ...td, textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: n === 0 && sample > 0 ? 'var(--warning-text)' : undefined }}
+                      title={n === 0 && sample > 0 ? t('Nikdy nezasáhlo v načteném vzorku — nadbytečné, nebo bez dat.', 'Never fired in the loaded sample — redundant, or starved of data.') : undefined}>
+                      {sample === 0 ? '—' : n.toLocaleString(numberLocale)}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/lending/risk/charts.tsx
+++ b/openbank-admin-ui/src/components/lending/risk/charts.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import {
+  Bar, BarChart, CartesianGrid, Cell, Legend, Pie, PieChart, ReferenceLine, ResponsiveContainer,
+  Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis,
+} from 'recharts'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { Decision, ReasonCount, StageRow, WeeklyOutcome } from './model'
+
+// Theme-agnostic chart palette. recharts writes `fill`/`stroke` as SVG attributes, where CSS
+// variables do not resolve — same constraint as the onboarding funnel page. One colour per
+// outcome, reused everywhere so APPROVE is the same green on every chart on the page.
+export const C_APPROVE = '#22c55e'
+export const C_REFER = '#f59e0b'
+export const C_DECLINE = '#ef4444'
+export const C_STAGE: Record<string, string> = { STAGE_1: '#6366f1', STAGE_2: '#f59e0b', STAGE_3: '#ef4444' }
+const C_BUCKET = ['#6366f1', '#a5b4fc', '#f59e0b', '#fb923c', '#ef4444']
+const OUTCOME_COLOUR: Record<string, string> = { APPROVE: C_APPROVE, REFER: C_REFER, DECLINE: C_DECLINE }
+
+const axisTick = { fontSize: 11, fill: 'var(--text-tertiary)' }
+
+export function OutcomeTrend({ data }: { data: WeeklyOutcome[] }) {
+  const { t } = useLanguage()
+  return (
+    <div style={{ height: 240 }}>
+      <ResponsiveContainer>
+        <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+          <XAxis dataKey="week" tick={axisTick} />
+          <YAxis allowDecimals={false} tick={axisTick} width={32} />
+          <Tooltip />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Bar dataKey="APPROVE" stackId="o" name={t('Schváleno', 'Approve')} fill={C_APPROVE} />
+          <Bar dataKey="REFER" stackId="o" name={t('K posouzení', 'Refer')} fill={C_REFER} />
+          <Bar dataKey="DECLINE" stackId="o" name={t('Zamítnuto', 'Decline')} fill={C_DECLINE} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export function ReasonPareto({ data }: { data: ReasonCount[] }) {
+  const rows = data.slice(0, 10).map(r => ({ ...r, label: r.ruleId ? `${r.code} · ${r.ruleId}` : r.code }))
+  return (
+    <div style={{ height: Math.max(160, rows.length * 30 + 40) }}>
+      <ResponsiveContainer>
+        <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 24, left: 8, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+          <XAxis type="number" allowDecimals={false} tick={axisTick} />
+          <YAxis type="category" dataKey="label" width={260} tick={{ ...axisTick, fontSize: 10 }} />
+          <Tooltip />
+          <Bar dataKey="count" fill={C_REFER} radius={[0, 3, 3, 0]}>
+            {rows.map(r => <Cell key={r.label} fill={r.code === 'EXCLUSION_MATCHED' ? C_DECLINE : C_REFER} />)}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+type ScatterProps = {
+  decisions: Decision[]
+  dstiLimit: number | null
+  dtiLimit: number | null
+  /** Plot total-debt-service DSTI instead of the engine's new-installment DSTI. */
+  includeExistingDebt: boolean
+}
+
+/**
+ * DSTI × DTI, one point per evaluated application, coloured by engine outcome, with the policy's
+ * own thresholds drawn as lines. The lines come from `/risk/policy`; when the policy carries no
+ * numeric threshold for an attribute there is no line, rather than an invented one.
+ */
+export function AffordabilityScatter({ decisions, dstiLimit, dtiLimit, includeExistingDebt }: ScatterProps) {
+  const { t } = useLanguage()
+  const points = decisions
+    .filter(d => d.affordability)
+    .map(d => ({
+      x: includeExistingDebt ? d.affordability!.dstiIncludingExistingDebt : d.affordability!.dsti,
+      y: d.affordability!.dti,
+      outcome: d.engineOutcome,
+      id: d.applicationId,
+    }))
+  const series = (['APPROVE', 'REFER', 'DECLINE'] as const).map(o => ({ o, pts: points.filter(p => p.outcome === o) }))
+  return (
+    <div style={{ height: 280 }}>
+      <ResponsiveContainer>
+        <ScatterChart margin={{ top: 12, right: 24, left: 0, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+          <XAxis type="number" dataKey="x" name="DSTI" tick={axisTick} domain={[0, (max: number) => Math.max(0.6, Math.ceil(max * 10) / 10)]}
+            label={{ value: includeExistingDebt ? t('DSTI vč. stávajícího dluhu', 'DSTI incl. existing debt') : t('DSTI (engine)', 'DSTI (engine)'), position: 'insideBottom', offset: -4, fontSize: 11 }} />
+          <YAxis type="number" dataKey="y" name="DTI" tick={axisTick} width={36} domain={[0, (max: number) => Math.max(10, Math.ceil(max))]} />
+          <ZAxis range={[40, 40]} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} formatter={(v, name) => [typeof v === 'number' ? v.toFixed(3) : String(v), String(name)]} />
+          {dstiLimit !== null && <ReferenceLine x={dstiLimit} stroke={C_DECLINE} strokeDasharray="4 4" label={{ value: `DSTI ${dstiLimit}`, fontSize: 10, position: 'top' }} />}
+          {dtiLimit !== null && <ReferenceLine y={dtiLimit} stroke={C_DECLINE} strokeDasharray="4 4" label={{ value: `DTI ${dtiLimit}`, fontSize: 10, position: 'right' }} />}
+          {series.map(s => <Scatter key={s.o} name={s.o} data={s.pts} fill={OUTCOME_COLOUR[s.o]} />)}
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export function StageMixPie({ stages }: { stages: StageRow[] }) {
+  const data = stages.filter(s => s.outstanding > 0).map(s => ({ name: s.stage.replace('_', ' '), value: s.outstanding, stage: s.stage }))
+  return (
+    <div style={{ height: 220 }}>
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="name" innerRadius={50} outerRadius={80} paddingAngle={2}>
+            {data.map(d => <Cell key={d.stage} fill={C_STAGE[d.stage]} />)}
+          </Pie>
+          <Tooltip formatter={v => (typeof v === 'number' ? v.toLocaleString() : String(v))} />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export function BucketBars({ buckets }: { buckets: { bucket: string; count: number; outstanding: number }[] }) {
+  const { t } = useLanguage()
+  const rows = buckets.map(b => ({ ...b, label: b.bucket.replace('DPD_', '').replace('_PLUS', '+').replace('_', '–') }))
+  return (
+    <div style={{ height: 220 }}>
+      <ResponsiveContainer>
+        <BarChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+          <XAxis dataKey="label" tick={axisTick} />
+          <YAxis allowDecimals={false} tick={axisTick} width={32} />
+          <Tooltip />
+          <Bar dataKey="count" name={t('Úvěry', 'Loans')} radius={[3, 3, 0, 0]}>
+            {rows.map((r, i) => <Cell key={r.bucket} fill={C_BUCKET[i % C_BUCKET.length]} />)}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/lending/risk/model.ts
+++ b/openbank-admin-ui/src/components/lending/risk/model.ts
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Types and PURE aggregation for the credit-risk console (ADR-0230 D1 over ADR-0213 evidence).
+//
+// Everything here is a function of the four `/api/v1/lending/risk/*` responses and nothing else:
+// no fetch, no React, no locale. That is what lets the arithmetic be unit-tested against the
+// exact JSON the service returns, and what keeps the page a rendering of numbers it did not
+// invent. Thresholds are READ from the policy payload — the console never hard-codes 0.45.
+
+export type EngineOutcome = 'APPROVE' | 'REFER' | 'DECLINE' | 'UNEVALUATED'
+
+export type Reason = { code: string; ruleId: string | null }
+export type Affordability = { dsti: number; dti: number; dstiIncludingExistingDebt: number }
+
+export type Decision = {
+  applicationId: string
+  partyId: string
+  status: string
+  createdAt: string
+  requestedAmount: number
+  currency: string
+  termPeriods: number
+  nominalAnnualRate: number
+  jurisdiction: string | null
+  productType: string | null
+  productKind: string
+  packVersion: number | null
+  engineOutcome: EngineOutcome
+  priceBand: string | null
+  reasons: Reason[]
+  matchedRuleIds: string[]
+  policyVersions: Record<string, number>
+  inputSnapshotHash: string | null
+  decidedEngineAt: string | null
+  affordability: Affordability | null
+  verifiedIncomeMonthly: number | null
+  existingDebtServiceMonthly: number | null
+  ageYears: number | null
+  residency: string | null
+  employmentTenureMonths: number | null
+  humanDecidedBy: string | null
+  humanDecisionReason: string | null
+  humanDecidedAt: string | null
+}
+
+export type OutcomeSummary = { engineOutcome: string; priceBand: string | null; count: number }
+
+export type Assessment = {
+  period: string
+  asOf: string
+  outstandingBalance: number
+  daysPastDue: number
+  bucket: string
+  stage: string
+  expectedCreditLoss: number
+  modelVersion: string
+}
+
+export type LoanRisk = {
+  loanId: string
+  applicationId: string
+  partyId: string
+  status: string
+  principal: number
+  currency: string
+  nominalAnnualRate: number
+  termPeriods: number
+  disbursedAt: string
+  assessment: Assessment | null
+}
+
+export type PolicyRule = {
+  id: string
+  attribute: string
+  operator: string
+  threshold: number | null
+  values: string[]
+  band: string | null
+  detail: string
+}
+export type PolicyTable = {
+  kind: string
+  name: string
+  version: number
+  effectiveFrom: string
+  effectiveTo: string | null
+  rules: PolicyRule[]
+}
+export type Policy = { asOf: string; source: string; codeSeeded: boolean; tables: PolicyTable[] }
+
+export const OUTCOMES: readonly EngineOutcome[] = ['APPROVE', 'REFER', 'DECLINE'] as const
+export const STAGES = ['STAGE_1', 'STAGE_2', 'STAGE_3'] as const
+export const BUCKETS = ['CURRENT', 'DPD_1_30', 'DPD_31_60', 'DPD_61_90', 'DPD_90_PLUS'] as const
+
+/** Where an application ended up, as a human disposition the engine's outcome can be compared with. */
+export type Disposition = 'approved' | 'declined' | 'lapsed' | 'inFlight'
+const APPROVED_STATES = new Set(['OFFERED', 'AWAITING_SIGNATURE', 'SIGNED', 'REFLECTION_PERIOD', 'READY_TO_DISBURSE', 'DISBURSED'])
+const LAPSED_STATES = new Set(['WITHDRAWN', 'EXPIRED'])
+
+export function disposition(status: string): Disposition {
+  if (APPROVED_STATES.has(status)) return 'approved'
+  if (status === 'DECLINED') return 'declined'
+  if (LAPSED_STATES.has(status)) return 'lapsed'
+  return 'inFlight'
+}
+
+/** Book-wide totals from the DB-grouped summary — never from the capped list. */
+export function outcomeTotals(summary: OutcomeSummary[]): Record<EngineOutcome, number> & { total: number } {
+  const acc = { APPROVE: 0, REFER: 0, DECLINE: 0, UNEVALUATED: 0, total: 0 }
+  for (const row of summary) {
+    const k = row.engineOutcome as EngineOutcome
+    if (k in acc) acc[k] += row.count
+    acc.total += row.count
+  }
+  return acc
+}
+
+export function priceBandTotals(summary: OutcomeSummary[]): { band: string; count: number }[] {
+  const m = new Map<string, number>()
+  for (const row of summary) {
+    if (row.engineOutcome !== 'APPROVE') continue
+    const band = row.priceBand ?? '—'
+    m.set(band, (m.get(band) ?? 0) + row.count)
+  }
+  return [...m.entries()].map(([band, count]) => ({ band, count })).sort((a, b) => b.count - a.count)
+}
+
+/** Monday of the ISO week containing the timestamp, as yyyy-mm-dd (UTC). */
+export function weekStart(iso: string): string {
+  const d = new Date(iso)
+  const day = (d.getUTCDay() + 6) % 7
+  d.setUTCDate(d.getUTCDate() - day)
+  return d.toISOString().slice(0, 10)
+}
+
+export type WeeklyOutcome = { week: string; APPROVE: number; REFER: number; DECLINE: number }
+
+export function weeklyOutcomes(decisions: Decision[]): WeeklyOutcome[] {
+  const m = new Map<string, WeeklyOutcome>()
+  for (const d of decisions) {
+    const at = d.decidedEngineAt ?? d.createdAt
+    const week = weekStart(at)
+    const row = m.get(week) ?? { week, APPROVE: 0, REFER: 0, DECLINE: 0 }
+    if (d.engineOutcome === 'APPROVE' || d.engineOutcome === 'REFER' || d.engineOutcome === 'DECLINE') row[d.engineOutcome] += 1
+    m.set(week, row)
+  }
+  return [...m.values()].sort((a, b) => a.week.localeCompare(b.week))
+}
+
+export type ReasonCount = { code: string; ruleId: string | null; count: number }
+
+/** The adverse-action Pareto: which reason (and which rule) refers or declines most. */
+export function reasonPareto(decisions: Decision[]): ReasonCount[] {
+  const m = new Map<string, ReasonCount>()
+  for (const d of decisions) {
+    for (const r of d.reasons) {
+      const key = `${r.code}|${r.ruleId ?? ''}`
+      const row = m.get(key) ?? { code: r.code, ruleId: r.ruleId, count: 0 }
+      row.count += 1
+      m.set(key, row)
+    }
+  }
+  return [...m.values()].sort((a, b) => b.count - a.count)
+}
+
+/** How often each policy rule matched — the "is this rule doing anything" column of a decision table. */
+export function ruleHits(decisions: Decision[]): Map<string, number> {
+  const m = new Map<string, number>()
+  for (const d of decisions) for (const id of d.matchedRuleIds) m.set(id, (m.get(id) ?? 0) + 1)
+  return m
+}
+
+export type OverrideRow = {
+  engine: EngineOutcome
+  approved: number
+  declined: number
+  lapsed: number
+  inFlight: number
+  /** Human went the other way: engine APPROVE ended DECLINED, or engine DECLINE was approved. */
+  overridden: number
+}
+
+export function overrideMatrix(decisions: Decision[]): OverrideRow[] {
+  const rows = new Map<EngineOutcome, OverrideRow>()
+  for (const o of OUTCOMES) rows.set(o, { engine: o, approved: 0, declined: 0, lapsed: 0, inFlight: 0, overridden: 0 })
+  for (const d of decisions) {
+    const row = rows.get(d.engineOutcome)
+    if (!row) continue
+    const disp = disposition(d.status)
+    row[disp] += 1
+    if ((d.engineOutcome === 'APPROVE' && disp === 'declined') || (d.engineOutcome === 'DECLINE' && disp === 'approved')) row.overridden += 1
+  }
+  return [...rows.values()]
+}
+
+/** Overrides as a share of the engine decisions a human has already disposed of. */
+export function overrideRate(matrix: OverrideRow[]): number | null {
+  let disposed = 0
+  let overridden = 0
+  for (const r of matrix) {
+    disposed += r.approved + r.declined
+    overridden += r.overridden
+  }
+  return disposed === 0 ? null : overridden / disposed
+}
+
+/** The numeric threshold a policy table applies to an attribute — the line the scatter overlays. */
+export function threshold(policy: Policy | null, kind: string, attribute: string): number | null {
+  if (!policy) return null
+  const asOf = policy.asOf
+  const tables = policy.tables
+    .filter(t => t.kind === kind && t.effectiveFrom <= asOf && (t.effectiveTo === null || asOf < t.effectiveTo))
+    .sort((a, b) => b.version - a.version)
+  for (const t of tables) {
+    const rule = t.rules.find(r => r.attribute === attribute && r.threshold !== null)
+    if (rule) return rule.threshold
+  }
+  return null
+}
+
+export type JurisdictionRow = { jurisdiction: string; APPROVE: number; REFER: number; DECLINE: number; total: number }
+
+export function byJurisdiction(decisions: Decision[]): JurisdictionRow[] {
+  const m = new Map<string, JurisdictionRow>()
+  for (const d of decisions) {
+    const j = d.jurisdiction ?? '—'
+    const row = m.get(j) ?? { jurisdiction: j, APPROVE: 0, REFER: 0, DECLINE: 0, total: 0 }
+    if (d.engineOutcome === 'APPROVE' || d.engineOutcome === 'REFER' || d.engineOutcome === 'DECLINE') row[d.engineOutcome] += 1
+    row.total += 1
+    m.set(j, row)
+  }
+  return [...m.values()].sort((a, b) => b.total - a.total)
+}
+
+export type StageRow = { stage: string; count: number; outstanding: number; ecl: number; coverage: number | null }
+export type PortfolioMix = {
+  currency: string
+  assessed: number
+  unassessed: number
+  stages: StageRow[]
+  buckets: { bucket: string; count: number; outstanding: number }[]
+  totalOutstanding: number
+  totalEcl: number
+  coverage: number | null
+  /** Share of assessed outstanding in stages 2 and 3 — the "non-performing plus watch" figure. */
+  stage23Share: number | null
+  npl90Share: number | null
+  modelVersions: string[]
+}
+
+/** Money is per currency; a book with two currencies gets two mixes, never one summed number. */
+export function portfolioMix(loans: LoanRisk[]): PortfolioMix[] {
+  const byCcy = new Map<string, LoanRisk[]>()
+  for (const l of loans) byCcy.set(l.currency, [...(byCcy.get(l.currency) ?? []), l])
+  return [...byCcy.entries()].map(([currency, rows]) => {
+    const assessed = rows.filter(r => r.assessment !== null)
+    const stages: StageRow[] = STAGES.map(stage => {
+      const s = assessed.filter(r => r.assessment!.stage === stage)
+      const outstanding = s.reduce((a, r) => a + r.assessment!.outstandingBalance, 0)
+      const ecl = s.reduce((a, r) => a + r.assessment!.expectedCreditLoss, 0)
+      return { stage, count: s.length, outstanding, ecl, coverage: outstanding > 0 ? ecl / outstanding : null }
+    })
+    const buckets = BUCKETS.map(bucket => {
+      const b = assessed.filter(r => r.assessment!.bucket === bucket)
+      return { bucket, count: b.length, outstanding: b.reduce((a, r) => a + r.assessment!.outstandingBalance, 0) }
+    })
+    const totalOutstanding = stages.reduce((a, s) => a + s.outstanding, 0)
+    const totalEcl = stages.reduce((a, s) => a + s.ecl, 0)
+    const s23 = stages.filter(s => s.stage !== 'STAGE_1').reduce((a, s) => a + s.outstanding, 0)
+    const npl = buckets.find(b => b.bucket === 'DPD_90_PLUS')?.outstanding ?? 0
+    return {
+      currency,
+      assessed: assessed.length,
+      unassessed: rows.length - assessed.length,
+      stages,
+      buckets,
+      totalOutstanding,
+      totalEcl,
+      coverage: totalOutstanding > 0 ? totalEcl / totalOutstanding : null,
+      stage23Share: totalOutstanding > 0 ? s23 / totalOutstanding : null,
+      npl90Share: totalOutstanding > 0 ? npl / totalOutstanding : null,
+      modelVersions: [...new Set(assessed.map(r => r.assessment!.modelVersion))].sort(),
+    }
+  }).sort((a, b) => b.totalOutstanding - a.totalOutstanding)
+}
+
+export type VintageRow = { month: string; loans: number; STAGE_1: number; STAGE_2: number; STAGE_3: number; unassessed: number }
+
+/** Disbursement month × current stage. The classic vintage read, on whatever the book holds. */
+export function vintage(loans: LoanRisk[]): VintageRow[] {
+  const m = new Map<string, VintageRow>()
+  for (const l of loans) {
+    const month = l.disbursedAt.slice(0, 7)
+    const row = m.get(month) ?? { month, loans: 0, STAGE_1: 0, STAGE_2: 0, STAGE_3: 0, unassessed: 0 }
+    row.loans += 1
+    const stage = l.assessment?.stage
+    if (stage === 'STAGE_1' || stage === 'STAGE_2' || stage === 'STAGE_3') row[stage] += 1
+    else row.unassessed += 1
+    m.set(month, row)
+  }
+  return [...m.values()].sort((a, b) => a.month.localeCompare(b.month))
+}
+
+const CSV_COLUMNS = [
+  'applicationId', 'partyId', 'status', 'createdAt', 'decidedEngineAt', 'engineOutcome', 'priceBand',
+  'reasons', 'matchedRuleIds', 'policyVersions', 'inputSnapshotHash', 'requestedAmount', 'currency',
+  'termPeriods', 'nominalAnnualRate', 'jurisdiction', 'productType', 'productKind', 'packVersion',
+  'dsti', 'dti', 'dstiIncludingExistingDebt', 'verifiedIncomeMonthly', 'existingDebtServiceMonthly',
+  'ageYears', 'residency', 'employmentTenureMonths', 'humanDecidedBy', 'humanDecisionReason', 'humanDecidedAt',
+] as const
+
+function csvCell(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  const s = typeof v === 'object' ? JSON.stringify(v) : String(v)
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+/** RFC 4180 flat export — one row per decision, reasons re-joined as `CODE:rule;…` for a notebook. */
+export function decisionsToCsv(decisions: Decision[]): string {
+  const rows = decisions.map(d => {
+    const flat: Record<(typeof CSV_COLUMNS)[number], unknown> = {
+      ...d,
+      reasons: d.reasons.map(r => `${r.code}:${r.ruleId ?? '-'}`).join(';'),
+      matchedRuleIds: d.matchedRuleIds.join(';'),
+      policyVersions: Object.entries(d.policyVersions).map(([k, v]) => `${k}=${v}`).join(';'),
+      dsti: d.affordability?.dsti ?? null,
+      dti: d.affordability?.dti ?? null,
+      dstiIncludingExistingDebt: d.affordability?.dstiIncludingExistingDebt ?? null,
+    }
+    return CSV_COLUMNS.map(c => csvCell(flat[c])).join(',')
+  })
+  return [CSV_COLUMNS.join(','), ...rows].join('\r\n') + '\r\n'
+}

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -62,6 +62,9 @@ export const PERMISSIONS = {
   // Lending compliance-pack reads include the operational lending roles accepted by
   // CompliancePackResource.listActive; maker/checker writes remain compliance/admin only.
   "lending:compliance:view":    [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER],
+  // Credit-risk console (ADR-0230 D1): the same set CreditRiskResource admits — the desk that may
+  // read the ADR-0214 evidence bundle, and nobody wider (it exposes every applicant's income).
+  "lending:risk:view":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER],
   "lending:compliance:propose": [ROLES.ADMIN, ROLES.COMPLIANCE],
   "lending:compliance:decide":  [ROLES.ADMIN, ROLES.COMPLIANCE],
   // Campaign-service audience endpoints use campaign.read for catalogue/preview, while
@@ -265,6 +268,7 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['campaign:view', ['/campaigns']],
   ['campaign:create', ['/campaigns/new']],
   ['lending:compliance:view', ['/lending/compliance-packs']],
+  ['lending:risk:view', ['/lending/risk']],
   ['approvals:view', ['/approvals']],
   ['system:view', [
     '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',

--- a/openbank-admin-ui/src/test/lending-risk-model.test.ts
+++ b/openbank-admin-ui/src/test/lending-risk-model.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  type Decision, type LoanRisk, type Policy,
+  byJurisdiction, decisionsToCsv, disposition, outcomeTotals, overrideMatrix, overrideRate,
+  portfolioMix, priceBandTotals, reasonPareto, ruleHits, threshold, vintage, weeklyOutcomes,
+} from '@/components/lending/risk/model'
+
+function decision(over: Partial<Decision> = {}): Decision {
+  return {
+    applicationId: 'a1', partyId: 'p1', status: 'FOUR_EYES', createdAt: '2026-09-01T10:00:00Z',
+    requestedAmount: 120000, currency: 'CZK', termPeriods: 12, nominalAnnualRate: 0.08,
+    jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', productKind: 'UNSECURED', packVersion: 1,
+    engineOutcome: 'APPROVE', priceBand: 'PRIME', reasons: [], matchedRuleIds: [],
+    policyVersions: { AFFORDABILITY: 1 }, inputSnapshotHash: 'h', decidedEngineAt: '2026-09-01T10:00:05Z',
+    affordability: { dsti: 0.17, dti: 2, dstiIncludingExistingDebt: 0.27 },
+    verifiedIncomeMonthly: 60000, existingDebtServiceMonthly: 6000, ageYears: 35, residency: 'CZ',
+    employmentTenureMonths: 48, humanDecidedBy: null, humanDecisionReason: null, humanDecidedAt: null,
+    ...over,
+  }
+}
+
+function loan(over: Partial<LoanRisk> = {}): LoanRisk {
+  return {
+    loanId: 'l1', applicationId: 'a1', partyId: 'p1', status: 'ACTIVE', principal: 100000,
+    currency: 'CZK', nominalAnnualRate: 0.08, termPeriods: 12, disbursedAt: '2026-07-15T00:00:00Z',
+    assessment: null, ...over,
+  }
+}
+
+const assessment = (stage: string, bucket: string, outstanding: number, ecl: number) => ({
+  period: '2026-08', asOf: '2026-08-31', outstandingBalance: outstanding, daysPastDue: 0,
+  bucket, stage, expectedCreditLoss: ecl, modelVersion: 'noop-flat-v1',
+})
+
+describe('credit-risk aggregation', () => {
+  it('takes book totals from the DB summary, not from the capped list', () => {
+    const totals = outcomeTotals([
+      { engineOutcome: 'APPROVE', priceBand: 'PRIME', count: 40 },
+      { engineOutcome: 'APPROVE', priceBand: 'STANDARD', count: 25 },
+      { engineOutcome: 'REFER', priceBand: null, count: 30 },
+      { engineOutcome: 'DECLINE', priceBand: null, count: 5 },
+    ])
+    expect(totals).toMatchObject({ APPROVE: 65, REFER: 30, DECLINE: 5, total: 100 })
+    expect(priceBandTotals([
+      { engineOutcome: 'APPROVE', priceBand: 'STANDARD', count: 25 },
+      { engineOutcome: 'APPROVE', priceBand: 'PRIME', count: 40 },
+      { engineOutcome: 'REFER', priceBand: 'PRIME', count: 9 },
+    ])).toEqual([{ band: 'PRIME', count: 40 }, { band: 'STANDARD', count: 25 }])
+  })
+
+  it('counts an override only where the human went the OTHER way', () => {
+    const rows = [
+      decision({ applicationId: '1', engineOutcome: 'APPROVE', status: 'DISBURSED' }),
+      decision({ applicationId: '2', engineOutcome: 'APPROVE', status: 'DECLINED' }),
+      decision({ applicationId: '3', engineOutcome: 'DECLINE', status: 'DECLINED' }),
+      decision({ applicationId: '4', engineOutcome: 'DECLINE', status: 'OFFERED' }),
+      decision({ applicationId: '5', engineOutcome: 'REFER', status: 'FOUR_EYES' }),
+      decision({ applicationId: '6', engineOutcome: 'APPROVE', status: 'EXPIRED' }),
+    ]
+    const matrix = overrideMatrix(rows)
+    const approve = matrix.find(r => r.engine === 'APPROVE')!
+    expect(approve).toMatchObject({ approved: 1, declined: 1, lapsed: 1, overridden: 1 })
+    expect(matrix.find(r => r.engine === 'DECLINE')!.overridden).toBe(1)
+    // Denominator is disposed decisions only: 4 (two approved, two declined), not all six.
+    expect(overrideRate(matrix)).toBeCloseTo(2 / 4, 10)
+    // A book where nothing has been disposed of has no rate — never a confident zero.
+    expect(overrideRate(overrideMatrix([decision({ status: 'FOUR_EYES' })]))).toBeNull()
+    expect(disposition('REFLECTION_PERIOD')).toBe('approved')
+    expect(disposition('KYC_PENDING')).toBe('inFlight')
+  })
+
+  it('reads thresholds from the policy payload rather than hard-coding them', () => {
+    const policy: Policy = {
+      asOf: '2026-09-05', source: 'StarterCreditPolicy', codeSeeded: true,
+      tables: [
+        { kind: 'AFFORDABILITY', name: 'old', version: 1, effectiveFrom: '2020-01-01', effectiveTo: '2026-01-01', rules: [{ id: 'o', attribute: 'DSTI', operator: 'LTE', threshold: 0.6, values: [], band: null, detail: '' }] },
+        { kind: 'AFFORDABILITY', name: 'new', version: 2, effectiveFrom: '2026-01-01', effectiveTo: null, rules: [{ id: 'n', attribute: 'DSTI', operator: 'LTE', threshold: 0.45, values: [], band: null, detail: '' }] },
+        { kind: 'ELIGIBILITY', name: 'e', version: 1, effectiveFrom: '2020-01-01', effectiveTo: null, rules: [{ id: 'r', attribute: 'RESIDENCY', operator: 'IN', threshold: null, values: ['CZ'], band: null, detail: '' }] },
+      ],
+    }
+    expect(threshold(policy, 'AFFORDABILITY', 'DSTI')).toBe(0.45)
+    // No numeric threshold and no policy at all both yield null — the chart then draws no line.
+    expect(threshold(policy, 'ELIGIBILITY', 'RESIDENCY')).toBeNull()
+    expect(threshold(policy, 'AFFORDABILITY', 'LTV')).toBeNull()
+    expect(threshold(null, 'AFFORDABILITY', 'DSTI')).toBeNull()
+  })
+
+  it('paretoes reasons by code AND rule, and counts rule hits', () => {
+    const rows = [
+      decision({ reasons: [{ code: 'AFFORDABILITY_FAILED', ruleId: 'af-dsti' }], matchedRuleIds: ['el-age'] }),
+      decision({ reasons: [{ code: 'AFFORDABILITY_FAILED', ruleId: 'af-dsti' }, { code: 'INPUT_MISSING', ruleId: null }], matchedRuleIds: ['el-age', 'af-dti'] }),
+    ]
+    expect(reasonPareto(rows)[0]).toEqual({ code: 'AFFORDABILITY_FAILED', ruleId: 'af-dsti', count: 2 })
+    expect(ruleHits(rows).get('el-age')).toBe(2)
+    expect(ruleHits(rows).get('af-dti')).toBe(1)
+    expect(ruleHits(rows).get('never-fires')).toBeUndefined()
+  })
+
+  it('keeps currencies apart and never sums CZK with EUR', () => {
+    const mixes = portfolioMix([
+      loan({ loanId: 'a', currency: 'CZK', assessment: assessment('STAGE_1', 'CURRENT', 100000, 3000) }),
+      loan({ loanId: 'b', currency: 'CZK', assessment: assessment('STAGE_3', 'DPD_90_PLUS', 100000, 45000) }),
+      loan({ loanId: 'c', currency: 'EUR', assessment: assessment('STAGE_1', 'CURRENT', 5000, 150) }),
+      loan({ loanId: 'd', currency: 'CZK', assessment: null }),
+    ])
+    expect(mixes.map(m => m.currency)).toEqual(['CZK', 'EUR'])
+    const czk = mixes[0]
+    expect(czk.totalOutstanding).toBe(200000)
+    expect(czk.coverage).toBeCloseTo(48000 / 200000, 10)
+    expect(czk.stage23Share).toBeCloseTo(0.5, 10)
+    expect(czk.npl90Share).toBeCloseTo(0.5, 10)
+    // An unassessed loan is counted as unassessed, never as Stage 1 with zero ECL.
+    expect(czk.unassessed).toBe(1)
+    expect(czk.stages.find(s => s.stage === 'STAGE_1')!.count).toBe(1)
+    expect(czk.modelVersions).toEqual(['noop-flat-v1'])
+  })
+
+  it('an empty or wholly unassessed book yields null ratios, not zeroes', () => {
+    const [mix] = portfolioMix([loan({ assessment: null })])
+    expect(mix.coverage).toBeNull()
+    expect(mix.stage23Share).toBeNull()
+    expect(mix.npl90Share).toBeNull()
+    expect(portfolioMix([])).toEqual([])
+  })
+
+  it('buckets vintages by disbursement month and keeps unassessed loans visible', () => {
+    const rows = vintage([
+      loan({ loanId: 'a', disbursedAt: '2026-07-15T00:00:00Z', assessment: assessment('STAGE_1', 'CURRENT', 1, 0) }),
+      loan({ loanId: 'b', disbursedAt: '2026-07-20T00:00:00Z', assessment: assessment('STAGE_3', 'DPD_90_PLUS', 1, 1) }),
+      loan({ loanId: 'c', disbursedAt: '2026-08-02T00:00:00Z', assessment: null }),
+    ])
+    expect(rows.map(r => r.month)).toEqual(['2026-07', '2026-08'])
+    expect(rows[0]).toMatchObject({ loans: 2, STAGE_1: 1, STAGE_3: 1, unassessed: 0 })
+    expect(rows[1]).toMatchObject({ loans: 1, unassessed: 1 })
+  })
+
+  it('groups weeks from the engine timestamp and jurisdictions from the row', () => {
+    const rows = [
+      decision({ applicationId: '1', decidedEngineAt: '2026-09-01T10:00:00Z', engineOutcome: 'APPROVE' }),
+      decision({ applicationId: '2', decidedEngineAt: '2026-09-06T10:00:00Z', engineOutcome: 'REFER' }),
+      decision({ applicationId: '3', decidedEngineAt: '2026-09-07T10:00:00Z', engineOutcome: 'DECLINE', jurisdiction: 'DE' }),
+    ]
+    const weeks = weeklyOutcomes(rows)
+    expect(weeks.map(w => w.week)).toEqual(['2026-08-31', '2026-09-07'])
+    expect(weeks[0]).toMatchObject({ APPROVE: 1, REFER: 1 })
+    expect(byJurisdiction(rows)).toEqual([
+      { jurisdiction: 'CZ', APPROVE: 1, REFER: 1, DECLINE: 0, total: 2 },
+      { jurisdiction: 'DE', APPROVE: 0, REFER: 0, DECLINE: 1, total: 1 },
+    ])
+  })
+
+  it('exports notebook-ready CSV with evidence intact and separators escaped', () => {
+    const csv = decisionsToCsv([decision({
+      reasons: [{ code: 'AFFORDABILITY_FAILED', ruleId: 'af-dsti' }, { code: 'INPUT_MISSING', ruleId: null }],
+      matchedRuleIds: ['el-age', 'af-dti'],
+      policyVersions: { ELIGIBILITY: 1, AFFORDABILITY: 2 },
+      humanDecisionReason: 'refused, "policy" says no\nsecond line',
+    })])
+    const [header, row] = csv.split('\r\n')
+    expect(header.split(',')).toContain('dstiIncludingExistingDebt')
+    expect(row).toContain('AFFORDABILITY_FAILED:af-dsti;INPUT_MISSING:-')
+    expect(row).toContain('el-age;af-dti')
+    expect(row).toContain('ELIGIBILITY=1;AFFORDABILITY=2')
+    // A comma, a quote and a newline inside a field must not break the row structure.
+    expect(row).toContain('"refused, ""policy"" says no\nsecond line"')
+    expect(csv.endsWith('\r\n')).toBe(true)
+    // Missing affordability exports as empty, never as 0.
+    expect(decisionsToCsv([decision({ affordability: null })]).split('\r\n')[1]).toContain(',,,')
+  })
+})

--- a/openbank-admin-ui/src/test/lending-risk-page.test.tsx
+++ b/openbank-admin-ui/src/test/lending-risk-page.test.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { roles: ['ROLE_CREDIT_RISK'] } }, status: 'authenticated' }),
+  signIn: vi.fn(),
+}))
+
+vi.mock('recharts', () => {
+  const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  const Nil = () => null
+  return {
+    ResponsiveContainer: Pass, BarChart: Pass, Bar: Pass, ScatterChart: Pass, Scatter: Nil,
+    PieChart: Pass, Pie: Pass, XAxis: Nil, YAxis: Nil, ZAxis: Nil, CartesianGrid: Nil,
+    Tooltip: Nil, Legend: Nil, Cell: Nil, ReferenceLine: Nil,
+  }
+})
+
+import CreditRiskPage from '@/app/lending/risk/page'
+
+const POLICY = {
+  asOf: '2026-09-05', source: 'StarterCreditPolicy', codeSeeded: true,
+  tables: [{
+    kind: 'AFFORDABILITY', name: 'starter-affordability', version: 1, effectiveFrom: '1970-01-01', effectiveTo: null,
+    rules: [{ id: 'starter-af-dsti', attribute: 'DSTI', operator: 'LTE', threshold: 0.45, values: [], band: null, detail: 'debt service to income above 45%' }],
+  }],
+}
+
+const DECISION = {
+  applicationId: 'app-1', partyId: 'party-1', status: 'FOUR_EYES', createdAt: '2026-09-01T10:00:00Z',
+  requestedAmount: 120000, currency: 'CZK', termPeriods: 12, nominalAnnualRate: 0.08,
+  jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', productKind: 'UNSECURED', packVersion: 1,
+  engineOutcome: 'APPROVE', priceBand: 'PRIME', reasons: [], matchedRuleIds: ['starter-af-dsti'],
+  policyVersions: { AFFORDABILITY: 1 }, inputSnapshotHash: 'h1', decidedEngineAt: '2026-09-01T10:00:05Z',
+  affordability: { dsti: 0.17, dti: 2, dstiIncludingExistingDebt: 0.27 },
+  verifiedIncomeMonthly: 60000, existingDebtServiceMonthly: 6000, ageYears: 35, residency: 'CZ',
+  employmentTenureMonths: 48, humanDecidedBy: null, humanDecisionReason: null, humanDecidedAt: null,
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+function route(url: string) {
+  if (url.includes('/risk/decisions/summary')) return json([{ engineOutcome: 'APPROVE', priceBand: 'PRIME', count: 300 }, { engineOutcome: 'REFER', priceBand: null, count: 100 }])
+  if (url.includes('/risk/decisions')) return json([DECISION])
+  if (url.includes('/risk/portfolio')) return json([])
+  if (url.includes('/risk/policy')) return json(POLICY)
+  return json([], 404)
+}
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(async (u: string) => route(String(u)))) })
+
+const tiles = () => Array.from(document.querySelectorAll('.stat-value')).map(n => n.textContent ?? '')
+
+describe('credit-risk console', () => {
+  it('reports the approve rate from the DB summary, not from the capped list', async () => {
+    render(<LanguageProvider><CreditRiskPage /></LanguageProvider>)
+    // 300 of 400 book-wide = 75%. The loaded list holds ONE row; a page deriving from it would say 100%.
+    await waitFor(() => expect(tiles().join(' ')).toMatch(/75/))
+    expect(tiles().join(' ')).not.toMatch(/\b100 %/)
+  })
+
+  it('states the policy provenance and the placeholder caveats', async () => {
+    render(<LanguageProvider><CreditRiskPage /></LanguageProvider>)
+    await waitFor(() => expect(screen.getByText(/code-seeded/i)).toBeInTheDocument())
+    expect(screen.getByText(/Bureau port is a no-op/i)).toBeInTheDocument()
+    expect(screen.getByText(/PD\/LGD are placeholder constants/i)).toBeInTheDocument()
+  })
+
+  it('takes the DSTI threshold from the policy response rather than a constant', async () => {
+    render(<LanguageProvider><CreditRiskPage /></LanguageProvider>)
+    await waitFor(() => expect(screen.getByText(/DSTI ≤ 0\.45/)).toBeInTheDocument())
+  })
+
+  it('does not claim a zero book while the endpoints are failing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'down' }, 503)))
+    render(<LanguageProvider><CreditRiskPage /></LanguageProvider>)
+    await waitFor(() => expect(screen.getByText(/did not answer/i)).toBeInTheDocument())
+    expect(tiles()).not.toContain('0')
+    expect(tiles().filter(v => v === '—').length).toBeGreaterThan(0)
+  })
+})

--- a/openbank-admin-ui/src/test/lending-risk-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-risk-rbac.guard.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(__dirname, '..')
+const page = readFileSync(resolve(root, 'app/lending/risk/page.tsx'), 'utf8')
+const roles = readFileSync(resolve(root, 'lib/auth/roles.ts'), 'utf8')
+const sidebar = readFileSync(resolve(root, 'components/layout/Sidebar.tsx'), 'utf8')
+const resource = readFileSync(
+  resolve(root, '../../openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditRiskResource.kt'),
+  'utf8',
+)
+
+describe('credit-risk console permissions mirror the service roles', () => {
+  it('gates the page and the nav entry on lending:risk:view', () => {
+    expect(roles).toContain('"lending:risk:view":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER]')
+    expect(roles).toContain("['lending:risk:view', ['/lending/risk']]")
+    expect(page).toContain('<AuthGuard permission="lending:risk:view">')
+    expect(sidebar).toContain("href: '/lending/risk'")
+    expect(sidebar).toContain("permission: 'lending:risk:view'")
+  })
+
+  it('grants the UI exactly the roles CreditRiskResource admits — no wider', () => {
+    const declared = /@RolesAllowed\(([^)]*)\)/.exec(resource)?.[1] ?? ''
+    const serviceRoles = [...declared.matchAll(/"(ROLE_[A-Z_]+)"/g)].map(m => m[1]).sort()
+    expect(serviceRoles).toEqual(['ROLE_ADMIN', 'ROLE_COMPLIANCE', 'ROLE_CREDIT_RISK', 'ROLE_LENDING_OFFICER'])
+    const uiLine = /"lending:risk:view":\s*\[([^\]]*)\]/.exec(roles)?.[1] ?? ''
+    const uiRoles = [...uiLine.matchAll(/ROLES\.([A-Z_]+)/g)]
+      .map(m => `ROLE_${m[1]}`)
+      .sort()
+    expect(uiRoles).toEqual(serviceRoles)
+  })
+
+  it('stays read-only: no mutating call from the console', () => {
+    expect(page).not.toMatch(/method:\s*'(POST|PUT|PATCH|DELETE)'/)
+    expect(page).toContain('ADR-0227')
+  })
+})

--- a/openbank-lending-service/CLAUDE.md
+++ b/openbank-lending-service/CLAUDE.md
@@ -64,3 +64,25 @@
   entry from `check-source-service-convention.py`'s `BASELINE` is the visible act that reopens it;
   the entry pins the `(module, value)` pair, so drifting to some third spelling fails the gate
   today regardless.
+
+- **The engine's DSTI is NOT the CNB definition, and both numbers now exist.**
+  `OriginationDecisionService.affordabilityRatios` is the single definition of the affordability
+  ratios — the ASSESSMENT leg reads it, and so does the credit-risk read side, so a console figure
+  and an engine figure cannot diverge. It returns three numbers: `dsti` (new installment over
+  verified income, what `PolicyAttribute.DSTI` carries into the affordability table),
+  `dti`, and `dstiIncludingExistingDebt` (adds `existingDebtServiceMonthly`, the CNB/EBA
+  total-debt-service definition). **Only the first two reach the engine.** `existingDebtServiceMonthly`
+  is collected at intake and persisted, and no starter rule tests it, so an applicant already
+  servicing debt meets the `DSTI ≤ 0.45` floor with headroom the bank does not see. Deliberate:
+  moving the floor to total debt service tightens credit and is a policy decision under ADR-0213 D4,
+  not a refactor. Whether to take it is #8894. Do not "fix" it by editing the ratio — the read side
+  would silently start disagreeing with the decisions already pinned in the evidence chain.
+
+- **The engine cannot DECLINE for adverse bureau data — the port is a no-op.** `CreditBureauPort`'s
+  default binding returns no adverse flag, so `CUSTOMER_TYPE` is `STANDARD` for every applicant and
+  `starter-ex-adverse` (the only EXCLUSION rule) can never match. A decline rate near zero is a
+  statement about the missing feed, not about the applicants. The credit-risk console says so on the
+  page, and its per-rule hit count shows the rule at zero. Same shape as the PD/LGD placeholders:
+  `RiskParameterSource`'s no-op returns flat constants and stamps `model_version` on every
+  provisioning row, which is why an ECL figure must always be quoted with that version.
+

--- a/openbank-lending-service/ktlint-baseline.xml
+++ b/openbank-lending-service/ktlint-baseline.xml
@@ -3,6 +3,9 @@
     <file name="src/main/kotlin/com/openbank/lending/application/port/in/LendingUseCases.kt">
         <error line="5" column="9" source="standard:package-name" />
     </file>
+    <file name="src/main/kotlin/com/openbank/lending/application/port/in/CreditRiskInsightUseCase.kt">
+        <error line="5" column="9" source="standard:package-name" />
+    </file>
     <file name="src/main/kotlin/com/openbank/lending/application/port/in/TerminateLoanUseCase.kt">
         <error line="5" column="9" source="standard:package-name" />
     </file>

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/CreditRiskInsightUseCase.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/CreditRiskInsightUseCase.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.application.port.`in`
+
+import com.openbank.lending.domain.model.CreditDecisionView
+import com.openbank.lending.domain.model.CreditPolicyView
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
+import com.openbank.lending.domain.model.LoanRiskView
+import io.smallrye.mutiny.Uni
+import java.time.LocalDate
+
+/**
+ * Read-only credit-risk insight (ADR-0230 D1): what the ADR-0213 engine decided, against which
+ * policy, and how the book is staged under IFRS 9. No mutation lives here — every credit
+ * disposition stays in the four-eyes paths of [ApplyForLoanUseCase] and the approval inbox.
+ */
+interface CreditRiskInsightUseCase {
+    /** Engine-evaluated applications, newest evaluation first. [limit] is clamped server-side. */
+    fun decisions(limit: Int): Uni<List<CreditDecisionView>>
+
+    /** Book-wide outcome × price-band totals — the figure a capped list cannot give. */
+    fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>>
+
+    /** Every loan with its latest provisioning record (null where never assessed). [limit] clamped. */
+    fun portfolio(limit: Int): Uni<List<LoanRiskView>>
+
+    /** The bundle the engine evaluates as of [asOf], flagged when it is the code-seeded starter. */
+    fun activePolicy(asOf: LocalDate): Uni<CreditPolicyView>
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
@@ -6,6 +6,7 @@ package com.openbank.lending.application.port.out
 
 import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.domain.model.LoanInstallment
@@ -33,6 +34,12 @@ interface LoanApplicationRepository {
      * pages to add up rows would be the same wrong answer, slower.
      */
     fun summariseByState(): Uni<List<ApplicationStateSummary>>
+
+    /** Applications the ADR-0213 engine has evaluated (`decidedEngineAt` set), newest evaluation first. */
+    fun findEvaluated(limit: Int): Uni<List<LoanApplication>>
+
+    /** Book-wide engine outcome × price-band totals, grouped in the database (credit-risk console). */
+    fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>>
 
     /**
      * Blind write of the decision fields. Correct only where the caller is not deciding anything
@@ -71,6 +78,9 @@ interface LoanRepository {
     /** Per-status totals across the whole loan book (issue #3294). See the note on
      *  [LoanApplicationRepository.summariseByState]. */
     fun summariseByState(): Uni<List<LoanStateSummary>>
+
+    /** Every loan regardless of status, newest disbursement first. Capped by the caller. */
+    fun findRecent(limit: Int): Uni<List<Loan>>
 }
 
 interface InstallmentRepository {
@@ -113,4 +123,7 @@ interface ProvisioningRepository {
     fun findByLoanAndPeriod(loanId: LoanId, period: String): Uni<LoanProvisioningRecord?>
 
     fun save(record: LoanProvisioningRecord): Uni<LoanProvisioningRecord>
+
+    /** The latest persisted record per loan — one row per loan that has ever been assessed. */
+    fun findLatestPerLoan(): Uni<List<LoanProvisioningRecord>>
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
@@ -56,6 +56,25 @@ interface LoanApplicationRepository {
      * The caller must treat `0` as a refusal and must not perform any side effect of the transition
      * — no evidence event, no workflow signal (issue #3850).
      */
+    /**
+     * The ASSESSMENT leg's claim: the same conditional transition as [compareAndSetStatus], plus the
+     * ADR-0213 engine evidence the evaluation produced (outcome, price band, reason codes, matched
+     * rules, pinned table versions, input snapshot hash, evaluation timestamp).
+     *
+     * It exists because [compareAndSetStatus] writes **only** status and the three human decision
+     * fields, so every engine output was computed, returned in the response, emitted as evidence —
+     * and never stored. The columns have existed since `V11__decision_engine_inputs.sql`; nothing
+     * wrote them, so `decision_outcome` was NULL on every row and a reader (the credit-risk console,
+     * a regulator's reconstruction) had only the outbox event to go on.
+     *
+     * Returns rows claimed, `0` meaning another actor moved the row on first — same contract, same
+     * caller obligation: no evidence event and no workflow signal on a refusal (issue #3850).
+     */
+    fun compareAndSetDecision(
+        application: LoanApplication,
+        from: OriginationState,
+    ): Uni<Int>
+
     fun compareAndSetStatus(
         id: LoanApplicationId,
         from: OriginationState,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
@@ -35,12 +35,6 @@ interface LoanApplicationRepository {
      */
     fun summariseByState(): Uni<List<ApplicationStateSummary>>
 
-    /** Applications the ADR-0213 engine has evaluated (`decidedEngineAt` set), newest evaluation first. */
-    fun findEvaluated(limit: Int): Uni<List<LoanApplication>>
-
-    /** Book-wide engine outcome × price-band totals, grouped in the database (credit-risk console). */
-    fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>>
-
     /**
      * Blind write of the decision fields. Correct only where the caller is not deciding anything
      * from the value it is overwriting — [compareAndSetStatus] is what an origination transition
@@ -70,10 +64,7 @@ interface LoanApplicationRepository {
      * Returns rows claimed, `0` meaning another actor moved the row on first — same contract, same
      * caller obligation: no evidence event and no workflow signal on a refusal (issue #3850).
      */
-    fun compareAndSetDecision(
-        application: LoanApplication,
-        from: OriginationState,
-    ): Uni<Int>
+    fun compareAndSetDecision(application: LoanApplication, from: OriginationState): Uni<Int>
 
     fun compareAndSetStatus(
         id: LoanApplicationId,
@@ -83,6 +74,22 @@ interface LoanApplicationRepository {
         decisionReason: String?,
         decidedAt: OffsetDateTime?,
     ): Uni<Int>
+}
+
+/**
+ * The credit-risk READ side over applications the ADR-0213 engine has already decided.
+ *
+ * Separate from [LoanApplicationRepository] on purpose: that port is the origination write path
+ * (save, claim a transition, four-eyes decide) and these are reporting queries with no bearing on
+ * an application's lifecycle. Splitting them keeps a reader from acquiring the write surface as a
+ * dependency, and keeps each implementation a coherent size.
+ */
+interface CreditDecisionQueryRepository {
+    /** Applications the engine has evaluated (`decidedEngineAt` set), newest evaluation first. */
+    fun findEvaluated(limit: Int): Uni<List<LoanApplication>>
+
+    /** Book-wide engine outcome × price-band totals, grouped in the database. */
+    fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>>
 }
 
 interface LoanRepository {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightService.kt
@@ -5,8 +5,8 @@
 package com.openbank.lending.application.usecase
 
 import com.openbank.lending.application.port.`in`.CreditRiskInsightUseCase
+import com.openbank.lending.application.port.out.CreditDecisionQueryRepository
 import com.openbank.lending.application.port.out.CreditPolicyPort
-import com.openbank.lending.application.port.out.LoanApplicationRepository
 import com.openbank.lending.application.port.out.LoanRepository
 import com.openbank.lending.application.port.out.ProvisioningRepository
 import com.openbank.lending.application.port.out.StarterCreditPolicy
@@ -32,16 +32,16 @@ import java.time.LocalDate
  */
 @ApplicationScoped
 class CreditRiskInsightService(
-    private val applications: LoanApplicationRepository,
+    private val decisions: CreditDecisionQueryRepository,
     private val loans: LoanRepository,
     private val provisioning: ProvisioningRepository,
     private val creditPolicy: CreditPolicyPort,
 ) : CreditRiskInsightUseCase {
 
     override fun decisions(limit: Int): Uni<List<CreditDecisionView>> =
-        applications.findEvaluated(limit.coerceIn(1, MAX_LIMIT)).map { rows -> rows.map(::toView) }
+        decisions.findEvaluated(limit.coerceIn(1, MAX_LIMIT)).map { rows -> rows.map(::toView) }
 
-    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = applications.summariseDecisions()
+    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = decisions.summariseDecisions()
 
     override fun portfolio(limit: Int): Uni<List<LoanRiskView>> =
         loans.findRecent(limit.coerceIn(1, MAX_LIMIT)).flatMap { book ->

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightService.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.application.usecase
+
+import com.openbank.lending.application.port.`in`.CreditRiskInsightUseCase
+import com.openbank.lending.application.port.out.CreditPolicyPort
+import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.application.port.out.ProvisioningRepository
+import com.openbank.lending.application.port.out.StarterCreditPolicy
+import com.openbank.lending.domain.model.CreditDecisionView
+import com.openbank.lending.domain.model.CreditPolicyView
+import com.openbank.lending.domain.model.DecisionEvidenceCodec
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
+import com.openbank.lending.domain.model.Loan
+import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.domain.model.LoanProvisioningRecord
+import com.openbank.lending.domain.model.LoanRiskAssessmentView
+import com.openbank.lending.domain.model.LoanRiskView
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.LocalDate
+
+/**
+ * The credit-risk read side (ADR-0230 D1). Composes what the origination and servicing paths
+ * already persist — the pinned ADR-0213 evidence on `loan_application`, the ADR-0028 Phase 3
+ * rows in `loan_provisioning` — into the views the console and a notebook consume. Nothing here
+ * computes a decision, an ECL or a stage: those numbers are read back from the records the
+ * governed paths wrote, so the console can never disagree with the evidence chain.
+ */
+@ApplicationScoped
+class CreditRiskInsightService(
+    private val applications: LoanApplicationRepository,
+    private val loans: LoanRepository,
+    private val provisioning: ProvisioningRepository,
+    private val creditPolicy: CreditPolicyPort,
+) : CreditRiskInsightUseCase {
+
+    override fun decisions(limit: Int): Uni<List<CreditDecisionView>> =
+        applications.findEvaluated(limit.coerceIn(1, MAX_LIMIT)).map { rows -> rows.map(::toView) }
+
+    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = applications.summariseDecisions()
+
+    override fun portfolio(limit: Int): Uni<List<LoanRiskView>> =
+        loans.findRecent(limit.coerceIn(1, MAX_LIMIT)).flatMap { book ->
+            provisioning.findLatestPerLoan().map { latest ->
+                val byLoan = latest.associateBy { it.loanId }
+                book.map { loan -> toView(loan, byLoan[loan.id]) }
+            }
+        }
+
+    override fun activePolicy(asOf: LocalDate): Uni<CreditPolicyView> = creditPolicy.activeBundle(asOf).map { bundle ->
+        CreditPolicyView(
+            asOf = asOf,
+            source = policySource(),
+            codeSeeded = creditPolicy is StarterCreditPolicy,
+            tables = bundle.tables,
+        )
+    }
+
+    /** The binding's own class name, with the CDI proxy/subclass suffixes stripped. */
+    private fun policySource(): String =
+        creditPolicy::class.java.simpleName.removeSuffix("_ClientProxy").removeSuffix("_Subclass")
+
+    private fun toView(a: LoanApplication): CreditDecisionView = CreditDecisionView(
+        applicationId = a.id.value,
+        partyId = a.partyId,
+        status = a.status.name,
+        createdAt = a.createdAt,
+        requestedAmount = a.requestedAmount.amount,
+        currency = a.requestedAmount.currency.code,
+        termPeriods = a.termPeriods,
+        nominalAnnualRate = a.nominalAnnualRate,
+        jurisdiction = a.jurisdiction,
+        productType = a.productType,
+        productKind = a.productKind.name,
+        packVersion = a.packVersion,
+        engineOutcome = a.decisionOutcome ?: UNEVALUATED,
+        priceBand = a.decisionPriceBand,
+        reasons = DecisionEvidenceCodec.reasons(a.decisionReasons),
+        matchedRuleIds = DecisionEvidenceCodec.matchedRuleIds(a.decisionMatchedRules),
+        policyVersions = DecisionEvidenceCodec.policyVersions(a.policyVersions),
+        inputSnapshotHash = a.decisionInputHash,
+        decidedEngineAt = a.decidedEngineAt,
+        affordability = OriginationDecisionService.affordabilityRatios(a),
+        verifiedIncomeMonthly = a.verifiedIncomeMonthly?.amount,
+        existingDebtServiceMonthly = a.existingDebtServiceMonthly?.amount,
+        ageYears = a.ageYears,
+        residency = a.residency,
+        employmentTenureMonths = a.employmentTenureMonths,
+        humanDecidedBy = a.decidedBy,
+        humanDecisionReason = a.decisionReason,
+        humanDecidedAt = a.decidedAt,
+    )
+
+    private fun toView(loan: Loan, latest: LoanProvisioningRecord?): LoanRiskView = LoanRiskView(
+        loanId = loan.id.value,
+        applicationId = loan.applicationId.value,
+        partyId = loan.partyId,
+        status = loan.status.name,
+        principal = loan.principal.amount,
+        currency = loan.principal.currency.code,
+        nominalAnnualRate = loan.nominalAnnualRate,
+        termPeriods = loan.termPeriods,
+        disbursedAt = loan.disbursedAt,
+        assessment = latest?.let { r ->
+            LoanRiskAssessmentView(
+                period = r.period,
+                asOf = r.asOf,
+                outstandingBalance = r.outstandingBalance.amount,
+                daysPastDue = r.daysPastDue,
+                bucket = r.bucket.name,
+                stage = r.stage.name,
+                expectedCreditLoss = r.expectedCreditLoss.amount,
+                modelVersion = r.modelVersion,
+            )
+        },
+    )
+
+    companion object {
+        /** Upper bound on one read; a notebook wanting more pages by `limit` is the wrong tool — use the warehouse. */
+        const val MAX_LIMIT = 1000
+
+        /** Never expected from `findEvaluated` (it filters on the engine timestamp); kept total, not a `!!`. */
+        const val UNEVALUATED = "UNEVALUATED"
+    }
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -142,7 +142,7 @@ class LendingService @Inject constructor(
             is OriginationTransitionResult.Rejected ->
                 Uni.createFrom().failure(IllegalStateException(result.reason))
             is OriginationTransitionResult.Applied ->
-                claimTransition(existing.status, outcome.recorded.copy(status = result.newState))
+                claimDecision(existing.status, outcome.recorded.copy(status = result.newState))
                     .signalWorkflow()
                     .call { _ -> events.emit(outcome.evidence) }
         }
@@ -167,13 +167,11 @@ class LendingService @Inject constructor(
      * resource already maps (422 on advance, 409 on decide). Nothing downstream of a refusal runs:
      * no evidence event, no workflow signal (issue #3850).
      *
-     * On success the claimed application is returned from memory. `update` returned the re-read
-     * entity, which differs in one respect worth naming: `update` writes only status and the three
-     * decision fields, so the ASSESSMENT leg's engine outputs (`decisionOutcome`, price band, reason
-     * codes, input hash) were never persisted and the re-read blanked them out of the response. That
-     * persistence gap is pre-existing and is NOT fixed here — it needs its own change and its own
-     * test. What changes is only that the response now carries the values the engine computed
-     * instead of nulls.
+     * On success the claimed application is returned from memory.
+     *
+     * This overload writes status and the three HUMAN decision fields only. The ASSESSMENT leg's
+     * engine outputs go through [claimDecision], which writes them in the same statement — see the
+     * note there for why they were previously computed and thrown away.
      */
     private fun claimTransition(from: OriginationState, updated: LoanApplication): Uni<LoanApplication> =
         applications.compareAndSetStatus(
@@ -184,6 +182,34 @@ class LendingService @Inject constructor(
             updated.decisionReason,
             updated.decidedAt,
         ).flatMap { claimed ->
+            if (claimed == 0) {
+                Uni.createFrom().failure(
+                    IllegalStateException(
+                        "Concurrent modification: application ${updated.id} is no longer in $from",
+                    ),
+                )
+            } else {
+                Uni.createFrom().item(updated)
+            }
+        }
+
+    /**
+     * The ASSESSMENT claim: the transition AND the ADR-0213 evidence, in one conditional statement.
+     *
+     * Until this existed the engine's outputs were computed, returned in the response and emitted as
+     * a `credit.decision.evaluated` event — and never stored, because the claim wrote only status and
+     * the three human decision fields. So `decision_outcome` was NULL on every row the engine had
+     * decided, and anything reading the application back (the credit-risk console, a per-loan
+     * reconstruction) saw an application with no decision on it. The columns had been there since
+     * `V11__decision_engine_inputs.sql`. Measured by `CreditRiskConsoleIT`, which drives a real
+     * application through ASSESSMENT and then reads it back over HTTP: before this change the read
+     * returned an empty list.
+     *
+     * Writing them in the SAME statement as the transition is deliberate — two statements could leave
+     * a row in DECISION_PENDING with no decision behind it.
+     */
+    private fun claimDecision(from: OriginationState, updated: LoanApplication): Uni<LoanApplication> =
+        applications.compareAndSetDecision(updated, from).flatMap { claimed ->
             if (claimed == 0) {
                 Uni.createFrom().failure(
                     IllegalStateException(

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
@@ -8,6 +8,7 @@ import com.openbank.lending.application.port.out.CreditAssessment
 import com.openbank.lending.application.port.out.CreditBureauPort
 import com.openbank.lending.application.port.out.CreditPolicyPort
 import com.openbank.lending.application.port.out.LendingOutboxMessage
+import com.openbank.lending.domain.model.AffordabilityRatios
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.infrastructure.compliance.CompliancePackGuard
 import com.openbank.libs.decision.PolicyApplication
@@ -130,7 +131,27 @@ class OriginationDecisionService(
             attributes[PolicyAttribute.PRODUCT_TYPE] = PolicyValue.Text(it)
         }
         attributes[PolicyAttribute.REQUESTED_AMOUNT] = PolicyValue.Numeric(application.requestedAmount.amount)
-        application.verifiedIncomeMonthly?.takeIf { it.isPositive() }?.let { income ->
+        affordabilityRatios(application)?.let { ratios ->
+            attributes[PolicyAttribute.DSTI] = PolicyValue.Numeric(ratios.dsti)
+            attributes[PolicyAttribute.DTI] = PolicyValue.Numeric(ratios.dti)
+        }
+        return attributes
+    }
+
+    companion object {
+        /**
+         * DSTI/DTI exactly as the ASSESSMENT leg reads them — the single definition, shared with the
+         * credit-risk read side so a console can never show a ratio the engine did not evaluate.
+         * Null when there is no positive verified income (the engine then fails closed to REFER with
+         * `INPUT_MISSING`, ADR-0213 D2).
+         *
+         * `dsti` is the NEW installment over income, which is what `PolicyAttribute.DSTI` has meant
+         * since the engine shipped; `dstiIncludingExistingDebt` adds `existingDebtServiceMonthly`
+         * (the CNB/EBA total-debt-service definition) and is exposed for the read side only. Making
+         * the engine read the total is a credit-policy change (ADR-0213 D4), not a refactor.
+         */
+        fun affordabilityRatios(application: LoanApplication): AffordabilityRatios? {
+            val income = application.verifiedIncomeMonthly?.takeIf { it.isPositive() } ?: return null
             val schedule = Amortization.schedule(
                 principal = application.requestedAmount,
                 nominalAnnualRate = application.nominalAnnualRate,
@@ -139,16 +160,16 @@ class OriginationDecisionService(
                 firstDueDate = application.firstDueDate,
             )
             val monthlyPayment = schedule.installments.first().payment.amount
-            attributes[PolicyAttribute.DSTI] =
-                PolicyValue.Numeric(monthlyPayment.divide(income.amount, MathContext.DECIMAL128))
-            attributes[PolicyAttribute.DTI] = PolicyValue.Numeric(
-                application.requestedAmount.amount.divide(
+            val existing = application.existingDebtServiceMonthly?.amount ?: BigDecimal.ZERO
+            return AffordabilityRatios(
+                dsti = monthlyPayment.divide(income.amount, MathContext.DECIMAL128),
+                dti = application.requestedAmount.amount.divide(
                     income.amount.multiply(BigDecimal(MONTHS_IN_YEAR)),
                     MathContext.DECIMAL128,
                 ),
+                dstiIncludingExistingDebt = monthlyPayment.add(existing).divide(income.amount, MathContext.DECIMAL128),
             )
         }
-        return attributes
     }
 
     private fun outcomeName(decision: PolicyDecision): String = when (decision) {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditRiskViews.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditRiskViews.kt
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.domain.model
+
+import com.openbank.libs.decision.PolicyTable
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Read models for the credit-risk console (ADR-0230 D1 read view over the ADR-0213 D4 decision
+ * evidence and the ADR-0028 Phase 3 provisioning history).
+ *
+ * WHY A SEPARATE SHAPE AND NOT THE AGGREGATES
+ * `LoanApplication` persists the engine's output as the CSV strings the evidence event carries
+ * (`decisionReasons = "CODE:ruleId,..."`, `policyVersions = "KIND=1,..."`). That is the right
+ * shape for a hash-bound evidence record and the wrong one for a chart: a risk analyst wants the
+ * reason CODE and the RULE as two columns, and the affordability ratios the engine actually read.
+ * These views decode the evidence once, server-side, so every consumer (console, notebook export)
+ * sees one decoding rather than each re-implementing the format.
+ *
+ * WHAT THEY DELIBERATELY DO NOT DO
+ * No score, no probability, no ranking. The ADR-0213 output contract is outcome + reasons + rule
+ * ids + versions + input hash, and a read model must not invent a number the engine never
+ * produced. The affordability ratios are the exact figures the ASSESSMENT leg computed
+ * (`OriginationDecisionService.affordabilityRatios`), never a re-estimate.
+ */
+data class DecisionReasonView(val code: String, val ruleId: String?)
+
+/**
+ * DSTI/DTI as the engine reads them plus the total-debt-service DSTI the engine does NOT read.
+ *
+ * `dsti` is `new installment / verified income` — the figure `PolicyAttribute.DSTI` carries into
+ * the affordability table today. `dstiIncludingExistingDebt` adds `existingDebtServiceMonthly`,
+ * the CNB/EBA definition of debt-service-to-income. Both are exposed so the console can show the
+ * gap rather than hide it; changing which one the ENGINE uses is a credit-policy decision
+ * (ADR-0213 D4), not a read-model change.
+ */
+data class AffordabilityRatios(val dsti: BigDecimal, val dti: BigDecimal, val dstiIncludingExistingDebt: BigDecimal)
+
+/** One engine-evaluated application, decoded from its pinned evidence fields. */
+data class CreditDecisionView(
+    val applicationId: UUID,
+    val partyId: UUID,
+    val status: String,
+    val createdAt: OffsetDateTime,
+    val requestedAmount: BigDecimal,
+    val currency: String,
+    val termPeriods: Int,
+    val nominalAnnualRate: BigDecimal,
+    val jurisdiction: String?,
+    val productType: String?,
+    val productKind: String,
+    val packVersion: Int?,
+    /** `APPROVE` / `REFER` / `DECLINE` (ADR-0213 D1). */
+    val engineOutcome: String,
+    val priceBand: String?,
+    val reasons: List<DecisionReasonView>,
+    val matchedRuleIds: List<String>,
+    /** Pinned table version per `PolicyTableKind` name. */
+    val policyVersions: Map<String, Int>,
+    val inputSnapshotHash: String?,
+    val decidedEngineAt: OffsetDateTime?,
+    val affordability: AffordabilityRatios?,
+    val verifiedIncomeMonthly: BigDecimal?,
+    val existingDebtServiceMonthly: BigDecimal?,
+    val ageYears: Int?,
+    val residency: String?,
+    val employmentTenureMonths: Int?,
+    /** The four-eyes checker's disposition, when one has been recorded (ADR-0028 D5). */
+    val humanDecidedBy: String?,
+    val humanDecisionReason: String?,
+    val humanDecidedAt: OffsetDateTime?,
+)
+
+/** Book-wide engine-outcome totals, grouped in the database so the console never sums a capped list. */
+data class DecisionOutcomeSummary(val engineOutcome: String, val priceBand: String?, val count: Long)
+
+/** The latest persisted IFRS 9 record for one loan (`loan_provisioning`, one row per loan-period). */
+data class LoanRiskAssessmentView(
+    val period: String,
+    val asOf: LocalDate,
+    val outstandingBalance: BigDecimal,
+    val daysPastDue: Int,
+    val bucket: String,
+    val stage: String,
+    val expectedCreditLoss: BigDecimal,
+    val modelVersion: String,
+)
+
+/**
+ * One loan with its latest provisioning record. `assessment` is null for a loan the scheduled
+ * cycle has never assessed — a real state the console must show as "not yet assessed", never as
+ * Stage 1 with zero ECL.
+ */
+data class LoanRiskView(
+    val loanId: UUID,
+    val applicationId: UUID,
+    val partyId: UUID,
+    val status: String,
+    val principal: BigDecimal,
+    val currency: String,
+    val nominalAnnualRate: BigDecimal,
+    val termPeriods: Int,
+    val disbursedAt: OffsetDateTime,
+    val assessment: LoanRiskAssessmentView?,
+)
+
+/**
+ * The policy bundle the engine would evaluate as of [asOf]. [codeSeeded] is true while the bundle
+ * comes from `StarterCreditPolicy` (ADR-0213 D3 phase 1) rather than the four-eyes-governed table
+ * store D4 describes — the console says so, because a risk committee reading a decision table
+ * must know whether anyone can change it and how.
+ */
+data class CreditPolicyView(
+    val asOf: LocalDate,
+    val source: String,
+    val codeSeeded: Boolean,
+    val tables: List<PolicyTable>,
+)
+
+/**
+ * Decodes the CSV evidence fields exactly as `OriginationDecisionService` writes them. Pure and
+ * total: a malformed fragment yields a best-effort entry rather than a throw, because a read model
+ * must never make a persisted decision unreadable.
+ */
+object DecisionEvidenceCodec {
+    private const val NO_RULE = "-"
+
+    fun reasons(csv: String?): List<DecisionReasonView> = fragments(csv).map { fragment ->
+        val split = fragment.indexOf(':')
+        if (split < 0) {
+            DecisionReasonView(code = fragment, ruleId = null)
+        } else {
+            val rule = fragment.substring(split + 1)
+            DecisionReasonView(
+                code = fragment.substring(0, split),
+                ruleId = rule.takeUnless { it == NO_RULE || it.isBlank() },
+            )
+        }
+    }
+
+    fun matchedRuleIds(csv: String?): List<String> = fragments(csv)
+
+    fun policyVersions(csv: String?): Map<String, Int> = fragments(csv).mapNotNull { fragment ->
+        val split = fragment.indexOf('=')
+        if (split < 0) {
+            null
+        } else {
+            val kind = fragment.substring(0, split).trim()
+            val version = fragment.substring(split + 1).trim().toIntOrNull()
+            if (kind.isEmpty() || version == null) null else kind to version
+        }
+    }.toMap()
+
+    private fun fragments(csv: String?): List<String> =
+        csv.orEmpty().split(',').map { it.trim() }.filter { it.isNotEmpty() }
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -11,6 +11,7 @@ import com.openbank.lending.application.port.out.LoanRepository
 import com.openbank.lending.application.port.out.ProvisioningRepository
 import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.domain.model.LoanInstallment
@@ -79,6 +80,29 @@ class LoanApplicationRepositoryImpl @Inject constructor(
             Array<Any?>::class.java,
         ).resultList
     }.map { rows -> foldApplicationSummaries(rows) }
+
+    @WithSession
+    override fun findEvaluated(limit: Int): Uni<List<LoanApplication>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM LoanApplicationEntity WHERE decidedEngineAt IS NOT NULL ORDER BY decidedEngineAt DESC, id ASC",
+            LoanApplicationEntity::class.java,
+        ).setMaxResults(limit).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithSession
+    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = sf.withSession { s ->
+        s.createQuery(
+            """
+            SELECT a.decisionOutcome, a.decisionPriceBand, count(a)
+            FROM LoanApplicationEntity a
+            WHERE a.decisionOutcome IS NOT NULL
+            GROUP BY a.decisionOutcome, a.decisionPriceBand
+            """.trimIndent(),
+            Array<Any?>::class.java,
+        ).resultList
+    }.map { rows ->
+        rows.map { r -> DecisionOutcomeSummary(r[0] as String, r[1] as? String, (r[2] as Number).toLong()) }
+    }
 
     private fun mapStatusFilter(status: String): OriginationState =
         OriginationState.entries.firstOrNull { it.name == status }
@@ -201,6 +225,12 @@ class LoanRepositoryImpl @Inject constructor(private val sf: Mutiny.SessionFacto
             Array<Any?>::class.java,
         ).resultList
     }.map { rows -> foldLoanSummaries(rows) }
+
+    @WithSession override fun findRecent(limit: Int): Uni<List<Loan>> = sf.withSession { s ->
+        s.createQuery("FROM LoanEntity ORDER BY disbursedAt DESC, id ASC", LoanEntity::class.java)
+            .setMaxResults(limit)
+            .resultList
+    }.map { it.map(mapper::toDomain) }
 
     @WithSession override fun findActive(limit: Int): Uni<List<Loan>> = sf.withSession { s ->
         s.createQuery(
@@ -330,6 +360,17 @@ class ProvisioningRepositoryImpl @Inject constructor(
             .setMaxResults(1)
             .resultList
     }.map { it.firstOrNull()?.let(mapper::toDomain) }
+
+    @WithSession override fun findLatestPerLoan(): Uni<List<LoanProvisioningRecord>> = sf.withSession { s ->
+        s.createQuery(
+            """
+                FROM LoanProvisioningEntity p
+                WHERE p.period = (SELECT max(q.period) FROM LoanProvisioningEntity q WHERE q.loanId = p.loanId)
+                ORDER BY p.loanId ASC
+            """.trimIndent(),
+            LoanProvisioningEntity::class.java,
+        ).resultList
+    }.map { it.map(mapper::toDomain) }
 
     @WithSession override fun findByLoanAndPeriod(loanId: LoanId, period: String): Uni<LoanProvisioningRecord?> =
         sf.withSession { s ->

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -175,12 +175,46 @@ class LoanApplicationRepositoryImpl @Inject constructor(
             .executeUpdate()
     }
 
+    override fun compareAndSetDecision(
+        application: LoanApplication,
+        from: OriginationState,
+    ): Uni<Int> = sf.withTransaction { s ->
+        s.createMutationQuery(DECISION_HQL)
+            .setParameter("to", application.status)
+            .setParameter("decidedBy", application.decidedBy)
+            .setParameter("reason", application.decisionReason)
+            .setParameter("decidedAt", application.decidedAt)
+            .setParameter("outcome", application.decisionOutcome)
+            .setParameter("band", application.decisionPriceBand)
+            .setParameter("reasons", application.decisionReasons)
+            .setParameter("matched", application.decisionMatchedRules)
+            .setParameter("versions", application.policyVersions)
+            .setParameter("hash", application.decisionInputHash)
+            .setParameter("engineAt", application.decidedEngineAt)
+            .setParameter("id", application.id.value)
+            .setParameter("from", from)
+            .executeUpdate()
+    }
+
     private companion object {
         /**
          * The `and status = :from` clause is the whole point — without it this is [update] with
          * extra steps. Named parameters because `decidedBy`, `decisionReason` and `decidedAt` are
          * all nullable and a positional vararg cannot carry a null.
          */
+        /**
+         * The ASSESSMENT claim. Same conditional `status = :from` guard as [ADVANCE_HQL]; the extra
+         * columns are the ADR-0213 evidence, written in the SAME statement as the transition so a
+         * row can never carry a decided state with no decision behind it.
+         */
+        const val DECISION_HQL =
+            "update LoanApplicationEntity " +
+                "set status = :to, decidedBy = :decidedBy, decisionReason = :reason, decidedAt = :decidedAt, " +
+                "decisionOutcome = :outcome, decisionPriceBand = :band, decisionReasons = :reasons, " +
+                "decisionMatchedRules = :matched, policyVersions = :versions, decisionInputHash = :hash, " +
+                "decidedEngineAt = :engineAt " +
+                "where id = :id and status = :from"
+
         const val ADVANCE_HQL =
             "update LoanApplicationEntity " +
                 "set status = :to, decidedBy = :decidedBy, decisionReason = :reason, decidedAt = :decidedAt " +

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -5,6 +5,7 @@
 package com.openbank.lending.infrastructure.persistence.repository
 
 import com.openbank.lending.application.port.out.CollateralRepository
+import com.openbank.lending.application.port.out.CreditDecisionQueryRepository
 import com.openbank.lending.application.port.out.InstallmentRepository
 import com.openbank.lending.application.port.out.LoanApplicationRepository
 import com.openbank.lending.application.port.out.LoanRepository
@@ -81,29 +82,6 @@ class LoanApplicationRepositoryImpl @Inject constructor(
         ).resultList
     }.map { rows -> foldApplicationSummaries(rows) }
 
-    @WithSession
-    override fun findEvaluated(limit: Int): Uni<List<LoanApplication>> = sf.withSession { s ->
-        s.createQuery(
-            "FROM LoanApplicationEntity WHERE decidedEngineAt IS NOT NULL ORDER BY decidedEngineAt DESC, id ASC",
-            LoanApplicationEntity::class.java,
-        ).setMaxResults(limit).resultList
-    }.map { it.map(mapper::toDomain) }
-
-    @WithSession
-    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = sf.withSession { s ->
-        s.createQuery(
-            """
-            SELECT a.decisionOutcome, a.decisionPriceBand, count(a)
-            FROM LoanApplicationEntity a
-            WHERE a.decisionOutcome IS NOT NULL
-            GROUP BY a.decisionOutcome, a.decisionPriceBand
-            """.trimIndent(),
-            Array<Any?>::class.java,
-        ).resultList
-    }.map { rows ->
-        rows.map { r -> DecisionOutcomeSummary(r[0] as String, r[1] as? String, (r[2] as Number).toLong()) }
-    }
-
     private fun mapStatusFilter(status: String): OriginationState =
         OriginationState.entries.firstOrNull { it.name == status }
             ?: LegacyOriginationMigration.mapLegacyStatus(status, wasSubmitted = true)
@@ -175,26 +153,24 @@ class LoanApplicationRepositoryImpl @Inject constructor(
             .executeUpdate()
     }
 
-    override fun compareAndSetDecision(
-        application: LoanApplication,
-        from: OriginationState,
-    ): Uni<Int> = sf.withTransaction { s ->
-        s.createMutationQuery(DECISION_HQL)
-            .setParameter("to", application.status)
-            .setParameter("decidedBy", application.decidedBy)
-            .setParameter("reason", application.decisionReason)
-            .setParameter("decidedAt", application.decidedAt)
-            .setParameter("outcome", application.decisionOutcome)
-            .setParameter("band", application.decisionPriceBand)
-            .setParameter("reasons", application.decisionReasons)
-            .setParameter("matched", application.decisionMatchedRules)
-            .setParameter("versions", application.policyVersions)
-            .setParameter("hash", application.decisionInputHash)
-            .setParameter("engineAt", application.decidedEngineAt)
-            .setParameter("id", application.id.value)
-            .setParameter("from", from)
-            .executeUpdate()
-    }
+    override fun compareAndSetDecision(application: LoanApplication, from: OriginationState): Uni<Int> =
+        sf.withTransaction { s ->
+            s.createMutationQuery(DECISION_HQL)
+                .setParameter("to", application.status)
+                .setParameter("decidedBy", application.decidedBy)
+                .setParameter("reason", application.decisionReason)
+                .setParameter("decidedAt", application.decidedAt)
+                .setParameter("outcome", application.decisionOutcome)
+                .setParameter("band", application.decisionPriceBand)
+                .setParameter("reasons", application.decisionReasons)
+                .setParameter("matched", application.decisionMatchedRules)
+                .setParameter("versions", application.policyVersions)
+                .setParameter("hash", application.decisionInputHash)
+                .setParameter("engineAt", application.decidedEngineAt)
+                .setParameter("id", application.id.value)
+                .setParameter("from", from)
+                .executeUpdate()
+        }
 
     private companion object {
         /**
@@ -219,6 +195,42 @@ class LoanApplicationRepositoryImpl @Inject constructor(
             "update LoanApplicationEntity " +
                 "set status = :to, decidedBy = :decidedBy, decisionReason = :reason, decidedAt = :decidedAt " +
                 "where id = :id and status = :from"
+    }
+}
+
+/**
+ * The credit-risk read side (`CreditDecisionQueryRepository`). Its own class rather than two more
+ * methods on [LoanApplicationRepositoryImpl]: that one is the origination write path and is already
+ * at detekt's `TooManyFunctions` threshold, and a reporting query has no business sitting next to a
+ * conditional state claim.
+ */
+@ApplicationScoped
+class CreditDecisionQueryRepositoryImpl @Inject constructor(
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: LendingMapper,
+) : CreditDecisionQueryRepository {
+
+    @WithSession
+    override fun findEvaluated(limit: Int): Uni<List<LoanApplication>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM LoanApplicationEntity WHERE decidedEngineAt IS NOT NULL ORDER BY decidedEngineAt DESC, id ASC",
+            LoanApplicationEntity::class.java,
+        ).setMaxResults(limit).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithSession
+    override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = sf.withSession { s ->
+        s.createQuery(
+            """
+            SELECT a.decisionOutcome, a.decisionPriceBand, count(a)
+            FROM LoanApplicationEntity a
+            WHERE a.decisionOutcome IS NOT NULL
+            GROUP BY a.decisionOutcome, a.decisionPriceBand
+            """.trimIndent(),
+            Array<Any?>::class.java,
+        ).resultList
+    }.map { rows ->
+        rows.map { r -> DecisionOutcomeSummary(r[0] as String, r[1] as? String, (r[2] as Number).toLong()) }
     }
 }
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditRiskResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditRiskResource.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.`in`.CreditRiskInsightUseCase
+import com.openbank.lending.domain.model.CreditDecisionView
+import com.openbank.lending.domain.model.CreditPolicyView
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
+import com.openbank.lending.domain.model.LoanRiskView
+import com.openbank.libs.authz.Authorize
+import io.smallrye.mutiny.Uni
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+/**
+ * Credit-risk read surface (ADR-0230 D1, ADR-0213 D4 evidence, ADR-0028 Phase 3).
+ *
+ * READ-ONLY BY CONSTRUCTION. Four `GET`s, no mutation: the console this serves renders decisions
+ * and never makes them (ADR-0227 D4 keeps disposal in the approval inbox). Role-gated to the
+ * credit desk and compliance — the same set that may read the evidence bundle — never
+ * `@PermitAll` (`LendingSecurityTest`), and OPA-annotated with the existing `lending.list` /
+ * `lending.read` actions so no new matrix grant is needed (rules.yaml: authz).
+ *
+ * Every list is capped server-side (`CreditRiskInsightService.MAX_LIMIT`) and the summary is
+ * grouped in the database, so a figure the console labels as a total IS a total (#3294).
+ */
+@Path("/api/v1/lending/risk")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Loan origination, servicing, collateral and IFRS 9 provisioning")
+@RolesAllowed("ROLE_CREDIT_RISK", "ROLE_COMPLIANCE", "ROLE_LENDING_OFFICER", "ROLE_ADMIN")
+class CreditRiskResource(private val insight: CreditRiskInsightUseCase, private val clock: Clock) {
+    @GET
+    @Path("/decisions")
+    @Operation(
+        summary = "Engine-evaluated applications with decoded ADR-0213 evidence (newest first)",
+        description = "Outcome, price band, reason codes with rule ids, matched rules, pinned policy " +
+            "versions, input hash and the affordability ratios the engine read. Capped at 1000.",
+    )
+    @Authorize(action = "lending.list", resource = "")
+    fun decisions(@QueryParam("limit") @DefaultValue("200") limit: Int): Uni<List<CreditDecisionView>> =
+        insight.decisions(limit)
+
+    @GET
+    @Path("/decisions/summary")
+    @Operation(summary = "Book-wide engine outcome × price-band totals, grouped in the database")
+    @Authorize(action = "lending.list", resource = "")
+    fun decisionSummary(): Uni<List<DecisionOutcomeSummary>> = insight.summariseDecisions()
+
+    @GET
+    @Path("/portfolio")
+    @Operation(
+        summary = "Loans with their latest IFRS 9 provisioning record (null where never assessed)",
+        description = "Stage, DPD bucket, ECL, outstanding and the PD/LGD model version that produced " +
+            "them, read back from loan_provisioning — never recomputed here. Capped at 1000.",
+    )
+    @Authorize(action = "lending.list", resource = "")
+    fun portfolio(@QueryParam("limit") @DefaultValue("500") limit: Int): Uni<List<LoanRiskView>> =
+        insight.portfolio(limit)
+
+    @GET
+    @Path("/policy")
+    @Operation(
+        summary = "The credit policy bundle the engine evaluates as of a date",
+        description = "Every decision table (exclusion, eligibility, affordability, pricing band) with " +
+            "its rules, version and effective window. codeSeeded=true while the ADR-0213 D3 starter " +
+            "policy is the binding, i.e. before the four-eyes table store (D4) exists.",
+    )
+    @Authorize(action = "lending.read", resource = "")
+    fun policy(@QueryParam("asOf") asOf: String?): Uni<CreditPolicyView> = insight.activePolicy(parseAsOf(asOf))
+
+    /** ISO date or today; a malformed value is the caller's error (400 via libs-runtime), not a 500. */
+    private fun parseAsOf(raw: String?): LocalDate {
+        if (raw.isNullOrBlank()) return LocalDate.now(clock)
+        return try {
+            LocalDate.parse(raw)
+        } catch (e: DateTimeParseException) {
+            throw IllegalArgumentException("query parameter 'asOf' must be an ISO-8601 date", e)
+        }
+    }
+}

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.17.0
+  version: 1.19.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -236,6 +236,104 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/LoanStateSummary' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/risk/decisions:
+    get:
+      tags: [Lending]
+      operationId: riskDecisions
+      summary: Engine-evaluated applications with decoded ADR-0213 evidence (newest first)
+      description: >-
+        The credit-risk console's primary read (ADR-0230 D1). Each row is one application the
+        deterministic engine evaluated: outcome, price band, machine-readable reason codes with the
+        rule that fired, matched rule ids, pinned policy versions, input snapshot hash and the
+        affordability ratios the engine read — decoded server-side from the evidence fields the
+        application pins (ADR-0214), never recomputed. Read-only; the console renders decisions and
+        never makes them (ADR-0227 D4).
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 1000, default: 200 }
+          description: Clamped server-side to 1..1000. A caller wanting the whole history uses the warehouse.
+      responses:
+        '200':
+          description: Newest evaluation first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/CreditDecisionView' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/risk/decisions/summary:
+    get:
+      tags: [Lending]
+      operationId: riskDecisionSummary
+      summary: Book-wide engine outcome × price-band totals, grouped in the database
+      description: >-
+        The figure /risk/decisions cannot give (it is capped): how many applications the engine
+        approved, referred and declined over the whole book, per price band. Same reasoning as
+        /applications/summary (issue #3294).
+      responses:
+        '200':
+          description: One entry per (outcome, priceBand) pair
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/DecisionOutcomeSummary' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/risk/portfolio:
+    get:
+      tags: [Lending]
+      operationId: riskPortfolio
+      summary: Loans with their latest IFRS 9 provisioning record (null where never assessed)
+      description: >-
+        Stage, DPD bucket, expected credit loss, outstanding balance and the PD/LGD model version
+        that produced them, read back from loan_provisioning (ADR-0028 Phase 3). A loan the
+        scheduled cycle has never assessed carries assessment=null — a real state the console shows
+        as such, never as Stage 1 with zero ECL.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 1000, default: 500 }
+      responses:
+        '200':
+          description: Newest disbursement first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/LoanRiskView' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/risk/policy:
+    get:
+      tags: [Lending]
+      operationId: riskPolicy
+      summary: The credit policy bundle the engine evaluates as of a date
+      description: >-
+        Every decision table (exclusion, eligibility, affordability, pricing band) with its rules,
+        version and effective window (ADR-0213 D1). codeSeeded is true while the ADR-0213 D3
+        starter policy is the binding — i.e. before the four-eyes table store D4 describes exists —
+        so a risk committee reading the table knows whether anyone can change it and how.
+      parameters:
+        - name: asOf
+          in: query
+          required: false
+          schema: { type: string, format: date }
+          description: ISO-8601 date; defaults to today. A malformed value is a 400.
+      responses:
+        '200':
+          description: The active bundle
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CreditPolicyView' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
   /api/v1/lending/applications/recent:
@@ -937,6 +1035,137 @@ components:
         principal:
           type: array
           items: { $ref: '#/components/schemas/MoneyTotal' }
+    DecisionReasonView:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+          enum: [INPUT_MISSING, RULE_NOT_EVALUABLE, POLICY_TABLE_MISSING, EXCLUSION_MATCHED, ELIGIBILITY_FAILED, AFFORDABILITY_FAILED, PRICING_BAND_UNMATCHED]
+        ruleId: { type: string, nullable: true }
+    AffordabilityRatios:
+      type: object
+      required: [dsti, dti, dstiIncludingExistingDebt]
+      description: >-
+        dsti is the new installment over verified income — what PolicyAttribute.DSTI carries into
+        the affordability table. dstiIncludingExistingDebt adds existingDebtServiceMonthly (the
+        CNB/EBA total-debt-service definition); it is exposed so the console can show the gap, and
+        is NOT what the engine evaluates today.
+      properties:
+        dsti: { type: number }
+        dti: { type: number }
+        dstiIncludingExistingDebt: { type: number }
+    CreditDecisionView:
+      type: object
+      required: [applicationId, partyId, status, createdAt, requestedAmount, currency, termPeriods, nominalAnnualRate, productKind, engineOutcome, reasons, matchedRuleIds, policyVersions]
+      properties:
+        applicationId: { type: string, format: uuid }
+        partyId: { type: string, format: uuid }
+        status: { type: string, description: The current OriginationState. }
+        createdAt: { type: string, format: date-time }
+        requestedAmount: { type: number }
+        currency: { type: string, minLength: 3, maxLength: 3 }
+        termPeriods: { type: integer }
+        nominalAnnualRate: { type: number }
+        jurisdiction: { type: string, nullable: true }
+        productType: { type: string, nullable: true }
+        productKind: { type: string }
+        packVersion: { type: integer, nullable: true }
+        engineOutcome: { type: string, enum: [APPROVE, REFER, DECLINE, UNEVALUATED] }
+        priceBand: { type: string, nullable: true }
+        reasons:
+          type: array
+          items: { $ref: '#/components/schemas/DecisionReasonView' }
+        matchedRuleIds:
+          type: array
+          items: { type: string }
+        policyVersions:
+          type: object
+          additionalProperties: { type: integer }
+          description: Pinned table version per PolicyTableKind name.
+        inputSnapshotHash: { type: string, nullable: true }
+        decidedEngineAt: { type: string, format: date-time, nullable: true }
+        affordability:
+          nullable: true
+          allOf: [{ $ref: '#/components/schemas/AffordabilityRatios' }]
+        verifiedIncomeMonthly: { type: number, nullable: true }
+        existingDebtServiceMonthly: { type: number, nullable: true }
+        ageYears: { type: integer, nullable: true }
+        residency: { type: string, nullable: true }
+        employmentTenureMonths: { type: integer, nullable: true }
+        humanDecidedBy: { type: string, nullable: true }
+        humanDecisionReason: { type: string, nullable: true }
+        humanDecidedAt: { type: string, format: date-time, nullable: true }
+    DecisionOutcomeSummary:
+      type: object
+      required: [engineOutcome, count]
+      properties:
+        engineOutcome: { type: string, enum: [APPROVE, REFER, DECLINE] }
+        priceBand: { type: string, nullable: true }
+        count: { type: integer, format: int64 }
+    LoanRiskAssessmentView:
+      type: object
+      required: [period, asOf, outstandingBalance, daysPastDue, bucket, stage, expectedCreditLoss, modelVersion]
+      properties:
+        period: { type: string, description: Reporting period key, yyyy-MM. }
+        asOf: { type: string, format: date }
+        outstandingBalance: { type: number }
+        daysPastDue: { type: integer }
+        bucket: { type: string, enum: [CURRENT, DPD_1_30, DPD_31_60, DPD_61_90, DPD_90_PLUS] }
+        stage: { type: string, enum: [STAGE_1, STAGE_2, STAGE_3] }
+        expectedCreditLoss: { type: number }
+        modelVersion: { type: string, description: The PD/LGD parameter set that produced the ECL. }
+    LoanRiskView:
+      type: object
+      required: [loanId, applicationId, partyId, status, principal, currency, nominalAnnualRate, termPeriods, disbursedAt]
+      properties:
+        loanId: { type: string, format: uuid }
+        applicationId: { type: string, format: uuid }
+        partyId: { type: string, format: uuid }
+        status: { type: string }
+        principal: { type: number }
+        currency: { type: string, minLength: 3, maxLength: 3 }
+        nominalAnnualRate: { type: number }
+        termPeriods: { type: integer }
+        disbursedAt: { type: string, format: date-time }
+        assessment:
+          nullable: true
+          allOf: [{ $ref: '#/components/schemas/LoanRiskAssessmentView' }]
+    PolicyRuleView:
+      type: object
+      required: [id, attribute, operator, values, detail]
+      properties:
+        id: { type: string }
+        attribute: { type: string }
+        operator: { type: string, enum: [GT, GTE, LT, LTE, EQ, NEQ, IN, NOT_IN] }
+        threshold: { type: number, nullable: true }
+        values:
+          type: array
+          items: { type: string }
+        band: { type: string, nullable: true }
+        detail: { type: string }
+    PolicyTableView:
+      type: object
+      required: [kind, name, version, effectiveFrom, rules]
+      properties:
+        kind: { type: string, enum: [EXCLUSION, ELIGIBILITY, AFFORDABILITY, PRICING_BAND] }
+        name: { type: string }
+        version: { type: integer }
+        effectiveFrom: { type: string, format: date }
+        effectiveTo: { type: string, format: date, nullable: true }
+        rules:
+          type: array
+          items: { $ref: '#/components/schemas/PolicyRuleView' }
+    CreditPolicyView:
+      type: object
+      required: [asOf, source, codeSeeded, tables]
+      properties:
+        asOf: { type: string, format: date }
+        source: { type: string, description: The CreditPolicyPort binding's class name. }
+        codeSeeded: { type: boolean }
+        tables:
+          type: array
+          items: { $ref: '#/components/schemas/PolicyTableView' }
     CustomerQuoteRequest:
       type: object
       required: [amount, termMonths]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightServiceTest.kt
@@ -4,7 +4,7 @@
 
 package com.openbank.lending.application.usecase
 
-import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.application.port.out.CreditDecisionQueryRepository
 import com.openbank.lending.application.port.out.LoanRepository
 import com.openbank.lending.application.port.out.ProvisioningRepository
 import com.openbank.lending.application.port.out.StarterCreditPolicy
@@ -29,7 +29,7 @@ import java.util.UUID
 
 class CreditRiskInsightServiceTest {
 
-    private val applications = mockk<LoanApplicationRepository>()
+    private val applications = mockk<CreditDecisionQueryRepository>()
     private val loans = mockk<LoanRepository>()
     private val provisioning = mockk<ProvisioningRepository>()
     private val service = CreditRiskInsightService(applications, loans, provisioning, StarterCreditPolicy())

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditRiskInsightServiceTest.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.application.usecase
+
+import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.application.port.out.ProvisioningRepository
+import com.openbank.lending.application.port.out.StarterCreditPolicy
+import com.openbank.lending.domain.model.Loan
+import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.domain.model.LoanProvisioningRecord
+import com.openbank.libs.domain.identifiers.LoanApplicationId
+import com.openbank.libs.domain.identifiers.LoanId
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.lending.AmortizationMethod
+import com.openbank.libs.lending.DelinquencyBucket
+import com.openbank.libs.lending.Ifrs9Stage
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class CreditRiskInsightServiceTest {
+
+    private val applications = mockk<LoanApplicationRepository>()
+    private val loans = mockk<LoanRepository>()
+    private val provisioning = mockk<ProvisioningRepository>()
+    private val service = CreditRiskInsightService(applications, loans, provisioning, StarterCreditPolicy())
+
+    private fun application(income: String?, existingDebt: String? = null) = LoanApplication(
+        partyId = UUID.randomUUID(),
+        requestedAmount = Money.of(BigDecimal("120000.00"), "CZK"),
+        nominalAnnualRate = BigDecimal("0.08"),
+        termPeriods = 12,
+        firstDueDate = LocalDate.of(2026, 10, 1),
+        proposedBy = "officer",
+        createdAt = OffsetDateTime.parse("2026-09-01T10:00:00Z"),
+        verifiedIncomeMonthly = income?.let { Money.of(BigDecimal(it), "CZK") },
+        existingDebtServiceMonthly = existingDebt?.let { Money.of(BigDecimal(it), "CZK") },
+        decisionOutcome = "APPROVE",
+        decisionPriceBand = "PRIME",
+        decisionReasons = "",
+        decisionMatchedRules = "starter-el-age,starter-el-residency,starter-af-dsti,starter-af-dti,starter-pr-prime",
+        policyVersions = "EXCLUSION=1,ELIGIBILITY=1,AFFORDABILITY=1,PRICING_BAND=1",
+        decisionInputHash = "abc",
+        decidedEngineAt = OffsetDateTime.parse("2026-09-01T10:00:05Z"),
+    )
+
+    @Test
+    fun `decisions decode the pinned evidence and carry the engine's own affordability ratios`() {
+        val app = application(income = "50000.00", existingDebt = "5000.00")
+        every { applications.findEvaluated(any()) } returns Uni.createFrom().item(listOf(app))
+
+        val view = service.decisions(10).await().indefinitely().single()
+
+        assertThat(view.engineOutcome).isEqualTo("APPROVE")
+        assertThat(view.priceBand).isEqualTo("PRIME")
+        assertThat(view.matchedRuleIds).hasSize(5).contains("starter-pr-prime")
+        assertThat(view.policyVersions).containsEntry("AFFORDABILITY", 1)
+        val ratios = requireNotNull(view.affordability)
+        // The same number the ASSESSMENT leg read — one definition, not a console re-estimate.
+        val engine = requireNotNull(OriginationDecisionService.affordabilityRatios(app))
+        assertThat(ratios.dsti).isEqualByComparingTo(engine.dsti)
+        assertThat(ratios.dti).isEqualByComparingTo(BigDecimal("120000").divide(BigDecimal("600000")))
+        // Existing debt service widens the total-DSTI figure by exactly debt/income.
+        assertThat(ratios.dstiIncludingExistingDebt.subtract(ratios.dsti)).isEqualByComparingTo(BigDecimal("0.1"))
+    }
+
+    @Test
+    fun `no verified income means no ratios, never a zero`() {
+        every { applications.findEvaluated(any()) } returns Uni.createFrom().item(listOf(application(income = null)))
+        assertThat(service.decisions(10).await().indefinitely().single().affordability).isNull()
+    }
+
+    @Test
+    fun `the read limit is clamped to the server maximum`() {
+        every { applications.findEvaluated(CreditRiskInsightService.MAX_LIMIT) } returns
+            Uni.createFrom().item(emptyList())
+        every { applications.findEvaluated(1) } returns Uni.createFrom().item(emptyList())
+        service.decisions(999_999).await().indefinitely()
+        service.decisions(-5).await().indefinitely()
+    }
+
+    @Test
+    fun `portfolio joins the latest assessment and leaves an unassessed loan null`() {
+        val assessed = loan()
+        val fresh = loan()
+        every { loans.findRecent(any()) } returns Uni.createFrom().item(listOf(assessed, fresh))
+        every { provisioning.findLatestPerLoan() } returns Uni.createFrom().item(
+            listOf(
+                LoanProvisioningRecord(
+                    loanId = assessed.id, period = "2026-08", asOf = LocalDate.of(2026, 8, 31),
+                    outstandingBalance = Money.of(BigDecimal("90000.00"), "CZK"), daysPastDue = 45,
+                    bucket = DelinquencyBucket.DPD_31_60, stage = Ifrs9Stage.STAGE_2,
+                    expectedCreditLoss = Money.of(BigDecimal("8100.00"), "CZK"),
+                    createdAt = OffsetDateTime.now(), modelVersion = "noop-flat-v1",
+                ),
+            ),
+        )
+
+        val views = service.portfolio(100).await().indefinitely().associateBy { it.loanId }
+
+        val a = requireNotNull(views[assessed.id.value].let { requireNotNull(it).assessment })
+        assertThat(a.stage).isEqualTo("STAGE_2")
+        assertThat(a.bucket).isEqualTo("DPD_31_60")
+        assertThat(a.expectedCreditLoss).isEqualByComparingTo("8100.00")
+        assertThat(a.modelVersion).isEqualTo("noop-flat-v1")
+        assertThat(requireNotNull(views[fresh.id.value]).assessment).isNull()
+    }
+
+    @Test
+    fun `the starter policy is reported as code-seeded with all four table kinds`() {
+        val view = service.activePolicy(LocalDate.of(2026, 9, 5)).await().indefinitely()
+        assertThat(view.codeSeeded).isTrue()
+        assertThat(view.source).isEqualTo("StarterCreditPolicy")
+        assertThat(view.tables.map { it.kind.name }).containsExactlyInAnyOrder(
+            "EXCLUSION",
+            "ELIGIBILITY",
+            "AFFORDABILITY",
+            "PRICING_BAND",
+        )
+    }
+
+    private fun loan() = Loan(
+        id = LoanId(UUID.randomUUID()),
+        applicationId = LoanApplicationId(UUID.randomUUID()),
+        partyId = UUID.randomUUID(),
+        principal = Money.of(BigDecimal("100000.00"), "CZK"),
+        nominalAnnualRate = BigDecimal("0.08"),
+        termPeriods = 12,
+        method = AmortizationMethod.ANNUITY,
+        firstDueDate = LocalDate.of(2026, 10, 1),
+        disbursedAt = OffsetDateTime.parse("2026-09-01T10:00:00Z"),
+        createdAt = OffsetDateTime.parse("2026-09-01T10:00:00Z"),
+    )
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -124,6 +124,9 @@ class LendingServiceTest {
     private fun stubClaim(claimed: Int = 1) {
         every { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) } returns
             Uni.createFrom().item(claimed)
+        // The ASSESSMENT leg claims through the decision-carrying overload instead, so both must be
+        // stubbed for a walk that crosses that state.
+        every { applications.compareAndSetDecision(any(), any()) } returns Uni.createFrom().item(claimed)
     }
 
     private fun verifyClaims(times: Int) =
@@ -242,6 +245,18 @@ class LendingServiceTest {
         assertThat(result.decisionPriceBand).isEqualTo("PRIME")
         assertThat(result.decisionInputHash).hasSize(64)
         assertThat(evidenceSlot.map { it.eventType }).contains("credit.decision.evaluated")
+
+        // The claim must carry the evidence into the database, not just into the response. Until
+        // `compareAndSetDecision` existed the ASSESSMENT leg claimed through `compareAndSetStatus`,
+        // which writes neither outcome nor price band, so every engine column stayed NULL while
+        // these very assertions passed against the in-memory copy.
+        val claimed = slot<LoanApplication>()
+        verify(exactly = 1) { applications.compareAndSetDecision(capture(claimed), OriginationState.ASSESSMENT) }
+        assertThat(claimed.captured.decisionOutcome).isEqualTo("APPROVE")
+        assertThat(claimed.captured.decisionPriceBand).isEqualTo("PRIME")
+        assertThat(claimed.captured.decisionInputHash).isEqualTo(result.decisionInputHash)
+        assertThat(claimed.captured.decidedEngineAt).isNotNull()
+        verify(exactly = 0) { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/DecisionEvidenceCodecTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/DecisionEvidenceCodecTest.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.domain
+
+import com.openbank.lending.domain.model.DecisionEvidenceCodec
+import com.openbank.lending.domain.model.DecisionReasonView
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The codec must read back exactly what `OriginationDecisionService` writes:
+ * reasons as `CODE:ruleId` with `-` for "no rule", versions as `KIND=n`, both comma-joined.
+ */
+class DecisionEvidenceCodecTest {
+
+    @Test
+    fun `decodes the reason csv the engine writes, mapping the dash to no rule`() {
+        val reasons = DecisionEvidenceCodec.reasons("AFFORDABILITY_FAILED:starter-af-dsti,INPUT_MISSING:-")
+        assertThat(reasons).containsExactly(
+            DecisionReasonView("AFFORDABILITY_FAILED", "starter-af-dsti"),
+            DecisionReasonView("INPUT_MISSING", null),
+        )
+    }
+
+    @Test
+    fun `decodes pinned policy versions per table kind`() {
+        assertThat(DecisionEvidenceCodec.policyVersions("EXCLUSION=1,ELIGIBILITY=2,AFFORDABILITY=1,PRICING_BAND=3"))
+            .containsExactlyInAnyOrderEntriesOf(
+                mapOf("EXCLUSION" to 1, "ELIGIBILITY" to 2, "AFFORDABILITY" to 1, "PRICING_BAND" to 3),
+            )
+    }
+
+    @Test
+    fun `is total - blanks and malformed fragments never throw`() {
+        assertThat(DecisionEvidenceCodec.reasons(null)).isEmpty()
+        assertThat(DecisionEvidenceCodec.reasons("")).isEmpty()
+        assertThat(DecisionEvidenceCodec.reasons("NOCOLON")).containsExactly(DecisionReasonView("NOCOLON", null))
+        assertThat(DecisionEvidenceCodec.policyVersions("ELIGIBILITY=x,=1,PRICING_BAND=2")).containsExactly(
+            java.util.AbstractMap.SimpleEntry("PRICING_BAND", 2),
+        )
+        assertThat(DecisionEvidenceCodec.matchedRuleIds(" a , ,b ")).containsExactly("a", "b")
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
@@ -188,6 +188,11 @@ class CustomerCreditJourneyResourceTest {
 
         override fun update(application: LoanApplication): Uni<LoanApplication> = Uni.createFrom().item(application)
 
+        override fun compareAndSetDecision(
+            application: LoanApplication,
+            from: OriginationState,
+        ): Uni<Int> = Uni.createFrom().item(1)
+
         override fun compareAndSetStatus(
             id: LoanApplicationId,
             from: OriginationState,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
@@ -6,7 +6,6 @@ package com.openbank.lending.infrastructure.rest
 
 import com.openbank.lending.application.port.out.LoanApplicationRepository
 import com.openbank.lending.domain.model.ApplicationStateSummary
-import com.openbank.lending.domain.model.DecisionOutcomeSummary
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
 import com.openbank.libs.domain.identifiers.LoanApplicationId
@@ -181,17 +180,10 @@ class CustomerCreditJourneyResourceTest {
 
         override fun summariseByState(): Uni<List<ApplicationStateSummary>> = Uni.createFrom().item(emptyList())
 
-        override fun findEvaluated(limit: Int): Uni<List<LoanApplication>> =
-            Uni.createFrom().item(rows.filter { it.decidedEngineAt != null }.take(limit))
-
-        override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = Uni.createFrom().item(emptyList())
-
         override fun update(application: LoanApplication): Uni<LoanApplication> = Uni.createFrom().item(application)
 
-        override fun compareAndSetDecision(
-            application: LoanApplication,
-            from: OriginationState,
-        ): Uni<Int> = Uni.createFrom().item(1)
+        override fun compareAndSetDecision(application: LoanApplication, from: OriginationState): Uni<Int> =
+            Uni.createFrom().item(1)
 
         override fun compareAndSetStatus(
             id: LoanApplicationId,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
@@ -6,6 +6,7 @@ package com.openbank.lending.infrastructure.rest
 
 import com.openbank.lending.application.port.out.LoanApplicationRepository
 import com.openbank.lending.domain.model.ApplicationStateSummary
+import com.openbank.lending.domain.model.DecisionOutcomeSummary
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
 import com.openbank.libs.domain.identifiers.LoanApplicationId
@@ -179,6 +180,11 @@ class CustomerCreditJourneyResourceTest {
             Uni.createFrom().item(emptyList())
 
         override fun summariseByState(): Uni<List<ApplicationStateSummary>> = Uni.createFrom().item(emptyList())
+
+        override fun findEvaluated(limit: Int): Uni<List<LoanApplication>> =
+            Uni.createFrom().item(rows.filter { it.decidedEngineAt != null }.take(limit))
+
+        override fun summariseDecisions(): Uni<List<DecisionOutcomeSummary>> = Uni.createFrom().item(emptyList())
 
         override fun update(application: LoanApplication): Uni<LoanApplication> = Uni.createFrom().item(application)
 

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/LendingSecurityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/LendingSecurityTest.kt
@@ -21,8 +21,13 @@ import org.junit.jupiter.api.Test
 class LendingSecurityTest {
 
     @Test
-    fun `no LendingResource endpoint is @PermitAll`() {
-        val methods = LendingResource::class.java.declaredMethods.filter { m ->
+    fun `no LendingResource endpoint is @PermitAll`() = assertNoPermitAll(LendingResource::class.java)
+
+    @Test
+    fun `no CreditRiskResource endpoint is @PermitAll`() = assertNoPermitAll(CreditRiskResource::class.java)
+
+    private fun assertNoPermitAll(resource: Class<*>) {
+        val methods = resource.declaredMethods.filter { m ->
             m.getAnnotation(GET::class.java) != null ||
                 m.getAnnotation(POST::class.java) != null ||
                 m.getAnnotation(PUT::class.java) != null ||

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CreditRiskConsoleIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CreditRiskConsoleIT.kt
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.integration
+
+import com.openbank.lending.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * The credit-risk read surface against a real Postgres, driven through the real origination
+ * path: the application is submitted and advanced so the ADR-0213 engine evaluates it at
+ * ASSESSMENT, and the console endpoints then read back the evidence the engine pinned.
+ *
+ * WHY THE REAL PATH AND NOT A SEEDED ROW. Seeding `decision_*` columns by JDBC would prove the
+ * query reads columns; it would not prove the read side decodes what the ENGINE writes. The codec
+ * unit test pins the format; this test pins that the two ends still meet over a real evaluation.
+ *
+ * The negative case (a role outside the desk is refused) is the control: the surface exposes
+ * book-wide exposure and every applicant's affordability inputs, so it must be at least as
+ * closed as the list endpoints.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@QuarkusTestResource(CreditRiskConsoleIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class CreditRiskConsoleIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("lending-events-out").toMutableMap()
+            props["quarkus.kafka.devservices.enabled"] = "false"
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    private lateinit var applicationId: String
+
+    private companion object {
+        /** SUBMITTED → KYC_PENDING → DOCS_REQUIRED → ASSESSMENT → (engine) → FOUR_EYES. */
+        const val ADVANCES_TO_FOUR_EYES = 4
+    }
+
+    @Test
+    @Order(1)
+    @TestSecurity(user = "risk-it-proposer", roles = ["ROLE_LENDING_OFFICER"])
+    fun `1 - submit an application with the inputs the starter policy needs`() {
+        val body = """
+            {"partyId":"${UUID.randomUUID()}",
+             "requestedAmount":{"amount":"120000.00","currency":{"code":"CZK"}},
+             "nominalAnnualRate":0.08,"termPeriods":12,"firstDueDate":"${LocalDate.now().plusMonths(1)}",
+             "verifiedIncomeMonthly":{"amount":"60000.00","currency":{"code":"CZK"}},
+             "existingDebtServiceMonthly":{"amount":"6000.00","currency":{"code":"CZK"}},
+             "ageYears":35,"residency":"CZ","employmentTenureMonths":48}
+        """.trimIndent()
+        applicationId = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/lending/applications")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+    }
+
+    @Test
+    @Order(2)
+    @TestSecurity(user = "risk-it-officer", roles = ["ROLE_LENDING_OFFICER"])
+    fun `2 - advance through ASSESSMENT so the engine evaluates`() {
+        repeat(ADVANCES_TO_FOUR_EYES) {
+            Given { contentType("application/json") } When {
+                post("/api/v1/lending/applications/$applicationId/advance")
+            } Then { statusCode(200) }
+        }
+    }
+
+    @Test
+    @Order(3)
+    @TestSecurity(user = "risk-it-analyst", roles = ["ROLE_CREDIT_RISK"])
+    fun `3 - the decisions read decodes what the engine pinned`() {
+        val response = Given { contentType("application/json") } When {
+            get("/api/v1/lending/risk/decisions?limit=50")
+        } Then { statusCode(200) } Extract { this }
+
+        val ids = response.jsonPath().getList<String>("applicationId")
+        assertThat(ids).contains(applicationId)
+        val i = ids.indexOf(applicationId)
+        val outcome = response.jsonPath().getString("[$i].engineOutcome")
+        assertThat(outcome).isIn("APPROVE", "REFER", "DECLINE")
+        assertThat(response.jsonPath().getString("[$i].inputSnapshotHash")).isNotBlank()
+        assertThat(response.jsonPath().getMap<String, Int>("[$i].policyVersions")).containsKeys(
+            "EXCLUSION",
+            "ELIGIBILITY",
+            "AFFORDABILITY",
+            "PRICING_BAND",
+        )
+        // 120k over 12 months at 8% is ~10.4k/month against 60k income: DSTI ≈ 0.17, total ≈ 0.27.
+        val dsti = response.jsonPath().getDouble("[$i].affordability.dsti")
+        val total = response.jsonPath().getDouble("[$i].affordability.dstiIncludingExistingDebt")
+        assertThat(dsti).isBetween(0.15, 0.20)
+        assertThat(total - dsti).isCloseTo(0.10, org.assertj.core.data.Offset.offset(0.001))
+        if (outcome == "APPROVE") {
+            assertThat(response.jsonPath().getString("[$i].priceBand")).isEqualTo("PRIME")
+        }
+    }
+
+    @Test
+    @Order(4)
+    @TestSecurity(user = "risk-it-analyst", roles = ["ROLE_CREDIT_RISK"])
+    fun `4 - the summary is grouped in the database and agrees with the list`() {
+        val summary = Given { contentType("application/json") } When {
+            get("/api/v1/lending/risk/decisions/summary")
+        } Then { statusCode(200) } Extract { this }
+        val total = summary.jsonPath().getList<Int>("count").sumOf { it.toLong() }
+        assertThat(total).isGreaterThanOrEqualTo(1L)
+        assertThat(summary.jsonPath().getList<String>("engineOutcome")).allSatisfy {
+            assertThat(it).isIn("APPROVE", "REFER", "DECLINE")
+        }
+    }
+
+    @Test
+    @Order(5)
+    @TestSecurity(user = "risk-it-compliance", roles = ["ROLE_COMPLIANCE"])
+    fun `5 - the policy read names the code-seeded starter and its four tables`() {
+        val policy = Given { contentType("application/json") } When {
+            get("/api/v1/lending/risk/policy?asOf=2026-09-05")
+        } Then { statusCode(200) } Extract { this }
+        assertThat(policy.jsonPath().getBoolean("codeSeeded")).isTrue()
+        assertThat(policy.jsonPath().getList<String>("tables.kind"))
+            .containsExactlyInAnyOrder("EXCLUSION", "ELIGIBILITY", "AFFORDABILITY", "PRICING_BAND")
+        // The DSTI threshold the console overlays is READ from here, so it must be present as data.
+        assertThat(policy.jsonPath().getList<String>("tables.rules.flatten().attribute")).contains("DSTI")
+
+        Given { contentType("application/json") } When {
+            get("/api/v1/lending/risk/policy?asOf=not-a-date")
+        } Then { statusCode(400) }
+    }
+
+    @Test
+    @Order(6)
+    @TestSecurity(user = "risk-it-analyst", roles = ["ROLE_CREDIT_RISK"])
+    fun `6 - the portfolio answers on an empty book and never fabricates an assessment`() {
+        val portfolio = Given { contentType("application/json") } When {
+            get("/api/v1/lending/risk/portfolio")
+        } Then { statusCode(200) } Extract { this }
+        // Whatever loans other suites left behind, none was assessed by the (disabled) cycle.
+        assertThat(portfolio.jsonPath().getList<Any?>("assessment")).allSatisfy { assertThat(it).isNull() }
+    }
+
+    @Test
+    @Order(7)
+    @TestSecurity(user = "risk-it-outsider", roles = ["ROLE_CUSTOMER"])
+    fun `7 - a role outside the credit desk is refused`() {
+        for (path in listOf("decisions", "decisions/summary", "portfolio", "policy")) {
+            Given { contentType("application/json") } When {
+                get("/api/v1/lending/risk/$path")
+            } Then { statusCode(403) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The credit decision engine (ADR-0213) has produced machine-readable evidence for every application since it shipped — outcome, reason codes with the rule that fired, pinned table versions, input snapshot hash — and nothing rendered any of it. A credit-risk analyst had two flat tables of enum strings. This adds a read-only credit-risk console over that evidence and over the IFRS 9 provisioning history, plus a notebook that reads its export.

While integration-testing it, the console came back empty against a real database. Cause: **the engine's evidence was never persisted.** That is fixed here (see "The defect this found").

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8893, Refs #8894, Refs #8895, Refs #8896

## The defect this found

`LendingService.claimTransition` writes status plus the three **human** decision fields. The ASSESSMENT leg ran the engine, put the result in the response, emitted `credit.decision.evaluated` — and then claimed the transition through that same method, which does not write any engine column. So `decision_outcome`, `decision_price_band`, `decision_reasons`, `decision_matched_rules`, `policy_versions`, `decision_input_hash` and `decided_engine_at` were **NULL on every row**, from `V11__decision_engine_inputs.sql` onward. A code comment in `claimTransition` described the gap and left it ("pre-existing and is NOT fixed here — it needs its own change and its own test").

Nothing could see it: the API response carried the values (computed in memory), the outbox event carried them, and no reader existed to notice the row did not. The evidence survived only as a Kafka event.

Fixed by `compareAndSetDecision`: the same conditional `where status = :from` claim, writing the evidence in the **same statement** as the transition, so a row can never hold a decided state with no decision behind it. `CreditRiskConsoleIT` is the test: it drives a real application through ASSESSMENT over HTTP and reads it back. Before the fix that read returned `[]` — that is how the defect was found, not by inspection.

## Changes

- **lending-service** — `GET /api/v1/lending/risk/{decisions,decisions/summary,portfolio,policy}`. Read-only; disposal stays in the approval inbox (ADR-0227 D4). Role-gated to the set that may read the ADR-0214 evidence bundle, OPA-annotated with the existing `lending.list` / `lending.read` actions, so no new `role_action_matrix` grant.
- Decision views decode the pinned evidence columns (`DecisionEvidenceCodec`, total by construction). The summary is a database `GROUP BY`, so a figure labelled a total is one (#3294's reasoning); the lists are clamped to 1000.
- `OriginationDecisionService.affordabilityRatios` becomes the single definition of DSTI/DTI, shared with the read side, so a console figure and an engine figure cannot diverge. It also returns total-debt-service DSTI, exposed and labelled as the CNB definition the engine does **not** read (#8894 decides whether that changes).
- Portfolio joins the latest `loan_provisioning` row per loan. A loan the cycle never assessed carries `assessment: null` — never Stage 1 with zero ECL.
- **admin-ui** `/lending/risk` — outcome trend, reason-code Pareto, DSTI×DTI scatter with thresholds **read from `/risk/policy`** rather than hard-coded, engine×disposition override matrix, jurisdiction split, decision tables with a per-rule hit count, IFRS 9 stage mix, DPD buckets, ECL coverage, vintage. CSV/JSON export.
- The page states what it cannot know: code-seeded policy, no-op bureau port (so `EXCLUSION` can never fire), placeholder PD/LGD with the model version shown next to every ECL.
- **docs/notebooks** — `credit-risk-decisioning.ipynb` reads the JSON export (pandas + matplotlib only). The export is the audit boundary: no notebook touches a money-path database.
- Threat-model supplement §10; two engineering notes in the service `CLAUDE.md`.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed). — no cross-service consumer; these are console reads.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed). — no schema change; the columns exist since V11 and were simply never written.
- [ ] Avro schema versioned backward-compatibly (if event changed). — no event change.
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR). — none added.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — none; recharts is already a dependency.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no auth code changed; the new surface is role-gated and read-only, and the money-path write path gains only the evidence columns in an existing conditional UPDATE.
- [x] PII path changed? → tag `gdpr-review-required`. — a new read exposes applicant income and affordability inputs to the credit desk; gated to the roles that already read the evidence bundle, capped at 1000 rows, no new storage and no new export target.
- [x] Cardholder data path changed? → tag `pci-review-required`. — no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

**GDPR.** The decisions read returns affordability inputs (income, existing debt service, age, residency, employment tenure) for evaluated applications. Compensating controls: role gate identical to the ADR-0214 evidence bundle, a server-side cap, no new persistence, and an export the analyst performs under their own identity rather than a background job.

**CNB.** The persistence fix restores the decision evidence in the database, which is what a supervisory reconstruction of a credit decision needs; until now only the event stream had it. The console also makes the DSTI definition gap visible and quantified (#8894), and the credit reporting gaps are inventoried in #8895.

## Rollout / Rollback

- Deployment strategy: rolling.
- Rollback plan: revert. The new endpoints are additive reads; the persistence fix writes columns that were NULL, so a rollback stops writing them again and leaves existing rows valid.
- Data migration reversible: N/A (no migration).

## Screenshots / demo (if UI change)

Not attached — the page needs a populated book to be worth a screenshot, and this environment's is empty. The render is covered by `lending-risk-page.test.tsx`.

## Reviewer notes

- **Where to look first:** `LendingService.claimDecision` and `DECISION_HQL`. Everything else is a read.
- **Falsification, not assertion.** The IT's decision assertions fail against the old persistence path (that is how the defect surfaced). Two console assertions were sabotage-checked: changing the policy threshold in the fixture reddens the "reads the threshold from policy" test, and widening the override denominator reddens the override-rate test.
- **Verified locally:** lending unit tests 21/21, `CreditRiskConsoleIT` against a real Postgres, ktlint + detekt clean, admin-ui `npm test` (my three files green; nine unrelated files failed on 5s timeouts under parallel load, the known non-determinism of that suite), `check-api-contract.py --base origin/main --enforce` → additive, 1.17.0 → 1.19.0.
- **Spec version:** 1.18.0 is claimed by #8838, so this takes 1.19.0. Whoever lands second re-checks.
- **One baseline entry added:** `ktlint-baseline.xml` gains the `package-name` violation every file in `port/in` carries (Kotlin keyword directory), matching the two entries already there.
- **Deliberately not here:** the warehouse has no lending stream at all (#8893), which is why this console reads the OLTP service directly and is capped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
