### PR TITLE
fix(security): fuzz KPI skips override-scoped runs — an override is not fleet coverage

### DIFF
--- a/.github/scripts/fuzz-coverage-aggregate.py
+++ b/.github/scripts/fuzz-coverage-aggregate.py
@@ -64,6 +64,12 @@ def aggregate(artifacts: Path, scope_file: Path, run_url: str) -> dict:
         "run": run_url,
         "inScope": len(scope.get("keep", [])),
         "excluded": scope.get("skipped", []),
+        # A dispatch-narrowed run is NOT a fleet coverage measurement — the security-kpis
+        # collector skips artifacts flagged override (and an old artifact without the flag
+        # is treated as NOT overridden, i.e. measured, because every scheduled run derives
+        # the full set; the flag exists from the workflow change that introduced it).
+        "override": bool(scope.get("override", False)),
+        "overrideRequested": scope.get("overrideRequested", []),
         "tested": tested,
         "coveragePct": round(100 * tested / len(services)) if services else 0,
         "totalExercised": sum(s["exercised"] for s in services),
@@ -104,6 +110,15 @@ def self_test() -> int:
             print("self-test FAIL: authz-OFF pass leaked into the coverage record"); bad += 1
         if cov["excluded"] != [["openbank-vop-service", "no postgresql:// URL"]]:
             print("self-test FAIL: excluded services must carry their reason"); bad += 1
+        if cov["override"] is not False or cov["overrideRequested"] != []:
+            print("self-test FAIL: a derived (non-override) scope must record override=false"); bad += 1
+        # an override scope must propagate the flag — the KPI collector keys off it
+        (root / "ovr.json").write_text(json.dumps({
+            "keep": ["openbank-ledger-service"], "skipped": [],
+            "override": True, "overrideRequested": ["openbank-ledger-service"]}))
+        ovr = aggregate(root, root / "ovr.json", "https://example.test/run/2")
+        if ovr["override"] is not True or ovr["overrideRequested"] != ["openbank-ledger-service"]:
+            print("self-test FAIL: override scope must surface override=true"); bad += 1
     print("fuzz-coverage-aggregate self-test: " + ("clean" if not bad else f"{bad} failure(s)"))
     return 1 if bad else 0
 

--- a/.github/scripts/security-kpis.py
+++ b/.github/scripts/security-kpis.py
@@ -218,45 +218,67 @@ def collect_fuzz() -> dict:
 
     try:
         runs = json.loads(gh("actions/workflows/api-fuzz.yml/runs?status=completed&per_page=10"))
-        artifacts = []
-        for run in runs.get("workflow_runs", []):
+
+        def download(artifact: dict) -> dict:
+            req = urllib.request.Request(
+                artifact["archive_download_url"],
+                headers={"Authorization": f"Bearer {token}",
+                         "Accept": "application/vnd.github+json"})
+            # Cross-host redirect must not carry the GitHub token — see _no_auth_redirect_opener.
+            try:
+                blob = _no_auth_redirect_opener().open(req, timeout=30).read()
+            except Exception as urllib_exc:
+                # Fallback for tokens/edges where the stripped-redirect dance still fails
+                # (observed with the workflow GITHUB_TOKEN on run 33972808389): the `gh` CLI is
+                # preinstalled on the runner and handles the 302 correctly. `gh api …/zip` writes
+                # the archive bytes to stdout.
+                import shutil
+                import subprocess
+                ghbin = shutil.which("gh")
+                if not ghbin:
+                    raise
+                out = subprocess.run(
+                    [ghbin, "api", f"repos/{repo}/actions/artifacts/{artifact['id']}/zip"],
+                    capture_output=True, timeout=60,
+                    env={**os.environ, "GH_TOKEN": token}, check=False)
+                if out.returncode != 0 or not out.stdout:
+                    raise urllib_exc
+                blob = out.stdout
+            return json.loads(zipfile.ZipFile(io.BytesIO(blob)).read("fuzz-coverage.json"))
+
+        # The LATEST run's artifact is not automatically the coverage measurement: a dispatch
+        # with a `services:` override fuzzes a hand-picked subset, and reporting 2/2 = 100 %
+        # about it reads as fleet coverage (measured 2026-09-05, run 33954836043 — an override
+        # probe for the date-param fixes displaced the weekly fleet number on the hub).
+        # Walk runs newest-first and take the first NON-override artifact; an old artifact
+        # without the flag predates the flag and every scheduled run derives the full set,
+        # so it counts as a measurement. Cap the walk: each candidate costs a download.
+        cov = None
+        skipped_overrides = 0
+        for run in runs.get("workflow_runs", [])[:10]:
             arts = json.loads(gh(f"actions/runs/{run['id']}/artifacts?per_page=100"))
             hit = [a for a in arts.get("artifacts", [])
                    if a["name"] == "fuzz-coverage" and not a.get("expired")]
-            if hit:
-                artifacts = hit
-                break
-        if not artifacts:
-            return {"available": False, "reason": "no fuzz-coverage artifact yet"}
-        req = urllib.request.Request(
-            artifacts[0]["archive_download_url"],
-            headers={"Authorization": f"Bearer {token}",
-                     "Accept": "application/vnd.github+json"})
-        # Cross-host redirect must not carry the GitHub token — see _no_auth_redirect_opener.
-        try:
-            blob = _no_auth_redirect_opener().open(req, timeout=30).read()
-        except Exception as urllib_exc:
-            # Fallback for tokens/edges where the stripped-redirect dance still fails
-            # (observed with the workflow GITHUB_TOKEN on run 33972808389): the `gh` CLI is
-            # preinstalled on the runner and handles the 302 correctly. `gh api …/zip` writes
-            # the archive bytes to stdout.
-            import shutil
-            import subprocess
-            ghbin = shutil.which("gh")
-            if not ghbin:
-                raise
-            out = subprocess.run(
-                [ghbin, "api", f"repos/{repo}/actions/artifacts/{artifacts[0]['id']}/zip"],
-                capture_output=True, timeout=60,
-                env={**os.environ, "GH_TOKEN": token}, check=False)
-            if out.returncode != 0 or not out.stdout:
-                raise urllib_exc
-            blob = out.stdout
-        cov = json.loads(zipfile.ZipFile(io.BytesIO(blob)).read("fuzz-coverage.json"))
-        return {"available": True, "inScope": cov["inScope"], "tested": cov["tested"],
-                "coveragePct": cov["coveragePct"], "totalExercised": cov["totalExercised"],
-                "excludedCount": len(cov.get("excluded", [])),
-                "run": cov.get("run", ""), "runDate": cov.get("generatedAt", "")[:10]}
+            if not hit:
+                continue
+            cand = download(hit[0])
+            if cand.get("override"):
+                skipped_overrides += 1
+                continue
+            cov = cand
+            break
+        if cov is None:
+            return {"available": False,
+                    "reason": f"no non-override fuzz-coverage artifact yet "
+                              f"({skipped_overrides} override run(s) skipped)"}
+        out = {"available": True, "inScope": cov["inScope"], "tested": cov["tested"],
+               "coveragePct": cov["coveragePct"], "totalExercised": cov["totalExercised"],
+               "excludedCount": len(cov.get("excluded", [])),
+               "run": cov.get("run", ""), "runDate": cov.get("generatedAt", "")[:10]}
+        if skipped_overrides:
+            out["note"] = (f"{skipped_overrides} newer override-scoped run(s) skipped — "
+                           "an override probes a hand-picked subset, not the fleet")
+        return out
     except Exception as exc:  # network/API degradation must not kill the other collectors
         import urllib.error
         detail = f"HTTP {exc.code}" if isinstance(exc, urllib.error.HTTPError) else exc.__class__.__name__

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -117,8 +117,15 @@ jobs:
               fh.write("services=" + json.dumps(keep) + "\n")
           # Durable scope record for the aggregate step: the job list alone is NOT
           # evidence of what was in scope (#2) — keep and skipped-with-reason both.
+          # `override` matters downstream: the security-kpis collector reads the LATEST
+          # run's artifact, and a dispatch-narrowed run is not a coverage measurement
+          # (the authenticated lane says so in its step summary; here it must be
+          # machine-readable, or the KPI reports 2/2 = 100 % about a two-service probe
+          # as if it were the fleet — measured 2026-09-05, run 33954836043).
           with open("fuzz-scope.json", "w") as fh:
-              json.dump({"keep": keep, "skipped": skipped}, fh, indent=2)
+              json.dump({"keep": keep, "skipped": skipped,
+                         "override": bool(override),
+                         "overrideRequested": override}, fh, indent=2)
           PY
 
       - name: Upload derived scope


### PR DESCRIPTION
## Summary
- Measured live: the hub showed fuzz coverage **2/2 = 100 %** — but run 33954836043 was a manual dispatch with a `services:` override (the date-param probe for #8835), not the fleet. The derived fleet scope against current main is **26 services**.
- The authenticated fuzz lane already warns about override runs in its step summary, but the KPI collector had no machine-readable signal and always read the LATEST run's artifact.
- Fix in three layers:
  - `api-fuzz.yml` writes `override` + `overrideRequested` into `fuzz-scope.json`
  - `fuzz-coverage-aggregate.py` propagates the flag into `fuzz-coverage.json` (self-test extended both ways)
  - `security-kpis.py` walks runs newest-first to the first **non-override** artifact; flagless old artifacts predate the flag and were full derivations, so they count. When only override runs exist, the KPI degrades to unavailable with the reason instead of inventing a number; when it skips newer overrides it says so in a `note`.
- Next scheduled weekly run (Thu 05:30 UTC) restores the fleet-wide number.

Refs #8590 (#2)
