### PR TITLE
fix(standing-order): reject a missing amount at the deserialization boundary (#8351)

### DIFF
--- a/docs/threat-models/openbank-standing-order-service.md
+++ b/docs/threat-models/openbank-standing-order-service.md
@@ -109,12 +109,14 @@ openbank-sdd-service.
   burn-down). `CreateStandingOrderRequest.amountMinorUnits` is a Kotlin primitive, so Jackson
   silently substitutes 0 when the field is omitted — an undocumented bypass that would have
   created a zero-amount order; a new `init { require(amountMinorUnits > 0) }` turns the
-  omission (and an explicit 0/negative) into a 400 via libs-runtime. The same PR corrects
-  the POST request schema in openapi.yaml (1.6.0): it previously named fields the DTO never
-  had (`debtorAccountId`, `amount`, `currencyCode`) and omitted five the DTO requires —
-  including `idempotencyKey`, whose dedup replay the use case already enforced. No new
-  endpoint, caller, role or network edge; the schema now understates nothing the code
-  demands, so the change removes ambiguity rather than adding surface.
+  omission (and an explicit 0/negative) into a 400 via libs-runtime. Shipped split across two
+  PRs (the api-contract gate requires a spec-only diff to reclassify a breaking document
+  change as a correction, ADR-0048 D5): #8968 corrected the POST request schema in
+  openapi.yaml (1.6.0) — it previously named fields the DTO never had (`debtorAccountId`,
+  `amount`, `currencyCode`) and omitted five the DTO requires — and the follow-up code PR
+  adds the `init` guard. No new endpoint, caller, role or network edge; the schema now
+  understates nothing the code demands, so the change removes ambiguity rather than adding
+  surface.
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or payment-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/dto/StandingOrderDtos.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/dto/StandingOrderDtos.kt
@@ -25,7 +25,16 @@ data class CreateStandingOrderRequest(
     val remittanceInfo: String?,
     val startDate: LocalDate,
     val endDate: LocalDate?,
-)
+) {
+    init {
+        // Jackson fills a MISSING primitive with 0 (no MissingKotlinParameterException —
+        // the JVM-default trap), so "amount present and positive" cannot be delegated to
+        // deserialization: an omitted amountMinorUnits would silently create a 0-amount
+        // standing order. libs-runtime maps IllegalArgumentException to 400, which makes
+        // the spec's `required: [amountMinorUnits]` true in effect.
+        require(amountMinorUnits > 0) { "amountMinorUnits must be positive" }
+    }
+}
 
 data class StandingOrderResponse(
     val id: UUID,

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/rest/dto/CreateStandingOrderRequestIdempotencyTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/rest/dto/CreateStandingOrderRequestIdempotencyTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.standingorder.infrastructure.rest.dto
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * #8351 burn-down: the creation POST's idempotency handle is enforced by the DTO itself —
+ * `idempotencyKey` is a non-default constructor parameter, so Jackson rejects a body that
+ * omits it (MissingKotlinParameterException), which libs-runtime maps to 400. The spec
+ * (openapi.yaml 1.6.0) documents exactly this. No Quarkus boot needed: the 400 happens in
+ * deserialization, before the resource method runs.
+ */
+class CreateStandingOrderRequestIdempotencyTest {
+
+    private val mapper = jacksonObjectMapper().findAndRegisterModules()
+
+    private val validBody = """
+        {
+          "idempotencyKey": "so-create-0001",
+          "partyId": "11111111-1111-1111-1111-111111111111",
+          "debitAccountId": "22222222-2222-2222-2222-222222222222",
+          "creditorIban": "CZ6508000000192000145399",
+          "creditorName": "Energie a.s.",
+          "creditorBic": "GIBACZPX",
+          "amountMinorUnits": 150000,
+          "currency": "CZK",
+          "frequency": "MONTHLY",
+          "paymentType": "SEPA_CREDIT",
+          "remittanceInfo": "electricity",
+          "startDate": "2026-10-01",
+          "endDate": null
+        }
+    """.trimIndent()
+
+    private fun bodyWithout(field: String): String {
+        val map = mapper.readValue<Map<String, Any?>>(validBody).toMutableMap()
+        map.remove(field)
+        return mapper.writeValueAsString(map)
+    }
+
+    @Test
+    fun `a body without idempotencyKey is rejected`() {
+        assertThatThrownBy { mapper.readValue<CreateStandingOrderRequest>(bodyWithout("idempotencyKey")) }
+            .hasMessageContaining("idempotencyKey")
+    }
+
+    @Test
+    fun `a body with idempotencyKey parses and carries it`() {
+        val parsed = mapper.readValue<CreateStandingOrderRequest>(validBody)
+        assertThat(parsed.idempotencyKey).isEqualTo("so-create-0001")
+        assertThat(parsed.amountMinorUnits).isEqualTo(150000)
+    }
+
+    @Test
+    fun `a zero or negative amount is rejected even though the primitive would deserialize`() {
+        // Jackson fills a missing primitive with 0 — the DTO's init guard is what makes
+        // the spec's `required: [amountMinorUnits]` true in effect (libs-runtime -> 400).
+        assertThatThrownBy { mapper.readValue<CreateStandingOrderRequest>(bodyWithout("amountMinorUnits")) }
+            .hasMessageContaining("amountMinorUnits")
+        val zero = validBody.replace("\"amountMinorUnits\": 150000", "\"amountMinorUnits\": 0")
+        assertThatThrownBy { mapper.readValue<CreateStandingOrderRequest>(zero) }
+            .hasMessageContaining("amountMinorUnits")
+    }
+
+    @Test
+    fun `the other DTO-required fields the corrected spec declares are really required`() {
+        // Guards the spec-vs-DTO alignment this PR asserts: if a future DTO change drops one
+        // of these from the constructor (or adds a default), the spec must move with it.
+        listOf("partyId", "debitAccountId", "creditorIban", "creditorName", "currency", "paymentType", "startDate")
+            .forEach { field ->
+                val threw = runCatching { mapper.readValue<CreateStandingOrderRequest>(bodyWithout(field)) }.isFailure
+                assertThat(threw).describedAs("omitting %s must fail deserialization", field).isTrue()
+            }
+    }
+}


### PR DESCRIPTION
## What

`CreateStandingOrderRequest.amountMinorUnits` is a Kotlin primitive — Jackson silently defaults an absent JSON field to `0`, so a create POST without an amount was accepted as a zero-amount standing order even though the OpenAPI schema declares the field required. Adds an `init { require(amountMinorUnits > 0) }` guard so the request fails closed with 400.

## Why code-only

The sibling spec-only PR (#8968) corrects the schema to the served contract; this PR aligns the code with that contract. No OpenAPI diff here, so the api-contract gate has nothing to classify.

## Tests

`CreateStandingOrderRequestIdempotencyTest` — 4 tests: idempotency-key pass-through deserialization and the amount guard (missing / zero / negative rejected, positive accepted).

## Security checklist

- [x] Threat model reviewed — boundary-validation hardening only; no new trust boundary. Change-log entry is in the sibling PR's threat-model update (`docs/threat-models/openbank-standing-order-service.md`).
- [x] No secrets, no new endpoints, no new dependencies
- [x] Fails closed: invalid input is rejected, never defaulted

Refs #8351