### PR TITLE
build(swift): give the test JVM 2g so the suite stops OOMing in CI

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -68,6 +68,23 @@ dependencies {
 // probe's answer first.
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 tasks.withType<Test> {
+    // Gradle's default test-JVM heap is 512m. This module exceeded it: on 2026-09-06 the CI job
+    // OOMed four minutes in, at the moment the pact consumer test starts its mock server
+    // (`JUnit5MockServerSupport`), then thrashed for forty minutes until the job was cancelled —
+    // thirteen `OutOfMemoryError` lines and not one failing assertion, so the job reads as a
+    // cancellation rather than as a memory fault. The earlier reading of the same defect was
+    // `SwiftPactFolderProviderVerificationTest` blowing its 8-minute budget: with the heap
+    // exhausted the verification only advances between full GCs, so it either overruns or dies.
+    // Locally, where the heap is not the constraint, the same test finishes in ~5-6 minutes, which
+    // is why this passes on a laptop and fails in CI on branches that never touch this service.
+    //
+    // `openbank-account-service` and `openbank-lending-service` already carry this override for
+    // the same failure, and account's comment sets the rule: a second OOMing module is the signal
+    // to raise the default in build-logic and to count the Quarkus boots per module. swift is the
+    // third, so that threshold is met — but a fleet default is a 50-module change and belongs in
+    // its own PR with those counts, not here (#8919).
+    maxHeapSize = "2g"
+
     // CI hang #3 (#2320) is GONE — measured, not assumed. `SwiftBootSmokeIT` used to hang 37+ min
     // at Quarkus boot on the runner pool (`@DisabledIfEnvironmentVariable` is evaluated AFTER
     // Quarkus starts QuarkusTestResource containers, quarkusio/quarkus#21555), so a blanket


### PR DESCRIPTION
## Summary

The `openbank-swift-service` test JVM ran at Gradle's 512m default and exceeded it. Seven open PRs
are currently red on `build (openbank-swift-service)`, and none of them touch this service. This
gives the task `maxHeapSize = "2g"`, matching account-service and lending-service.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8919

## Changes

- `openbank-swift-service/build.gradle.kts`: `maxHeapSize = "2g"` on `tasks.withType<Test>`, with
  the measurement and the reason it is per-module rather than a fleet default.

## What was measured

From the failing job (run 34016248642, `Build + test (:openbank-swift-service)`):

```
09:52:00  job start
09:56:57  Type implements CloseableResource but not AutoCloseable: au.com.dius.pact.consumer.junit5.JUnit5MockServerSupport
09:56:57  Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "idle-connection-evictor-1"
          … 12 more OutOfMemoryError lines through 09:57:53
10:37:13  ##[error]The operation was canceled.
```

Step 10 is the only `cancelled` step; every other step is `success` or `skipped`, and no test
reports a failing assertion. That is why this reads as a cancellation rather than as a memory
fault, and why it was first filed as a slow test.

**The earlier diagnosis in #8919 was wrong and is corrected there.** The 8-minute
`TimeoutException` on `SwiftPactFolderProviderVerificationTest` and this cancellation are the same
defect at two stages: with the heap exhausted, verification advances only between full GCs. The
timing table in that issue was taken on a machine where the heap was never the constraint, so it
does not describe CI.

## Why per-module and not build-logic

`openbank-account-service` states the rule in place:

> Deliberately per-module rather than a fleet default: nothing measures test heap anywhere, so a
> global bump would be an unmeasured ratchet applied to 50 modules to fix one. **If a second module
> starts OOMing, that is the signal to raise it in build-logic** and to count the Quarkus boots per
> module rather than keep paying for them.

lending was the second, swift is the third, so that threshold is met. A fleet default is a
50-module change and wants the boot count the comment asks for; it is left to #8919 rather than
folded in here.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated. — build configuration only; the suite itself is unchanged.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — an A/B of the full swift suite
      with and without the override is running locally; the numbers go on this PR as a comment
      when it finishes. Opening now because seven PRs are blocked on it.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [ ] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — build configuration, no shipped artifact changes.
- Rollback plan: revert the commit.
- Data migration reversible: N/A

## Reviewer notes

The commit type is `build`, deliberately: nothing shipped changes, so this must not cut a
swift-service release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
