### PR TITLE
feat(analytics-sink): derive the post-settlement transaction fact from the events already ingested

### DIFF
--- a/openbank-analytics-sink/src/main/resources/clickhouse/V13__settled_transactions.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V13__settled_transactions.sql
@@ -1,0 +1,101 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The post-settlement transaction fact ADR-0282 phase 1 asks for (issue #8792).
+--
+-- WHAT THE ISSUE SAID, AND WHAT THE WAREHOUSE SAYS. #8792 states that the only transaction fact in
+-- analytics is the initiated event, that it carries no rail, and that it is emitted before the money
+-- moves. Measured 2026-09-05, two of those three are no longer true: THREE transaction event kinds
+-- are ingested — TransactionInitiated (63), TransactionCompleted (47), TransactionFailed (13) — and
+-- the initiated payload does carry `rail`, alongside amount, currencyCode, instructionType, type,
+-- source/target account and initiatedByPartyId.
+--
+-- WHAT IS ACTUALLY MISSING IS THE OPPOSITE SHAPE. The post-settlement event EXISTS and is
+-- content-free: TransactionCompleted carries only a referenceNumber. So "did it settle" and "what
+-- settled" live in two different events, and every consumer that wants a settled amount has to know
+-- to join them. Nothing did, which is why the fact read as absent.
+--
+-- Both events are keyed by the transaction's own aggregate_id, so the join is exact rather than
+-- heuristic. Verified before writing this: all 47 completed transactions join back to an initiated
+-- event carrying an amount, 47 of 47.
+--
+-- SETTLEMENT TIME COMES FROM THE COMPLETED EVENT, THE ECONOMICS FROM THE INITIATED ONE. Mixing them
+-- is the whole point: a fact stamped with the initiation time would put a payment in the wrong day
+-- and, for a month-boundary settlement, the wrong reporting period. occurred_at throughout, never
+-- ingested_at — a backfill must land in the period it happened.
+--
+-- WHAT IS STILL GENUINELY MISSING, AND IS NOT PAPERED OVER HERE. Category, MCC and merchant are
+-- absent from every transaction payload and cannot be derived: no view can invent them, and this one
+-- does not try. `rail` is present but reads UNKNOWN for 55 of 63 initiated events, so it is a
+-- declared field with no producer filling it — a column that exists and lies is worse than one that
+-- is missing, so `rail` is surfaced verbatim rather than defaulted, and a consumer can see UNKNOWN
+-- for what it is. Those three fields plus a populated rail are the producer change that remains.
+--
+-- NEVER THE COUNTERPARTY NAME AND NEVER THE FREE-TEXT MESSAGE. #8792 requires the enrichment to be
+-- designed minimal rather than filtered afterwards, and this view selects a closed column list: no
+-- `payload` passthrough, so a field added to the event later cannot arrive here by accident.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_settled_transactions AS
+SELECT
+    c.aggregate_id                                          AS transaction_id,
+    c.occurred_at                                           AS settled_at,
+    toStartOfMonth(c.occurred_at)                           AS settled_month,
+    toDecimal64OrNull(JSONExtractString(i.payload, 'amount'), 2) AS amount,
+    JSONExtractString(i.payload, 'currencyCode')            AS currency_code,
+    JSONExtractString(i.payload, 'type')                    AS transaction_type,
+    JSONExtractString(i.payload, 'instructionType')         AS instruction_type,
+    -- Surfaced verbatim. UNKNOWN is what the producer wrote, and it must stay distinguishable from
+    -- a rail this view failed to read.
+    JSONExtractString(i.payload, 'rail')                    AS rail,
+    JSONExtractString(i.payload, 'sourceAccountId')         AS source_account_id,
+    JSONExtractString(i.payload, 'targetAccountId')         AS target_account_id,
+    JSONExtractString(i.payload, 'initiatedByPartyId')      AS initiated_by_party_id,
+    i.occurred_at                                           AS initiated_at
+FROM
+(
+    SELECT aggregate_id, occurred_at
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionCompleted'
+) AS c
+INNER JOIN
+(
+    SELECT aggregate_id, occurred_at, payload
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionInitiated'
+) AS i
+    ON i.aggregate_id = c.aggregate_id;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Per-party settled spend, from the account side rather than the initiator side.
+--
+-- WHY NOT initiated_by_party_id. It is populated on 50 of 63 initiated events, so keying on it
+-- silently drops a fifth of the traffic — and drops it as "this party spent less", which is the
+-- flattering direction and therefore the dangerous one for anything that rewards behaviour.
+-- Ownership through V5's account key covers every transaction with a known account, and both legs
+-- are unioned so an internal transfer between two of the customer's own accounts appears as both,
+-- exactly as V10's monthly flows already treats it.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_settled_spend AS
+SELECT
+    party_id,
+    settled_month,
+    countIf(direction = 'OUT')                 AS outbound_count,
+    sumIf(amount, direction = 'OUT')           AS outbound_amount,
+    countIf(direction = 'IN')                  AS inbound_count,
+    sumIf(amount, direction = 'IN')            AS inbound_amount,
+    uniqExact(transaction_id)                  AS settled_transactions
+FROM
+(
+    SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'OUT' AS direction
+    FROM openbank_analytics.silver_settled_transactions AS t
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.source_account_id
+
+    UNION ALL
+
+    SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'IN' AS direction
+    FROM openbank_analytics.silver_settled_transactions AS t
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.target_account_id
+)
+GROUP BY party_id, settled_month;

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -1084,6 +1084,108 @@ data:
         max(occurred_at)                                          AS last_occurred_at
     FROM openbank_analytics.silver_party_events
     GROUP BY party_id, aggregate_type;
+  13-settled-transactions.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- The post-settlement transaction fact ADR-0282 phase 1 asks for (issue #8792).
+    --
+    -- WHAT THE ISSUE SAID, AND WHAT THE WAREHOUSE SAYS. #8792 states that the only transaction fact in
+    -- analytics is the initiated event, that it carries no rail, and that it is emitted before the money
+    -- moves. Measured 2026-09-05, two of those three are no longer true: THREE transaction event kinds
+    -- are ingested — TransactionInitiated (63), TransactionCompleted (47), TransactionFailed (13) — and
+    -- the initiated payload does carry `rail`, alongside amount, currencyCode, instructionType, type,
+    -- source/target account and initiatedByPartyId.
+    --
+    -- WHAT IS ACTUALLY MISSING IS THE OPPOSITE SHAPE. The post-settlement event EXISTS and is
+    -- content-free: TransactionCompleted carries only a referenceNumber. So "did it settle" and "what
+    -- settled" live in two different events, and every consumer that wants a settled amount has to know
+    -- to join them. Nothing did, which is why the fact read as absent.
+    --
+    -- Both events are keyed by the transaction's own aggregate_id, so the join is exact rather than
+    -- heuristic. Verified before writing this: all 47 completed transactions join back to an initiated
+    -- event carrying an amount, 47 of 47.
+    --
+    -- SETTLEMENT TIME COMES FROM THE COMPLETED EVENT, THE ECONOMICS FROM THE INITIATED ONE. Mixing them
+    -- is the whole point: a fact stamped with the initiation time would put a payment in the wrong day
+    -- and, for a month-boundary settlement, the wrong reporting period. occurred_at throughout, never
+    -- ingested_at — a backfill must land in the period it happened.
+    --
+    -- WHAT IS STILL GENUINELY MISSING, AND IS NOT PAPERED OVER HERE. Category, MCC and merchant are
+    -- absent from every transaction payload and cannot be derived: no view can invent them, and this one
+    -- does not try. `rail` is present but reads UNKNOWN for 55 of 63 initiated events, so it is a
+    -- declared field with no producer filling it — a column that exists and lies is worse than one that
+    -- is missing, so `rail` is surfaced verbatim rather than defaulted, and a consumer can see UNKNOWN
+    -- for what it is. Those three fields plus a populated rail are the producer change that remains.
+    --
+    -- NEVER THE COUNTERPARTY NAME AND NEVER THE FREE-TEXT MESSAGE. #8792 requires the enrichment to be
+    -- designed minimal rather than filtered afterwards, and this view selects a closed column list: no
+    -- `payload` passthrough, so a field added to the event later cannot arrive here by accident.
+    -- ─────────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_settled_transactions AS
+    SELECT
+        c.aggregate_id                                          AS transaction_id,
+        c.occurred_at                                           AS settled_at,
+        toStartOfMonth(c.occurred_at)                           AS settled_month,
+        toDecimal64OrNull(JSONExtractString(i.payload, 'amount'), 2) AS amount,
+        JSONExtractString(i.payload, 'currencyCode')            AS currency_code,
+        JSONExtractString(i.payload, 'type')                    AS transaction_type,
+        JSONExtractString(i.payload, 'instructionType')         AS instruction_type,
+        -- Surfaced verbatim. UNKNOWN is what the producer wrote, and it must stay distinguishable from
+        -- a rail this view failed to read.
+        JSONExtractString(i.payload, 'rail')                    AS rail,
+        JSONExtractString(i.payload, 'sourceAccountId')         AS source_account_id,
+        JSONExtractString(i.payload, 'targetAccountId')         AS target_account_id,
+        JSONExtractString(i.payload, 'initiatedByPartyId')      AS initiated_by_party_id,
+        i.occurred_at                                           AS initiated_at
+    FROM
+    (
+        SELECT aggregate_id, occurred_at
+        FROM openbank_analytics.bronze_events
+        WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionCompleted'
+    ) AS c
+    INNER JOIN
+    (
+        SELECT aggregate_id, occurred_at, payload
+        FROM openbank_analytics.bronze_events
+        WHERE upper(aggregate_type) = 'TRANSACTION' AND event_type = 'TransactionInitiated'
+    ) AS i
+        ON i.aggregate_id = c.aggregate_id;
+
+    -- ─────────────────────────────────────────────────────────────────────────────
+    -- Per-party settled spend, from the account side rather than the initiator side.
+    --
+    -- WHY NOT initiated_by_party_id. It is populated on 50 of 63 initiated events, so keying on it
+    -- silently drops a fifth of the traffic — and drops it as "this party spent less", which is the
+    -- flattering direction and therefore the dangerous one for anything that rewards behaviour.
+    -- Ownership through V5's account key covers every transaction with a known account, and both legs
+    -- are unioned so an internal transfer between two of the customer's own accounts appears as both,
+    -- exactly as V10's monthly flows already treats it.
+    -- ─────────────────────────────────────────────────────────────────────────────
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_settled_spend AS
+    SELECT
+        party_id,
+        settled_month,
+        countIf(direction = 'OUT')                 AS outbound_count,
+        sumIf(amount, direction = 'OUT')           AS outbound_amount,
+        countIf(direction = 'IN')                  AS inbound_count,
+        sumIf(amount, direction = 'IN')            AS inbound_amount,
+        uniqExact(transaction_id)                  AS settled_transactions
+    FROM
+    (
+        SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'OUT' AS direction
+        FROM openbank_analytics.silver_settled_transactions AS t
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.source_account_id
+
+        UNION ALL
+
+        SELECT pa.party_id AS party_id, t.settled_month, t.amount, t.transaction_id, 'IN' AS direction
+        FROM openbank_analytics.silver_settled_transactions AS t
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa ON pa.account_id = t.target_account_id
+    )
+    GROUP BY party_id, settled_month;
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
## Summary

ADR-0282 phase 1 asks for a post-settlement transaction fact. Measuring the warehouse before building changed what the work is: the post-settlement event already exists and is content-free, so "did it settle" and "what settled" live in two different events that nobody joined.

Stacked on #8897 because both edit the ClickHouse boot ConfigMap, where a clean merge can silently drop one side's key.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8792 · Refs #2891 · ADR-0282 phase 1

## Two of the issue's three premises are stale

#8792 says the only transaction fact is the initiated event, that it carries no rail, and that it precedes the money moving. Measured 2026-09-05:

| event kind | rows |
|---|---|
| TransactionInitiated | 63 |
| TransactionCompleted | 47 |
| TransactionFailed | 13 |

The initiated payload carries `rail`, amount, currencyCode, instructionType, type, source and target account, and initiatedByPartyId. What it lacks is category, MCC and merchant, which remains true.

## Changes

- `V13__settled_transactions.sql` and its boot ConfigMap key.
  - `silver_settled_transactions` joins completed to initiated on the transaction's own aggregate id. Settlement time from the completed event, economics from the initiated one.
  - `gold_party_settled_spend` per party per month, both legs, through V5's account key.

## Measured

| property | value |
|---|---|
| settled rows | 47 |
| distinct transaction ids | 47 |
| null amounts | 0 |
| rows where settled precedes initiated | 0 |
| completed events joining to an amount | 47 of 47 |

Falsified: dropping the event_type filter on the initiated side inflates the fact to 94 rows over the same 47 ids, which is exactly the fan-out the filter prevents.

## What is not papered over

Category, MCC and merchant are absent from every transaction payload and cannot be derived. No view can invent them and this one does not try.

`rail` is declared but reads UNKNOWN for 42 of 47 settled transactions. It is surfaced verbatim rather than defaulted, because a column that exists and lies is worse than one that is missing.

Per-party coverage is 17 transaction legs of 47 settled transactions, and the cause is measured rather than assumed. Not one referenced account is external: zero unknown source accounts and zero unknown target accounts. 33 have a source account that is ours but absent from `silver_party_accounts`, because only `AccountCreated` carries `partyId`, 19 of 19, while `BALANCE_UPDATED`, `HOLD_PLACED`, `HOLD_RELEASED` and `AccountStatusChanged` carry none.

So 19 of 29 accounts are reachable from a party. #2891 is narrower than "no ACCOUNT event carries partyId" and is not closed. That is the producer change that remains, alongside a populated rail.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

No unit tests: this change is two SQL views and a ConfigMap key, with no Kotlin or TypeScript consumer yet. Both ClickHouse gates run on it, and the behaviour was verified against the sandbox warehouse with a falsification. A consumer arrives with the Lipa earn evaluation and brings its own pin, as the Customer 360 route does for V5 and V12.

The ClickHouse migration is not Flyway and has no runner: an operator applies `clickhouse/V*.sql` by hand and the boot ConfigMap covers a fresh cluster. Rollback is `DROP VIEW` on the two names, which removes no data because both are views.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. Verified against the diff: zero added.
- [x] No new third-party dependency. Verified: no build or lock file in the diff.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

The view names no counterparty and carries no free-text message. It selects a closed column list with no payload passthrough, so a field added to the event later cannot arrive here by accident. Both objects are views, so a crypto-shredded bronze row disappears from them with no separate anonymisation step.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
