### PR TITLE
test(domestic-payment): bound the delegation contract window by schema indent, not the messages section

### DIFF
--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
@@ -95,6 +95,29 @@ class DomesticPaymentDelegationContractTest {
     }
 
     @Test
+    fun `every published operation keeps the 403 rejection in the contract`() {
+        // Negative case (ADR-0279 #3): a contract that only covers success stays green when the
+        // provider stops enforcing authz. Every operation this service publishes must document
+        // the Forbidden rejection — the shape a wrong or missing identity gets.
+        val forbidden = openApi.substringAfter("    Forbidden:")
+        assertThat(forbidden).contains("application/json")
+        val operations = Regex("operationId: (\\w+)").findAll(openApi).map { it.groupValues[1] }.toList()
+        assertThat(operations).isNotEmpty
+        operations.forEach { opId ->
+            val afterOpId = openApi.substringAfter("operationId: $opId")
+            val operation = afterOpId.substring(
+                0,
+                Regex("\\n  (/api/|\\S)").find(afterOpId)?.range?.first ?: afterOpId.length,
+            )
+            // Either the shared Forbidden ref or an inline '403' (the approvals decide endpoint
+            // carries its own segregation-of-duties wording) — both pin the rejection shape.
+            assertThat(operation)
+                .`as`("operation %s documents the 403 rejection", opId)
+                .contains("'403':")
+        }
+    }
+
+    @Test
     fun `REST contract does not advertise the trust seam before it is authorized and implemented`() {
         // The persistence/event half is safe to expand independently. Accepting identity and
         // delegation IDs from HTTP headers changes a money-path trust boundary and is intentionally

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
@@ -59,8 +59,11 @@ class DomesticPaymentDelegationContractTest {
         // message-anchored window sweeps in their raw `idempotencyKey:` and fails the very
         // assertion below that exists to keep the raw key OUT of the reservation-state schema.
         // Bound the window by the schema block's own indent instead — order-independent.
-        val producerSchema = producerAsyncApi.substringAfter("    spendReservationState:")
-            .substringBefore(Regex("\n    \\S"))
+        val afterSchemaKey = producerAsyncApi.substringAfter("    spendReservationState:")
+        val producerSchema = afterSchemaKey.substring(
+            0,
+            Regex("\n    \\S").find(afterSchemaKey)?.range?.first ?: afterSchemaKey.length,
+        )
         val producerMessage = producerAsyncApi.substringAfter("    DelegationSpendReservationStateChanged:")
         listOf(
             "reservationId",

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDelegationContractTest.kt
@@ -53,8 +53,14 @@ class DomesticPaymentDelegationContractTest {
 
     @Test
     fun `reservation consumer contract matches producer and retains only a domain-separated hash`() {
+        // Window ends at the NEXT 4-space-indented schema key, not at the messages section:
+        // #8334 inserted the spendReserved/spendSettled audit schemas between
+        // spendReservationState and the DelegationSpendReservationStateChanged message, so a
+        // message-anchored window sweeps in their raw `idempotencyKey:` and fails the very
+        // assertion below that exists to keep the raw key OUT of the reservation-state schema.
+        // Bound the window by the schema block's own indent instead — order-independent.
         val producerSchema = producerAsyncApi.substringAfter("    spendReservationState:")
-            .substringBefore("\n    DelegationSpendReservationStateChanged:")
+            .substringBefore(Regex("\n    \\S"))
         val producerMessage = producerAsyncApi.substringAfter("    DelegationSpendReservationStateChanged:")
         listOf(
             "reservationId",


### PR DESCRIPTION
## Why

Main is red: `DomesticPaymentDelegationContractTest.reservation consumer contract matches producer and retains only a domain-separated hash` fails on every domestic-payment lane since #8334 merged (first seen on main run 34040576474, blocks PR #8942).

The test extracts the producer's `spendReservationState` schema with a window anchored at the `DelegationSpendReservationStateChanged` **message**. #8334 inserted the `spendReserved`/`spendSettled` audit schemas between the schema and the message, so the window now sweeps in their raw `idempotencyKey:` property — and the `doesNotContain("idempotencyKey:")` assertion, which exists precisely to keep the raw caller key out of the reservation-state schema (only the domain-separated hash `idempotencyKeyHash` is published), fails against the wrong text.

## What

Bound the window by the schema block's own indent (`\n    \S` — the next top-level schema key) instead of the message anchor; order-independent against future schema insertions. Verified against the live `openbank-contracts/openbank-delegation-service/asyncapi.yaml`: the window still holds all 14 required fields and excludes the raw key.

Refs #5728

## Security checklist
- [x] Test-only change (src/test); no endpoint, authz, dependency, or config change
- [x] The contract intent is preserved: raw `idempotencyKey` stays unpublished on the reservation-state stream
