### PR TITLE
fix(kyb): unknown case-status filter is a 400, not the MANUAL_REVIEW list

### DIFF
--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/KybResource.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/KybResource.kt
@@ -185,8 +185,14 @@ class KybResource {
             return Response.ok(onboarding.listForParty(partyId).map { CaseResponse.from(it, partyId) }).build()
         }
         requireOperator()
-        val st =
-            status?.let { runCatching { CaseStatus.valueOf(it.uppercase()) }.getOrNull() } ?: CaseStatus.MANUAL_REVIEW
+        // #9038: absent status means the operator review queue (MANUAL_REVIEW), but an UNPARSEABLE
+        // one used to silently substitute MANUAL_REVIEW too — a typo answered the WRONG list with
+        // a 200. libs-runtime maps IllegalArgumentException to 400; never a service-local mapper
+        // (#526).
+        val st = status?.let {
+            runCatching { CaseStatus.valueOf(it.uppercase()) }
+                .getOrElse { _ -> throw IllegalArgumentException("unknown case status '$it'") }
+        } ?: CaseStatus.MANUAL_REVIEW
         return Response.ok(
             onboarding.listByStatus(st, page.coerceAtLeast(0), size.coerceIn(1, MAX_PAGE)).map {
                 CaseResponse.from(it, null)

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/integration/KybCaseApiIT.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/integration/KybCaseApiIT.kt
@@ -192,4 +192,24 @@ class KybCaseApiIT {
             { post("/api/v1/kyb/lookup") } Then
             { statusCode(404) }
     }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_KYC"])
+    fun `a typo in the case status filter is a 400, not the MANUAL_REVIEW list`() {
+        // #9038: an unparseable status used to silently substitute MANUAL_REVIEW and answer the
+        // WRONG list with a 200. Absent still means the operator review queue.
+        Given {
+            queryParam("status", "MANUAL_REVIE")
+        } When
+            { get("/api/v1/kyb/cases") } Then
+            { statusCode(400) }
+        Given { this } When
+            { get("/api/v1/kyb/cases") } Then
+            { statusCode(200) }
+        Given {
+            queryParam("status", "MANUAL_REVIEW")
+        } When
+            { get("/api/v1/kyb/cases") } Then
+            { statusCode(200) }
+    }
 }


### PR DESCRIPTION
Refs #9038 (first site of the fleet sweep), follows #8699 / #9037.

## Root cause
`GET /api/v1/kyb/cases?status=…` used `runCatching { CaseStatus.valueOf(…) }.getOrNull() ?: MANUAL_REVIEW` — an unparseable status did not merely drop the filter (the #8699 shape), it silently substituted `MANUAL_REVIEW` and answered the **wrong list** with a 200. An analyst typo looked like an empty review queue.

## Fix
Absent still means the operator review queue (deliberate default); a typo now throws `IllegalArgumentException` → libs-runtime 400 (#526).

`ManualAttestationRegistryAdapter` LegalFormClass → OTHER fallback deliberately left: it maps self-declared manual attestation data where OTHER is a designed sentinel, not a caller error.

## Tests
New IT in `KybCaseApiIT`: typo status → 400, absent → 200, valid → 200. Local gate green: `:openbank-kyb-service:test ktlintCheck detekt`.

## Security checklist
- [x] No secrets, credentials, or PII added to code or logs
- [x] Input validation tightened, not loosened
- [x] No new outbound edges or trust boundaries introduced
- [x] Behaviour change is fail-closed (unknown filter rejected instead of silently defaulted)