### PR TITLE
fix(swift): give the test JVM the same 2g ceiling account and lending already run

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -68,6 +68,18 @@ dependencies {
 // probe's answer first.
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 tasks.withType<Test> {
+    // Gradle's default test-JVM heap is 512m (the account-service comment at
+    // openbank-account-service/build.gradle.kts documents it and asks to be told when a second
+    // module OOMs — this is that signal). swift-service's suite boots Quarkus repeatedly AND
+    // runs SwiftPactFolderProviderVerificationTest, which loads every pact naming this service
+    // as provider into the same fork. Measured 2026-09-06: two unrelated PRs (#8781, #8697)
+    // died in the same minute — `OutOfMemoryError: Java heap space` across ClassGraph-worker /
+    // vert.x-eventloop / Finalizer threads ~3 minutes into the suite, after which the JVM hung
+    // in GC until the 45-minute job timeout (#8781) or the pact verification Timed out
+    // downstream of the GC storm (#8697). Same 2g ceiling account/lending/product-catalog
+    // already run with; a ceiling, not an allocation.
+    maxHeapSize = "2g"
+
     // CI hang #3 (#2320) is GONE — measured, not assumed. `SwiftBootSmokeIT` used to hang 37+ min
     // at Quarkus boot on the runner pool (`@DisabledIfEnvironmentVariable` is evaluated AFTER
     // Quarkus starts QuarkusTestResource containers, quarkusio/quarkus#21555), so a blanket


### PR DESCRIPTION
## Problem

swift-service's test fork runs at Gradle's default 512m heap. The suite boots Quarkus repeatedly and runs `SwiftPactFolderProviderVerificationTest` (every pact naming swift-service as provider, one fork). On 2026-09-06 two unrelated PRs died identically:

- **#8781** — `OutOfMemoryError` across ClassGraph-worker / vert.x-eventloop / Finalizer threads ~3 min in, then GC-spiral hang until the 45-minute job timeout
- **#8697** — same OOM, then `SwiftPactFolderProviderVerificationTest ... status COMPLETED` failed with `TimeoutException` downstream of the GC storm

## Fix

`maxHeapSize = "2g"` on swift's test tasks — the ceiling account-service, lending-service and product-catalog already carry. account-service's comment explicitly asks to be told when a second module OOMs rather than applying an unmeasured fleet-wide ratchet; swift is that measured case. A ceiling is not an allocation.

Refs #8345 (the pact tail #8697 is landing), unblocks #8781 and #8697.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → no — test-JVM heap ceiling in a build file only.
- [x] PII path changed? → no.
- [x] Cardholder data path changed? → no.

## Compliance impact

None: CI build-file change (test heap ceiling), no runtime behaviour, no data path, no schema.