### PR TITLE
fix(lending): every event settles its own aggregate identity, and four gain partyId

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -257,6 +257,7 @@ class LendingService @Inject constructor(
             append(""""aggregateType":"LOAN_APPLICATION",""")
             append(""""aggregateId":"$id",""")
             append(""""loanApplicationId":"$id",""")
+            append(""""partyId":"${application.partyId}",""")
             append(""""fromState":"$from",""")
             append(""""toState":"${to.name}",""")
             append(""""actorId":"$actor",""")
@@ -666,7 +667,8 @@ class LendingService @Inject constructor(
                                 // event types in this file/OriginationDecisionService/TerminationService — not
                                 // "lending-service" as the topic-fallback table would say (a pre-existing,
                                 // self-consistent naming choice this PR preserves rather than introduces).
-                                payload = """{"loanId":"${saved.id.value}","partyId":"${saved.partyId}",""" +
+                                payload = """{"aggregateType":"LOAN","aggregateId":"${saved.id.value}",""" +
+                                    """"loanId":"${saved.id.value}","partyId":"${saved.partyId}",""" +
                                     """"principal":"${saved.principal}",""" +
                                     """"occurredAt":"${saved.disbursedAt.toInstant()}",""" +
                                     """"sourceService":"lending"}""",
@@ -796,7 +798,8 @@ class LendingService @Inject constructor(
                         // #3914: occurredAt is `accruedAt`, the very instant stamped on the installment by
                         // markAccrued above — the recognition event itself, not the emit.
                         // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
-                        payload = """{"loanId":"${installment.loanId.value}","installment":${installment.number},""" +
+                        payload = """{"aggregateType":"LOAN","aggregateId":"${installment.loanId.value}",""" +
+                            """"loanId":"${installment.loanId.value}","installment":${installment.number},""" +
                             """"interest":"${installment.interest}","dueDate":"${installment.dueDate}",""" +
                             """"occurredAt":"${accruedAt.toInstant()}",""" +
                             """"sourceService":"lending"}""",
@@ -845,7 +848,8 @@ class LendingService @Inject constructor(
                                 // once into a local so payload and any future reuse cannot disagree.
                                 val writtenOffAt = clock.instant()
                                 // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
-                                val wPayload = """{"loanId":"${written.id.value}",""" +
+                                val wPayload = """{"aggregateType":"LOAN","aggregateId":"${written.id.value}",""" +
+                                    """"loanId":"${written.id.value}",""" +
                                     """"partyId":"${written.partyId}",""" +
                                     """"writtenOff":"$outstanding",""" +
                                     """"writtenOffBy":"${request.writtenOffBy}",""" +
@@ -1100,7 +1104,8 @@ class LendingService @Inject constructor(
                         // #3914: no rescheduledAt column on Loan; clock at the completed reschedule, same
                         // house convention as write-off above.
                         // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
-                        payload = """{"loanId":"${updated.id.value}","partyId":"${updated.partyId}",""" +
+                        payload = """{"aggregateType":"LOAN","aggregateId":"${updated.id.value}",""" +
+                            """"loanId":"${updated.id.value}","partyId":"${updated.partyId}",""" +
                             """"newPrincipal":"$newPrincipal",""" +
                             """"newNominalAnnualRate":"${request.newNominalAnnualRate}",""" +
                             """"newTermPeriods":${request.newTermPeriods},""" +
@@ -1355,7 +1360,8 @@ class LendingService @Inject constructor(
         snapshot: ProvisioningSnapshot,
         period: String,
         record: LoanProvisioningRecord,
-    ): String = """{"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
+    ): String = """{"aggregateType":"LOAN","aggregateId":"${loan.id.value}",""" +
+        """"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
         """"previousStage":"${prior.stage}","newStage":"${snapshot.stage}",""" +
         """"daysPastDue":${snapshot.daysPastDue},"period":"$period","asOf":"${snapshot.asOf}",""" +
         """"occurredAt":"${record.createdAt.toInstant()}","sourceService":"lending"}"""
@@ -1367,7 +1373,8 @@ class LendingService @Inject constructor(
         snapshot: ProvisioningSnapshot,
         delta: Money,
         record: LoanProvisioningRecord,
-    ): String = """{"loanId":"${loan.id.value}","period":"$period",""" +
+    ): String = """{"aggregateType":"LOAN","aggregateId":"${loan.id.value}",""" +
+        """"loanId":"${loan.id.value}","partyId":"${loan.partyId}","period":"$period",""" +
         """"stage":"${snapshot.stage}",""" +
         """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
         """"delta":"$delta","occurredAt":"${record.createdAt.toInstant()}",""" +

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
@@ -165,6 +165,7 @@ class OriginationDecisionService(
             append(""""aggregateType":"LOAN_APPLICATION",""")
             append(""""aggregateId":"$id",""")
             append(""""loanApplicationId":"$id",""")
+            append(""""partyId":"${application.partyId}",""")
             append(""""outcome":"${outcomeName(decision)}",""")
             append(""""priceBand":${application.decisionPriceBand?.let { band -> "\"$band\"" } ?: "null"},""")
             append(""""policyVersions":"${application.policyVersions}",""")

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/TerminationService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/TerminationService.kt
@@ -346,6 +346,7 @@ class TerminationService(
             append(""""aggregateType":"LOAN",""")
             append(""""aggregateId":"$id",""")
             append(""""loanId":"$id",""")
+            append(""""partyId":"${loan.partyId}",""")
             append(""""fromState":"${from.name}",""")
             append(""""toState":"${to.name}",""")
             append(""""actorId":"$actor",""")
@@ -378,7 +379,8 @@ class TerminationService(
         LendingOutboxMessage(
             aggregateId = loan.id.value,
             eventType = type,
-            payload = """{"eventType":"$type","loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
+            payload = """{"eventType":"$type","aggregateType":"LOAN","aggregateId":"${loan.id.value}",""" +
+                """"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
                 """"occurredAt":"${clock.instant()}","sourceService":"lending"}""",
         ),
     )

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingEventIdentityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingEventIdentityTest.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+
+/**
+ * Every lending event must carry its OWN aggregate identity on the wire (#8893).
+ *
+ * WHY THIS EXISTS. The analytics sink resolves an event's `aggregate_type` from the payload, then
+ * from an inference, and finally from the TOPIC — `openbank.lending.events` yields `LENDING` for
+ * every type alike. It then resolves the id with `idForType(type, node)`, whose `when` has no
+ * `LENDING` branch and whose trailing fallback is `?: accountId ?: partyId`. So a payload that
+ * omits `aggregateType`/`aggregateId` but carries `partyId` — four of this service's types did —
+ * lands in `bronze_events` keyed by the BORROWER, and `silver_current_state`, which groups by
+ * `(aggregate_type, aggregate_id)`, collapses every loan of that borrower into one aggregate.
+ * That is the corruption `AnalyticsConsumer.resolveAggregateId`'s KDoc documents from #4553,
+ * reproduced on a new domain. The producer settling its own identity is what prevents it.
+ *
+ * WHY A SOURCE SCAN RATHER THAN ELEVEN FLOWS. The behavioural assertions live beside the flows
+ * that already drive each event (`LendingServiceTest`), and they are the real coverage. This test
+ * answers the question those cannot: is there an emit site anywhere in the service that a future
+ * change could add WITHOUT identity? Two of the eleven event types are emitted through a
+ * parameterised helper (`loan.withdrawn`, `loan.accelerated` via `TerminationService.emitDomainEvent`),
+ * so a grep for `eventType = "..."` literals finds nine and misses two — the same two-idiom trap
+ * this repo has hit before. Scanning the payload builders catches both idioms.
+ */
+class LendingEventIdentityTest {
+
+    private companion object {
+        /** The literal that opens a JSON payload in this service: a raw string starting with `{`. */
+        const val TQ = "\"\"\""
+        const val PAYLOAD_OPENING = "\"\"\"{"
+
+        /** Opening line plus the next three: room for a leading `eventType`, nothing more. */
+        const val IDENTITY_WINDOW = 4
+    }
+
+    private val sources = listOf(
+        "LendingService.kt",
+        "OriginationDecisionService.kt",
+        "TerminationService.kt",
+    ).map { Path.of("src/main/kotlin/com/openbank/lending/application/usecase", it) }
+
+    @Test
+    fun `every payload builder in the service names its aggregate identity`() {
+        // A payload literal starts either at `"""{` (a raw-string builder) or inside the
+        // `append("""{` of a buildString. Two builders put the `eventType` discriminator first and
+        // the identity on the next line, so the window is the opening line plus the next few —
+        // narrow enough that identity has to be at the TOP of the payload, wide enough to allow
+        // the discriminator ahead of it.
+        val offenders = mutableListOf<String>()
+        for (file in sources) {
+            assertThat(Files.exists(file)).describedAs("$file").isTrue()
+            val lines = file.readText().lines()
+            for ((i, line) in lines.withIndex()) {
+                if (!line.contains(PAYLOAD_OPENING)) continue
+                val window = lines.subList(i, minOf(i + IDENTITY_WINDOW, lines.size)).joinToString("\n")
+                if (!window.contains("aggregateType") || !window.contains("aggregateId")) {
+                    offenders += "${file.fileName}:${i + 1}: ${line.trim()}"
+                }
+            }
+        }
+        assertThat(offenders)
+            .describedAs("payload builders that do not name aggregateType and aggregateId up front")
+            .isEmpty()
+    }
+
+    @Test
+    fun `the eleven event types are the ones this test speaks for`() {
+        // A new event type must consciously join this list, which is what makes the scan above a
+        // ratchet rather than a snapshot. Nine are literals; two arrive as a parameter.
+        val text = sources.joinToString("\n") { it.readText() }
+        val literals = Regex(""""(credit|loan)\.[a-z._]+"""").findAll(text)
+            .map { it.value.trim('"') }.toSet()
+        assertThat(literals).containsExactlyInAnyOrder(
+            "credit.application.transition",
+            "credit.decision.evaluated",
+            "credit.loan.transition",
+            "loan.disbursed",
+            "loan.interest_accrued",
+            "loan.written_off",
+            "loan.rescheduled",
+            "loan.stage_changed",
+            "loan.provisioned",
+            "loan.withdrawn",
+            "loan.accelerated",
+        )
+    }
+
+    @Test
+    fun `the scan flags a payload that omits identity, and passes one that has it`() {
+        // The control. Without it the scan above could be vacuous: a matcher that never fires
+        // reports an empty offender list exactly like a clean tree does. Both directions, because
+        // a matcher that fires on EVERYTHING is equally useless.
+        val bad = listOf("""payload = $TQ{"loanId":"x","partyId":"p"}$TQ""")
+        val good = listOf(
+            """payload = $TQ{"aggregateType":"LOAN","aggregateId":"x",$TQ +""",
+            """    $TQ"loanId":"x"}$TQ""",
+        )
+        assertThat(bad.first().contains(PAYLOAD_OPENING)).describedAs("the scan sees a payload here").isTrue()
+        assertThat(bad.joinToString("\n").contains("aggregateType")).isFalse()
+        assertThat(good.first().contains(PAYLOAD_OPENING)).isTrue()
+        assertThat(good.joinToString("\n").let { it.contains("aggregateType") && it.contains("aggregateId") }).isTrue()
+    }
+
+    @Test
+    fun `identity and party survive JSON parsing, not just string matching`() {
+        // A payload is assembled from concatenated raw strings, so "the source contains the key" is
+        // not the same claim as "the emitted JSON has the field". One representative payload of each
+        // shape is parsed here; the per-event behavioural assertions live in LendingServiceTest.
+        val mapper = ObjectMapper()
+        val loanShaped = """{"aggregateType":"LOAN","aggregateId":"11111111-1111-1111-1111-111111111111",""" +
+            """"loanId":"11111111-1111-1111-1111-111111111111","partyId":"22222222-2222-2222-2222-222222222222",""" +
+            """"occurredAt":"2026-09-06T00:00:00Z","sourceService":"lending"}"""
+        val node = mapper.readTree(loanShaped)
+        assertThat(node.get("aggregateType").asText()).isEqualTo("LOAN")
+        // The whole point: the id is the LOAN, never the borrower.
+        assertThat(node.get("aggregateId").asText()).isEqualTo(node.get("loanId").asText())
+        assertThat(node.get("aggregateId").asText()).isNotEqualTo(node.get("partyId").asText())
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -1955,6 +1955,23 @@ class LendingServiceTest {
     private fun sourceServiceOf(message: LendingOutboxMessage): String =
         com.fasterxml.jackson.databind.ObjectMapper().readTree(message.payload).get("sourceService").asText()
 
+    private fun fieldOf(message: LendingOutboxMessage, field: String): String? =
+        com.fasterxml.jackson.databind.ObjectMapper().readTree(message.payload).get(field)?.asText()
+
+    /**
+     * The wire identity of one event (#8893): the sink keys `bronze_events` on
+     * `(aggregate_type, aggregate_id)` and falls back to `partyId` when the payload settles neither,
+     * so asserting the pair is asserting that one borrower's loans stay distinct downstream.
+     */
+    private fun assertLoanIdentity(message: LendingOutboxMessage, loanId: java.util.UUID) {
+        assertThat(fieldOf(message, "aggregateType")).isEqualTo("LOAN")
+        assertThat(fieldOf(message, "aggregateId")).isEqualTo(loanId.toString())
+        val party = fieldOf(message, "partyId")
+        if (party != null) {
+            assertThat(fieldOf(message, "aggregateId")).isNotEqualTo(party)
+        }
+    }
+
     @Test
     fun `loan disbursed carries sourceService on the wire`() {
         val app = proposedApplication().copy(status = OriginationState.READY_TO_DISBURSE, decidedBy = "bob")
@@ -1967,11 +1984,14 @@ class LendingServiceTest {
         every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
         stubBorrowerCreditSucceeds()
 
-        service.disburse(app.id, "dave").await().indefinitely()
+        val loan = service.disburse(app.id, "dave").await().indefinitely()
 
         val disbursed = emitted.single { it.eventType == "loan.disbursed" }
         assertThat(sourceServiceOf(disbursed)).isEqualTo("lending")
         assertThat(disbursed.payload).contains("\"sourceService\":\"lending\"")
+        // The id comes from the returned aggregate, never from the payload under test.
+        assertLoanIdentity(disbursed, loan.id.value)
+        assertThat(fieldOf(disbursed, "partyId")).isEqualTo(app.partyId.toString())
     }
 
     @Test
@@ -1997,6 +2017,7 @@ class LendingServiceTest {
 
         service.accrueDueInterest(LocalDate.parse("2026-08-01"), 500).await().indefinitely()
 
+        assertLoanIdentity(emitted.single { it.eventType == "loan.interest_accrued" }, loanId.value)
         assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.interest_accrued" }))
             .isEqualTo("lending")
     }
@@ -2027,8 +2048,9 @@ class LendingServiceTest {
         service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol", reason = "insolvency"))
             .await().indefinitely()
 
-        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.written_off" }))
-            .isEqualTo("lending")
+        val writtenOff = emitted.single { it.eventType == "loan.written_off" }
+        assertThat(sourceServiceOf(writtenOff)).isEqualTo("lending")
+        assertLoanIdentity(writtenOff, loanId.value)
     }
 
     @Test
@@ -2043,8 +2065,9 @@ class LendingServiceTest {
 
         service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
 
-        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.rescheduled" }))
-            .isEqualTo("lending")
+        val rescheduled = emitted.single { it.eventType == "loan.rescheduled" }
+        assertThat(sourceServiceOf(rescheduled)).isEqualTo("lending")
+        assertLoanIdentity(rescheduled, loanId.value)
     }
 
     @Test
@@ -2088,9 +2111,14 @@ class LendingServiceTest {
 
         service.runProvisioningCycle("2026-07", asOf, 500).await().indefinitely()
 
-        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.stage_changed" }))
-            .isEqualTo("lending")
-        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.provisioned" }))
-            .isEqualTo("lending")
+        val stage = emitted.single { it.eventType == "loan.stage_changed" }
+        val provisioned = emitted.single { it.eventType == "loan.provisioned" }
+        assertThat(sourceServiceOf(stage)).isEqualTo("lending")
+        assertThat(sourceServiceOf(provisioned)).isEqualTo("lending")
+        assertLoanIdentity(stage, loanId.value)
+        assertLoanIdentity(provisioned, loanId.value)
+        // `loan.provisioned` carried no party at all before #8893, so an ECL history in the
+        // warehouse could not be attributed to a borrower.
+        assertThat(fieldOf(provisioned, "partyId")).isEqualTo(loan.partyId.toString())
     }
 }


### PR DESCRIPTION
## Summary

Every lending event now settles its own aggregate identity on the wire (`aggregateType` + `aggregateId`), and the four evidence events that had no `partyId` now carry one. Producer-side prerequisite for #8893: without it, subscribing the warehouse to `openbank.lending.events` would not merely be incomplete, it would corrupt the read model.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8893

## Why this is a defect and not a nice-to-have

`AnalyticsConsumer.resolveAggregateType` falls back to the TOPIC when the payload names no type, and `openbank.lending.events` yields `LENDING` for every event alike. `resolveAggregateId` then calls `idForType(type, node)`, whose `when` has no `LENDING` branch, so it takes the trailing fallback — `?: accountId ?: partyId`.

Six of this service's eleven event types carry `partyId` and named no identity, so each would land in `bronze_events` keyed by the **borrower**. `bronze_events` is `ORDER BY (aggregate_type, aggregate_id, event_id)` and `silver_current_state` groups by `(aggregate_type, aggregate_id)`, so every loan of one borrower would collapse into a single aggregate. That is the corruption `resolveAggregateId`'s KDoc documents from the TRANSACTION/ACCOUNT incident (#4553), about to be reproduced on a new domain.

Nothing is broken in production today — the sink is not subscribed to this topic — so this is a latent trap being closed before the subscription lands, not an outage.

## The counting trap, recorded because it cost a wrong number

My first inventory said nine event types. `TerminationService.emitDomainEvent(loan, type)` takes the discriminator as a **parameter**, so `loan.withdrawn` and `loan.accelerated` exist only at their call sites and a grep for `eventType = "…"` literals never sees them. Eleven, not nine — and both of the invisible two were in the broken set. Same two-idiom trap this repo already documents for event payloads.

## Changes

- `aggregateType` + `aggregateId` added to the eight payloads that lacked them (six `loan.*` plus the two emitted through the parameterised helper). The three that already had identity are unchanged.
- `partyId` added to `loan.provisioned`, `credit.application.transition`, `credit.decision.evaluated` and `credit.loan.transition` — every case where the aggregate carrying the party is already in hand.
- `loan.interest_accrued` deliberately keeps `loanId` only: the accrual sweep holds an installment, not a loan, so adding the party would put a repository read on every row of a scheduled pass. The loan dimension carries the party and `loanId` is the join key.
- `LendingEventIdentityTest`: a ratchet over both emit idioms, plus a two-directional control so the scan cannot pass vacuously.
- Behavioural assertions added to the flows in `LendingServiceTest` that already drive each event. The asserted id comes from the returned aggregate or a value the test owns, never read back out of the payload under test.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved). — no new boundary; the payload shape is covered by unit assertions over the real builders.
- [ ] Contract tests updated (if public API changed). — no REST change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — not a REST change.
- [ ] Flyway migration added + rollback note (if DB changed). — no schema change.
- [x] Avro schema versioned backward-compatibly (if event changed). — there is no Avro: `openbank.lending.events` is raw JSON with no AsyncAPI contract, grandfathered in `.github/event-contract-baseline.txt` (#1916). All changes are additive fields; the two known consumers (anacredit's `LoanStageEventConsumer`, engagement's `LendingArrearsEventConsumer`) parse via `readTree` and ignore unknown fields.
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — see the compliance note: `partyId` is a pseudonymous identifier, added to four event types that already ride a topic carrying it on seven others.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. — none added.
- [x] No new third-party dependency, OR: dependency review attached. — none.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no auth or crypto change; payload fields only.
- [x] PII path changed? → tag `gdpr-review-required`. — yes, tagged.
- [x] Cardholder data path changed? → tag `pci-review-required`. — no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

**GDPR.** `partyId` reaches four more event types on a topic where seven already carried it, and audit-service is the only current consumer. It is a pseudonymous internal identifier, not a direct identifier, and no name, income or contact data is added. The consequence to weigh is downstream: once the warehouse subscribes (#8893), these rows become personal data there and fall under the ADR-0023 crypto-erasure machinery — which is an argument for deciding it now, in review, rather than discovering it after the subscription lands.

**CNB.** Loan-level attribution is what makes an IFRS 9 stage and ECL history reconstructible per borrower rather than per row. The regulatory reporting gaps themselves are inventoried in #8895.

## Rollout / Rollback

- Deployment strategy: rolling.
- Rollback plan: revert. Every change is an additive JSON field; consumers ignore unknown fields, so a rollback returns to the previous payloads with no consumer change.
- Data migration reversible: N/A. Events already emitted keep their old shape — this fixes the shape going forward and does not rewrite history.

## Screenshots / demo (if UI change)

Not a UI change.

## Reviewer notes

- **The judgement call to check:** `loan.interest_accrued` keeping `loanId` only. If you would rather pay the per-installment lookup, that is a one-line change and I would rather have the argument in review than assume.
- **Why the ratchet test scans source rather than driving eleven flows:** the behavioural assertions beside each flow are the real coverage; the scan answers what they cannot, namely whether a future emit site could be added without identity. It has a control in both directions.
- **The test caught its own strictness once:** the first version checked only the opening line and flagged the two builders that put `eventType` first and the identity on the next line. Widened to a small window, so identity must still sit at the top of the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
