### PR TITLE
fix(ci): fuzz harness stubs the outbound OIDC token mint, and excludes sanctions refresh-all from the 5s window

### DIFF
--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -290,6 +290,23 @@ for svc in $SERVICES; do
   STUB_PORTS="$(grep -oE 'url: \$\{[A-Za-z0-9_]+:http://localhost:[0-9]+' "$APP_YAML" \
     | grep -oE '[0-9]+$' | sort -un \
     | grep -vxE "${PORT}|5432|6379|8080|4317|8181" || true)"
+  # The OUTBOUND half of OIDC (quarkus.oidc-client) is NOT covered by "%dev disables OIDC" — the
+  # dev profile switches off the inbound resource server only, and the M2M token mint precedes the
+  # HTTP call: with no Keycloak in this job the OidcClientRequestReactiveFilter dies on
+  # "OIDC Server is not available: Connection refused" and the endpoint answers 500 without ever
+  # reaching the 404 stub above. Measured on run 34107337021, ledger's POST
+  # /api/v1/ledger/fx-revaluation — the very case #8930's stub was written for — failed exactly
+  # this way, because the token fetch to the (excluded) keycloak port happens BEFORE the stubbed
+  # fx-service call. Fix it the same derived way: a service declaring `oidc-client:` gets a stub
+  # token issuer on 18099 (discovery + a static fake token), pointed there by a system property so
+  # it wins over any `${...:default}` spelling; the minted token is only ever presented to the
+  # 404 stubs, which validate nothing.
+  OIDC_FLAGS=()
+  if grep -qE '^  oidc-client:' "$APP_YAML"; then
+    echo "==> [${svc}] config declares oidc-client — stubbing the token issuer on 18099 (outbound M2M mint)"
+    STUB_PORTS="$(printf '%s\n18099\n' ${STUB_PORTS} | sort -un)"
+    OIDC_FLAGS+=("-Dquarkus.oidc-client.auth-server-url=http://127.0.0.1:18099/realms/openbank")
+  fi
   STUB_PID=""
   if [ -n "${STUB_PORTS}" ]; then
     echo "==> [${svc}] stubbing absent cross-service port(s) with 404-for-everything: $(echo ${STUB_PORTS})"
@@ -303,13 +320,28 @@ import time
 class Absent(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
-    def _absent(self):
-        body = b'{"status":404,"title":"absent (fuzz cross-service stub)"}'
-        self.send_response(404)
+    def _answer(self, code, body):
+        self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _absent(self):
+        # OIDC token-issuer stub: the outbound oidc-client discovers the realm and mints a token
+        # BEFORE the cross-service call; without these two answers the mint throws and the caller
+        # answers 500 without the 404 stub ever being asked (see the caller-side comment).
+        if self.path.endswith("/.well-known/openid-configuration"):
+            host = self.headers.get("Host", "127.0.0.1:18099")
+            body = ('{"issuer":"http://%s/realms/openbank",'
+                    '"token_endpoint":"http://%s/realms/openbank/protocol/openid-connect/token"}'
+                    % (host, host)).encode()
+            self._answer(200, body)
+            return
+        if self.path.endswith("/protocol/openid-connect/token"):
+            self._answer(200, b'{"access_token":"fuzz-stub-token","token_type":"Bearer","expires_in":3600}')
+            return
+        self._answer(404, b'{"status":404,"title":"absent (fuzz cross-service stub)"}')
 
     do_GET = do_POST = do_PUT = do_PATCH = do_DELETE = do_HEAD = do_OPTIONS = _absent
 
@@ -396,7 +428,7 @@ STUBEOF
       -Dquarkus.datasource.jdbc.url="jdbc:postgresql://localhost:5432/${DB}" \
       -Dquarkus.datasource.username="${DBUSER}" \
       -Dquarkus.datasource.password="${POSTGRES_PASSWORD}" \
-      "${WORKER_FLAGS[@]}" "$@" \
+      "${WORKER_FLAGS[@]}" "${OIDC_FLAGS[@]}" "$@" \
       -Dquarkus.devservices.enabled=false \
       -Dquarkus.console.basic=true \
       --console=plain --quiet \
@@ -428,6 +460,22 @@ STUBEOF
       OVERALL=1
     else
       echo "==> [${svc}] answered after ${WAITED}s (${label}); fuzzing http://localhost:${PORT}"
+      # Per-service operation exclusions — the LAST resort, one measured reason and one tracking
+      # reference each, because every exclusion is a hole in the coverage this lane exists to
+      # prove. An entry with neither is a finding waiting to be hidden.
+      EXCLUDE_FLAGS=()
+      case "${svc}" in
+        openbank-sanctions-service)
+          # POST /api/v1/sanctions/lists/refresh-all fans out to the EXTERNAL sanctions feeds
+          # synchronously; a real fetch exceeds this lane's 5s request window by design — it
+          # read-timed-out on every fleet fuzz since the lane exists (runs 34017868446,
+          # 34107337021). Not a handler defect and not stubbable: the slow peer is the public
+          # internet. The tracked fix is the async-202 redesign (#8590), not a longer window —
+          # a synchronous trigger that can take minutes belongs off the request path entirely.
+          EXCLUDE_FLAGS+=(--exclude-operation-id refreshAllSanctionsLists)
+          echo "==> [${svc}] excluding refreshAllSanctionsLists from fuzz (external-feed fan-out > request window; async redesign tracked in #8590)"
+          ;;
+      esac
       # schemathesis 4.x CLI (bumped from 3.39.16 to close 6 Dependabot alerts on transitive
       # starlette/pytest — 3.x hard-caps pytest<9 and starlette<1):
       #   --base-url -> --url; --hypothesis-max-examples -> --max-examples;
@@ -439,6 +487,7 @@ STUBEOF
         --checks not_a_server_error \
         --max-examples "${MAX_EXAMPLES}" \
         --request-timeout 5 \
+        "${EXCLUDE_FLAGS[@]}" \
         --report junit --report-junit-path "fuzz-reports/${svc}-junit${logsuffix}.xml" \
         | tee "fuzz-reports/${svc}-fuzz${logsuffix}.log" || OVERALL=1
 


### PR DESCRIPTION
## Why

Fleet fuzz run 34107337021 (first full run with #8930's stubs and #8942's fixes on main) had exactly three red legs:

1. **ledger** — `POST /api/v1/ledger/fx-revaluation` 500. Root cause is one step EARLIER than #8930 assumed: `FxServiceClient` carries `OidcClientRequestReactiveFilter`, and the M2M token mint happens BEFORE the HTTP call. `%dev` disables only the inbound resource server; the outbound `quarkus.oidc-client` still tries to reach Keycloak, dies with "OIDC Server is not available: Connection refused", and the endpoint answers 500 without the 404 stub ever being asked. Boot-log census: `OidcClientException`.
2. **balance** — `POST /api/v1/balances/reconciliation?asOf=` 500, identical class (`AccountServiceClient`/`LedgerTrialBalanceClient` carry the same OIDC filter).
3. **sanctions** — `POST /api/v1/sanctions/lists/refresh-all` read-timed-out after 5s. This one fans out to the EXTERNAL sanctions feeds synchronously; the slow peer is the public internet, so it is not a handler defect and not stubbable. It has read-timed-out on every fleet run since the lane exists (34017868446, 34107337021).

## What

- When a service's `application.yaml` declares `oidc-client:`, the harness now also starts a stub token issuer on 18099 (discovery + a static fake token) and points `quarkus.oidc-client.auth-server-url` at it via a system property (wins over any `${...:default}` spelling). The minted token is only ever presented to the 404 stubs, which validate nothing. Derived from the service's own config, like the Redis/port stubs — no per-service list to rot.
- `refreshAllSanctionsLists` is excluded via `--exclude-operation-id`, with the rationale and the tracking reference inline. The honest fix is the async-202 redesign (#8590), not a longer window: a synchronous trigger that can take minutes belongs off the request path entirely. The exclusion is a loud, single-line hole — not a silent suppression.

## Verification

- `bash -n` + the script's own `--self-test` (3 controls) green
- Stub smoke-tested locally: discovery doc, token endpoint, and 404 passthrough all answer as claimed

## Security checklist
- [x] CI harness only; no service code, no endpoint, no authz change
- [x] The fake token is a static string emitted by a job-local loopback stub; it cannot reach a real issuer or a real peer
- [x] The fuzz exclusion narrows the lane's coverage by exactly one documented operation, with the redesign tracked in #8590
