### PR TITLE
fix(notification): allow out-of-order Flyway for the duplicate V14

### DIFF
--- a/.github/scripts/check-flyway-version-commit-order.py
+++ b/.github/scripts/check-flyway-version-commit-order.py
@@ -75,6 +75,12 @@ KNOWN_VIOLATIONS: dict[str, str] = {
         "V15 (Stories) deployed before the additive graph migrations V13/V14; "
         "QUARKUS_FLYWAY_OUT_OF_ORDER=true set in components/campaign/campaign-service.yaml, "
         "with its own note to remove once all environments have recorded V13/V14.",
+    "openbank-notification-service/src/main/resources/db/migration/V14__notification_deduplication_key.sql":
+        "Two migrations carry version 14: V14__synthetic_outbox_taint.sql reached main 2026-08-24 "
+        "(#6731) and this one 2026-09-06 (24e15de97). Renumbering is blocked — renaming a migration "
+        "already on main is treated as editing it — so QUARKUS_FLYWAY_OUT_OF_ORDER=true is set in "
+        "components/notifications/notification-service.yaml, with its own note to remove once every "
+        "environment has recorded both V14s.",
 }
 
 

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -74,6 +74,22 @@ spec:
             - name: management
               containerPort: 8085
           env:
+            # TWO migrations carry version 14. `V14__synthetic_outbox_taint.sql` reached main on
+            # 2026-08-24 (#6731) and `V14__notification_deduplication_key.sql` on 2026-09-06
+            # (24e15de97) — the same number, merged twelve days apart. Once the earlier one is
+            # recorded in `flyway_schema_history`, Flyway refuses the later with
+            # "Detected resolved migration not applied to database: 14" and the pod crashloops on
+            # every boot (issue #5628).
+            #
+            # Renumbering is not available: renaming a migration that has already reached main is
+            # treated as editing it by `check-db-migration.py`, and the checksum rule forbids that
+            # once applied anywhere. So this is the remediation the ordering gate itself prescribes,
+            # and the same one campaign-service and security-scanner already carry.
+            #
+            # Keep it explicit until every environment has recorded both V14s, then remove it in a
+            # separately reviewed cleanup — never let out-of-order migrations become implicit.
+            - name: QUARKUS_FLYWAY_OUT_OF_ORDER
+              value: "true"
             # JDBC leg: Hibernate ORM + Flyway (blocking) onto the CNPG primary.
             - name: QUARKUS_DATASOURCE_JDBC_URL
               value: jdbc:postgresql://notifications-db-rw.notifications.svc:5432/openbank_notifications


### PR DESCRIPTION
## Summary

`check-flyway-version-commit-order.py --enforce` fails on `main` itself, so the gate is red on **every** open PR regardless of what that PR touches. Cause: two migrations in `openbank-notification-service` carry version 14. This applies the remediation the gate's own message prescribes — the Flyway out-of-order escape plus the matching baseline entry.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #6731

## Changes

- `openbank-infra/gitops/components/notifications/notification-service.yaml` — `QUARKUS_FLYWAY_OUT_OF_ORDER=true`, matching the existing `campaign-service` and `security-scanner` precedent, with a comment naming both migrations and their merge dates.
- `.github/scripts/check-flyway-version-commit-order.py` — the matching `KNOWN_VIOLATIONS` entry, citing the env var above.

## The collision

`V14__synthetic_outbox_taint.sql` reached `main` 2026-08-24 (`f8d165dd69`, #6731); `V14__notification_deduplication_key.sql` reached it 2026-09-06 (`24e15de972`). The same number, merged twelve days apart, with a clean textual merge — the version is the *filename prefix*, so two differently-named files never conflict. Root `CLAUDE.md` documents this shape; nothing prevents it.

Renumbering is unavailable: renaming a migration already applied is the same checksum change as editing one. So the fix is Flyway's own escape.

Without the env var the service does not boot — Flyway refuses a migration whose version is not greater than the schema high-water mark.

## Measurements

| probe | result |
|---|---|
| `--enforce` on a detached worktree of `origin/main` | **rc=1** |
| `--enforce` on this branch | rc=0, `433 migration(s) across 57 service(s), 3 known baseline entries — clean` |
| `--selftest` | OK (flags the #5628 shape, spares monotonic versions, recognises a baselined entry) |
| manifest parses, env entry present | `[{'name': 'QUARKUS_FLYWAY_OUT_OF_ORDER', 'value': 'true'}]` |

## A gap this exposed, deliberately not fixed here

Falsified both halves: **removing the env var while keeping the baseline entry still returns rc=0.** The gate takes the remediation on trust and cannot see whether the gitops half exists. So a baselined violation with a forgotten env var reads green while the service crashloops on boot — the failure this baseline mechanism exists to make safe.

Not fixed in this PR because deriving a service's manifest path is not mechanical: this service lives under `components/notifications/`, not `components/notification-service/`, so a name-based lookup would be wrong for exactly the services that need it. A correct version would require the baseline entry to *name* its manifest and the gate to assert the env var in that file — a change to the entry format, and its own PR.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated. — no production code changed; the gate's own `--selftest` covers the baseline path
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — no Kotlin touched
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed). — no migration added; this makes the two existing ones applicable
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). — both edits carry in-place comments

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
