### PR TITLE
test(fleet): add per-module k6 read baselines for 10 money-path services

### DIFF
--- a/openbank-account-service/src/test/k6/account-read-baseline.js
+++ b/openbank-account-service/src/test/k6/account-read-baseline.js
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-account-service.
+//
+// Account reads are on the hot path of every payment initiation (debtor lookup) and of
+// the whole customer app. There was no load evidence behind their SLO.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-account-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8103 PERF_READ_TOKEN=<token> \
+////     PERF_PARTY_ID=<uuid> PERF_ACCOUNT_ID=<uuid> \
+//     k6 run openbank-account-service/src/test/k6/account-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8103";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const PARTY_ID = __ENV.PERF_PARTY_ID || "00000000-0000-0000-0000-000000000001";
+const ACCOUNT_ID = __ENV.PERF_ACCOUNT_ID || "00000000-0000-0000-0000-000000000002";
+
+const listMs = new Trend("account_list_ms", true);
+const detailMs = new Trend("account_detail_ms", true);
+const balanceMs = new Trend("account_balance_ms", true);
+const searchMs = new Trend("account_search_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    "account_list_ms": ["p(95)<800"],
+    "account_detail_ms": ["p(95)<400"],
+    "account_balance_ms": ["p(95)<400"],
+    // Trigram IBAN search is the expensive read; a looser tripwire on purpose.
+    "account_search_ms": ["p(95)<1200"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const l = http.get(`${BASE_URL}/api/v1/accounts?partyId=${PARTY_ID}&limit=20`, {
+    headers: readHeaders,
+    tags: { name: "account_list" },
+  });
+  listMs.add(l.timings.duration);
+  check(l, { "account list 200": (res) => res.status === 200 });
+
+  const d = http.get(`${BASE_URL}/api/v1/accounts/${ACCOUNT_ID}`, {
+    headers: readHeaders,
+    tags: { name: "account_detail" },
+  });
+  detailMs.add(d.timings.duration);
+  check(d, { "account detail 200": (res) => res.status === 200 });
+
+  const b = http.get(`${BASE_URL}/api/v1/accounts/${ACCOUNT_ID}/balance`, {
+    headers: readHeaders,
+    tags: { name: "account_balance" },
+  });
+  balanceMs.add(b.timings.duration);
+  check(b, { "account balance 200": (res) => res.status === 200 });
+
+  const s = http.get(`${BASE_URL}/api/v1/accounts/search?q=CZ&limit=20`, {
+    headers: readHeaders,
+    tags: { name: "account_search" },
+  });
+  searchMs.add(s.timings.duration);
+  check(s, { "account search 200": (res) => res.status === 200 });
+}

--- a/openbank-balance-service/src/test/k6/balance-read-baseline.js
+++ b/openbank-balance-service/src/test/k6/balance-read-baseline.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-balance-service.
+//
+// Every payment authorisation reads a balance before it decides; this is the most
+// read-amplified money-path surface and had no latency baseline.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-balance-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8104 PERF_READ_TOKEN=<token> \
+////     PERF_ACCOUNT_ID=<uuid> \
+//     k6 run openbank-balance-service/src/test/k6/balance-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8104";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const ACCOUNT_ID = __ENV.PERF_ACCOUNT_ID || "00000000-0000-0000-0000-000000000002";
+const CURRENCY = __ENV.PERF_CURRENCY || "CZK";
+
+const allMs = new Trend("balance_all_ms", true);
+const currencyMs = new Trend("balance_currency_ms", true);
+const reconMs = new Trend("balance_reconciliation_latest_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // The single-currency read is the authorisation hot path — the tightest tripwire here.
+    "balance_currency_ms": ["p(95)<250"],
+    "balance_all_ms": ["p(95)<400"],
+    "balance_reconciliation_latest_ms": ["p(95)<800"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const a = http.get(`${BASE_URL}/api/v1/balances/${ACCOUNT_ID}`, {
+    headers: readHeaders,
+    tags: { name: "balance_all" },
+  });
+  allMs.add(a.timings.duration);
+  check(a, { "balances for account 200": (res) => res.status === 200 });
+
+  const c = http.get(`${BASE_URL}/api/v1/balances/${ACCOUNT_ID}/${CURRENCY}`, {
+    headers: readHeaders,
+    tags: { name: "balance_currency" },
+  });
+  currencyMs.add(c.timings.duration);
+  check(c, { "balance for currency 200": (res) => res.status === 200 });
+
+  const r = http.get(`${BASE_URL}/api/v1/balances/reconciliation/latest`, {
+    headers: readHeaders,
+    tags: { name: "balance_reconciliation_latest" },
+  });
+  reconMs.add(r.timings.duration);
+  check(r, { "latest reconciliation 200": (res) => res.status === 200 });
+}

--- a/openbank-consent-service/src/test/k6/consent-read-baseline.js
+++ b/openbank-consent-service/src/test/k6/consent-read-baseline.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-consent-service.
+//
+// Every PSD2 TPP call resolves a consent first, so consent lookup latency is additive to
+// the whole open-banking surface. Validation is a POST and is deliberately excluded.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-consent-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8140 PERF_READ_TOKEN=<token> \
+////     PERF_PARTY_ID=<uuid> PERF_GRANTEE_ID=<tpp-id> \
+//     k6 run openbank-consent-service/src/test/k6/consent-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8140";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const PARTY_ID = __ENV.PERF_PARTY_ID || "00000000-0000-0000-0000-000000000001";
+const GRANTEE_ID = __ENV.PERF_GRANTEE_ID || "tpp-perf-baseline";
+
+const byPartyMs = new Trend("consent_by_party_ms", true);
+const byGranteeMs = new Trend("consent_by_grantee_ms", true);
+const activeMs = new Trend("consent_active_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // The active-consent resolve runs on EVERY TPP request — the tightest tripwire.
+    "consent_active_ms": ["p(95)<250"],
+    "consent_by_party_ms": ["p(95)<500"],
+    "consent_by_grantee_ms": ["p(95)<500"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const p = http.get(`${BASE_URL}/api/v1/consents/party/${PARTY_ID}`, {
+    headers: readHeaders,
+    tags: { name: "consent_by_party" },
+  });
+  byPartyMs.add(p.timings.duration);
+  check(p, { "consents by party 200": (res) => res.status === 200 });
+
+  const g = http.get(`${BASE_URL}/api/v1/consents/grantee/${GRANTEE_ID}`, {
+    headers: readHeaders,
+    tags: { name: "consent_by_grantee" },
+  });
+  byGranteeMs.add(g.timings.duration);
+  check(g, { "consents by grantee 200": (res) => res.status === 200 });
+
+  const a = http.get(`${BASE_URL}/api/v1/consents/party/${PARTY_ID}/grantee/${GRANTEE_ID}/active`, {
+    headers: readHeaders,
+    tags: { name: "consent_active" },
+  });
+  activeMs.add(a.timings.duration);
+  check(a, { "active consent 200": (res) => res.status === 200 });
+}

--- a/openbank-domestic-payment/src/test/k6/domestic-payment-read-baseline.js
+++ b/openbank-domestic-payment/src/test/k6/domestic-payment-read-baseline.js
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-domestic-payment.
+//
+// The domestic payment list is offset-paginated like its SEPA sibling and shares the same
+// degradation risk; nothing measured it.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-domestic-payment state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8112 PERF_READ_TOKEN=<token> \
+//     k6 run openbank-domestic-payment/src/test/k6/domestic-payment-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8112";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+
+const listMs = new Trend("domestic_payment_list_ms", true);
+const approvalsMs = new Trend("domestic_payment_approvals_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    "domestic_payment_list_ms": ["p(95)<1000"],
+    "domestic_payment_approvals_ms": ["p(95)<600"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const l = http.get(`${BASE_URL}/api/v1/domestic-payments?limit=50&offset=0`, {
+    headers: readHeaders,
+    tags: { name: "domestic_payment_list" },
+  });
+  listMs.add(l.timings.duration);
+  check(l, { "domestic payment list 200": (res) => res.status === 200 });
+
+  const a = http.get(`${BASE_URL}/api/v1/domestic-payments/approvals`, {
+    headers: readHeaders,
+    tags: { name: "domestic_payment_approvals" },
+  });
+  approvalsMs.add(a.timings.duration);
+  check(a, { "domestic payment approvals 200": (res) => res.status === 200 });
+}

--- a/openbank-fx-service/src/test/k6/fx-read-baseline.js
+++ b/openbank-fx-service/src/test/k6/fx-read-baseline.js
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-fx-service.
+//
+// FX rate lookup sits INSIDE the payment path for any cross-currency instruction, so its
+// p95 is additive to every payment it touches. The history read is the expensive one.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-fx-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8120 PERF_READ_TOKEN=<token> \
+//     k6 run openbank-fx-service/src/test/k6/fx-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8120";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const BASE = __ENV.PERF_FX_BASE || "EUR";
+const QUOTE = __ENV.PERF_FX_QUOTE || "CZK";
+
+const ratesMs = new Trend("fx_rates_ms", true);
+const pairMs = new Trend("fx_pair_ms", true);
+const historyMs = new Trend("fx_history_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // A single pair lookup is in the payment critical path — keep it tight.
+    "fx_pair_ms": ["p(95)<200"],
+    "fx_rates_ms": ["p(95)<400"],
+    "fx_history_ms": ["p(95)<1000"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const r = http.get(`${BASE_URL}/api/v1/fx/rates`, {
+    headers: readHeaders,
+    tags: { name: "fx_rates" },
+  });
+  ratesMs.add(r.timings.duration);
+  check(r, { "fx rates 200": (res) => res.status === 200 });
+
+  const p = http.get(`${BASE_URL}/api/v1/fx/rates/${BASE}/${QUOTE}`, {
+    headers: readHeaders,
+    tags: { name: "fx_pair" },
+  });
+  pairMs.add(p.timings.duration);
+  check(p, { "fx pair 200": (res) => res.status === 200 });
+
+  const h = http.get(`${BASE_URL}/api/v1/fx/rates/${BASE}/${QUOTE}/history?limit=100`, {
+    headers: readHeaders,
+    tags: { name: "fx_history" },
+  });
+  historyMs.add(h.timings.duration);
+  check(h, { "fx history 200": (res) => res.status === 200 });
+}

--- a/openbank-ledger-service/src/test/k6/ledger-read-baseline.js
+++ b/openbank-ledger-service/src/test/k6/ledger-read-baseline.js
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-ledger-service.
+//
+// perf/k6/money-path-smoke.js already probes /api/v1/journals fleet-wide; this lane is the
+// ledger's OWN baseline and adds the two aggregate reads (trial balance, accounting day)
+// that dominate close-period latency and are absent from the fleet smoke.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-ledger-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8101 PERF_READ_TOKEN=<token> \
+//     k6 run openbank-ledger-service/src/test/k6/ledger-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8101";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+
+const journalsMs = new Trend("ledger_journals_ms", true);
+const trialBalanceMs = new Trend("ledger_trial_balance_ms", true);
+const accountingDayMs = new Trend("ledger_accounting_day_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    "ledger_journals_ms": ["p(95)<800"],
+    // A whole-book aggregate: generous tripwire, but a regression here is a close-cycle risk.
+    "ledger_trial_balance_ms": ["p(95)<2000"],
+    "ledger_accounting_day_ms": ["p(95)<300"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const j = http.get(`${BASE_URL}/api/v1/journals?limit=20`, {
+    headers: readHeaders,
+    tags: { name: "ledger_journals" },
+  });
+  journalsMs.add(j.timings.duration);
+  check(j, { "journal list 200": (res) => res.status === 200 });
+
+  const t = http.get(`${BASE_URL}/api/v1/journals/trial-balance`, {
+    headers: readHeaders,
+    tags: { name: "ledger_trial_balance" },
+  });
+  trialBalanceMs.add(t.timings.duration);
+  check(t, { "trial balance 200": (res) => res.status === 200 });
+
+  const d = http.get(`${BASE_URL}/api/v1/ledger/accounting-days/current`, {
+    headers: readHeaders,
+    tags: { name: "ledger_accounting_day" },
+  });
+  accountingDayMs.add(d.timings.duration);
+  check(d, { "current accounting day 200": (res) => res.status === 200 });
+}

--- a/openbank-sca-service/src/test/k6/sca-read-baseline.js
+++ b/openbank-sca-service/src/test/k6/sca-read-baseline.js
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-sca-service.
+//
+// SCA is a synchronous blocker in front of every PSD2-scoped payment: a slow challenge or
+// device read is a slow payment. Only the READ side is exercised — minting a challenge
+// is a write and stays out of this lane.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-sca-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8130 PERF_READ_TOKEN=<token> \
+////     PERF_PARTY_ID=<uuid> PERF_SCA_CHALLENGE_ID=<uuid> \
+//     k6 run openbank-sca-service/src/test/k6/sca-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8130";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const PARTY_ID = __ENV.PERF_PARTY_ID || "00000000-0000-0000-0000-000000000001";
+const CHALLENGE_ID = __ENV.PERF_SCA_CHALLENGE_ID || "00000000-0000-0000-0000-000000000003";
+
+const devicesMs = new Trend("sca_devices_ms", true);
+const challengeMs = new Trend("sca_challenge_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // SCA blocks a human at a screen; both reads are sub-second by requirement.
+    "sca_devices_ms": ["p(95)<300"],
+    "sca_challenge_ms": ["p(95)<300"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const d = http.get(`${BASE_URL}/api/v1/sca/parties/${PARTY_ID}/devices`, {
+    headers: readHeaders,
+    tags: { name: "sca_devices" },
+  });
+  devicesMs.add(d.timings.duration);
+  check(d, { "sca device list 200": (res) => res.status === 200 });
+
+  const c = http.get(`${BASE_URL}/api/v1/sca/challenges/${CHALLENGE_ID}`, {
+    headers: readHeaders,
+    tags: { name: "sca_challenge" },
+  });
+  challengeMs.add(c.timings.duration);
+  check(c, { "sca challenge detail 200": (res) => res.status === 200 });
+}

--- a/openbank-sepa-instant/src/test/k6/sepa-instant-read-baseline.js
+++ b/openbank-sepa-instant/src/test/k6/sepa-instant-read-baseline.js
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-sepa-instant.
+//
+// SCT Inst carries a 10-second scheme deadline end to end, so its own read latency is
+// part of a hard external budget rather than a comfort metric.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-sepa-instant state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8111 PERF_READ_TOKEN=<token> \
+////     PERF_ACCOUNT_ID=<uuid> \
+//     k6 run openbank-sepa-instant/src/test/k6/sepa-instant-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8111";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const ACCOUNT_ID = __ENV.PERF_ACCOUNT_ID || "00000000-0000-0000-0000-000000000002";
+
+const listMs = new Trend("sepa_instant_list_ms", true);
+const byDebtorMs = new Trend("sepa_instant_by_debtor_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // Tighter than the other payment lanes: SCT Inst has a 10s scheme deadline.
+    "sepa_instant_list_ms": ["p(95)<600"],
+    "sepa_instant_by_debtor_ms": ["p(95)<400"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const l = http.get(`${BASE_URL}/api/v1/sepa-instant`, {
+    headers: readHeaders,
+    tags: { name: "sepa_instant_list" },
+  });
+  listMs.add(l.timings.duration);
+  check(l, { "sct inst list 200": (res) => res.status === 200 });
+
+  const d = http.get(`${BASE_URL}/api/v1/sepa-instant/debtor/${ACCOUNT_ID}`, {
+    headers: readHeaders,
+    tags: { name: "sepa_instant_by_debtor" },
+  });
+  byDebtorMs.add(d.timings.duration);
+  check(d, { "sct inst by debtor 200": (res) => res.status === 200 });
+}

--- a/openbank-sepa-payment/src/test/k6/sepa-payment-read-baseline.js
+++ b/openbank-sepa-payment/src/test/k6/sepa-payment-read-baseline.js
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-sepa-payment.
+//
+// The SEPA payment read side backs both the customer app's payment list and the ops
+// console; the offset-paginated list is the endpoint most likely to degrade with volume.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-sepa-payment state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8110 PERF_READ_TOKEN=<token> \
+//     k6 run openbank-sepa-payment/src/test/k6/sepa-payment-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8110";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+
+const listMs = new Trend("sepa_payment_list_ms", true);
+const approvalsMs = new Trend("sepa_payment_approvals_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    // OFFSET pagination degrades with table size — this tripwire is the early warning.
+    "sepa_payment_list_ms": ["p(95)<1000"],
+    "sepa_payment_approvals_ms": ["p(95)<600"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const l = http.get(`${BASE_URL}/api/v1/sepa-payments?limit=50&offset=0`, {
+    headers: readHeaders,
+    tags: { name: "sepa_payment_list" },
+  });
+  listMs.add(l.timings.duration);
+  check(l, { "sepa payment list 200": (res) => res.status === 200 });
+
+  const a = http.get(`${BASE_URL}/api/v1/sepa-payments/approvals`, {
+    headers: readHeaders,
+    tags: { name: "sepa_payment_approvals" },
+  });
+  approvalsMs.add(a.timings.duration);
+  check(a, { "sepa payment approvals 200": (res) => res.status === 200 });
+}

--- a/openbank-transaction-service/src/test/k6/transaction-read-baseline.js
+++ b/openbank-transaction-service/src/test/k6/transaction-read-baseline.js
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 read baseline for openbank-transaction-service.
+//
+// Transaction history is the single most-requested read in the customer app, and the
+// search endpoint is the one with a non-trivial query plan behind it.
+//
+// READ-ONLY BY CONSTRUCTION: every request below is a GET. No openbank-transaction-service state is created,
+// mutated or deleted, so this lane is safe against any booted stack, including a shared
+// sandbox. Write-path benchmarking for money-path services stays in the manual, isolated
+// perf/k6/money-path-write-benchmark.js lane.
+//
+// Discovered as an artifact by openbank-admin-ui/scripts/collect-test-intelligence.mjs
+// (<module>/src/test/k6/*.js) and executed by the perf workflow — never by Gradle `test`.
+//
+// Run:
+//   BASE_URL=http://localhost:8102 PERF_READ_TOKEN=<token> \
+////     PERF_ACCOUNT_ID=<uuid> \
+//     k6 run openbank-transaction-service/src/test/k6/transaction-read-baseline.js
+//
+// Thresholds are ADVISORY in the CI lane (ADR-0243 / issue #334): the run records the
+// breach, Test Intelligence retains it as failed evidence. They are tripwires to
+// investigate, calibrated to be generous until the first stable baseline exists.
+import http from "k6/http";
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+
+// A 401 is rejection evidence, not a handler baseline: a run without a valid read identity
+// must fail loudly rather than publish the latency of an auth rejection.
+http.setResponseCallback(http.expectedStatuses(200));
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8102";
+// PERF_READ_TOKEN is injected by the scheduled workflow from an environment secret.
+// Deliberately no default; never logged, never used as a k6 tag.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
+const ACCOUNT_ID = __ENV.PERF_ACCOUNT_ID || "00000000-0000-0000-0000-000000000002";
+
+const listMs = new Trend("txn_list_ms", true);
+const searchMs = new Trend("txn_search_ms", true);
+
+export const options = {
+  scenarios: {
+    // A steady read baseline, not a soak or a spike.
+    steady_reads: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    "txn_list_ms": ["p(95)<800"],
+    "txn_search_ms": ["p(95)<1500"],
+
+    "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    "checks": ["rate==1.0"],
+  },
+};
+
+export default function () {
+  const l = http.get(`${BASE_URL}/api/v1/transactions?accountId=${ACCOUNT_ID}&limit=20`, {
+    headers: readHeaders,
+    tags: { name: "txn_list" },
+  });
+  listMs.add(l.timings.duration);
+  check(l, { "transaction list 200": (res) => res.status === 200 });
+
+  const s = http.get(`${BASE_URL}/api/v1/transactions/search?accountId=${ACCOUNT_ID}&limit=20`, {
+    headers: readHeaders,
+    tags: { name: "txn_search" },
+  });
+  searchMs.add(s.timings.duration);
+  check(s, { "transaction search 200": (res) => res.status === 200 });
+}

--- a/perf/scenarios.yaml
+++ b/perf/scenarios.yaml
@@ -20,3 +20,86 @@ scenarios:
     safety_boundary: Every request is invalid by construction (no valid token, no accepted body, nothing created), so the lane is safe against any stack — the rejection path IS the subject. A 200 or 5xx on any probe is a finding, not a pass.
     blocker: Requires an auth-ENABLED disposable boot before it can join the scheduled perf gate — the current perf-gate harness boots with quarkus.oidc.enabled=false, which would make every identity probe a false 200. Wiring = a second boot profile in perf-gate.yml (auth on, disposable identity) reusing the same throwaway postgres; tracked in #8590 #4. Validated locally against a stub in both directions (exit 0 on a well-behaved target, exit 99 with breaches counted on a 200-answering one).
     assertions: no-token and malformed-token probes must 401/403; NUL-byte query param must 400/401/403 (NulByteGuards boundary, never 500); enumeration sweep must 401/403/404 (200 = IDOR) with a latency trend for the timing side-channel; oversized header must 400/401/431.
+
+  # Per-module money-path read baselines (<module>/src/test/k6/*.js).
+  # Every one is GET-only, so unlike money-path-write-benchmark they need no isolated
+  # target or synthetic-data teardown — only a least-privilege read identity.
+  - id: account-read-baseline
+    definition: openbank-account-service/src/test/k6/account-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-account-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-account-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises account list (partyId, cursor), account detail, account balance, trigram IBAN search. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: balance-read-baseline
+    definition: openbank-balance-service/src/test/k6/balance-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-balance-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-balance-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises all balances for an account, single-currency balance, latest reconciliation run. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: ledger-read-baseline
+    definition: openbank-ledger-service/src/test/k6/ledger-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-ledger-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-ledger-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises journal list, trial balance, current accounting day. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: transaction-read-baseline
+    definition: openbank-transaction-service/src/test/k6/transaction-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-transaction-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-transaction-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises transaction list (accountId, cursor) and transaction search. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: sepa-payment-read-baseline
+    definition: openbank-sepa-payment/src/test/k6/sepa-payment-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-sepa-payment; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-sepa-payment target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises SEPA payment list (offset-paginated) and the pending-approval queue. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: sepa-instant-read-baseline
+    definition: openbank-sepa-instant/src/test/k6/sepa-instant-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-sepa-instant; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-sepa-instant target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises SCT Inst payment list and per-debtor list. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: domestic-payment-read-baseline
+    definition: openbank-domestic-payment/src/test/k6/domestic-payment-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-domestic-payment; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-domestic-payment target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises domestic payment list (offset-paginated) and the pending-approval queue. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: fx-read-baseline
+    definition: openbank-fx-service/src/test/k6/fx-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-fx-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-fx-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises all rates, single currency pair, pair history. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: sca-read-baseline
+    definition: openbank-sca-service/src/test/k6/sca-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-sca-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-sca-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises enrolled device credentials for a party and challenge detail. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.
+
+  - id: consent-read-baseline
+    definition: openbank-consent-service/src/test/k6/consent-read-baseline.js
+    execution_mode: planned-read-only-sandbox
+    safety_boundary: Read-only by construction — every request is a GET against openbank-consent-service; nothing is created, mutated or deleted, so the lane is safe against a shared sandbox.
+    target_schedule: "0 5 * * *"
+    blocker: Needs a booted openbank-consent-service target and a least-privilege read identity (PERF_READ_TOKEN) wired into the perf gate; a 401 is rejection evidence, not a handler baseline. Seeded read fixtures (party/account ids) are required for the id-scoped probes.
+    assertions: Exercises consents by party, consents by grantee, active-consent resolve. Advisory p95 tripwires per route plus http_req_failed rate<0.01 and checks rate==1.0 — a route that did not answer 200 invalidates the percentile.


### PR DESCRIPTION
## Summary

Adds 10 per-module k6 read baselines under `<module>/src/test/k6/` for money-path services and registers each in `perf/scenarios.yaml` (13 scenarios now). The performance column was empty for almost the whole fleet because there were three fleet-wide scenarios and two unregistered per-module files.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore
- [ ] security
- [ ] breaking change

Type is `test` — definitions only, nothing shipped, nothing executed by the build.

## Linked issues

Refs #265

## Changes

10 GET-only baselines for account, balance, ledger, transaction, sepa-payment, sepa-instant, domestic-payment, fx, sca, consent — each registered in `perf/scenarios.yaml` with the id matching the file basename.

## Definition of Done

- [x] Hexagonal layering preserved — no Kotlin touched.
- [ ] Unit tests added/updated — N/A, these are k6 definitions.
- [ ] Integration tests added/updated — N/A
- [ ] Contract tests updated — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, `src/test/k6` is not a JVM source set.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — N/A (specs were READ, not changed)
- [ ] Flyway migration — N/A
- [ ] Avro schema — N/A
- [ ] Docs updated — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII — the bearer comes from `PERF_READ_TOKEN` with no default and is never tagged or logged.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — scenario definitions, executed by the perf workflow.
- Rollback plan: revert the commit.
- Data migration reversible: N/A

## Reviewer notes

**The `checks: rate==1.0` threshold is the load-bearing one**, not the percentiles. It stops a latency figure being published for a route that did not answer 200 — without it a 401 or 404 reads as excellent latency, which is exactly how a perf gate goes green about an endpoint it never exercised. Every scenario also declares `http_req_failed: rate<0.01`.

**Endpoints were read from each service's own `openapi.yaml`**, including required query parameters and defaults. No route is invented. All ten are GET-only, so there is no idempotency caveat; writes stay in the existing isolated `money-path-write-benchmark` lane.

**Verified with k6 v2.2.0** — `k6 inspect` passes on all ten and resolves the `options` object, reporting the same threshold counts the files declare, which evaluates the init context rather than merely parsing. Collector discovery was replicated from the real `performance()` logic: all ten found, each attributed to the right component.

**What this does NOT establish.** No scenario has ever run against a booted service, so **no threshold is calibrated** — they are deliberately generous first guesses and the first real run should set them. Checks are status-only, so a 200 with a wrong body passes. And the id-scoped probes default to placeholder UUIDs that 404 against a real stack — which `checks: rate==1.0` correctly turns into a failure rather than a published 404 latency, so **these cannot go green until the perf gate seeds fixtures and supplies a read identity**. Each scenario's `blocker:` field records that.

**Follow-up found while doing this**: `openbank-product-catalog` and `openbank-flaky-test-hunter` already carry per-module k6 files that appear in no `scenarios.yaml` entry, so they render with no plan or execution-mode metadata. Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

