### PR TITLE
fix(infra): let the SLSA attestation land on admin-ui — drop the ECR tag immutability

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
@@ -92,10 +92,34 @@ locals {
   # re-push fails, so flipping the fleet would break the self-heal that exists to
   # rescue stranded deploys.
   #
-  # openbank-admin-ui is IMMUTABLE in the live account and stays that way — it is
-  # built by its own workflow (build-push-admin-ui.sh) off a version, not a sha,
-  # and tightening is never reverted here to make a plan quieter.
-  ecr_immutable_repositories = toset(["openbank-admin-ui"])
+  # openbank-admin-ui WAS the one IMMUTABLE repository. It is not any more, and the
+  # reason is a real incompatibility rather than a quieter plan (the rule this comment
+  # used to state still holds: never loosen a control to make Terraform agree with the
+  # account).
+  #
+  # cosign v2 stores every attestation for an image under ONE tag, `sha256-<digest>.att`,
+  # and attaching a second predicate must append to it — a rewrite. #8847 added SLSA build
+  # provenance alongside the CycloneDX SBOM, so each build now attests twice, and on an
+  # immutable repository the second write is refused:
+  #
+  #   TAG_INVALID: The image tag 'sha256-<digest>.att' already exists ... and cannot be
+  #   overwritten because the tag is immutable
+  #
+  # #8982 stopped that from failing the build (the kyverno SLSA policy is Audit, so a
+  # deploy is not gated on the envelope) and admin-ui deploys work again. What it could not
+  # do is make the attestation land: admin-ui is now the one deploy image in the fleet with
+  # no build provenance, tolerated on every run. This is the other half — the repository
+  # joins the fleet default, so the third leg of ADR-0030 D4 is actually written, and
+  # #8982's tolerate branch becomes the safety net it reads as rather than the steady state.
+  #
+  # The tag scheme is not ours to change: cosign v3 writes OCI 1.1 referrers, which the
+  # pinned kyverno 3.2.6 cannot discover, so v2 and its `.att` tag are load-bearing until
+  # issue #770. Under that constraint an immutable repository holds exactly one attestation.
+  #
+  # What the platform gives up is tag-reuse protection on one repository, which no other
+  # repository has. What it keeps is the part that proves authenticity — the KMS cosign
+  # signature and both attestations, verified at admission. Revisit at #770.
+  ecr_immutable_repositories = toset([])
 }
 
 resource "aws_ecr_repository" "service" {


### PR DESCRIPTION
## Summary

Admin-ui is the one deploy image in the fleet shipping without build provenance. cosign v2 keeps all attestations for a digest under one `sha256-<digest>.att` tag, so the second predicate must append to it, and `openbank-admin-ui` is the fleet's only IMMUTABLE ECR repository, which refuses the write. #8982 stopped that from failing the build; this makes the attestation actually land.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8847, #8982, #770

## Changes

- `ecr-service-repositories.tf` — `ecr_immutable_repositories` becomes empty, with the mechanism, the trade and the way back recorded where the decision lives.

## Context, corrected

An earlier revision of this PR claimed admin-ui deploys were blocked. That was true when it was written and is not true now: #8982 landed at 21:26 UTC and tolerates the `TAG_INVALID`, so deploys succeed again. The remaining defect is narrower and quieter. Every admin-ui build now prints

```
WARNING: SLSA attestation ... rejected by the immutable-tag repository
```

and ships anyway, because the kyverno SLSA policy is Audit. The attestation is the leg that proves our CI built the image from this commit, which is exactly what an attacker with a stolen ECR push credential cannot forge, so leaving it permanently unwritten is worth fixing rather than tolerating.

Verified against the live account and the plan on this branch, not from the code alone: the repository is still IMMUTABLE, and the tofu plan (run 34060108418) shows one in-place change, `image_tag_mutability IMMUTABLE -> MUTABLE` on `openbank-admin-ui`. The five adds in that plan are unrelated pending drift (kyb-service ECR, its pod identity, two ARC helm releases) that any manual apply will also create — worth knowing before someone runs it.

## Alternatives considered

- **Leave #8982's tolerate as the steady state.** Rejected: it makes a missing supply-chain leg permanent and silent on the one image a human operator uses.
- **Keep immutability, store provenance under a different attachment tag prefix.** Both kyverno policies discover attestations at the default location, so this needs a matching change to an Enforce policy — larger and riskier than the trade here.
- **cosign v3 with OCI 1.1 referrers**, which stores the two attestations separately and makes immutability compatible again. Blocked by the pinned kyverno 3.2.6, tracked as #770.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

One Terraform local changes; the plan output above is the verification. An earlier revision also added a diagnostic helper to `cosign-attest.sh`; #8982 landed an equivalent message first, so that half was dropped rather than merged twice.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

This trades one control for another, so state both plainly. After the apply, a tag in `openbank-admin-ui` can be overwritten, as it already can in every service repository — and the SLSA provenance attestation starts being written, where today it never is. Authenticity rests on the signature and the attestations, not on tag immutability.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

ADR-0030 D4's provenance chain is restored to all three legs rather than reduced.

## Rollout / Rollback

- Deployment strategy: merge, then the Platform tofu workflow's manual apply. Nothing changes until that apply runs, and the next admin-ui build after it should print the provenance attest without the warning.
- Rollback plan: put `openbank-admin-ui` back into `ecr_immutable_repositories` and apply; provenance goes back to being skipped by #8982's tolerate branch.
- Data migration reversible: N/A

## Reviewer notes

The judgement call is whether provenance on admin-ui is worth tag mutability on admin-ui. Also worth deciding whether `#8982`'s tolerate branch should stay once this applies — it becomes unreachable for admin-ui, and it is a reasonable guard for any repository that is immutable in future, but a tolerate branch nobody expects to fire is also how a missing attestation goes unnoticed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
