### PR TITLE
chore(fleet): extend pitest mutation testing to 3 money-path services

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -13,7 +13,7 @@ on:
       services:
         description: "Space-separated list of service modules to run pitest on (the matrix below is the source of truth)"
         required: false
-        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service openbank-sdd-service openbank-interest-service"
+        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service openbank-sdd-service openbank-interest-service openbank-delegation-service openbank-vop-service openbank-standing-order-service"
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); the pitest job below already declares contents: read too, belt-and-suspenders.
@@ -61,6 +61,19 @@ jobs:
           # by the thin-domain criterion (clearing/swift/lending/settlement/billing 1-2 files).
           - openbank-sdd-service
           - openbank-interest-service
+          # 2026-09-07 sweep: three money_path_services measured (branch sites over every
+          # src/main/kotlin/**/domain/**.kt, counting `if (` / `when (` / `require(` / `check(`):
+          # delegation 60 across 7 files (SpendCeilings per-tx/daily/monthly ceiling arithmetic and
+          # the zero-clamped headroom — real BigDecimal money math), vop 21 across 2 files
+          # (VopNameMatchPolicy's three-band decision: bounded Levenshtein, initials, legal-form
+          # stripping — the sanctions "matching decision logic" shape), standing-order 9 across 2
+          # files (recurrence dates per Frequency, MAX_CONSECUTIVE_FAILURES, ONCE/endDate
+          # completion boundaries — it decides whether the next payment fires). psd2 (1 file, 0
+          # branches) and settlement/clearing (thin, 0 branches) were measured and REJECTED; the
+          # seven documented exclusions in rules.yaml: coverage.money_path_depth stand unchanged.
+          - openbank-delegation-service
+          - openbank-vop-service
+          - openbank-standing-order-service
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/openbank-delegation-service/build.gradle.kts
+++ b/openbank-delegation-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 tasks.test {
@@ -97,3 +100,20 @@ kover {
 // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
+
+// Mutation testing (ADR-0063 / ADR-0030 D3).
+// ADR-0249 D3 spend-ceiling arithmetic (SpendCeilings.evaluate / headroom clamp,
+// SpendReservation lifecycle) is real money-movement math on BigDecimal — the criterion in
+// rules.yaml: coverage.money_path_depth. 60 branch sites across 7 domain files.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.delegation.domain.*")
+    targetTests = setOf("com.openbank.delegation.domain.*", "com.openbank.delegation.application.usecase.*")
+    // Advisory (ADR-0063): pitest.yml reports the score; the Gradle task itself must not
+    // fail the run, so the threshold is 0. The workflow owns the 70% check.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.delegation.domain.*Kt")
+}

--- a/openbank-standing-order-service/build.gradle.kts
+++ b/openbank-standing-order-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -70,4 +73,21 @@ kover {
             }
         }
     }
+}
+
+// Mutation testing (ADR-0063 / ADR-0030 D3).
+// StandingOrder carries the recurrence/failure arithmetic that decides whether the next
+// payment fires: calculateNextDate per Frequency, MAX_CONSECUTIVE_FAILURES, and the
+// ONCE/endDate completion boundaries. 9 branch sites across 2 domain files.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.standingorder.domain.*")
+    targetTests = setOf("com.openbank.standingorder.domain.*", "com.openbank.standingorder.application.usecase.*")
+    // Advisory (ADR-0063): pitest.yml reports the score; the Gradle task itself must not
+    // fail the run, so the threshold is 0. The workflow owns the 70% check.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.standingorder.domain.*Kt")
 }

--- a/openbank-vop-service/build.gradle.kts
+++ b/openbank-vop-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -75,3 +78,20 @@ kover {
 // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
+
+// Mutation testing (ADR-0063 / ADR-0030 D3).
+// VopNameMatchPolicy is a three-band decision with bounded Levenshtein, token/initial and
+// legal-form rules — the same "substantive domain decision logic" criterion that put
+// sanctions-service on the list (rules.yaml: coverage.money_path_depth). 21 branch sites.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.vop.domain.*")
+    targetTests = setOf("com.openbank.vop.domain.*", "com.openbank.vop.usecase.*")
+    // Advisory (ADR-0063): pitest.yml reports the score; the Gradle task itself must not
+    // fail the run, so the threshold is 0. The workflow owns the 70% check.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.vop.domain.*Kt")
+}


### PR DESCRIPTION
## Summary

Adds a `pitest { }` block to delegation-service, vop-service and standing-order-service — and adds all three to the `pitest.yml` matrix, which is the half that actually populates the Test Intelligence `mutation` column. Three further candidates were assessed and **rejected** on measurement.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [x] chore (build / tooling)
- [ ] security
- [ ] breaking change

## Linked issues

Refs #265

## Changes

| module | domain files | branch sites | what the domain layer computes |
|---|---:|---:|---|
| delegation-service | 7 | 60 | `SpendCeilings.evaluate` — per-tx/daily/monthly ceiling arithmetic, the `<=` boundary, zero-clamped headroom, reservation lifecycle |
| vop-service | 2 | 21 | three-band MATCH/CLOSE_MATCH/NO_MATCH — bounded Levenshtein, token reordering, legal-form stripping |
| standing-order-service | 2 | 9 | `calculateNextDate` per `Frequency`, `MAX_CONSECUTIVE_FAILURES`, and the ONCE/`endDate` boundary that decides whether the next payment fires |

**Rejected**: psd2-service (1 file, **0** branch sites, zero functions — Open Banking DTOs), settlement-service (**0**), clearing-service (**0**).

## Definition of Done

- [x] Hexagonal layering preserved — `src/main` untouched.
- [ ] Unit tests added/updated — N/A, this configures mutation testing over existing tests.
- [ ] Integration tests added/updated — N/A
- [ ] Contract tests updated — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — see Reviewer notes
- [x] No new lint warnings — build-script blocks only.
- [ ] OpenAPI spec regenerated — N/A
- [ ] Flyway migration — N/A
- [ ] Avro schema — N/A
- [ ] Docs updated — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency — `info.solidsoft.pitest` 1.19.0 is the version the other 12 modules already use.
- [x] Auth / crypto / payment code changed? — no.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — build config plus three weekly-workflow matrix legs.
- Rollback plan: revert the commit.
- Data migration reversible: N/A

## Reviewer notes

**The `pitest.yml` matrix change is the point, not the Gradle blocks.** The collector reads `<module>/build/reports/pitest/mutations.xml`, and nothing writes that file unless the module runs in the workflow — a Gradle block alone would have left the column exactly as grey as before.

**Measured end to end on one module**: `:openbank-vop-service:pitest` completed and wrote `mutations.xml` — **122 mutations, 104 killed, 85.2%**, above the workflow's 70% advisory bar. delegation and standing-order register their task but were **not run** (machine load), so their kill scores are unmeasured and either could come in below 70% and add a warning to the weekly run.

**`mutationThreshold = 0` on all three**, matching the fleet. This is advisory; the workflow reports the score. A blocking threshold would red-gate the fleet.

**Packages verified from the source tree**, not derived from module names — note `com.openbank.standingorder` (no separator), and vop's use cases live in `com.openbank.vop.usecase.*`, not `application.usecase.*`.

**The seven documented exclusions in `rules.yaml: coverage.money_path_depth` are untouched.** Re-measured for the record: sca 11, consent 12, swift 5, **lending 17**, billing 0, clearing 0, settlement 0. lending has grown from the recorded 0 to 17 across 4 files — but that block's stated trigger is money-movement *arithmetic*, not a rising branch count, so it is deliberately left alone and flagged here for whoever owns that block. clearing is now *thinner* than the note records (2 files / 0 branches vs 3 / 1), so its exclusion is better justified than when written.

**Not checked**: whether three extra matrix legs push the weekly pitest workflow past any runner or API budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

