### PR TITLE
fix(swift): raise test-worker heap to 3g — 2g still OOMs the full suite on CI

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -76,9 +76,15 @@ tasks.withType<Test> {
     // died in the same minute — `OutOfMemoryError: Java heap space` across ClassGraph-worker /
     // vert.x-eventloop / Finalizer threads ~3 minutes into the suite, after which the JVM hung
     // in GC until the 45-minute job timeout (#8781) or the pact verification Timed out
-    // downstream of the GC storm (#8697). Same 2g ceiling account/lending/product-catalog
-    // already run with; a ceiling, not an allocation.
-    maxHeapSize = "2g"
+    // downstream of the GC storm (#8697). 2g (the account/lending/product-catalog ceiling)
+    // proved NOT enough: measured 2026-09-06 the suite OOM'd at 2g on three consecutive CI
+    // attempts of one unchanged commit (PR #8942, run 34032738729) — OutOfMemoryError across
+    // ClassGraph-worker / vert.x-eventloop / Finalizer / HttpClient threads ~6 minutes in,
+    // surfacing as SwiftPactFolderProviderVerificationTest "Uncaught exception during scan"
+    // (the scan is just the allocation that trips the exhausted heap, not the cause). Raised
+    // to 3g; a ceiling, not an allocation. A duplicate `maxHeapSize = "2g"` further down this
+    // block (added independently by #8796 for the same #8916 defect) was consolidated here.
+    maxHeapSize = "3g"
 
     // CI hang #3 (#2320) is GONE — measured, not assumed. `SwiftBootSmokeIT` used to hang 37+ min
     // at Quarkus boot on the runner pool (`@DisabledIfEnvironmentVariable` is evaluated AFTER
@@ -101,18 +107,6 @@ tasks.withType<Test> {
     // runner until the 45-minute fleet job timeout takes the whole matrix down with it — the
     // failure mode that caused the exclusion in the first place. Fail fast, not fail wide.
     systemProperty("junit.jupiter.execution.timeout.default", "8m")
-
-    // Test-worker heap: Gradle's 512 MiB default is not enough for this module's CI lane.
-    // The suite boots several @QuarkusTest instances plus Testcontainers (Postgres) in one
-    // worker, and on the shared runner pool the test JVM dies with OutOfMemoryError roughly
-    // six minutes in — measured 2026-09-06 on five consecutive runs of one unchanged commit
-    // (PR #8796, Services CI run 33990777002): three of the seven swift-lane attempts OOM'd
-    // before the pact suite even ran, and the crippled JVM then dragged the job into the
-    // 45-minute matrix timeout (issue #8916). Same defect and same per-module fix as
-    // account/lending (2g) and product-catalog (1536m) above; deliberately NOT a fleet-wide
-    // bump in build-logic, per the same comment there: nothing measures test heap across the
-    // ~50 modules, so a global raise is an unmeasured ratchet.
-    maxHeapSize = "2g"
 
     // Pact rootDir + Pact Broker property forwarding centralised into
     // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`


### PR DESCRIPTION
## Why

The 2g ceiling (#8934, and independently #8796) is not enough for this module's full CI suite. Measured 2026-09-06 on PR #8942 (run 34032738729): **three consecutive attempts** OOM'd ~6 minutes into `:openbank-swift-service:test` — `OutOfMemoryError: Java heap space` across ClassGraph-worker / vert.x-eventloop / Finalizer / HttpClient threads, surfacing as `SwiftPactFolderProviderVerificationTest` "Uncaught exception during scan". The ClassGraph scan is merely the allocation that trips the exhausted heap — the same misdirection documented in the test class itself (#1348, #1948).

Same commit passes locally, so this is runner-pool memory pressure, not a code regression: nothing on swift-service's test classpath changed between the last green lane (13:11 UTC) and the failures.

## What

- `maxHeapSize` 2g → 3g (a ceiling, not an allocation)
- Consolidated the duplicate `maxHeapSize = "2g"` blocks that #8934 and #8796 each added to the same `tasks.withType<Test>` block into one, with the failure evidence in the comment

Refs #8916

## Security checklist
- [x] No new endpoint, no authz surface change
- [x] No dependency or config change (build-file test JVM setting only)
- [x] No secret, no PII, no money-path logic touched
