### PR TITLE
fix(party): replay the anonymous VoP pact + JSON security-abort envelope

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
@@ -12,6 +12,9 @@ import com.openbank.party.application.port.out.GdprAggregationAuthException
 import com.openbank.party.application.usecase.PartyAlreadyExistsException
 import com.openbank.party.application.usecase.PartyMergeRejectedException
 import com.openbank.party.application.usecase.PartyNotFoundException
+import io.quarkus.security.AuthenticationFailedException
+import io.quarkus.security.ForbiddenException
+import io.quarkus.security.UnauthorizedException
 import io.vertx.pgclient.PgException
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
@@ -144,4 +147,59 @@ class GdprAggregationAuthMapper : ExceptionMapper<GdprAggregationAuthException> 
     companion object {
         private const val BAD_GATEWAY = 502
     }
+}
+
+// Security-abort responses must be the JSON error envelope like every other error here.
+// Without these mappers Quarkus REST's built-in handling writes the exception MESSAGE as a
+// plain-text entity while the response keeps the resource's negotiated application/json
+// content-type — a 401 whose body is the literal text "Not Authenticated" under a JSON
+// content-type. Any client parsing the error as JSON (and Pact-JVM's matching engine, which
+// plans the body comparison from the content-type) chokes on it: same defect class measured
+// on the anonymous IBAN-lookup pact replay in account-service (#8803); here it breaks the
+// anonymous VoP lookup pact replay (#8875). A user @Provider mapper wins over Quarkus'
+// built-in. These live in the SERVICE, not libs-runtime, on purpose: a shared-library
+// @Provider naming an `io.quarkus.security` type would be loaded by ArC in every consumer,
+// including services without quarkus-security on the classpath — the #6240 boot-failure
+// class, enforced by the provider-type-classpath gate.
+@Provider
+class QuarkusUnauthorizedExceptionMapper : ExceptionMapper<UnauthorizedException> {
+    override fun toResponse(exception: UnauthorizedException): Response = Response.status(Response.Status.UNAUTHORIZED)
+        .entity(
+            ApiError(
+                Ids.randomId().toString(),
+                Response.Status.UNAUTHORIZED.statusCode,
+                "UNAUTHORIZED",
+                "Unauthorized",
+                timestamp = Instant.now(),
+            ),
+        ).build()
+}
+
+@Provider
+class QuarkusAuthenticationFailedExceptionMapper : ExceptionMapper<AuthenticationFailedException> {
+    override fun toResponse(exception: AuthenticationFailedException): Response =
+        Response.status(Response.Status.UNAUTHORIZED)
+            .entity(
+                ApiError(
+                    Ids.randomId().toString(),
+                    Response.Status.UNAUTHORIZED.statusCode,
+                    "UNAUTHORIZED",
+                    "Unauthorized",
+                    timestamp = Instant.now(),
+                ),
+            ).build()
+}
+
+@Provider
+class QuarkusForbiddenExceptionMapper : ExceptionMapper<ForbiddenException> {
+    override fun toResponse(exception: ForbiddenException): Response = Response.status(Response.Status.FORBIDDEN)
+        .entity(
+            ApiError(
+                Ids.randomId().toString(),
+                Response.Status.FORBIDDEN.statusCode,
+                "FORBIDDEN",
+                "Forbidden",
+                timestamp = Instant.now(),
+            ),
+        ).build()
 }

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
@@ -23,6 +23,7 @@ import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestIdentityAssociation
 import io.quarkus.test.security.TestSecurity
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
 import io.vertx.core.Vertx
@@ -96,6 +97,9 @@ class PartyPactFolderProviderVerificationTest {
     @Inject
     lateinit var vertx: Vertx
 
+    @Inject
+    lateinit var testIdentityAssociation: TestIdentityAssociation
+
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
     /**
@@ -137,7 +141,15 @@ class PartyPactFolderProviderVerificationTest {
     @ExtendWith(PactVerificationInvocationContextProvider::class)
     fun verifyPacts(context: PactVerificationContext?) {
         // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
-        context?.verifyInteraction()
+        if (context == null) return
+        // #8875: the anonymous VoP interaction must be replayed WITHOUT the class-level
+        // @TestSecurity identity, or the provider never executes the 401 branch the contract
+        // asserts. QuarkusSecurityTestExtension re-applies @TestSecurity before the next
+        // invocation, so clearing it here cannot leak into the authenticated interactions.
+        if (context.interaction.description.endsWith("no caller identity")) {
+            testIdentityAssociation.setTestIdentity(null)
+        }
+        context.verifyInteraction()
     }
 
     @State("a party has been created")

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/SecurityAbortExceptionMapperTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/SecurityAbortExceptionMapperTest.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import io.quarkus.security.AuthenticationFailedException
+import io.quarkus.security.ForbiddenException
+import io.quarkus.security.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * #8875: security aborts must render the JSON ApiError envelope — the built-in Quarkus
+ * handling writes the exception message as plain text under the resource's negotiated
+ * application/json content-type, which breaks any JSON-parsing client (and the anonymous
+ * VoP party-lookup pact replay). Same defect class as account-service's #8803.
+ */
+class SecurityAbortExceptionMapperTest {
+
+    @Test
+    fun `maps UnauthorizedException to a 401 UNAUTHORIZED ApiError`() {
+        val response = QuarkusUnauthorizedExceptionMapper()
+            .toResponse(UnauthorizedException("Not Authenticated"))
+
+        assertThat(response.status).isEqualTo(401)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(401)
+        assertThat(error.code).isEqualTo("UNAUTHORIZED")
+        // fixed message — the raw exception text is not leaked into the response
+        assertThat(error.message).isEqualTo("Unauthorized")
+        assertThat(error.traceId).isNotBlank()
+    }
+
+    @Test
+    fun `maps AuthenticationFailedException to the same 401 envelope`() {
+        val response = QuarkusAuthenticationFailedExceptionMapper()
+            .toResponse(AuthenticationFailedException("bad token"))
+
+        assertThat(response.status).isEqualTo(401)
+        val error = response.entity as ApiError
+        assertThat(error.code).isEqualTo("UNAUTHORIZED")
+        assertThat(error.message).isEqualTo("Unauthorized")
+    }
+
+    @Test
+    fun `maps ForbiddenException to a 403 FORBIDDEN ApiError`() {
+        val response = QuarkusForbiddenExceptionMapper()
+            .toResponse(ForbiddenException("wrong role"))
+
+        assertThat(response.status).isEqualTo(403)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(403)
+        assertThat(error.code).isEqualTo("FORBIDDEN")
+        assertThat(error.message).isEqualTo("Forbidden")
+    }
+}


### PR DESCRIPTION
Closes #8875

## Co a proč
Pact `openbank-vop-service → openbank-party-service` nese anonymní interakci (`GET ... with no caller identity`), která assertuje 401 s JSON error tělem. Folder replay ale běžel pod class-level `@TestSecurity` identitou, takže se 401 větev nikdy nevykonala — a kdyby ano, vestavěná Quarkus handling psala `Not Authenticated` jako plain text pod `application/json` content-typem. Stejná defektní třída jako #8803 (account-service, PR #8852).

## Změny
- **`PartyPactFolderProviderVerificationTest`**: pro interakci končící "no caller identity" se testovací identita smaže (`TestIdentityAssociation.setTestIdentity(null)`); `QuarkusSecurityTestExtension` ji před další invokací znovu aplikuje, takže nic neuniká do autentizovaných interakcí.
- **`ExceptionMappers.kt`**: tři service-local `@Provider` mappery — `UnauthorizedException` / `AuthenticationFailedException` → 401 `UNAUTHORIZED`, `ForbiddenException` → 403 `FORBIDDEN`, vše v `ApiError` envelope s fixní zprávou (raw exception text neleakne). Záměrně **ne** v libs-runtime: sdílený `@Provider` nad `io.quarkus.security` typy by ArC naložil i ve službách bez quarkus-security na classpath (#6240, gate `provider-type-classpath`).
- Nový `SecurityAbortExceptionMapperTest` (3 testy).

## Ověření (lokálně, worktree)
- `PartyPactFolderProviderVerificationTest`: **11/11 interakcí PASS** včetně anonymní VoP (předtím se anonymní větev nereplayovala).
- `SecurityAbortExceptionMapperTest`: 3/3.
- `ktlintMainSourceSetCheck` + `ktlintTestSourceSetCheck`: čisté.

party-service není v `money_path_services` (rules.yaml), takže bez security checklistu / threat-model zápisu.