### PR TITLE
test(fleet): add E2E journey suites to 5 money-path services

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/e2e/AccountLifecycleE2E.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/e2e/AccountLifecycleE2E.kt
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.e2e
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * End-to-end journey for an account's whole life: **open it, find it in the party's account list,
+ * freeze it, unfreeze it, close it — and after every transition, read the account back through the
+ * API and check the state the customer would actually see.**
+ *
+ * Driven entirely through the real HTTP surface (`@QuarkusTest` + RestAssured + `@TestSecurity`)
+ * against a real Postgres, Redpanda and Valkey (`PostgresRedpandaRedisTestResource`, per-job
+ * Testcontainers). No use case or repository is called directly and nothing is mocked.
+ *
+ * ### Service boundaries — what is NOT claimed here
+ *
+ * Balance is owned by balance-service (N3 / ADR-0024) and the account-service balance endpoint
+ * delegates over REST, so this journey never asserts a balance: that hop is not stubbed, it is
+ * simply not travelled. Likewise the account-opened event's DISPATCH to a broker is out of scope —
+ * the outbox row is this service's own durable state, but no consumer runs in this process, so the
+ * journey stops at what this service owns.
+ *
+ * ### Why the read-back matters
+ *
+ * The transition endpoints return the new state in their own response body, which is the same code
+ * path that just computed it. Reading the account back with a separate `GET` after each transition
+ * is what proves the change was persisted rather than merely rendered — the failure mode of an
+ * aggregate with an application-assigned `@Id` written with `persist` instead of `merge` is
+ * precisely that the response looks right and no row changed.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.account.it.PostgresRedpandaRedisTestResource::class)
+class AccountLifecycleE2E {
+
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_OPERATOR"])
+    fun `an account is opened, discoverable, frozen, unfrozen and closed, with every state read back`() {
+        val partyId = UUID.randomUUID()
+
+        // 1. Open.
+        val opened = RestAssured.given()
+            .contentType("application/json")
+            .header("Idempotency-Key", UUID.randomUUID().toString())
+            .body(openRequest(partyId))
+            .post("/api/v1/accounts")
+        assertThat(opened.statusCode)
+            .describedAs("POST /api/v1/accounts: %s", opened.body.asString())
+            .isEqualTo(201)
+        val accountId = opened.jsonPath().getString("id")
+        assertThat(accountId).isNotNull()
+        assertThat(opened.jsonPath().getString("status")).isEqualTo("ACTIVE")
+
+        // 2. Read back — the account exists with the attributes it was opened with.
+        assertThat(statusOf(accountId)).isEqualTo("ACTIVE")
+        val detail = RestAssured.given().get("/api/v1/accounts/$accountId")
+        assertThat(detail.jsonPath().getString("accountType")).isEqualTo("CURRENT")
+        assertThat(detail.jsonPath().getString("currencyCode")).isEqualTo("CZK")
+
+        // 3. Discoverable through the party's list — the query path, not the by-id path.
+        val list = RestAssured.given().queryParam("partyId", partyId.toString()).get("/api/v1/accounts")
+        assertThat(list.statusCode).isEqualTo(200)
+        assertThat(list.jsonPath().getList<String>("data.id"))
+            .describedAs("the newly opened account must appear in its own party's list")
+            .contains(accountId)
+
+        // 4. Freeze, and read back.
+        assertThat(transition(accountId, "freeze", "Suspicious activity")).isEqualTo(200)
+        assertThat(statusOf(accountId))
+            .describedAs("a frozen account must READ BACK as FROZEN, not merely answer FROZEN")
+            .isEqualTo("FROZEN")
+
+        // 5. Unfreeze, and read back.
+        assertThat(transition(accountId, "unfreeze", "Review completed")).isEqualTo(200)
+        assertThat(statusOf(accountId)).isEqualTo("ACTIVE")
+
+        // 6. Close, and read back. A closed account stays readable — closure is a state, not a
+        //    deletion; an audit trail that disappears on close is not an audit trail.
+        assertThat(transition(accountId, "close", "Customer request")).isEqualTo(200)
+        assertThat(statusOf(accountId)).isEqualTo("CLOSED")
+    }
+
+    /**
+     * The journey's ownership boundary, end to end: the same account, read with a customer-scoped
+     * identity header, is visible to its owner and absent for anyone else — 404 rather than 403, so
+     * the endpoint is not an existence oracle (IDOR defense-in-depth, A1).
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_OPERATOR"])
+    fun `a customer-scoped read sees only its own account`() {
+        val partyId = UUID.randomUUID()
+        val opened = RestAssured.given()
+            .contentType("application/json")
+            .header("Idempotency-Key", UUID.randomUUID().toString())
+            .body(openRequest(partyId))
+            .post("/api/v1/accounts")
+        assertThat(opened.statusCode).isEqualTo(201)
+        val accountId = opened.jsonPath().getString("id")
+
+        assertThat(
+            RestAssured.given()
+                .header("X-Customer-Party-Id", partyId.toString())
+                .get("/api/v1/accounts/$accountId").statusCode,
+        ).isEqualTo(200)
+
+        assertThat(
+            RestAssured.given()
+                .header("X-Customer-Party-Id", UUID.randomUUID().toString())
+                .get("/api/v1/accounts/$accountId").statusCode,
+        ).isEqualTo(404)
+    }
+
+    /**
+     * Known-negative control for the observable the journey leans on: `statusOf` must be able to
+     * fail. An account id that was never opened has no status to read at all.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_OPERATOR"])
+    fun `the status observable answers 404 for an account that was never opened`() {
+        val response: Response = RestAssured.given().get("/api/v1/accounts/${UUID.randomUUID()}")
+        assertThat(response.statusCode).isEqualTo(404)
+    }
+
+    private fun transition(accountId: String, action: String, reason: String): Int = RestAssured.given()
+        .contentType("application/json")
+        .body("""{"reason": "$reason"}""")
+        .post("/api/v1/accounts/$accountId/$action")
+        .statusCode
+
+    private fun statusOf(accountId: String): String {
+        val response = RestAssured.given().get("/api/v1/accounts/$accountId")
+        assertThat(response.statusCode)
+            .describedAs("GET /api/v1/accounts/%s: %s", accountId, response.body.asString())
+            .isEqualTo(200)
+        return response.jsonPath().getString("status")
+    }
+
+    private fun openRequest(partyId: UUID): String =
+        """
+        {
+          "partyId": "$partyId",
+          "productId": "$PRODUCT_ID",
+          "accountType": "CURRENT",
+          "currencyCode": "CZK",
+          "legalName": "E2E Journey Customer"
+        }
+        """.trimIndent()
+
+    private companion object {
+        const val ACTOR = "00000000-0000-0000-0000-000000000099"
+
+        /** Seeded CZK current-account product (see AccountApiIT). */
+        const val PRODUCT_ID = "00000000-2222-0000-0000-000000000001"
+    }
+}

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/e2e/BalancePocketJourneyE2E.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/e2e/BalancePocketJourneyE2E.kt
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.e2e
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * End-to-end journey for a customer's money as the bank actually moves it: **open a CZK pocket,
+ * credit it, put a card authorization hold on it, watch available diverge from booked, release the
+ * hold, and end back at a consistent position** — with the booked / available / reserved triple
+ * read back from the API after every single step.
+ *
+ * Driven through the real HTTP surface (`@QuarkusTest` + RestAssured + `@TestSecurity`) against a
+ * real Postgres (Flyway applied) and Redpanda via `PostgresRedpandaTestResource`. Nothing is
+ * mocked and no use case is called directly.
+ *
+ * ### Service boundaries
+ *
+ * None is crossed. The ledger REST client in this service is used only by reconciliation, which
+ * this journey does not exercise, and the reconciliation scheduler is disabled under `%test`. The
+ * balance-changed event's dispatch to a broker is out of scope: no consumer runs in this process,
+ * so the journey stops at this service's own durable state and does not claim the hop happened.
+ *
+ * ### Why the triple, and not the status code
+ *
+ * `bookedAmount`, `availableAmount` and `reservedAmount` are three numbers that must stay in a
+ * fixed relation (`available = booked + arranged overdraft - reserved`). A hold that decremented
+ * BOOKED instead of AVAILABLE — the classic defect — returns exactly the same 201, and only the
+ * read-back triple can tell the two apart. Every assertion below is on the triple after the fact,
+ * never on the write's own response alone.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.balance.it.PostgresRedpandaTestResource::class)
+class BalancePocketJourneyE2E {
+
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_API"])
+    fun `a pocket is opened, credited, held against, and released, staying consistent throughout`() {
+        val accountId = UUID.randomUUID()
+
+        // 1. Open the CZK pocket with an opening balance.
+        val initialized = RestAssured.given()
+            .contentType("application/json")
+            .body("""{"currency": "CZK", "initialAmount": "1000.00"}""")
+            .post("/api/v1/balances/$accountId/initialize")
+        assertThat(initialized.statusCode)
+            .describedAs("POST initialize: %s", initialized.body.asString())
+            .isEqualTo(201)
+        assertPocket(accountId, booked = "1000.00", available = "1000.00", reserved = "0")
+
+        // 2. Money arrives. Booked and available both rise.
+        val credited = RestAssured.given()
+            .contentType("application/json")
+            .body("""{"amount": "250.00", "currency": "CZK", "referenceId": "e2e-journey-credit"}""")
+            .post("/api/v1/balances/$accountId/credit")
+        assertThat(credited.statusCode)
+            .describedAs("POST credit: %s", credited.body.asString())
+            .isEqualTo(200)
+        assertPocket(accountId, booked = "1250.00", available = "1250.00", reserved = "0")
+
+        // 3. A card authorization reserves funds. Available falls, booked does NOT — this is the
+        //    step where a wrong implementation still answers 201.
+        val hold = RestAssured.given()
+            .contentType("application/json")
+            .body(
+                """{"amount": "400.00", "currency": "CZK", "reason": "card authorization",
+                    "referenceId": "e2e-journey-hold"}""",
+            )
+            .post("/api/v1/balances/$accountId/holds")
+        assertThat(hold.statusCode)
+            .describedAs("POST holds: %s", hold.body.asString())
+            .isEqualTo(201)
+        val holdId = hold.jsonPath().getString("id")
+        assertThat(holdId).isNotNull()
+        assertPocket(accountId, booked = "1250.00", available = "850.00", reserved = "400.00")
+
+        // 4. A second hold beyond what is now AVAILABLE must fail closed, and must not move a
+        //    single one of the three numbers. Available is 850, so 900 is affordable against
+        //    BOOKED and unaffordable against AVAILABLE — the amount is chosen to discriminate.
+        val overdrawn = RestAssured.given()
+            .contentType("application/json")
+            .body(
+                """{"amount": "900.00", "currency": "CZK", "reason": "beyond available",
+                    "referenceId": "e2e-journey-overdrawn"}""",
+            )
+            .post("/api/v1/balances/$accountId/holds")
+        assertThat(overdrawn.statusCode).isEqualTo(422)
+        assertThat(overdrawn.jsonPath().getString("error")).isEqualTo("INSUFFICIENT_FUNDS")
+        assertPocket(accountId, booked = "1250.00", available = "850.00", reserved = "400.00")
+
+        // 5. The authorization expires / is released. The reservation is given back in full.
+        val released = RestAssured.given().delete("/api/v1/balances/holds/$holdId")
+        assertThat(released.statusCode)
+            .describedAs("DELETE hold: %s", released.body.asString())
+            .isEqualTo(200)
+        assertPocket(accountId, booked = "1250.00", available = "1250.00", reserved = "0")
+
+        // 6. Releasing the same hold twice must not credit the customer twice.
+        RestAssured.given().delete("/api/v1/balances/holds/$holdId")
+        assertPocket(accountId, booked = "1250.00", available = "1250.00", reserved = "0")
+    }
+
+    /**
+     * The same account carries independent per-currency pockets (ADR-0024): a second currency is
+     * added and the CZK pocket's numbers are unchanged, read back through both the per-currency
+     * and the all-pockets endpoints.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_API"])
+    fun `a second currency pocket does not disturb the first`() {
+        val accountId = UUID.randomUUID()
+        RestAssured.given().contentType("application/json")
+            .body("""{"currency": "CZK", "initialAmount": "500.00"}""")
+            .post("/api/v1/balances/$accountId/initialize").then().statusCode(201)
+        RestAssured.given().contentType("application/json")
+            .body("""{"currency": "EUR", "initialAmount": "20.00"}""")
+            .post("/api/v1/balances/$accountId/initialize").then().statusCode(201)
+
+        assertPocket(accountId, booked = "500.00", available = "500.00", reserved = "0")
+
+        val all = RestAssured.given().get("/api/v1/balances/$accountId")
+        assertThat(all.statusCode).isEqualTo(200)
+        assertThat(all.jsonPath().getList<String>("balances.currency"))
+            .containsExactlyInAnyOrder("CZK", "EUR")
+    }
+
+    /**
+     * Known-negative control for the observable every assertion above depends on. If `pocket`
+     * silently returned an empty/zero triple, `assertPocket` would pass against anything.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_API"])
+    fun `the pocket observable answers 404 for an account that was never initialized`() {
+        val response: Response = RestAssured.given().get("/api/v1/balances/${UUID.randomUUID()}/CZK")
+        assertThat(response.statusCode).isEqualTo(404)
+        assertThat(response.jsonPath().getString("error")).isEqualTo("NOT_FOUND")
+    }
+
+    private fun assertPocket(accountId: UUID, booked: String, available: String, reserved: String) {
+        val response = RestAssured.given().get("/api/v1/balances/$accountId/CZK")
+        assertThat(response.statusCode)
+            .describedAs("GET pocket: %s", response.body.asString())
+            .isEqualTo(200)
+        val path = response.jsonPath()
+        assertThat(BigDecimal(path.getString("bookedAmount")))
+            .describedAs("bookedAmount").isEqualByComparingTo(BigDecimal(booked))
+        assertThat(BigDecimal(path.getString("availableAmount")))
+            .describedAs("availableAmount").isEqualByComparingTo(BigDecimal(available))
+        assertThat(BigDecimal(path.getString("reservedAmount")))
+            .describedAs("reservedAmount").isEqualByComparingTo(BigDecimal(reserved))
+    }
+
+    private companion object {
+        const val ACTOR = "00000000-0000-0000-0000-000000000099"
+    }
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/e2e/DomesticPaymentJourneyE2E.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/e2e/DomesticPaymentJourneyE2E.kt
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.e2e
+
+import com.openbank.domestic.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * End-to-end journey for a Czech domestic credit transfer: **submit the payment, read it back,
+ * find it on the debtor's payment list, retry the submission the way a client with a lost response
+ * would, and ask for the confirmation document before the payment is eligible for one.**
+ *
+ * Driven through the real HTTP surface (`@QuarkusTest` + RestAssured + `@TestSecurity`) against a
+ * real Postgres (full Flyway chain) and Valkey via `PostgresRedisTestResource`. No use case,
+ * repository or domain object is touched directly and nothing is mocked out of the request path.
+ *
+ * ### Service boundaries — stated, not pretended
+ *
+ * Two hops leave this service and neither is travelled here.
+ *
+ *  * **Kafka dispatch.** Both outgoing channels are switched to the in-memory connector, so the
+ *    payment's outbox row is written to this service's own database but nothing reaches a broker
+ *    and no downstream consumer runs. The journey therefore stops at durable local state.
+ *  * **document-service.** The confirmation endpoint renders through document-service's preview
+ *    API. This journey deliberately asks for the confirmation of a payment that has NOT reached
+ *    SETTLED, where the service's own status check rejects the request with 409 *before* any
+ *    outbound call is made — so the assertion is about this service's rule, and the unreachable
+ *    document-service is never consulted. The SETTLED path is not claimed.
+ *
+ * ### Why the read-back is the observable
+ *
+ * `POST` returns the aggregate the handler just built in memory. The `GET` is a different code
+ * path over the committed row, so the field-by-field comparison below is what distinguishes "the
+ * payment was accepted" from "the payment was accepted and stored as submitted" — the whitespace
+ * on every field of the request is deliberate, because normalisation happening on the way IN but
+ * not being persisted is exactly the defect a status-code assertion cannot see.
+ */
+@QuarkusTest
+@QuarkusTestResource(DomesticPaymentJourneyE2E.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class DomesticPaymentJourneyE2E {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchOutgoingChannelsToInMemory("events-out", "notification-requests-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_PAYMENTS"])
+    fun `a submitted payment is stored normalised, listed for its debtor, and replays on retry`() {
+        val key = "e2e-journey-${UUID.randomUUID()}"
+        val debtorAccountId = UUID.randomUUID()
+        val endToEndId = "E2E-JOURNEY-${UUID.randomUUID().toString().take(8)}"
+
+        // 1. Submit.
+        val created = post(key, requestBody(debtorAccountId, AMOUNT, endToEndId))
+        assertThat(created.statusCode)
+            .describedAs("POST /api/v1/domestic-payments: %s", created.body.asString())
+            .isEqualTo(201)
+        assertThat(created.header("X-Idempotency-Replayed")).isNull()
+        val paymentId = created.jsonPath().getString("id")
+        assertThat(paymentId).isNotNull()
+
+        // 2. Read it back over the committed row and check what was actually stored — the
+        //    request's padded fields must have been trimmed and the currency upper-cased.
+        val stored = RestAssured.given().get("/api/v1/domestic-payments/$paymentId")
+        assertThat(stored.statusCode)
+            .describedAs("GET /api/v1/domestic-payments/%s: %s", paymentId, stored.body.asString())
+            .isEqualTo(200)
+        val path = stored.jsonPath()
+        assertThat(path.getString("id")).isEqualTo(paymentId)
+        assertThat(path.getString("creditorAccountNumber")).isEqualTo("9876543210")
+        assertThat(path.getString("creditorBankCode")).isEqualTo("0100")
+        assertThat(path.getString("creditorName")).isEqualTo("Brno Utility")
+        assertThat(path.getString("currency")).isEqualTo("CZK")
+        assertThat(BigDecimal(path.getString("amount"))).isEqualByComparingTo(AMOUNT)
+        assertThat(path.getString("status"))
+            .describedAs("a freshly submitted payment is RECEIVED, not settled")
+            .isEqualTo("RECEIVED")
+
+        // 3. Discoverable on the debtor's own list — the query path, not the by-id path.
+        val list = RestAssured.given()
+            .queryParam("debtorAccountId", debtorAccountId.toString())
+            .get("/api/v1/domestic-payments")
+        assertThat(list.statusCode)
+            .describedAs("GET list: %s", list.body.asString())
+            .isEqualTo(200)
+        assertThat(list.body.asString())
+            .describedAs("the submitted payment must appear on its debtor's list")
+            .contains(paymentId)
+
+        // 4. The client's response was lost and it retries with the same key: one payment, not two.
+        val replay = post(key, requestBody(debtorAccountId, AMOUNT, endToEndId))
+        assertThat(replay.statusCode).isEqualTo(201)
+        assertThat(replay.header("X-Idempotency-Replayed")).isEqualTo("true")
+        assertThat(replay.jsonPath().getString("id")).isEqualTo(paymentId)
+
+        // 5. The same key with a DIFFERENT command is a client bug and must fail loudly rather
+        //    than silently paying either amount.
+        val changed = post(key, requestBody(debtorAccountId, AMOUNT.add(BigDecimal("0.01")), endToEndId))
+        assertThat(changed.statusCode).isEqualTo(409)
+        assertThat(changed.contentType).startsWith("application/problem+json")
+        assertThat(changed.jsonPath().getString("code")).isEqualTo("IDEMPOTENCY_KEY_REUSED")
+
+        // 6. The stored payment is untouched by either follow-up call.
+        val afterRetries = RestAssured.given().get("/api/v1/domestic-payments/$paymentId")
+        assertThat(afterRetries.statusCode).isEqualTo(200)
+        assertThat(BigDecimal(afterRetries.jsonPath().getString("amount"))).isEqualByComparingTo(AMOUNT)
+        assertThat(afterRetries.jsonPath().getString("status")).isEqualTo("RECEIVED")
+
+        // 7. A confirmation document is only available for a SETTLED payment. This one is
+        //    RECEIVED, so the request is refused by this service's own rule and document-service
+        //    (which is not running) is never called — see the class KDoc.
+        val confirmation = RestAssured.given().get("/api/v1/domestic-payments/$paymentId/confirmation")
+        assertThat(confirmation.statusCode)
+            .describedAs("confirmation of a non-SETTLED payment: %s", confirmation.body.asString())
+            .isEqualTo(409)
+    }
+
+    /**
+     * Known-negative control for the read-back observable: an id that was never submitted must be
+     * a 404, otherwise every `GET` assertion above could be passing against a stub response.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_PAYMENTS"])
+    fun `the payment observable answers 404 for a payment that was never submitted`() {
+        assertThat(
+            RestAssured.given().get("/api/v1/domestic-payments/${UUID.randomUUID()}").statusCode,
+        ).isEqualTo(404)
+    }
+
+    private fun post(key: String, body: String): Response = RestAssured.given()
+        .contentType("application/json")
+        .header("Idempotency-Key", key)
+        .body(body)
+        .post("/api/v1/domestic-payments")
+
+    /** Deliberately padded and lower-cased — step 2 asserts the stored row is normalised. */
+    private fun requestBody(debtorAccountId: UUID, amount: BigDecimal, endToEndId: String): String =
+        """
+        {
+          "debtorAccountId": "$debtorAccountId",
+          "debtorAccountNumber": " 1234567890 ",
+          "debtorBankCode": " 0800 ",
+          "debtorName": " Alice Example ",
+          "creditorAccountNumber": " 9876543210 ",
+          "creditorBankCode": " 0100 ",
+          "creditorName": " Brno Utility ",
+          "amount": $amount,
+          "currency": " czk ",
+          "variableSymbol": " 2026001 ",
+          "specificSymbol": null,
+          "constantSymbol": " 0308 ",
+          "messageForPayee": " Utility bill ",
+          "priority": "STANDARD",
+          "transferScope": null,
+          "technicalAccountCode": null,
+          "statementLabel": " Monthly settlement ",
+          "endToEndId": "$endToEndId"
+        }
+        """.trimIndent()
+
+    private companion object {
+        const val ACTOR = "00000000-0000-0000-0000-000000000099"
+        val AMOUNT: BigDecimal = BigDecimal("1500.00")
+    }
+}

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/e2e/FxConversionJourneyE2E.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/e2e/FxConversionJourneyE2E.kt
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fx.e2e
+
+import com.openbank.fx.domain.screening.ScreeningMatchStatus
+import com.openbank.fx.domain.screening.ScreeningResult
+import com.openbank.fx.domain.screening.ScreeningRole
+import com.openbank.fx.infrastructure.client.SanctionsScreeningAdapter
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusMock
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * End-to-end journey for a customer converting CZK into EUR: **look up the rate the bank is
+ * quoting, execute the conversion at that rate, read the settled conversion back, and confirm the
+ * rate that was actually applied is the one that was quoted** — plus the replay behaviour a client
+ * relies on when it retries.
+ *
+ * Driven through the real HTTP surface (`@QuarkusTest` + RestAssured + `@TestSecurity`) against a
+ * real Postgres (Flyway applied, seeding the rate table) and Valkey via `PostgresRedisTestResource`.
+ *
+ * ### The one stubbed edge, stated explicitly
+ *
+ * Sanctions screening is a call OUT of this service to sanctions-service, which is not running
+ * here. It is stubbed to CLEAR (`QuarkusMock` over [SanctionsScreeningAdapter]) — and this journey
+ * therefore makes NO claim about the screening hop itself. The stub is not convenience: the use
+ * case fails CLOSED, so an unreachable sanctions-service routes every conversion to HOLD, which
+ * settles nothing, and the journey would then assert over a state it was not written for while
+ * still looking green. Fraud scoring, by contrast, fails open by design (#4221) and runs after the
+ * write, so it is left alone. The outbound Kafka channel is switched to the in-memory connector:
+ * the outbox ROW is this service's own state and is not asserted here, but the DISPATCH to a
+ * broker is out of scope and is not claimed to have happened.
+ *
+ * ### Why the rate is the observable
+ *
+ * A conversion's status is one bit; the number that decides whether a customer was treated
+ * correctly is the rate applied and the amount received. Both are read back with a separate `GET`,
+ * against the rate independently quoted by `/api/v1/fx/rates/{base}/{quote}` before the trade.
+ */
+@QuarkusTest
+@QuarkusTestResource(FxConversionJourneyE2E.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.fx.it.PostgresRedisTestResource::class)
+class FxConversionJourneyE2E {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = InMemoryConnector.switchOutgoingChannelsToInMemory("fx-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @BeforeEach
+    fun screeningIsClear() {
+        val port = mockk<SanctionsScreeningAdapter>()
+        coEvery { port.screen(any(), any(), any()) } answers {
+            ScreeningResult(
+                subject = firstArg(),
+                role = ScreeningRole.DEBTOR,
+                status = ScreeningMatchStatus.CLEAR,
+                score = 0.0,
+                matchedEntity = null,
+            )
+        }
+        QuarkusMock.installMockForType(port, SanctionsScreeningAdapter::class.java)
+    }
+
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_PAYMENTS"])
+    fun `a quoted rate is the rate a settled conversion is read back at`() {
+        // 1. The customer asks what the bank quotes.
+        val quote = RestAssured.given().get("/api/v1/fx/rates/CZK/EUR")
+        assertThat(quote.statusCode)
+            .describedAs("GET /api/v1/fx/rates/CZK/EUR: %s", quote.body.asString())
+            .isEqualTo(200)
+        // `askRate` is the side a customer BUYS the quote currency at, and it is what
+        // `FxService` stamps onto the conversion as `appliedRate`.
+        val quotedAskRate = BigDecimal(quote.jsonPath().getString("askRate"))
+
+        // 2. They convert 1000.00 CZK.
+        val executed = convert(idempotencyKey = "e2e-journey-${UUID.randomUUID()}")
+        assertThat(executed.statusCode)
+            .describedAs("POST /api/v1/fx/convert: %s", executed.body.asString())
+            .isEqualTo(201)
+        assertThat(executed.jsonPath().getString("status")).isEqualTo("SETTLED")
+        val conversionId = executed.jsonPath().getString("id")
+
+        // 3. Read the conversion back — a separate query path from the one that wrote it.
+        val readBack = RestAssured.given().get("/api/v1/fx/conversions/$conversionId")
+        assertThat(readBack.statusCode)
+            .describedAs("GET /api/v1/fx/conversions/%s: %s", conversionId, readBack.body.asString())
+            .isEqualTo(200)
+        val stored = readBack.jsonPath()
+        assertThat(stored.getString("status")).isEqualTo("SETTLED")
+        assertThat(stored.getString("fromCurrency")).isEqualTo("CZK")
+        assertThat(stored.getString("toCurrency")).isEqualTo("EUR")
+        assertThat(stored.getLong("fromAmountMinorUnits")).isEqualTo(FROM_MINOR_UNITS)
+
+        // 4. The customer actually received something, and the persisted amounts agree with what
+        //    the write returned. A conversion that settles at zero is the silent-loss defect.
+        assertThat(stored.getLong("toAmountMinorUnits"))
+            .describedAs("a SETTLED conversion must credit a non-zero amount")
+            .isGreaterThan(0L)
+            .isEqualTo(executed.jsonPath().getLong("toAmountMinorUnits"))
+        assertThat(BigDecimal(stored.getString("appliedRate")))
+            .describedAs("the rate on the stored conversion must be the ask rate quoted before the trade")
+            .isEqualByComparingTo(quotedAskRate)
+        assertThat(stored.getString("settledAt"))
+            .describedAs("a SETTLED conversion must carry a settlement time")
+            .isNotNull()
+    }
+
+    /**
+     * The retry a client makes when it does not know whether its first call landed: the same
+     * `Idempotency-Key` must return the SAME conversion, not a second trade at a second rate.
+     * Asserted on the id read back, not on the status code.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_PAYMENTS"])
+    fun `a retried conversion replays the first trade instead of executing a second`() {
+        val key = "e2e-journey-replay-${UUID.randomUUID()}"
+
+        val first = convert(key)
+        assertThat(first.statusCode).isEqualTo(201)
+        val firstId = first.jsonPath().getString("id")
+
+        val retry = convert(key)
+        assertThat(retry.statusCode).isEqualTo(201)
+        assertThat(retry.jsonPath().getString("id"))
+            .describedAs("a retry under the same Idempotency-Key must not execute a second trade")
+            .isEqualTo(firstId)
+
+        // A genuinely new key IS a new trade — the control that proves the check above can fail.
+        val fresh = convert("e2e-journey-replay-${UUID.randomUUID()}")
+        assertThat(fresh.statusCode).isEqualTo(201)
+        assertThat(fresh.jsonPath().getString("id")).isNotEqualTo(firstId)
+    }
+
+    /** Known-negative control: the read-back observable must be able to say "no such conversion". */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_PAYMENTS"])
+    fun `the conversion observable answers 404 for a conversion that was never executed`() {
+        assertThat(
+            RestAssured.given().get("/api/v1/fx/conversions/${UUID.randomUUID()}").statusCode,
+        ).isEqualTo(404)
+    }
+
+    private fun convert(idempotencyKey: String): Response = RestAssured.given()
+        .contentType("application/json")
+        .header("Idempotency-Key", idempotencyKey)
+        .body(
+            """
+            {
+              "partyId": "$PARTY_ID",
+              "accountId": null,
+              "partyName": "Jan Novak",
+              "fromCurrency": "CZK",
+              "toCurrency": "EUR",
+              "fromAmountMinorUnits": $FROM_MINOR_UNITS
+            }
+            """.trimIndent(),
+        )
+        .post("/api/v1/fx/convert")
+
+    private companion object {
+        const val ACTOR = "00000000-0000-0000-0000-000000000099"
+        const val PARTY_ID = "00000000-3333-0000-0000-000000000001"
+        const val FROM_MINOR_UNITS = 100_000L
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/e2e/LedgerPostingJourneyE2E.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/e2e/LedgerPostingJourneyE2E.kt
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.e2e
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * End-to-end journey for the ledger money path: **post a balanced journal, see the trial balance
+ * move by exactly that amount, reverse it, and see the trial balance return to where it started.**
+ *
+ * Every step is driven through the service's real HTTP surface (`@QuarkusTest` + RestAssured +
+ * `@TestSecurity`) against a real Postgres with the full Flyway chain applied
+ * (`PostgresRedpandaTestResource`, per-job Testcontainers) — no use case, repository or domain
+ * object is called directly, and nothing is mocked. Each assertion is on state **read back through
+ * the API** (`GET /api/v1/journals/{id}` and `GET /api/v1/journals/trial-balance`), never on the
+ * status code of the write alone.
+ *
+ * ### Service boundaries
+ *
+ * Nothing here crosses one. Posting a journal is self-contained: the entry, its lines and its
+ * outbox row are written by this service against its own database. The outbox DISPATCH (the hop
+ * that would put `ledger.journal.posted` on a broker and reach balance-service) is deliberately
+ * NOT part of this journey — Redpanda is started by the shared test resource but no consumer
+ * exists in this process, so the journey stops at the durable state this service owns. It does not
+ * claim the downstream hop happened.
+ *
+ * ### Why the trial balance is the observable
+ *
+ * A 201 proves an HTTP handler ran. The per-account net on the trial balance is the number the
+ * bank is actually run on, and it is derived by a different code path (aggregation query) from the
+ * one that wrote the rows — so it can disagree with the write, which is what makes asserting on it
+ * worth doing. Balance-neutrality of a post/reverse pair is the ledger's defining invariant
+ * (#939): the original flips to REVERSED and a mirrored compensating entry posts, so the net is
+ * unchanged while history stays immutable.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
+class LedgerPostingJourneyE2E {
+
+    /**
+     * The whole journey in one test, in order, because each step's precondition is the previous
+     * step's observed outcome — a split into independent tests would either re-post the setup or
+     * depend on method ordering, and neither states the invariant.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_OPERATOR"])
+    fun `posting a journal moves the trial balance and reversing it restores the opening position`() {
+        val today = LocalDate.now().toString()
+        val transactionId = UUID.randomUUID()
+
+        val netBefore = trialBalanceNet(today)
+
+        // 1. Post a balanced CZK journal through the public endpoint.
+        val posted = post(
+            "/api/v1/journals",
+            journalPayload(transactionId, today, AMOUNT),
+        )
+        assertThat(posted.statusCode)
+            .describedAs("POST /api/v1/journals: %s", posted.body.asString())
+            .isEqualTo(201)
+        assertThat(posted.jsonPath().getString("status")).isEqualTo("POSTED")
+        val journalId = posted.jsonPath().getString("id")
+        assertThat(journalId).isNotNull()
+
+        // 2. Read the entry back through the API — the write must be durable and complete.
+        val readBack = RestAssured.given().get("/api/v1/journals/$journalId")
+        assertThat(readBack.statusCode).isEqualTo(200)
+        assertThat(readBack.jsonPath().getString("status")).isEqualTo("POSTED")
+        assertThat(readBack.jsonPath().getString("transactionId")).isEqualTo(transactionId.toString())
+        assertThat(readBack.jsonPath().getList<Any>("lines")).hasSize(2)
+
+        // 3. The entry is also reachable by its business key, not only by its surrogate id.
+        val byTransaction = RestAssured.given().get("/api/v1/journals/transaction/$transactionId")
+        assertThat(byTransaction.statusCode).isEqualTo(200)
+        assertThat(byTransaction.body.asString()).contains(journalId)
+
+        // 4. The trial balance moved by exactly the posted amount, on exactly the two accounts.
+        val netAfterPost = trialBalanceNet(today)
+        assertThat(delta(netBefore, netAfterPost))
+            .describedAs("per-account net movement caused by the posting")
+            .isEqualTo(
+                mapOf(
+                    codeOf(GL_ASSET) to AMOUNT.negate(),
+                    codeOf(GL_LIABILITY) to AMOUNT,
+                ),
+            )
+
+        // 5. Reverse it.
+        val reversed = RestAssured.given()
+            .contentType("application/json")
+            .body("""{"reason": "E2E journey reversal", "reversedBy": "$ACTOR"}""")
+            .post("/api/v1/journals/$journalId/reverse")
+        assertThat(reversed.statusCode)
+            .describedAs("POST reverse: %s", reversed.body.asString())
+            .isEqualTo(200)
+        assertThat(reversed.jsonPath().getString("status")).isEqualTo("REVERSED")
+
+        // 6. Read back: the original entry is REVERSED, immutably — history is not deleted.
+        val afterReversal = RestAssured.given().get("/api/v1/journals/$journalId")
+        assertThat(afterReversal.statusCode).isEqualTo(200)
+        assertThat(afterReversal.jsonPath().getString("status")).isEqualTo("REVERSED")
+        assertThat(afterReversal.jsonPath().getList<Any>("lines")).hasSize(2)
+
+        // 7. And the trial balance is back to the opening position, per account.
+        assertThat(trialBalanceNet(today))
+            .describedAs("a post/reverse pair must be balance-neutral on every account (#939)")
+            .isEqualTo(netBefore)
+
+        // 8. The journey's terminal state fails closed: a second reversal is rejected and the
+        //    per-account net does not move again.
+        val repeat = RestAssured.given()
+            .contentType("application/json")
+            .body("""{"reason": "E2E journey repeat", "reversedBy": "$ACTOR"}""")
+            .post("/api/v1/journals/$journalId/reverse")
+        assertThat(repeat.statusCode).isEqualTo(409)
+        assertThat(trialBalanceNet(today)).isEqualTo(netBefore)
+    }
+
+    /**
+     * Known-negative control for the observable this journey depends on. If `trialBalanceNet` ever
+     * returned a constant (an empty map, say), every equality above would pass vacuously. Posting
+     * a second, different amount must therefore be VISIBLE to it.
+     */
+    @Test
+    @TestSecurity(user = ACTOR, roles = ["ROLE_OPERATOR"])
+    fun `the trial-balance observable is capable of registering a change`() {
+        val today = LocalDate.now().toString()
+        val before = trialBalanceNet(today)
+        val response = post("/api/v1/journals", journalPayload(UUID.randomUUID(), today, CONTROL_AMOUNT))
+        assertThat(response.statusCode).isEqualTo(201)
+
+        assertThat(trialBalanceNet(today))
+            .describedAs("control: an unreversed posting MUST change the trial balance")
+            .isNotEqualTo(before)
+    }
+
+    private fun post(path: String, body: String): Response = RestAssured.given()
+        .contentType("application/json")
+        .body(body)
+        .post(path)
+
+    /** Per-account signed net (credit - debit) in CZK, as the API renders it. */
+    private fun trialBalanceNet(asOf: String): Map<String, BigDecimal> {
+        val response = RestAssured.given().get("/api/v1/journals/trial-balance?asOf=$asOf")
+        assertThat(response.statusCode)
+            .describedAs("GET trial-balance: %s", response.body.asString())
+            .isEqualTo(200)
+        val lines = response.jsonPath().getList<Map<String, Any>>("lines")
+        return lines.filter { it["currency"] == "CZK" }.associate {
+            val credit = BigDecimal(it["totalCredit"].toString())
+            val debit = BigDecimal(it["totalDebit"].toString())
+            // stripTrailingZeros: BigDecimal.equals is scale-sensitive (0.0 != 0.00) and the JSON
+            // scale grows with everything posted before this test.
+            it["code"] as String to (credit - debit).stripTrailingZeros()
+        }
+    }
+
+    /** Accounts whose net changed, and by how much. Silent about untouched accounts. */
+    private fun delta(before: Map<String, BigDecimal>, after: Map<String, BigDecimal>): Map<String, BigDecimal> =
+        (before.keys + after.keys).mapNotNull { code ->
+            val movement = (after[code] ?: BigDecimal.ZERO) - (before[code] ?: BigDecimal.ZERO)
+            if (movement.compareTo(BigDecimal.ZERO) == 0) null else code to movement.stripTrailingZeros()
+        }.toMap()
+
+    /**
+     * The trial balance is keyed by account CODE while a journal line names the account by id, so
+     * the two seeded posting accounts have to be resolved to their codes. Read through the same
+     * API surface as everything else rather than by a direct SQL lookup.
+     */
+    private fun codeOf(glAccountId: String): String {
+        val response = RestAssured.given().get("/api/v1/journals/trial-balance?asOf=${LocalDate.now()}")
+        assertThat(response.statusCode).isEqualTo(200)
+        val line = response.jsonPath().getList<Map<String, Any>>("lines")
+            .firstOrNull { it["glAccountId"] == glAccountId }
+        assertThat(line)
+            .describedAs("seeded GL account %s must appear on the trial balance", glAccountId)
+            .isNotNull()
+        return line!!["code"] as String
+    }
+
+    private fun journalPayload(transactionId: UUID, date: String, amount: BigDecimal): String =
+        """
+        {
+          "idempotencyKey": "${UUID.randomUUID()}",
+          "transactionId": "$transactionId",
+          "entryDate": "$date",
+          "valueDate": "$date",
+          "description": "E2E posting journey",
+          "createdBy": "$ACTOR",
+          "lines": [
+            {"glAccountId": "$GL_ASSET", "side": "DEBIT", "amount": "$amount",
+             "currencyCode": "CZK", "baseAmount": "$amount", "baseCurrencyCode": "CZK"},
+            {"glAccountId": "$GL_LIABILITY", "side": "CREDIT", "amount": "$amount",
+             "currencyCode": "CZK", "baseAmount": "$amount", "baseCurrencyCode": "CZK"}
+          ]
+        }
+        """.trimIndent()
+
+    private companion object {
+        const val ACTOR = "00000000-0000-0000-0000-000000000099"
+
+        /** Deterministic posting accounts seeded by `V3__ledger_governance.sql`. */
+        const val GL_ASSET = "a0000000-0000-0000-0000-000000000001"
+        const val GL_LIABILITY = "a0000000-0000-0000-0000-000000000002"
+
+        val AMOUNT: BigDecimal = BigDecimal("742.13")
+        val CONTROL_AMOUNT: BigDecimal = BigDecimal("11.11")
+    }
+}


### PR DESCRIPTION
## Summary

Adds E2E journey suites to 5 money-path services (ledger, account, balance, fx, domestic-payment). Before this, **zero** service modules produced `e2e` evidence — the Test Intelligence column was filled only by admin-ui's Playwright specs. `src/main` untouched.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore
- [ ] security
- [ ] breaking change

Type is `test` — no shipped code changes, so this must not release a component.

## Linked issues

Refs #265

## Changes

Five `@QuarkusTest` + RestAssured + `@TestSecurity` suites driving each service through its real HTTP surface against Testcontainers Postgres/Redpanda/Valkey. Nothing calls a use case or repository directly.

## Definition of Done

- [x] Hexagonal layering preserved — `src/main` untouched.
- [x] Unit tests added/updated.
- [x] Integration tests added/updated.
- [ ] Contract tests updated — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — see Reviewer notes
- [x] No new lint warnings — ktlintCheck + detekt clean after a format pass.
- [ ] OpenAPI spec regenerated — N/A
- [ ] Flyway migration — N/A
- [ ] Avro schema — N/A
- [ ] Docs updated — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no production code changed.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only.
- Rollback plan: revert the commit.
- Data migration reversible: N/A

## Reviewer notes

**The classification rule was read, not guessed.** `classifyJUnitEvidence` gives `integration` priority over `e2e`, so a class named `*IT` or living under `.integration.` can never reach this column no matter what it does. These take both identity routes — an `.e2e.` package **and** an `*E2E` class name — so no Gradle task change was needed.

**Proved with the real collector.** Running `collect-test-intelligence.mjs` over the JUnit XML these suites actually produced moves components-with-execution-evidence from **0/63 to 5/63**, all five classified `e2e`, while the control `com.openbank.ledger.domain.JournalTest` still classifies `unit`. An E2E suite the collector still calls `unit` would have changed nothing.

**Each journey asserts an outcome, not a status code** — the trial-balance delta equals the posted amount and returns to the opening position after reversal; a 900 hold against 850 available fails 422 *and moves nothing*; the applied FX rate equals the quoted rate; same key + changed amount is 409 and leaves the stored payment untouched. Four of the five carry an explicit known-negative control so the assertions cannot pass vacuously.

**Stubbed edges are declared, not pretended.** fx stubs sanctions screening to CLEAR — without it the use case fails closed to HOLD and the journey would assert over the wrong state. fx and domestic-payment switch outgoing Kafka to the in-memory connector, so the outbox *dispatch* hop is explicitly **not** claimed by these tests.

**13 tests, 0 failures, 0 skipped.** The skipped count is stated because a service that fails to boot reports its tests as skipped, which scans as a pass.

**Not verified**: in CI the `run.json` envelope takes precedence over the JUnit fallback, and that path could not be exercised locally — the classification holds either way only if CI's envelope producer labels the suite `e2e` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

