### PR TITLE
fix(ci): read the live PR body in the security-checklist gate, not the frozen event payload

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4034,7 +4034,14 @@ gates:
     selftest_expect: pass
     selftest_inputs: [".github/scripts/check-security-checklist.py", ".github/PULL_REQUEST_TEMPLATE.md"]
     run: |
-      python3 .github/scripts/check-security-checklist.py --body "${PR_BODY}" --base "${PR_DIFF_BASE}" --enforce
+      # PR_BODY is github.event.pull_request.body — frozen at the last synchronize event.
+      # Editing the body to add the checklist (the documented remediation) only reached this
+      # gate after an otherwise-pointless empty commit pushed to re-emit the event (measured
+      # 2026-09-06 on #8934: body edited 11:45Z, run at 11:46Z still read the old body).
+      # The live body is the truth the gate means to check; the frozen one is the fallback
+      # when the API is unreachable. One contents-read API call per shard run.
+      LIVE_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .body 2>/dev/null || true)"
+      python3 .github/scripts/check-security-checklist.py --body "${LIVE_BODY:-${PR_BODY}}" --base "${PR_DIFF_BASE}" --enforce
 
   # ADR-0030 D2, third half (#6037, PR #6048): the coverage gate proves a threat model EXISTS
   # and the diff gate proves it is TOUCHED when a trust boundary moves. Neither reads a single

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
       # that need them are set here rather than in the manifest.
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       BASE_REF: ${{ github.base_ref || github.ref_name }}
       # `gh` needs GH_TOKEN; the job-level `permissions: contents: read` above is what
       # scopes it. check-msg-channel-image-parity.py reads a file at an arbitrary historical


### PR DESCRIPTION
## Problem

`PR_BODY` is `github.event.pull_request.body` — frozen at the last synchronize event. The documented remediation for a missing `## Security checklist` is to edit the PR body, but the gate kept reading the frozen snapshot: measured on #8934, the body was edited at 11:45Z and the gate run at 11:46Z still failed on the old text. The only way through was an otherwise-pointless empty commit to re-emit the event — four money-path PRs needed that dance today (#8011, #8310, #8334, #8934).

## Fix

The security-checklist gate now fetches the **live** body via the pulls API (one contents-read call per shard run, using the `GH_TOKEN` the job already carries) and falls back to the frozen payload only when the API is unreachable.

Refs #8757 — this removes the second half of that trap ("I added the checklist and the gate still fails"). The first half (`--body-file` never applying the template) remains and is a workflow/docs decision, not a gate bug.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → no — CI gate input plumbing only.
- [ ] PII path changed? → no.
- [ ] Cardholder data path changed? → no.

## Compliance impact

None: changes which PR-body snapshot a CI gate reads; no product code, no data path.