### PR TITLE
fix(ci): resolve the PR diff base by deepening, not by HEAD^2 under fetch-depth 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,18 +430,33 @@ jobs:
       # creation-time base and both claimed the same openapi info.version (#481 x #524).
       # Exported per shard because every shard may hold a `needs_base: true` gate; a gate
       # that reads it while it is empty is failed by run-gates.py rather than run vacuously.
+      #
+      # The previous HEAD^2 shortcut did not survive contact with this job's fetch-depth: 1
+      # checkout: the merge commit's parent objects are not in the object database, so
+      # `rev-parse --verify HEAD^2` fails and every long-lived PR fell back to the
+      # creation-time base.sha. A branch that had absorbed main since opening then diffed
+      # the whole absorbed window — measured 2026-09-06 on #8334: a ~17-file notification
+      # PR reported 620 touched money-path files (security-checklist-money-path) and 33
+      # "changed" contract tests (adversarial-contract-test), all of them main's own merged
+      # work. Deepen the base branch until the TRUE merge-base resolves; branch refs are
+      # fetchable here while arbitrary shas are not (verified 2026-09-06: `git fetch origin
+      # <sha>` answers "couldn't find remote ref" for short shas and works for full ones,
+      # but a ref fetch is the stable path).
       - name: resolve PR diff base (current merge-base, not creation-time base.sha)
         if: github.event_name == 'pull_request'
         env:
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          base="${EVENT_BASE_SHA}"
-          git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
-          if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
-            base="$(git rev-parse 'HEAD^1')"
-          else
-            git fetch --depth=1 origin "${base}" 2>/dev/null || true
+          base=""
+          git fetch -q --depth=1 origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          for _ in 1 2 3 4 5 6 7 8; do
+            if base="$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null)"; then break; fi
+            git fetch -q --deepen=400 origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          done
+          if [ -z "${base}" ]; then
+            echo "::warning::merge-base against origin/${BASE_REF} did not resolve after deepening; falling back to the event base.sha, which is stale for a PR that has absorbed main since opening"
+            base="${EVENT_BASE_SHA}"
           fi
           echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           echo "PR_DIFF_BASE=${base}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The gates job checks out at `fetch-depth: 1`. The `resolve PR diff base` step relied on `git rev-parse --verify HEAD^2` to detect the synthetic merge commit — but at depth 1 the parent objects are not in the object database, the verify always fails, and every PR silently fell back to `github.event.pull_request.base.sha`, which is frozen at PR-creation time.

For any long-lived PR that had absorbed main since opening, `$PR_DIFF_BASE...HEAD` then covered **the whole absorbed window**, and every gate that diffs it flagged main's own merged work as the PR's:

- measured on #8334 (a ~17-file notification change): **620 'touched money-path files'** (`security-checklist-money-path`) and **33 'changed contract tests'** (`adversarial-contract-test`) — all of it main's work, none of it the PR's
- same signature on #8310

## Fix

Deepen the base branch ref in 400-commit steps until the true `git merge-base origin/<base> HEAD` resolves (branch refs are fetchable; arbitrary shas are not — verified 2026-09-06). Verified on a depth-1 clone of the failing branch: merge-base resolved on the second iteration and the diff window shrank to the real 17 files.

Falls back to the event base.sha with a `::warning::` if the histories never connect, so the step degrades loudly instead of lying quietly.

## Not in scope

The fallback still exists for pathological histories; the warning makes it visible instead of silent.