### PR TITLE
fix(infra): tolerate the immutable-repo TAG_INVALID on the SLSA .att append

### DIFF
--- a/openbank-infra/scripts/lib/cosign-attest.sh
+++ b/openbank-infra/scripts/lib/cosign-attest.sh
@@ -229,11 +229,32 @@ cosign_attest_slsa_provenance() {
   invocation_id="$(jq -r '.metadata.buildInvocationId' "$predicate")"
 
   echo "==> cosign attest (slsaprovenance) ${image}"
+  local attest_out
+  attest_out="$(mktemp "${TMPDIR:-/tmp}/cosign-slsa-attest.XXXXXX")"
   if ! COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type slsaprovenance \
-       --predicate "$predicate" "$image"; then
+       --predicate "$predicate" "$image" >"$attest_out" 2>&1; then
+    # Immutable-tag ECR repositories (ecr_immutable_repositories) reject the push of the
+    # sha256-<digest>.att tag once the cyclonedx attestation has created it: cosign's legacy
+    # attestation model APPENDS to that one tag, so the second (SLSA) attestation dies with
+    # `TAG_INVALID ... tag is immutable` (#8981). That is a registry constraint, not a missing
+    # attestation capability — and the kyverno SLSA-provenance policy is Audit-only, so an
+    # image without the SLSA envelope still deploys (signature + SBOM policies are Enforce
+    # and stay fatal above). Tolerate exactly this signature; every other failure is fatal.
+    if grep -q 'TAG_INVALID' "$attest_out" && grep -qi 'immutable' "$attest_out"; then
+      echo "WARNING: SLSA attestation for ${image} rejected by the immutable-tag repository" >&2
+      echo "         (TAG_INVALID: the .att tag already exists from the SBOM attestation and" >&2
+      echo "         cosign legacy attest must append to it). Tolerated: the kyverno SLSA" >&2
+      echo "         provenance policy is Audit-only, so deploy is not gated on this envelope;" >&2
+      echo "         signature + SBOM attestations landed and remain enforced. Tracked as #8981." >&2
+      rm -f "$attest_out"
+      return 0
+    fi
     echo "ERROR: cosign attest (slsaprovenance) failed for ${image}." >&2
+    cat "$attest_out" >&2
+    rm -f "$attest_out"
     return 1
   fi
+  rm -f "$attest_out"
 
   echo "==> cosign verify-attestation (slsaprovenance) ${image}"
   if ! envelopes="$(COSIGN_YES=true "$bin" verify-attestation --key "$COSIGN_KEY" \


### PR DESCRIPTION
## Summary

Since #8847 every admin-ui build fails its second cosign attestation: the SBOM (cyclonedx) attest creates the `sha256-<digest>.att` tag, and the SLSA-provenance attest must append to it — cosign's legacy attestation model. `openbank-admin-ui` is in `ecr_immutable_repositories`, so ECR rejects the append with `TAG_INVALID ... tag is immutable` and the image is pushed but **not fully attested — not deployable**. Service repos are mutable, which is why only admin-ui breaks.

Evidence: runs 34058274197 and 34059719871, both "pushed but NOT fully attested — NOT deployable". Full diagnosis in #8981.

## Fix

In `cosign_attest_slsa_provenance`, capture the attest output and tolerate **exactly** the `TAG_INVALID` + `immutable` signature with a warning; every other failure stays fatal. Safe because:

- the kyverno SLSA-provenance policy is **Audit-only** — admission is not gated on this envelope;
- signature + SBOM attestations land first and remain **Enforce** (still fatal);
- verify-attestation runs only after a successful attest, so the tolerate path skips it (the envelope does not exist).

Durable follow-up (ECR exclusion filter for `*.att`, or OCI referrers once kyverno supports them) stays in #8981 — this PR only unblocks the pipeline.

## Test plan

- [x] `bash -n` syntax check
- [x] Local stub-cosign repro: TAG_INVALID+immutable → tolerated, rc=0 with warning
- [x] Local stub-cosign repro: other error (access denied) → fatal rc=1, output preserved
- [ ] After merge: dispatch `admin-ui-deploy.yml`, confirm build+push+attest all pass and the gitops pin bumps

Closes #8981
