### PR TITLE
docs(notification): record why OTP_CODE and WELCOME stay, and correct ADR-0176

### DIFF
--- a/docs/adr/0176-operator-initiated-customer-messaging.md
+++ b/docs/adr/0176-operator-initiated-customer-messaging.md
@@ -166,8 +166,15 @@ and drop the lattice.
 Two further corrections the collapse makes moot but which are worth recording. `WELCOME` is **not**
 marketing: its rendered body ("Thank you for joining OpenBank, {name}") promotes no product. The
 first draft inherited that label from an unexamined comment in `OversightWebhook.kt` — and had it
-been right, D6's marketing hard-deny would have made the **live onboarding flow non-compliant
-today**, which the draft never noticed. And the first draft used the name `MARKETING` on both this
+been right, D6's marketing hard-deny would have refused it.
+
+> **Correction, 2026-09-05 (#8568).** That sentence originally said the hard-deny would have made
+> "the live onboarding flow non-compliant today". It would not have: `WELCOME` has **no producer**
+> — nothing anywhere emits it, verified by emission shape rather than by name — so there is no live
+> flow to make non-compliant. The correction above stands on its own merits; only the claim about
+> live impact was wrong. Kept in the enum for now: the onboarding moment it would occupy already
+> carries `KYC_APPROVED` and then `ACCOUNT_OPENED`, so a third greeting is a product decision about
+> replacing one of those, not an omission to fill. And the first draft used the name `MARKETING` on both this
 axis and D6's, so one template was simultaneously deliverable (D1) and refused (D6). Sensitivity and
 purpose are orthogonal, and now only one of them uses the word.
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -42,11 +42,19 @@ enum class NotificationTemplate(val variables: Set<String>) {
     KYC_REJECTED(setOf("reason")),
     CONSENT_GRANTED(setOf("scope")),
     CONSENT_REVOKED(setOf("scope")),
+
+    // No producer, and deliberately kept: it is the only member of TemplateSensitivity's
+    // SECRET_TEMPLATES, so deleting it as "unproduced" would silently empty the at-rest redaction
+    // guard (#8568). sca-service refuses TOTP outright (#8567) — there is no transport for a code.
     OTP_CODE(setOf("code")),
 
     // No PASSWORD_RESET template (#8568): no password flow exists anywhere in the system —
     // the app authenticates with passkeys/biometrics and Keycloak runs with
     // resetPasswordAllowed=false and no SMTP, so nothing could ever produce one.
+
+    // No producer (#8568). Kept rather than removed because the onboarding moment it would occupy
+    // already carries KYC_APPROVED and then ACCOUNT_OPENED — a third greeting there is a product
+    // decision about REPLACING one of those, not a gap to fill.
     WELCOME(setOf("name")),
 
     /** Decoupled/push SCA — "you have a payment to approve" (#4). [detail] = the human summary. */

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
@@ -45,6 +45,18 @@ object TemplateSensitivity {
      * Membership is decided by one question: *if a bank operator read this body, could
      * they use it to act as the customer?* Add a template here the moment its rendered
      * form carries a code, token, link with an embedded token, or password.
+     *
+     * **`OTP_CODE` is the last member, and removing it would empty this set (#8568).** It has no
+     * producer — sca-service refuses `ScaMethod.TOTP` outright (#8567), because nothing in the
+     * fleet can deliver a code and a push to the device that asked for it is not a second factor.
+     * That makes it look like the "declared but never produced" templates removed in #8834 and
+     * #8857, and it is not: an empty `SECRET_TEMPLATES` turns [isSecret] permanently false and
+     * [bodyForStorage] into the identity function, so the FIRST secret-bearing template anyone
+     * adds later would be stored in cleartext by default. The redaction rule would be off and
+     * nothing would say so.
+     *
+     * So this entry is load-bearing while unused, and stays until either a real second channel
+     * exists or a deliberate decision retires the mechanism with it.
      */
     val SECRET_TEMPLATES: Set<NotificationTemplate> = setOf(
         NotificationTemplate.OTP_CODE,


### PR DESCRIPTION
Closes #8568.

## What changed since I filed it

#8857 already removed `PASSWORD_RESET` — no password flow exists anywhere, the app authenticates with passkeys and Keycloak runs with `resetPasswordAllowed=false` and no SMTP. That was the one of my three proposals that survives.

I had proposed removing the other two on the same reasoning. **Checking each properly says otherwise, and one of them would have been a real defect.**

## `OTP_CODE` must not be removed

It is the **only member** of `TemplateSensitivity.SECRET_TEMPLATES`. Deleting it as "unproduced" makes `isSecret()` permanently false and `bodyForStorage()` the identity function — so the **first secret-bearing template anyone adds later would be stored in cleartext by default**, with nothing to say the redaction rule had been switched off.

It has no producer: sca-service refuses `ScaMethod.TOTP` outright (#8567) because nothing in the fleet can deliver a code and a push to the device that asked for it is not a second factor. That makes it look exactly like `KYC_DOCUMENT_REQUIRED` (#8834) and `PASSWORD_RESET` (#8857).

**That resemblance is the trap**, and I nearly walked into it. It is now written next to the enum constant *and* next to the set, so the next person following the "remove unproduced templates" pattern stops here.

## `WELCOME` stays, for a different reason

It genuinely has no producer. But the onboarding moment it would occupy **already carries `KYC_APPROVED` and then `ACCOUNT_OPENED`**, both of which started firing this week (#8439's consumer on main, and #8469). A third greeting at that moment is a product decision about *replacing* one of those, not a gap to fill.

Practical point too: `WELCOME` is a fixture in 8 places in `NotificationConsumerIT`, which needs the IT stack I cannot run locally. Rewriting them blind to save one enum constant is risk without payoff.

## ADR-0176 corrected

It said the marketing hard-deny "would have made the **live onboarding flow non-compliant today**". It would not have — `WELCOME` has no producer at all, verified by **emission shape rather than by name**, which matters here because the same string is also an unrelated onboarding *funnel step* (`WELCOME → IDENTITY → EMAIL → …`) in analytics and admin-ui.

The correction that ADR makes (WELCOME is not marketing) stands on its own merits; only its claim about live impact was wrong, and that is recorded as a dated note rather than rewritten.

## Verification

Comments and one ADR note — no behaviour change. `NotificationModelTest` **7 tests, 0 failures**; `ktlintCheck` clean; `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)