### PR TITLE
fix(libs-runtime,transaction): 401s carry a JSON envelope, and the auth-negative pacts are replayed anonymously

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
@@ -174,6 +174,24 @@ class WebApplicationExceptionMapper : ExceptionMapper<WebApplicationException> {
 }
 
 /**
+ * Anonymous caller refused by `@RolesAllowed` (Quarkus security layer), which never reaches the
+ * JAX-RS application — so without this mapper RESTEasy's default writes the plain-text body
+ * "Not Authenticated" under the endpoint's negotiated `application/json` content type: every
+ * client's JSON parser throws on a body that is not JSON, on the most common error an API has
+ * (measured on transaction-service, 2026-09-06, via the auth-negative pact interactions #8697 —
+ * the provider replay could not even COMPARE the response). Answers the standard JSON envelope,
+ * deliberately without the exception message: "why" is between the caller and the auth server.
+ */
+@Provider
+class UnauthorizedExceptionMapper : ExceptionMapper<io.quarkus.security.UnauthorizedException> {
+    override fun toResponse(exception: io.quarkus.security.UnauthorizedException): Response =
+        Response.status(Response.Status.UNAUTHORIZED)
+            .type(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+            .entity(apiError(401, ErrorCode.UNAUTHORIZED.code, "Unauthorized"))
+            .build()
+}
+
+/**
  * Last-resort mapper. Logs the full stack trace and returns a sanitised 500 — never leak
  * internal exception messages to the client, since they may contain SQL fragments,
  * stack traces or PII.

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -135,6 +135,46 @@ tasks.withType<Test> {
     timeout.set(Duration.ofMinutes(25))
 }
 
+// Auth-negative pact interactions ("...with a missing or expired token", #8697) cannot run in
+// the `test` task: TransactionPactFolderProviderVerificationTest authenticates every request via
+// class-level @TestSecurity, so a "missing token" interaction is unrepresentable and replays as
+// 201 against a contract that says 401. They are verified, unauthenticated, by `pactNegativeTest`
+// below. pact-jvm 4.7.3's JUnit5 provider supports ONLY the `pact.filter.description` filter
+// (measured: no other pact.filter.* string exists in the jar), so the split keys on the
+// interaction description; the two regexes are complements, so every committed interaction is
+// verified by exactly one of the tasks and neither can silently absorb the other's share.
+tasks.named<Test>("test") {
+    systemProperty("pact.filter.description", "^(?!.*with a missing or expired token).*$")
+    // …and the negative class itself belongs exclusively to `pactNegativeTest` — here it would
+    // replay the whole non-negative share of the contracts without their @State handlers.
+    exclude("**/TransactionPactNegativeAuthProviderVerificationTest*")
+}
+
+/**
+ * Replays exactly the auth-negative pact interactions, with NO @TestSecurity, so the request is
+ * genuinely anonymous and the 401 comes from the resource's own @RolesAllowed — the behaviour the
+ * consumer contracts pin. `check` depends on it, so CI cannot go green having verified only the
+ * authenticated share of the contracts.
+ */
+val pactNegativeTest = tasks.register<Test>("pactNegativeTest") {
+    description = "Provider-verifies the auth-negative pact interactions (anonymous caller, 401)."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    systemProperty("pact.filter.description", "^.*with a missing or expired token$")
+    systemProperty("junit.jupiter.execution.timeout.default", "8m")
+    timeout.set(Duration.ofMinutes(15))
+    filter {
+        includeTestsMatching("*TransactionPactNegativeAuthProviderVerificationTest*")
+    }
+    // Testcontainers per fork; keep the run to a single JVM like the main task's CI lane does.
+    maxParallelForks = 1
+}
+
+tasks.named("check") {
+    dependsOn(pactNegativeTest)
+}
+
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; fleet rollout #1266). Weekly +
 // manual via pitest.yml, advisory — never a per-PR gate. info.solidsoft.pitest 1.19.0 supports Gradle 9.
 pitest {

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
@@ -148,6 +148,17 @@ class TransactionPactFolderProviderVerificationTest {
         // No setup needed: the message producer below returns a deterministic payload.
     }
 
+    @State("no valid M2M identity is presented")
+    fun stateNoValidM2mIdentity() {
+        // interest-service's withholding-remittance debit, sdd-service's collection debit and
+        // swift-service's settlement debit all assert that a request with a missing or expired
+        // token is refused with 401 (#8697). Intentionally empty: the pact interaction sends no
+        // (or an invalid) Authorization header, and the resource's security answers 401 on its
+        // own — any setup here could only weaken that. Declared rather than left implicit because
+        // pact-jvm passes SILENTLY over an unhandled state name, which is how #468's missing
+        // states stayed invisible; MissingStateChangeMethod is the loud failure we want.
+    }
+
     @PactVerifyProvider("a transaction.initiated event for fraud screening")
     fun produceTransactionInitiated(): String {
         val event = TransactionInitiatedEvent(
@@ -199,5 +210,25 @@ class TransactionPactNegativeAuthzTest {
         } Then {
             statusCode(403)
         }
+    }
+
+    @Test
+    fun `an anonymous caller is refused with 401`() {
+        // The auth-negative pact interactions (#8697) contract on exactly this: no valid M2M
+        // identity ⇒ 401, answered by the resource's own security with no identity installed.
+        val response = Given { this } When {
+            contentType("application/json")
+            body(
+                """{"idempotencyKey":"pact-negative-401","type":"TRANSFER",""" +
+                    """"sourceAccountId":"${UUID.randomUUID()}","targetAccountId":"${UUID.randomUUID()}",""" +
+                    """"amount":1.00,"currencyCode":"CZK"}""",
+            )
+            post("/api/v1/transactions")
+        }
+        response.then().statusCode(401)
+            .contentType(io.restassured.http.ContentType.JSON)
+            // libs-runtime's UnauthorizedExceptionMapper: the standard envelope, so a client's
+            // JSON parser never meets the plain-text "Not Authenticated" the default wrote.
+            .body("code", org.hamcrest.Matchers.equalTo("UNAUTHORIZED"))
     }
 }

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactNegativeAuthProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactNegativeAuthProviderVerificationTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider replay of the auth-NEGATIVE pact interactions (issue #8697's regenerated consumer
+ * pacts: interest-service withholding remittance, sdd-service collection debit, swift-service
+ * MT103 settlement — each asserting that a missing or expired token is refused with 401).
+ *
+ * These interactions cannot run in [TransactionPactFolderProviderVerificationTest]: that class
+ * carries class-level `@TestSecurity(user = "pact-verifier", roles = [ROLE_OPERATOR])`, which
+ * authenticates EVERY request the pact target makes, so the "missing token" case is
+ * unrepresentable there — the replayed request arrives authenticated and the endpoint correctly
+ * answers 201. Quarkus test security has no per-interaction opt-out, and pact-jvm's `@State`
+ * callback is a plain method that cannot change it.
+ *
+ * The split is therefore by authentication posture, and it is enforced by Gradle, not by
+ * convention: this class runs ONLY in the `pactNegativeTest` task, which sets
+ * `pact.filter.providerState` to exactly [NEGATIVE_STATE] (and `pact.filter.emptyState=false`),
+ * while the module's main `test` task excludes that state. The two filters are complements, so
+ * every committed interaction is verified by exactly one task and neither task can silently
+ * absorb the other's share. The 401 here is REAL: with no `@TestSecurity` the request is
+ * anonymous, and `@RolesAllowed` refuses it — the same refusal the consumers contract on.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
+@Provider("openbank-transaction-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify
+class TransactionPactNegativeAuthProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun before(context: PactVerificationContext) {
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State(NEGATIVE_STATE)
+    fun stateNoValidM2mIdentity() {
+        // Intentionally empty: the interaction sends no (or an invalid) Authorization header and
+        // the resource's own security must be what answers 401. Any setup here — seeding a
+        // principal, stubbing a filter — could only weaken the very thing under contract.
+    }
+
+    companion object {
+        const val NEGATIVE_STATE = "no valid M2M identity is presented"
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
@@ -132,6 +132,17 @@ class TransactionPactProviderVerificationTest {
         // No setup needed: the message producer below returns a deterministic payload.
     }
 
+    @State("no valid M2M identity is presented")
+    fun stateNoValidM2mIdentity() {
+        // interest-service's withholding-remittance debit, sdd-service's collection debit and
+        // swift-service's settlement debit all assert that a request with a missing or expired
+        // token is refused with 401 (#8697). Intentionally empty: the pact interaction sends no
+        // (or an invalid) Authorization header, and the resource's security answers 401 on its
+        // own — any setup here could only weaken that. Declared rather than left implicit because
+        // pact-jvm passes SILENTLY over an unhandled state name, which is how #468's missing
+        // states stayed invisible; MissingStateChangeMethod is the loud failure we want.
+    }
+
     @PactVerifyProvider("a transaction.initiated event for fraud screening")
     fun produceTransactionInitiated(): String {
         val event = TransactionInitiatedEvent(


### PR DESCRIPTION
## Co a proč

#8697 (regenerované consumer pacty) přinesl tři auth-negativní interakce (interest withholding, sdd collection, swift MT103 — „missing or expired token ⇒ 401"). Odhalily dva reálné defekty, a main je od jeho merge červený na transaction buildu, aniž to kdokoli viděl (pacts/ se v path-scoped CI nemapuje na žádnou službu — follow-up issue přibude):

1. **libs-runtime** — anonymní volající odmítnutý `@RolesAllowed` dostal RESTEasy default plain-text `Not Authenticated` pod content-type `application/json`: JSON parser každého klienta (včetně produkčních) spadne na nejčastější chybě API. Nový `UnauthorizedExceptionMapper` vrací standardní ApiError envelope, fleet-wide.
2. **transaction-service** — folder provider verifikace má class-level `@TestSecurity`, takže „missing token" interakce je v ní nereprezentovatelná (replayed as 201). Rozdělení podle autentikační posture vynucené Gradlem: `test` vyloučí auth-negativní interakce (`pact.filter.description` je jediný filter, který pact-jvm 4.7.3 JUnit5 provider implementuje — ověřeno v jaru), nový task `pactNegativeTest` replayuje právě je, bez `@TestSecurity`, takže 401 vzniká vlastní security resource. `check` na něm závisí.

## Ověření (lokálně)

- `:openbank-transaction-service:test` — 11 folder pact interakcí zelených (negativní vyloučené)
- `:openbank-transaction-service:pactNegativeTest` — 3 auth-negativní interakce zelené (anonymní, reálná 401)
- `TransactionPactNegativeAuthzTest` — anonymní POST nově dostává 401 s JSON `{"code":"UNAUTHORIZED"}`

## Security checklist

- [x] Auth/PII/Cardholder data: zváženo — žádná PII v logu ani v odpovědi; 401 úmyslně bez detailu
- [x] Žádné nové externí volání ani credentials v gitu
- [x] Změna zpřísňuje (neverší) authz chování: jen formát chybové odpovědi + nové negativní testy