### PR TITLE
fix(infra): restore admin-ui ECR tag immutability via sha256-* exclusion

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
@@ -92,41 +92,47 @@ locals {
   # re-push fails, so flipping the fleet would break the self-heal that exists to
   # rescue stranded deploys.
   #
-  # openbank-admin-ui WAS the one IMMUTABLE repository. It is not any more, and the
-  # reason is a real incompatibility rather than a quieter plan (the rule this comment
-  # used to state still holds: never loosen a control to make Terraform agree with the
-  # account).
+  # openbank-admin-ui is IMMUTABLE_WITH_EXCLUSION — the durable answer to the #8981
+  # incident, replacing both half-measures that preceded it:
   #
   # cosign v2 stores every attestation for an image under ONE tag, `sha256-<digest>.att`,
   # and attaching a second predicate must append to it — a rewrite. #8847 added SLSA build
-  # provenance alongside the CycloneDX SBOM, so each build now attests twice, and on an
-  # immutable repository the second write is refused:
+  # provenance alongside the CycloneDX SBOM, so each build attests twice, and on a plain
+  # IMMUTABLE repository the second write was refused (`TAG_INVALID ... tag is immutable`,
+  # every admin-ui deploy broken 2026-09-05/06, #8981). #8982 taught the attest script to
+  # tolerate that one failure (the kyverno SLSA policy is Audit-only, so deploys were
+  # unblocked but provenance silently missing); #8979 then made the attestation land by
+  # dropping immutability entirely — which also dropped the protection nobody else in the
+  # fleet lacks: a `sandbox-<sha>` deploy tag on this repository could be force-overwritten
+  # underneath a pinned GitOps manifest.
   #
-  #   TAG_INVALID: The image tag 'sha256-<digest>.att' already exists ... and cannot be
-  #   overwritten because the tag is immutable
+  # IMMUTABLE_WITH_EXCLUSION keeps BOTH halves: every deploy tag is immutable again, and
+  # only the cosign-internal `sha256-*` tags (`.att` append + `.sig` rewrite) stay mutable,
+  # which is the smallest surface the cosign v2 tag scheme can work with. The tag scheme is
+  # not ours to change: cosign v3 writes OCI 1.1 referrers, which the pinned kyverno 3.2.6
+  # cannot discover, so v2 and its `.att` tag are load-bearing until issue #770.
   #
-  # #8982 stopped that from failing the build (the kyverno SLSA policy is Audit, so a
-  # deploy is not gated on the envelope) and admin-ui deploys work again. What it could not
-  # do is make the attestation land: admin-ui is now the one deploy image in the fleet with
-  # no build provenance, tolerated on every run. This is the other half — the repository
-  # joins the fleet default, so the third leg of ADR-0030 D4 is actually written, and
-  # #8982's tolerate branch becomes the safety net it reads as rather than the steady state.
-  #
-  # The tag scheme is not ours to change: cosign v3 writes OCI 1.1 referrers, which the
-  # pinned kyverno 3.2.6 cannot discover, so v2 and its `.att` tag are load-bearing until
-  # issue #770. Under that constraint an immutable repository holds exactly one attestation.
-  #
-  # What the platform gives up is tag-reuse protection on one repository, which no other
-  # repository has. What it keeps is the part that proves authenticity — the KMS cosign
-  # signature and both attestations, verified at admission. Revisit at #770.
-  ecr_immutable_repositories = toset([])
+  # The #8982 tolerate branch in cosign-attest.sh stays deliberately: with the exclusion in
+  # place it never fires, and if it ever DOES fire again the pipeline config has regressed
+  # (exclusion lost, or the repo flipped back to IMMUTABLE) — the WARNING is the alarm.
+  ecr_immutable_with_exclusion_repositories = {
+    openbank-admin-ui = ["sha256-*"]
+  }
 }
 
 resource "aws_ecr_repository" "service" {
   for_each = local.service_ecr_repositories
 
   name                 = each.key
-  image_tag_mutability = contains(local.ecr_immutable_repositories, each.key) ? "IMMUTABLE" : "MUTABLE"
+  image_tag_mutability = contains(keys(local.ecr_immutable_with_exclusion_repositories), each.key) ? "IMMUTABLE_WITH_EXCLUSION" : "MUTABLE"
+
+  dynamic "image_tag_mutability_exclusion_filter" {
+    for_each = lookup(local.ecr_immutable_with_exclusion_repositories, each.key, [])
+    content {
+      filter      = image_tag_mutability_exclusion_filter.value
+      filter_type = "WILDCARD"
+    }
+  }
 
   # AES256 (the ECR-managed key) rather than KMS: matches every repository that
   # exists today, and a KMS switch is a destroy-and-recreate, not an in-place edit.


### PR DESCRIPTION
## Summary

#8979 let the SLSA attestation land on admin-ui by dropping ECR tag immutability outright — a real protection lost: a `sandbox-<sha>` deploy tag could be force-overwritten underneath a pinned GitOps manifest, on the fleet's only deploy repository without tag-reuse protection.

This PR restores immutability **and** keeps the attestation landing, via `IMMUTABLE_WITH_EXCLUSION`:

- `openbank-admin-ui` → `IMMUTABLE_WITH_EXCLUSION` with one WILDCARD filter `sha256-*`
- deploy tags (`sandbox-*`) are immutable again — force-overwrite is refused by ECR
- only cosign v2's internal tags stay mutable: the `sha256-<digest>.att` append (SBOM + SLSA share one tag, #8981) and the `sha256-<digest>.sig` rewrite — the smallest surface the cosign legacy tag scheme can work with; OCI referrers stay blocked on kyverno discovery (#770)

**#8982 tolerance branch decision** (acceptance criterion): it **stays deliberately**. With the exclusion in place it never fires; if it ever fires again, the registry configuration has regressed (exclusion lost, or repo flipped to plain IMMUTABLE) and the WARNING is the alarm. This is now stated in the tf comment next to the setting.

AWS provider here is `~> 6.53`, so `image_tag_mutability_exclusion_filter` (≥ 6.8.0) is available.

## Test plan

- [x] `tofu fmt -check` clean
- [x] `tofu init -backend=false` + `tofu validate` — configuration valid (only a pre-existing unrelated deprecation warning)
- [ ] CI `tofu plan (preview)` job on this PR shows exactly one change: `openbank-admin-ui` mutability `MUTABLE` → `IMMUTABLE_WITH_EXCLUSION` + exclusion filter, no other repository touched
- [ ] After merge: manual `Platform OpenTofu` apply dispatch (workflow_dispatch on main, APPLY role)
- [ ] Post-apply verification 1: a fresh admin-ui build logs `attested + verified SLSA provenance` (as run 34106157489 does today)
- [ ] Post-apply verification 2: an attempted overwrite of an existing `sandbox-*` tag is rejected by ECR (`TAG_INVALID`)

Closes #9029
Refs #8981
Refs #8979
Refs #8982

no-test-justification: the change is a Terraform registry setting (ECR tag mutability + exclusion filter); no repo test surface can express it — verification is the CI tofu plan preview (exactly one in-place change) plus the post-apply live checks listed above (SLSA attestation lands, sandbox-* overwrite refused).
