### PR TITLE
feat(lending): expose the credit-offer eligibility decision to push surfaces (#8918)

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -483,6 +483,33 @@ therefore fail-**open** while reading as fail-closed.
 `init` gate does not run until first use, which for a rarely-exercised path can be never — the
 warning that the code cannot fire would itself never fire.
 
+## 9e. The credit-offer eligibility read surface (ADR-0269 rule 2, #8918) — STRIDE supplement
+
+`GET /api/v1/lending/credit-offers/eligibility/{partyId}` is a NEW inbound REST surface on a
+money-path service, so it is modelled here before it is wired (ADR-0030 D2).
+
+It exposes a decision the service already made in-process. The gate calls itself the one place a
+credit offer is cleared, and that was true of its intent and false of its reach: it had no wire
+surface, so the only caller was `CustomerQuoteResource` asking the PULL question. Every push
+surface ADR-0269 governs had no way to ask, which is why rule 2's distress floor was enforced
+nowhere on that side.
+
+The sensitivity is the point: an allowed/suppressed pair plus a reason code is a statement about a
+named person's financial distress — `ARREARS`, `INSOLVENCY`, `HARDSHIP`. It is a smaller disclosure
+than the underlying facts and a real one.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **E**levation of privilege | A backend service reaches other lending endpoints through the door opened for this read | The OPA rule `service-credit-offer-eligibility` is scoped to ONE action and one principal. Tests assert the same identity gets nothing else from it, and that the edge does not inherit it. The action is read-only and has no write counterpart to be confused with. |
+| **I**nformation disclosure | A caller enumerates party ids and harvests who is in arrears | Callers are in-repo M2M on the shared `openbank-services` client, so this is every backend service at once — accepted for a single read, and the reason it is not widened. The route is not on the customer edge and no customer token reaches it. Rate limiting and per-caller identity are NOT solved here: the shared client cannot distinguish campaign-service from any other, which is a known limit of the current M2M model (ADR-0206 D5) rather than something this route introduces. |
+| **S**poofing the surface | A caller asks the PULL question to skip the consent half | `OfferSurface.PUSH` is fixed in code and is not a parameter. PULL's consent exemption exists for a customer who asked; making the surface caller-supplied would hand that exemption to anyone who passed the right string. |
+| **T**ampering / misleading | An unreachable gate is read as permission | The route answers a decision or an error and never "probably fine". Callers must fail closed; `SIGNALS_UNAVAILABLE` already suppresses inside the gate rather than guessing. The failure direction is stated in the OpenAPI description so a caller cannot claim it was undocumented. |
+| **R**epudiation | The bank cannot show why a customer was or was not marketed to | `policyVersion` is in the response, so a decision can be tied to the decision-table version that produced it (ADR-0213). The reason code is contract, not a log line. |
+| **D**oS / availability | A large campaign sweep multiplies one DB read plus one analytics profile call per party | Real and unsolved here: this slice reduces the volume by moving the check to delivery rather than enrolment, but not the unit cost. Caching would need an explicit freshness bound, because a stale "not in distress" outlives the arrears that ended it — the harmful direction. Recorded in #8918 rather than inherited by accident. |
+
+**Not modelled here:** the caller's side. campaign-service consuming this route is a separate change
+with its own threat surface, and is deliberately not in this slice.
+
 ## 10. Change log
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or credit-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "4c3ca5f21160b847"
+    openbank.tech/policy-checksum: "39793f26a102da79"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -679,11 +679,26 @@ data:
     	input.action == "lending.intake"
     }
 
-    # NO BLANKET SERVICE (M2M) rule on purpose: the only in-repo M2M caller is the one named
-    # above (the admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the
-    # observability/security scanners use the management port, and ledger posting is an
-    # OUTBOUND call from lending). A blanket SERVICE allow would open every endpoint to any
-    # M2M client. If a future caller lands (e.g. anacredit moving from Kafka to REST), add
+    # ADR-0269 rule 2: campaign-service asks whether it may market credit to a party before it
+    # delivers a credit campaign step. The named, action-scoped rule this file's note below asks
+    # for — a future caller landing — rather than a blanket M2M allow.
+    #
+    # Scoped to ONE read action. campaign-service has no business in any other lending endpoint, and
+    # it authenticates on the SHARED `openbank-services` client, so this identity is every backend
+    # service at once: whatever is opened here is opened to all of them. A read of "may we offer" is
+    # proportionate to that; nothing else in lending would be.
+    #
+    # Read-only by construction — the action has no write counterpart to be confused with, which is
+    # why it needs no entry in the `prohibited` veto below.
+    allowed_reasons contains "service-credit-offer-eligibility" if {
+    	input.principal.id == "service-account-openbank-services"
+    	input.action == "lending.creditOffer.eligibility"
+    }
+
+    # NO BLANKET SERVICE (M2M) rule on purpose: in-repo M2M callers are the ones named above (the
+    # admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the observability/security
+    # scanners use the management port, and ledger posting is an OUTBOUND call from lending). A blanket
+    # SERVICE allow would open every endpoint to any M2M client. If a future caller lands, add
     # another named, action-scoped rule here.
 
     # 2026-08-05 (#3734): operator-lending-write was role-only, and rules.yaml's role_action_matrix

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c3ca5f21160b847"
+        openbank.tech/policy-checksum: "39793f26a102da79"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending_rest_ext.rego
+++ b/openbank-infra/gitops/components/lending/lending_rest_ext.rego
@@ -134,11 +134,26 @@ allowed_reasons contains "edge-customer-intake" if {
 	input.action == "lending.intake"
 }
 
-# NO BLANKET SERVICE (M2M) rule on purpose: the only in-repo M2M caller is the one named
-# above (the admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the
-# observability/security scanners use the management port, and ledger posting is an
-# OUTBOUND call from lending). A blanket SERVICE allow would open every endpoint to any
-# M2M client. If a future caller lands (e.g. anacredit moving from Kafka to REST), add
+# ADR-0269 rule 2: campaign-service asks whether it may market credit to a party before it
+# delivers a credit campaign step. The named, action-scoped rule this file's note below asks
+# for — a future caller landing — rather than a blanket M2M allow.
+#
+# Scoped to ONE read action. campaign-service has no business in any other lending endpoint, and
+# it authenticates on the SHARED `openbank-services` client, so this identity is every backend
+# service at once: whatever is opened here is opened to all of them. A read of "may we offer" is
+# proportionate to that; nothing else in lending would be.
+#
+# Read-only by construction — the action has no write counterpart to be confused with, which is
+# why it needs no entry in the `prohibited` veto below.
+allowed_reasons contains "service-credit-offer-eligibility" if {
+	input.principal.id == "service-account-openbank-services"
+	input.action == "lending.creditOffer.eligibility"
+}
+
+# NO BLANKET SERVICE (M2M) rule on purpose: in-repo M2M callers are the ones named above (the
+# admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the observability/security
+# scanners use the management port, and ledger posting is an OUTBOUND call from lending). A blanket
+# SERVICE allow would open every endpoint to any M2M client. If a future caller lands, add
 # another named, action-scoped rule here.
 
 # 2026-08-05 (#3734): operator-lending-write was role-only, and rules.yaml's role_action_matrix

--- a/openbank-infra/gitops/components/lending/lending_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/lending/lending_rest_ext_test.rego
@@ -122,3 +122,32 @@ test_shared_no_operator_rule_on_create if {
 		with input as {"principal": shared, "action": "lending.create"}
 		with data.rules as rules_mock
 }
+
+# ── ADR-0269 rule 2: the credit-offer eligibility read (issue #8918) ─────────────────────────
+
+test_shared_service_may_read_credit_offer_eligibility if {
+	"service-credit-offer-eligibility" in rest.allowed_reasons
+		with input as {"principal": shared, "action": "lending.creditOffer.eligibility"}
+		with data.rules as rules_mock
+}
+
+# The rule opens ONE action. The shared client is every backend service at once, so a rule that
+# leaked past its action would hand all of them a lending endpoint they have no business in.
+test_shared_service_gets_nothing_else_from_that_rule if {
+	not "service-credit-offer-eligibility" in rest.allowed_reasons
+		with input as {"principal": shared, "action": "lending.disburse"}
+		with data.rules as rules_mock
+}
+
+test_shared_service_gets_no_read_of_loans_from_that_rule if {
+	not "service-credit-offer-eligibility" in rest.allowed_reasons
+		with input as {"principal": shared, "action": "lending.read"}
+		with data.rules as rules_mock
+}
+
+# And it is scoped to the identity, not to the action alone: the edge does not inherit it.
+test_edge_does_not_inherit_the_eligibility_rule if {
+	not "service-credit-offer-eligibility" in rest.allowed_reasons
+		with input as {"principal": edge, "action": "lending.creditOffer.eligibility"}
+		with data.rules as rules_mock
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResource.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.usecase.CreditOfferEligibilityService
+import com.openbank.lending.domain.model.CreditOfferDecision
+import com.openbank.lending.domain.model.OfferSurface
+import com.openbank.libs.authz.Authorize
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/**
+ * May the bank say something about credit to this customer, unprompted? (ADR-0269 rules 1 and 2.)
+ *
+ * ## Why this route exists
+ *
+ * [CreditOfferEligibilityService] describes itself as the one place any credit offer is cleared —
+ * "everything upstream of an offer asks this service and acts on nothing else". That was true of
+ * its intent and false of its reach: it had no wire surface at all, so the only caller was
+ * in-process ([CustomerQuoteResource], asking the PULL question). Every out-of-process surface that
+ * ADR-0269 governs — a campaign step, a pre-approved tile, an agent nudge — had no way to ask.
+ *
+ * The result was that rule 2, the distress suppression floor, was enforced nowhere on the push
+ * side: a customer who had switched credit offers on and then fallen into arrears was still
+ * marketed to. This route is the missing half of that sentence, not a new policy.
+ *
+ * ## Why PUSH is fixed, and not a parameter
+ *
+ * The surface is not the caller's to choose. PULL exists for a customer who ASKED — it deliberately
+ * skips the consent half, because requiring an opt-in before answering a question the customer just
+ * asked is a dark pattern in the other direction. Letting a caller name its own surface would make
+ * that exemption available to anyone who passed the right string, which is precisely the asymmetry
+ * the ADR spends rule 1 constructing. A caller that legitimately serves a customer-initiated
+ * request already has [CustomerQuoteResource].
+ *
+ * ## What a caller must do with a failure
+ *
+ * Refuse. Not "proceed and log": an unreachable eligibility service means the bank does not know
+ * whether it may market credit to this person, and the answer to not knowing is no. This route
+ * answers with a decision or an error; it never answers "probably fine".
+ */
+@Path("/api/v1/lending/credit-offers")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CreditOfferEligibilityResource(private val eligibility: CreditOfferEligibilityService) {
+
+    @GET
+    @Path("/eligibility/{partyId}")
+    @Authorize(action = "lending.creditOffer.eligibility", resource = "")
+    @Operation(summary = "Whether an UNPROMPTED credit offer may be surfaced to this party")
+    fun eligibility(@PathParam("partyId") partyId: UUID): Uni<Response> =
+        CoroutineScope(Dispatchers.Unconfined).async {
+            // 200 for both outcomes, on purpose. "You may not offer" is a successful answer to the
+            // question asked, not a client error — and a caller that has to distinguish a refusal
+            // from a transport failure by status code will eventually get it wrong in the
+            // permissive direction. The reason lives in the body; the absence of a body is the
+            // failure.
+            when (val decision = eligibility.evaluate(partyId, OfferSurface.PUSH)) {
+                is CreditOfferDecision.Allowed -> Response.ok(
+                    mapOf(
+                        "allowed" to true,
+                        "reasonCode" to null,
+                        "policyVersion" to decision.policyVersion,
+                    ),
+                ).build()
+
+                is CreditOfferDecision.Suppressed -> Response.ok(
+                    mapOf(
+                        // The code is part of the contract, not a log line: a caller has to be able
+                        // to count "declined for arrears" separately from "never opted in", and a
+                        // conduct review will ask for exactly that split.
+                        "allowed" to false,
+                        "reasonCode" to decision.code.name,
+                        "policyVersion" to decision.policyVersion,
+                    ),
+                ).build()
+            }
+        }.asUni()
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResource.kt
@@ -64,32 +64,31 @@ class CreditOfferEligibilityResource(private val eligibility: CreditOfferEligibi
     @Path("/eligibility/{partyId}")
     @Authorize(action = "lending.creditOffer.eligibility", resource = "")
     @Operation(summary = "Whether an UNPROMPTED credit offer may be surfaced to this party")
-    fun eligibility(@PathParam("partyId") partyId: UUID): Uni<Response> =
-        CoroutineScope(Dispatchers.Unconfined).async {
-            // 200 for both outcomes, on purpose. "You may not offer" is a successful answer to the
-            // question asked, not a client error — and a caller that has to distinguish a refusal
-            // from a transport failure by status code will eventually get it wrong in the
-            // permissive direction. The reason lives in the body; the absence of a body is the
-            // failure.
-            when (val decision = eligibility.evaluate(partyId, OfferSurface.PUSH)) {
-                is CreditOfferDecision.Allowed -> Response.ok(
-                    mapOf(
-                        "allowed" to true,
-                        "reasonCode" to null,
-                        "policyVersion" to decision.policyVersion,
-                    ),
-                ).build()
+    fun eligibility(@PathParam("partyId") partyId: UUID): Uni<Response> = CoroutineScope(Dispatchers.Unconfined).async {
+        // 200 for both outcomes, on purpose. "You may not offer" is a successful answer to the
+        // question asked, not a client error — and a caller that has to distinguish a refusal
+        // from a transport failure by status code will eventually get it wrong in the
+        // permissive direction. The reason lives in the body; the absence of a body is the
+        // failure.
+        when (val decision = eligibility.evaluate(partyId, OfferSurface.PUSH)) {
+            is CreditOfferDecision.Allowed -> Response.ok(
+                mapOf(
+                    "allowed" to true,
+                    "reasonCode" to null,
+                    "policyVersion" to decision.policyVersion,
+                ),
+            ).build()
 
-                is CreditOfferDecision.Suppressed -> Response.ok(
-                    mapOf(
-                        // The code is part of the contract, not a log line: a caller has to be able
-                        // to count "declined for arrears" separately from "never opted in", and a
-                        // conduct review will ask for exactly that split.
-                        "allowed" to false,
-                        "reasonCode" to decision.code.name,
-                        "policyVersion" to decision.policyVersion,
-                    ),
-                ).build()
-            }
-        }.asUni()
+            is CreditOfferDecision.Suppressed -> Response.ok(
+                mapOf(
+                    // The code is part of the contract, not a log line: a caller has to be able
+                    // to count "declined for arrears" separately from "never opted in", and a
+                    // conduct review will ask for exactly that split.
+                    "allowed" to false,
+                    "reasonCode" to decision.code.name,
+                    "policyVersion" to decision.policyVersion,
+                ),
+            ).build()
+        }
+    }.asUni()
 }

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.19.0
+  version: 1.20.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -149,6 +149,41 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/lending/credit-offers/eligibility/{partyId}:
+    get:
+      tags: [Lending]
+      operationId: creditOfferEligibility
+      summary: Whether an UNPROMPTED credit offer may be surfaced to this party
+      description: >-
+        ADR-0269 rules 1 and 2, for callers OUTSIDE this service. The eligibility gate is the one
+        place a credit offer is cleared, but it had no wire surface, so every push surface the ADR
+        governs — a campaign step, a pre-approved tile, an agent nudge — had no way to ask, and the
+        distress floor was enforced nowhere on that side.
+
+        The surface is fixed to PUSH and is deliberately NOT a parameter: PULL skips the consent
+        half because a customer who asked has already spoken for themselves, and letting a caller
+        name its own surface would hand that exemption to anyone who passed the right string. A
+        caller serving a customer-initiated request wants /intake/quotes instead.
+
+        Answers 200 for BOTH outcomes. "You may not offer" is a successful answer to the question
+        asked, not a client error, and a caller distinguishing a refusal from a transport failure by
+        status code will eventually get it wrong in the permissive direction. A caller that cannot
+        reach this route must refuse to offer: not knowing whether it may market credit is answered
+        no, never "probably fine".
+      parameters:
+        - name: partyId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: The decision, allowed or suppressed with its reason
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreditOfferEligibilityDecision'
+        '403': { description: Caller is not permitted this action }
 
   /api/v1/lending/intake/quotes:
     post:
@@ -1166,6 +1201,25 @@ components:
         tables:
           type: array
           items: { $ref: '#/components/schemas/PolicyTableView' }
+    CreditOfferEligibilityDecision:
+      type: object
+      required: [allowed, policyVersion]
+      properties:
+        allowed: { type: boolean }
+        reasonCode:
+          type: string
+          nullable: true
+          description: >-
+            Null when allowed. Part of the contract rather than a log line: a caller must be able to
+            count "declined for arrears" separately from "never opted in", and a conduct review asks
+            for exactly that split. SIGNALS_UNAVAILABLE means the gate could not read what it needed
+            and refused rather than guessed.
+          enum: [CONSENT_ABSENT, SIGNALS_UNAVAILABLE, INSOLVENCY, ENFORCEMENT, ARREARS, HARDSHIP,
+                 NEGATIVE_BALANCE, AFFORDABILITY_COOLING, BUFFER_BELOW_FLOOR, FREQUENCY_CAP,
+                 NO_MATERIAL_CHANGE, HISTORY_TOO_THIN]
+        policyVersion:
+          type: integer
+          description: The version of the decision table that produced this answer (ADR-0213).
     CustomerQuoteRequest:
       type: object
       required: [amount, termMonths]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResourceTest.kt
@@ -43,18 +43,17 @@ class CreditOfferEligibilityResourceTest {
         complete = true,
     )
 
-    private fun resource(consent: Boolean, signals: BorrowerDistressSignals = healthy) =
-        CreditOfferEligibilityResource(
-            CreditOfferEligibilityService(
-                consent = object : CreditOffersConsentPort {
-                    override suspend fun hasCreditOffersConsent(partyId: UUID) = consent
-                },
-                distress = object : BorrowerDistressPort {
-                    override suspend fun signalsFor(partyId: UUID) = signals
-                },
-                clock = clock,
-            ),
-        )
+    private fun resource(consent: Boolean, signals: BorrowerDistressSignals = healthy) = CreditOfferEligibilityResource(
+        CreditOfferEligibilityService(
+            consent = object : CreditOffersConsentPort {
+                override suspend fun hasCreditOffersConsent(partyId: UUID) = consent
+            },
+            distress = object : BorrowerDistressPort {
+                override suspend fun signalsFor(partyId: UUID) = signals
+            },
+            clock = clock,
+        ),
+    )
 
     @Suppress("UNCHECKED_CAST")
     private fun body(consent: Boolean, signals: BorrowerDistressSignals = healthy): Map<String, Any?> =

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CreditOfferEligibilityResourceTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.BorrowerDistressPort
+import com.openbank.lending.application.port.out.CreditOffersConsentPort
+import com.openbank.lending.application.usecase.CreditOfferEligibilityService
+import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The wire surface of ADR-0269's push gate.
+ *
+ * These assert the two properties a caller depends on and cannot check for itself: that a refusal
+ * arrives as a readable decision rather than an error to be guessed at, and that the PUSH surface
+ * is not negotiable — a caller must not be able to obtain the PULL answer, which skips the consent
+ * half.
+ */
+class CreditOfferEligibilityResourceTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-09-06T10:00:00Z"), ZoneOffset.UTC)
+    private val party = UUID.randomUUID()
+
+    private val healthy = BorrowerDistressSignals(
+        hasArrears = false,
+        hasNegativeBalance = false,
+        enforcementSignal = CourtRegisterSignalState.CLEAR,
+        insolvencySignal = CourtRegisterSignalState.CLEAR,
+        inHardshipArrangement = false,
+        lastAffordabilityFailureAt = null,
+        bufferDays = 90,
+        monthsObserved = 12,
+        lastCreditContactAt = null,
+        inputsChangedSinceLastContact = true,
+        complete = true,
+    )
+
+    private fun resource(consent: Boolean, signals: BorrowerDistressSignals = healthy) =
+        CreditOfferEligibilityResource(
+            CreditOfferEligibilityService(
+                consent = object : CreditOffersConsentPort {
+                    override suspend fun hasCreditOffersConsent(partyId: UUID) = consent
+                },
+                distress = object : BorrowerDistressPort {
+                    override suspend fun signalsFor(partyId: UUID) = signals
+                },
+                clock = clock,
+            ),
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun body(consent: Boolean, signals: BorrowerDistressSignals = healthy): Map<String, Any?> =
+        resource(consent, signals).eligibility(party).await().indefinitely().entity as Map<String, Any?>
+
+    @Test
+    fun `a consenting party with no distress may be offered credit`() {
+        assertThat(body(consent = true)).containsEntry("allowed", true).containsEntry("reasonCode", null)
+    }
+
+    @Test
+    fun `no consent is a refusal that names itself`() {
+        // The caller has to be able to count "never opted in" apart from "in arrears": one is a
+        // preference and the other is a conduct fact, and a single "declined" number hides which.
+        assertThat(body(consent = false))
+            .containsEntry("allowed", false)
+            .containsEntry("reasonCode", "CONSENT_ABSENT")
+    }
+
+    @Test
+    fun `consent does not lift the distress floor`() {
+        // ADR-0269 rule 2 is the whole point of this route: a customer who agreed to hear about
+        // credit and is in arrears must still not be marketed to.
+        assertThat(body(consent = true, signals = healthy.copy(hasArrears = true)))
+            .containsEntry("allowed", false)
+            .containsEntry("reasonCode", "ARREARS")
+    }
+
+    @Test
+    fun `an incomplete signal set refuses rather than guesses`() {
+        assertThat(body(consent = true, signals = healthy.copy(complete = false)))
+            .containsEntry("allowed", false)
+            .containsEntry("reasonCode", "SIGNALS_UNAVAILABLE")
+    }
+
+    @Test
+    fun `a refusal is a 200, so a caller cannot mistake it for a transport failure`() {
+        // A 4xx would invite "treat errors as allow" in a caller's retry path. The refusal is a
+        // successful answer to the question asked.
+        assertThat(resource(consent = false).eligibility(party).await().indefinitely().status).isEqualTo(200)
+    }
+
+    @Test
+    fun `the answer carries the policy version that produced it`() {
+        assertThat(body(consent = true)["policyVersion"]).isNotNull()
+    }
+}


### PR DESCRIPTION
Part 1 of #8918. The lending half only — campaign-service consuming this is a separate PR.

## What is wrong today

`CreditOfferEligibilityService` describes itself as the one place a credit offer is cleared:
*"everything upstream of an offer — the pre-approved read at the edge, a campaign step, an L2 agent
capability — asks this service and acts on nothing else."*

That was true of its intent and false of its reach. It had **no wire surface**, so its only caller
was `CustomerQuoteResource`, in-process, asking the `PULL` question. Every push surface ADR-0269
governs had no way to ask.

The consequence is concrete: a customer who switched credit offers on and has since fallen into
arrears is still marketed to. #8883 checks that they *agreed* to hear about credit. Nothing checks
whether telling them right now is harmful — and rule 2 exists because the most responsive target
for a credit offer is often the worst borrower.

## What this adds

`GET /api/v1/lending/credit-offers/eligibility/{partyId}` → `allowed`, `reasonCode`,
`policyVersion`.

### Decisions worth review

- **`PUSH` is fixed in code, not a parameter.** `PULL` skips the consent half because a customer who
  asked has spoken for themselves. Letting a caller name its own surface would hand that exemption
  to anyone passing the right string — the exact asymmetry rule 1 spends its length constructing. A
  caller serving a customer-initiated request already has `/intake/quotes`.
- **200 for both outcomes.** "You may not offer" answers the question asked; it is not a client
  error. A caller that distinguishes a refusal from a transport failure by status code will
  eventually get it wrong in the permissive direction. The reason is in the body; the absence of a
  body is the failure.
- **`reasonCode` is contract, not a log line.** "Declined for arrears" and "never opted in" have to
  be countable apart; a conduct review asks for exactly that split.
- **The OPA rule is scoped to one action and one principal.** The shared `openbank-services` client
  is every backend service at once, so whatever opens here opens to all of them. A read of "may we
  offer" is proportionate to that; nothing else in lending would be.

## Verification

- 6/6 resource tests, 0 failures (read from the JUnit XML).
- OPA 20/20. **Falsified:** removing the rego rule fails exactly the one positive test while all
  three negative ones stay green — so the rule is load-bearing and the negatives are not passing for
  an unrelated reason.
- **Falsified, the fixed-`PUSH` property too** (this had not finished when the PR was opened; the
  build host was saturated and the run was killed — it has since been completed). Swapping `PUSH`
  for `PULL` fails exactly one test, `no consent is a refusal that names itself`, and the other five
  stay green.

  The asymmetry is the evidence: the distress-floor test passes under `PULL` as well, because the
  floor applies to both surfaces. Had it also failed, the tests would not be measuring the
  difference between "the customer asked" and "the bank is pushing" — only the consent-dependent one
  should move, and only it did.

## Threat model

Section **9e** added — a new inbound REST surface on a money-path service needs one (ADR-0030 D2).
It records what this does **not** solve: the shared M2M client cannot distinguish campaign-service
from any other backend caller, so there is no per-caller rate limit or attribution. That is a known
limit of the M2M model (ADR-0206 D5) rather than something this route introduces, and it should not
be read as solved.

## Why the consumer is a separate PR

My first recommendation on #8918 was to check at **enrolment**. That is wrong: a journey runs for
days or weeks, so a customer can fall into arrears on day two and keep receiving credit marketing
for the rest of it. Consent does not have this hole because `consentRevoked` is signalled into the
running workflow; distress has no equivalent. The check therefore belongs at **delivery**, in the
contact gate, where the per-party consent/caps/quiet-hours decision already happens. Full reasoning
in the revised comment on #8918.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The route returns a
      decision and a reason code about a party id the caller already holds; no distress *facts*
      (balances, loan states) cross the boundary, only the conclusion drawn from them.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification. **One added**, and stated
      rather than ticked away: `@Suppress("UNCHECKED_CAST")` in the test, casting the JAX-RS
      `Response.entity` to `Map<String, Any?>` to assert on the body. Test-only, and the cast fails
      loudly in the test itself if the shape ever changes.
- [x] No new third-party dependency. Nothing added to any `build.gradle.kts` or the version
      catalogue — the diff is one resource, its test, the OpenAPI, the OPA bundle and the threat
      model.
- [x] Auth / crypto / payment code changed? → **yes, authorisation.** A new `@Authorize` action and
      a new OPA rule on a money-path service. Tagging `security-review-required`: the scoping of
      `service-credit-offer-eligibility` is the part worth a second pair of eyes, because the shared
      `openbank-services` principal means whatever it opens is open to every backend service.
- [x] PII path changed? → **arguably yes.** The response states that a named party is in arrears,
      insolvent, or in a hardship arrangement. That is special-category-adjacent personal data even
      though it never leaves the internal network. Tagging `gdpr-review-required` rather than
      deciding alone that "internal only" settles it.
- [x] Cardholder data path changed? → no. Nothing here reads or writes PAN, and lending's card
      surfaces are untouched.
