### PR TITLE
feat(campaign): check the ADR-0269 distress floor before every credit send (#8918)

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -209,6 +209,7 @@ V9.1 openbank-infra/gitops/components/document-service/document-service-service.
 V9.1 openbank-infra/gitops/components/release-steward/release-steward.yaml:58: plaintext http:// env value http://litellm.ai-platform.svc:4000
 V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:100: plaintext http:// env value http://consent-service.consent.svc:8106
 V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:103: plaintext http:// env value http://clickhouse.analytics.svc:8123
+V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:147: plaintext http:// env value http://lending-service.lending.svc:8126
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:62: plaintext http:// env value http://keda-add-ons-http-interceptor-proxy.keda:8080
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:68: plaintext http:// env value http://account-service.accounts.svc:8100
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:70: plaintext http:// env value http://balance-service.balances.svc:8103

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -507,8 +507,17 @@ than the underlying facts and a real one.
 | **R**epudiation | The bank cannot show why a customer was or was not marketed to | `policyVersion` is in the response, so a decision can be tied to the decision-table version that produced it (ADR-0213). The reason code is contract, not a log line. |
 | **D**oS / availability | A large campaign sweep multiplies one DB read plus one analytics profile call per party | Real and unsolved here: this slice reduces the volume by moving the check to delivery rather than enrolment, but not the unit cost. Caching would need an explicit freshness bound, because a stale "not in distress" outlives the arrears that ended it — the harmful direction. Recorded in #8918 rather than inherited by accident. |
 
-**Not modelled here:** the caller's side. campaign-service consuming this route is a separate change
-with its own threat surface, and is deliberately not in this slice.
+**Update (#8918 part 2): the caller now exists.** campaign-service consumes this route before every
+credit send, which turns a declared-but-unused surface into a live cross-namespace ingress edge —
+`campaign` was added to this namespace's allowed ingress by `gen-network-policies.py`.
+
+What that changes, and what it does not:
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **I**nformation disclosure | A second namespace can now reach an endpoint that states whether a named party is in arrears | The edge is declared, generated and reviewable rather than ambient — an undeclared caller is still DROPPED by the same policy. The blast radius is unchanged in kind: the shared `openbank-services` principal already made this readable by any backend service, which is the limitation recorded above, not one this edge introduces. |
+| **D**oS / availability | A campaign sweep drives call volume into lending | Reduced, not solved: the check sits at DELIVERY rather than enrolment, so the volume is what is actually being sent today rather than everyone in a segment. Unit cost (one DB read + one analytics call per party) is unchanged and is recorded in #8918. |
+| **T**ampering | A lending outage is read by the caller as permission to market | campaign-service raises rather than answering "not allowed": an outage is retriable infrastructure state, never a customer-policy suppression, so nothing is sent AND nothing is recorded as a distress refusal. |
 
 ## 10. Change log
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/CampaignMetricsPort.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/CampaignMetricsPort.kt
@@ -93,6 +93,17 @@ enum class SendHandoffOutcome {
 /** How a journey step resolved when no delivery was attempted. A bounded set — safe as a tag. */
 enum class StepResolution {
     SUPPRESSED_CONSENT,
+
+    /**
+     * ADR-0269 rule 2: the party consented to credit offers and the distress floor refused anyway
+     * — arrears, an overdrawn balance, a hardship arrangement, an insolvency marker.
+     *
+     * Its own value rather than folding into SUPPRESSED_CONSENT. Those two are opposite facts about
+     * the customer: one chose not to hear from us, the other is someone we chose not to speak to.
+     * A single number cannot answer "how many people did we decline to offer credit to, and why",
+     * and that is exactly what a conduct review asks — and what the ADR's own success measure needs.
+     */
+    SUPPRESSED_CREDIT_DISTRESS,
     SUPPRESSED_CAP,
     SUPPRESSED_QUIET_HOURS,
     SUPPRESSED_LIST,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -386,3 +386,35 @@ interface CampaignScheduler {
     /** Removes the schedule entirely. Called when a campaign closes; safe when none exists. */
     fun delete(campaignId: UUID)
 }
+
+/**
+ * ADR-0269 rule 2: may the bank surface an unprompted credit offer to this party RIGHT NOW?
+ *
+ * Separate from [ConsentCheckPort] because it answers a different question. Consent asks whether
+ * the customer agreed to hear about credit; this asks whether telling them is harmful today —
+ * arrears, an overdrawn balance, a hardship arrangement, an insolvency marker. A customer can
+ * consent and still be someone the bank must not market credit to, which is the whole of rule 2.
+ *
+ * Consulted at DELIVERY, not at enrolment. A journey runs for days, so a party enrolled while
+ * healthy can be in arrears by the third step — an enrolment-time answer expires the moment it is
+ * given, and unlike consent there is no revocation signal to terminate the journey mid-flight.
+ */
+fun interface CreditOfferGatePort {
+    /**
+     * True when an offer may be surfaced, false when the floor refuses.
+     *
+     * Throws [CreditOfferGateUnavailableException] when it cannot answer at all. That distinction
+     * is not pedantry and it is the same one this codebase already draws for the contact gate:
+     * "a gate outage is retriable infrastructure state, never a customer-policy suppression."
+     * Folding an outage into `false` would write a distress suppression against a party who may be
+     * perfectly healthy, burn the step permanently instead of retrying it, and corrupt the one
+     * metric that has to answer "how many people did we decline to offer credit to, and why".
+     *
+     * Nothing is sent in either case — the difference is whether the journey may try again.
+     */
+    suspend fun mayOffer(partyId: UUID): Boolean
+}
+
+/** The credit floor could not be reached. Retriable infrastructure state, not a policy answer. */
+class CreditOfferGateUnavailableException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.port.out.BannerPlacementPort
 import com.openbank.campaign.application.port.out.BannerPlacementRequest
 import com.openbank.campaign.application.port.out.CampaignMetricsPort
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.NotificationSendRequest
@@ -50,7 +51,15 @@ import java.util.UUID
  * rethrows so the Temporal activity retries instead of terminating a journey on a transient blip.
  */
 @ApplicationScoped
-@Suppress("TooManyFunctions") // One method per activity declared by CampaignJourneyActivities.
+// TooManyFunctions: one method per activity declared by CampaignJourneyActivities.
+// LongParameterList: nine collaborators, each a distinct outbound port this class genuinely drives
+// (repositories, the contact gate, two transports, metrics, the ADR-0269 credit floor) plus the
+// dry-run switch. Bundling them into a holder would hide which ports a given delivery path touches
+// and make the CDI graph less honest, for no reduction in real coupling.
+//
+// ONE annotation, not two: a second @Suppress on the same declaration replaces the first rather
+// than adding to it, so the split version silently stopped suppressing TooManyFunctions.
+@Suppress("TooManyFunctions", "LongParameterList")
 open class CampaignJourneyActivitiesImpl(
     private val campaigns: CampaignRepository,
     private val enrolments: EnrolmentRepository,
@@ -59,6 +68,13 @@ open class CampaignJourneyActivitiesImpl(
     private val notificationSend: NotificationSendPort,
     private val bannerPlacement: BannerPlacementPort,
     private val metrics: CampaignMetricsPort,
+    /**
+     * ADR-0269 rule 2. Consulted HERE, in the send path, rather than at enrolment: a journey runs
+     * for days, so a party enrolled while healthy can be in arrears by the third step. Consent has
+     * no such hole — its revocation is signalled into the running workflow — but distress has no
+     * equivalent signal, so an enrolment-time answer would expire the moment it was given.
+     */
+    private val creditOfferGate: CreditOfferGatePort,
     /**
      * When true, a step runs every gate and then stops short of the transport: nothing is emitted to
      * notification-service on any channel, and the send log records DRY_RUN.
@@ -149,6 +165,13 @@ open class CampaignJourneyActivitiesImpl(
             enrolments.findByCampaignAndParty(campaignId, partyId)?.contentVariant
         } else {
             null
+        }
+        // Before ANY delivery attempt for this step, and therefore before the push fallback too: a
+        // customer the distress floor refuses must not receive the fallback either. Checked per
+        // step rather than once per journey because the answer changes underneath a running one.
+        if (campaign.productKind.isCredit && !creditOfferGate.mayOffer(partyId)) {
+            sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, SendOutcome.SUPPRESSED_CREDIT_DISTRESS)
+            return resolved(StepResolution.SUPPRESSED_CREDIT_DISTRESS, StepOutcome.SUPPRESSED)
         }
         return deliverEligibleStep(
             StepDeliveryContext(campaign, step, campaignId, partyId, stepOrder, contentVariant),

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -135,6 +135,14 @@ enum class SendOutcome {
     SUPPRESSED_LIST,
 
     /**
+     * ADR-0269 rule 2 refused this step: the party may hear about credit and must not hear it now.
+     * A recorded row, not silence — the send log is where an operator reconstructs why a journey
+     * went quiet, and "the distress floor stopped it" is the answer they need. The column is TEXT
+     * with no CHECK constraint, so this needs no migration.
+     */
+    SUPPRESSED_CREDIT_DISTRESS,
+
+    /**
      * The step's ADR-0200 D1 branch condition did not hold, so nothing was attempted (#3585).
      *
      * A recorded row rather than silence: a skipped step that leaves no trace makes the console's

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/lending/CreditOfferGateClient.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/lending/CreditOfferGateClient.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.lending
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
+import com.openbank.campaign.application.port.out.CreditOfferGateUnavailableException
+import com.openbank.libs.web.SyntheticTaintClientFilter
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import kotlinx.coroutines.CancellationException
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+@RegisterRestClient(configKey = "lending-service")
+@RegisterProvider(SyntheticTaintClientFilter::class)
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/lending/credit-offers")
+@Produces(MediaType.APPLICATION_JSON)
+interface CreditOfferEligibilityClient {
+    @GET
+    @Path("/eligibility/{partyId}")
+    @Timeout(ELIGIBILITY_TIMEOUT_MS)
+    fun eligibility(@PathParam("partyId") partyId: UUID): Uni<CreditOfferEligibilityResponse>
+}
+
+/** Only what this service acts on. `policyVersion` is deliberately not read here — see below. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreditOfferEligibilityResponse(val allowed: Boolean = false, val reasonCode: String? = null)
+
+/** A short budget: this sits in the send path, and a slow refusal must not hold a journey open. */
+const val ELIGIBILITY_TIMEOUT_MS = 3_000L
+
+/**
+ * ADR-0269 rule 2, asked of lending-service (#8918, route added in #8956).
+ *
+ * ## Nothing is sent on failure — but an outage is not a suppression
+ *
+ * An unreachable floor raises [CreditOfferGateUnavailableException] rather than answering `false`.
+ * Both stop the send; only one of them is honest. Recording a distress suppression because
+ * lending-service timed out would write a conduct fact about a party who may be perfectly healthy,
+ * consume the step permanently instead of letting the journey retry, and corrupt the metric that
+ * exists to answer "how many people did we decline to offer credit to, and why". This service
+ * already draws that line for the contact gate; this follows it rather than inventing a second
+ * convention.
+ *
+ * `allowed` still defaults to `false` on the DTO, so a 200 whose body omits the field cannot
+ * deserialise into permission.
+ *
+ * ## Why the reason code is logged but not returned
+ *
+ * The caller has one decision to make and needs one bit to make it. The code says WHY, which
+ * belongs in the log and in lending's own metrics — handing it back would invite a caller to branch
+ * on individual codes and, sooner or later, to treat one of them as benign.
+ */
+@ApplicationScoped
+class HttpCreditOfferGate(@param:RestClient private val client: CreditOfferEligibilityClient) : CreditOfferGatePort {
+
+    private val log = Logger.getLogger(HttpCreditOfferGate::class.java)
+
+    override suspend fun mayOffer(partyId: UUID): Boolean = try {
+        val decision = client.eligibility(partyId).awaitSuspending()
+        if (!decision.allowed) {
+            log.infof("credit offer suppressed for party=%s reason=%s", partyId, decision.reasonCode ?: "unstated")
+        }
+        decision.allowed
+    } catch (e: CancellationException) {
+        // Rethrown, never swallowed: a cancelled coroutine reported as "not allowed" would be a
+        // business decision invented from a shutdown, and would read in the metrics as a real
+        // suppression that never happened.
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        // TooGenericExceptionCaught is the point: every failure means the same thing here — the
+        // bank cannot tell whether it may offer — and narrowing this would let some unanticipated
+        // fault through as permission.
+        log.warnf(e, "credit offer gate unreachable for party=%s; refusing to send, will retry", partyId)
+        throw CreditOfferGateUnavailableException("credit offer gate unavailable for party $partyId", e)
+    }
+}

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -115,6 +115,10 @@ consent-service:
 incentive-service:
   url: ${INCENTIVE_SERVICE_URL:http://localhost:8156}
 
+# ADR-0269 rule 2 (#8918): the credit distress floor, asked per credit send.
+lending-service:
+  url: ${LENDING_SERVICE_URL:http://lending-service.lending.svc:8126}
+
 analytics:
   clickhouse-url: ${CLICKHOUSE_URL:http://localhost:8123}
   clickhouse-user: ${CLICKHOUSE_USER:}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.44.0
+  version: 1.45.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -601,7 +601,7 @@ paths:
             type: string
             enum:
               [SENT, DRY_RUN, FAILED, SUPPRESSED_CONSENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS,
-               SUPPRESSED_LIST, SKIPPED_CONDITION, CONVERTED]
+               SUPPRESSED_LIST, SUPPRESSED_CREDIT_DISTRESS, SKIPPED_CONDITION, CONVERTED]
         - name: page
           in: query
           required: false
@@ -1400,6 +1400,10 @@ components:
             # Present in SendOutcome since ADR-0219 and missing from this enum until now — the
             # spec understated the values a client could receive (corrected in 1.9.0).
             - SUPPRESSED_LIST
+            # ADR-0269 rule 2 (#8918): the credit distress floor refused the send. A client that
+            # does not model it would render an unknown outcome, so it is advertised here rather
+            # than left for the same understatement this enum was already corrected for once.
+            - SUPPRESSED_CREDIT_DISTRESS
             # The step's branch condition did not hold, so nothing was attempted (1.10.0, #3585).
             # Not a suppression: no policy denied anything.
             - SKIPPED_CONDITION

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignCreditDistressGateTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignCreditDistressGateTest.kt
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.application.workflow
+import com.openbank.campaign.application.port.out.BannerPlacementPort
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ConsentCheckPort
+import com.openbank.campaign.application.port.out.ConversionContext
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
+import com.openbank.campaign.application.port.out.CreditOfferGateUnavailableException
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignProductKind
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SendOutcome
+import com.openbank.campaign.domain.model.SendRecord
+import com.openbank.campaign.infrastructure.observability.CampaignMetricsAdapter
+import com.openbank.libs.contact.ContactConsentPort
+import com.openbank.libs.contact.ContactCounterPort
+import com.openbank.libs.contact.ContactPolicy
+import com.openbank.libs.contact.ContactPolicyGate
+import com.openbank.libs.contact.ContactSuppressionPort
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 2 in the SEND path (#8918).
+ *
+ * The floor is checked here rather than at enrolment because a journey runs for days: a party
+ * enrolled while healthy can be in arrears by the third step. Consent has no such hole — its
+ * revocation is signalled into the running workflow — so these tests exist for the half that has
+ * no signal, and they assert the send is stopped, not merely that a flag was read.
+ */
+class CampaignCreditDistressGateTest {
+
+    private val campaigns: CampaignRepository = mockk()
+    private val enrolments: EnrolmentRepository = mockk()
+    private val sendLog: SendLogRepository = mockk()
+    private val consentCheck: ConsentCheckPort = mockk()
+    private val notificationSend: NotificationSendPort = mockk()
+    private val bannerPlacement: BannerPlacementPort = mockk()
+
+    private val registry = SimpleMeterRegistry()
+    private val metrics = CampaignMetricsAdapter().apply { bindTo(registry) }
+
+    private val campaignId = UUID.randomUUID()
+    private val partyId = UUID.randomUUID()
+
+    private fun activities(mayOffer: suspend (UUID) -> Boolean) = object : CampaignJourneyActivitiesImpl(
+        campaigns,
+        enrolments,
+        sendLog,
+        ContactPolicyGate(
+            consent = ContactConsentPort { p, s -> consentCheck.hasActiveConsent(p, s) },
+            counters = object : ContactCounterPort {
+                override suspend fun sendsInWindow(partyId: UUID, windowStart: Instant): Int = 0
+                override suspend fun impressionsInWindow(partyId: UUID, windowStart: Instant) = 0
+            },
+            suppression = ContactSuppressionPort { emptyList() },
+            policy = ContactPolicy(sendCapPerWindow = 2, quietHoursStart = 0, quietHoursEnd = 0),
+        ),
+        notificationSend,
+        bannerPlacement,
+        metrics,
+        CreditOfferGatePort { mayOffer(it) },
+        dryRun = false,
+    ) {
+        override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }
+    }
+
+    private fun givenStep(kind: CampaignProductKind) {
+        coEvery { campaigns.findById(campaignId) } returns Campaign(
+            id = campaignId,
+            name = "loan-offer",
+            goal = "activation",
+            productKind = kind,
+            segmentRef = SegmentRef("all", 1),
+            steps = listOf(
+                CampaignStep(
+                    order = 1,
+                    template = "MARKETING_PRODUCT_OFFER",
+                    channel = Channel.EMAIL,
+                    variables = emptyMap(),
+                    delaySeconds = 0,
+                ),
+            ),
+            state = CampaignState.ACTIVE,
+            createdBy = "operator",
+            approvedBy = "approver",
+            createdAt = Instant.now(),
+            updatedAt = Instant.now(),
+        )
+        coEvery { sendLog.countRecentForParty(partyId, any()) } returns 0
+        coEvery { sendLog.conversionContextFor(campaignId, partyId) } returns ConversionContext(null, false)
+        coEvery { consentCheck.hasActiveConsent(partyId, any()) } returns true
+        coEvery { sendLog.record(any()) } just Runs
+        coEvery { notificationSend.requestSend(any()) } just Runs
+    }
+
+    @Test
+    fun `a party in distress is not sent a credit step`() {
+        givenStep(CampaignProductKind.UNSECURED)
+
+        val outcome = activities(mayOffer = { false }).deliverStep(campaignId, partyId, 1)
+
+        assertThat(outcome).isEqualTo(StepOutcome.SUPPRESSED)
+        // The claim is that nothing LEFT the platform, not that a boolean was consulted.
+        coVerify(exactly = 0) { notificationSend.requestSend(any()) }
+    }
+
+    @Test
+    fun `the suppression is recorded so a quiet journey can be explained`() {
+        givenStep(CampaignProductKind.UNSECURED)
+
+        activities(mayOffer = { false }).deliverStep(campaignId, partyId, 1)
+
+        // Asserted on the repository's own interface and on the RECORD'S CONTENT — the 5-arg
+        // helper is a private extension in the impl, so verifying it would pin an internal shape
+        // rather than the row an operator actually reads.
+        val written = slot<SendRecord>()
+        coVerify(exactly = 1) { sendLog.record(capture(written)) }
+        assertThat(written.captured.outcome).isEqualTo(SendOutcome.SUPPRESSED_CREDIT_DISTRESS)
+        assertThat(written.captured.campaignId).isEqualTo(campaignId)
+        assertThat(written.captured.partyId).isEqualTo(partyId)
+        assertThat(written.captured.stepOrder).isEqualTo(1)
+    }
+
+    @Test
+    fun `a cleared party still receives the credit step`() {
+        givenStep(CampaignProductKind.UNSECURED)
+
+        val outcome = activities(mayOffer = { true }).deliverStep(campaignId, partyId, 1)
+
+        assertThat(outcome).isEqualTo(StepOutcome.SENT)
+    }
+
+    @Test
+    fun `a non-credit campaign never consults the floor`() {
+        givenStep(CampaignProductKind.NONE)
+        var asked = false
+
+        val outcome = activities(mayOffer = {
+            asked = true
+            false
+        }).deliverStep(campaignId, partyId, 1)
+
+        // Not merely "it was sent": asking at all would put a lending call in the path of every
+        // marketing send in the bank, and would make a lending outage stop unrelated campaigns.
+        assertThat(asked).isFalse()
+        assertThat(outcome).isEqualTo(StepOutcome.SENT)
+    }
+
+    @Test
+    fun `an unreachable floor stops the send and stays retriable, not recorded as distress`() {
+        givenStep(CampaignProductKind.UNSECURED)
+        val gate = activities(
+            mayOffer = { throw CreditOfferGateUnavailableException("lending-service unreachable") },
+        )
+
+        // Propagates, so Temporal retries the activity. The first version of this swallowed the
+        // outage into `false`, which stops the send just as well and lies about why: it would write
+        // a distress suppression against a party who may be perfectly healthy, burn the step
+        // instead of retrying, and corrupt the metric a conduct review reads. This service already
+        // draws that line for the contact gate — "a gate outage is retriable infrastructure state,
+        // never a customer-policy suppression".
+        assertThatThrownBy { gate.deliverStep(campaignId, partyId, 1) }
+            .isInstanceOf(CreditOfferGateUnavailableException::class.java)
+
+        coVerify(exactly = 0) { notificationSend.requestSend(any()) }
+        coVerify(exactly = 0) { sendLog.record(any()) }
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.port.out.BannerPlacementPort
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.ConversionContext
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendHandoffOutcome
@@ -109,6 +110,7 @@ class CampaignJourneyActivitiesImplTest {
             notificationSend,
             bannerPlacement,
             metrics,
+            CreditOfferGatePort { true },
             dryRun = false,
         ) {
             override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.BannerPlacementRequest
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.NotificationSendRequest
@@ -217,6 +218,7 @@ class CampaignJourneyActivitiesTest {
                 notificationSend,
                 bannerPlacement,
                 metrics,
+                CreditOfferGatePort { true },
                 dryRun = false,
             )
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyMetricsTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyMetricsTest.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.port.out.BannerPlacementPort
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.ConversionContext
+import com.openbank.campaign.application.port.out.CreditOfferGatePort
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendLogRepository
@@ -104,6 +105,7 @@ class CampaignJourneyMetricsTest {
             notificationSend,
             bannerPlacement,
             metrics,
+            CreditOfferGatePort { true },
             dryRun = dryRun,
         ) {
             override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -139,6 +139,12 @@ spec:
             # explicit svc URL so gen-network-policies.py sees the edge.
             - name: CONSENT_SERVICE_URL
               value: http://consent-service.consent.svc:8106
+            # ADR-0269 rule 2 (#8918): the distress floor, asked before every credit
+            # send. Same reason for the explicit svc URL as the consent edge above —
+            # gen-network-policies.py derives the NetworkPolicy from these env URLs, so
+            # an omitted one is a call that is both unconfigured AND dropped in-cluster.
+            - name: LENDING_SERVICE_URL
+              value: http://lending-service.lending.svc:8126
             # ADR-0210: read-only segment evaluation against the silver layer.
             # ClickHouse requires auth: the `analytics` user, password from the
             # Vault-backed clickhouse-auth Secret projected into this namespace

--- a/openbank-infra/gitops/components/lending/network-policies.yaml
+++ b/openbank-infra/gitops/components/lending/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: campaign
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Part 2 of #8918. #8956 exposed the eligibility decision and has merged, so this targets `main`
directly and is a single commit. Verified after the rebase that the route it calls is on `main` and
that the suite still passes on that base (276 tests, 45 suites) — a `--onto` rebase over a
squash-merged parent is exactly where a dependency goes missing quietly.

## What was still wrong after rule 1

#8862 and #8883 made campaign-service check that a party **agreed** to hear about credit. Nothing
checked whether telling them is **harmful today**. A customer who switched credit offers on and has
since fallen into arrears was still enrolled and still marketed to — the case ADR-0269 rule 2 exists
for, and the one it is sharpest about, because the most responsive target for a credit offer is
often the worst borrower.

## Why the check is at delivery, not enrolment

My first analysis on #8918 recommended enrolment. **That was wrong on correctness, not
performance.**

A journey runs for days — steps carry `delaySeconds` — so a party enrolled while healthy can be in
arrears by the third step. Consent does not have this hole: `consentRevoked` is signalled into the
running workflow and terminates it (ADR-0200 D2). Distress has no equivalent signal, so an
enrolment-time answer expires the moment it is given. ADR-0269 also says lending refuses to
**surface** an offer — surfacing is delivery; enrolment is not a marketing act.

The check sits before **any** delivery attempt for the step, so it covers the push fallback too: a
party the floor refuses must not receive the fallback either.

## An outage is not a suppression

The first version of the adapter mapped every failure to "do not send". That sounds prudent and is
wrong. It would:

- write `SUPPRESSED_CREDIT_DISTRESS` against a party who may be perfectly healthy,
- consume the step permanently instead of letting the journey retry,
- corrupt the one metric that has to answer *"how many people did we decline to offer credit to,
  and why"* — the ADR's own success measure.

This service already draws that line for the contact gate: *"a gate outage is retriable
infrastructure state, never a customer-policy suppression."* An unreachable floor now throws and
Temporal retries. Nothing is sent either way; only one of them is honest about why.

**A failing test found this, not review.**

## Other decisions

- `SUPPRESSED_CREDIT_DISTRESS` is its own `StepResolution` **and** `SendOutcome`, never folded into
  `SUPPRESSED_CONSENT`. "Chose not to hear from us" and "someone we chose not to speak to" are
  opposite facts, and the send log is where an operator reconstructs why a journey went quiet. The
  `outcome` column is `TEXT` with no `CHECK`, so this needs no migration.
- **A non-credit campaign never consults the floor.** Asking would put a lending call in the path of
  every marketing send in the bank and make a lending outage stop unrelated campaigns. Pinned by a
  test asserting the gate is not even *called*, not merely that the send happened.

## Verification

**276 tests, 0 failures, 45 suites.** The suite count is quoted deliberately: a stale single-class
XML from an earlier filtered run already reported "5 tests, 3 failures" here and would have had me
report failures that did not exist.

**Falsified:** neutering the gate fails exactly the three tests that assert it — party in distress
not sent, suppression recorded, outage stays retriable — while *a cleared party is sent* and *a
non-credit campaign is unaffected* stay green. Had those also failed, the tests would be measuring
"did delivery happen" rather than the gate.

`detekt` (not just `ktlint`) caught `LongParameterList`. Suppressed with the reason, and **merged
into the existing annotation** — a second `@Suppress` on the same declaration replaces the first
rather than adding to it, so the split version silently dropped `TooManyFunctions`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The client sends a party
      id and logs a reason code; no distress facts are stored here.
- [x] No new `@Suppress` without justification. Two, both stated: `TooGenericExceptionCaught` on the
      adapter's catch (every failure means the same thing — the bank cannot tell whether it may
      offer) and `LongParameterList` as above.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No. This is a new outbound call on an existing M2M
      client; the authorisation for it is the OPA rule in #8956.
- [x] PII path changed? Not stored or logged beyond a party id and a reason code — but this service
      now *learns* that a named party is in distress, which is why the reason code is deliberately
      not returned to callers or persisted, only logged.
- [x] Cardholder data path changed? No.
