### PR TITLE
test(notification): make the deduplication predicate reachable from a unit test

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -37,6 +37,7 @@ import com.openbank.notification.domain.model.PushSendOutcome
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.client.PartyContactClient
 import com.openbank.notification.infrastructure.client.PartyMergeResolver
+import com.openbank.notification.infrastructure.persistence.NotificationDeduplication
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationPreferenceRepository
@@ -58,7 +59,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.jboss.logging.Logger
-import java.sql.SQLException
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
@@ -83,10 +83,10 @@ class NotificationConsumer @Inject constructor(
 
     companion object {
         /** Name of the notifications deduplication partial unique index, a stable duplicate discriminator. */
-        const val NOTIFICATION_DEDUPLICATION_CONSTRAINT = "uq_notifications_deduplication_key"
+        const val NOTIFICATION_DEDUPLICATION_CONSTRAINT = NotificationDeduplication.CONSTRAINT
 
         /** Postgres SQLState for unique_violation, as surfaced by the reactive pg client. */
-        const val SQLSTATE_UNIQUE_VIOLATION = "23505"
+        const val SQLSTATE_UNIQUE_VIOLATION = NotificationDeduplication.SQLSTATE_UNIQUE_VIOLATION
 
         /**
          * Generic, PII-free push body (ADR-0135 §3, issue #1182). Lock-screen-visible push
@@ -403,12 +403,7 @@ class NotificationConsumer @Inject constructor(
      * constraint name must appear in the message so an unrelated unique violation on this
      * table is not swallowed as a dedup skip.
      */
-    private fun Throwable.isDeduplicationConflict(): Boolean = generateSequence(this) { it.cause }
-        .filterIsInstance<SQLException>()
-        .any {
-            it.sqlState == SQLSTATE_UNIQUE_VIOLATION &&
-                it.message?.contains(NOTIFICATION_DEDUPLICATION_CONSTRAINT) == true
-        }
+    private fun Throwable.isDeduplicationConflict(): Boolean = NotificationDeduplication.isConflict(this)
 
     private fun publishOversight(req: NotificationRequest): Uni<Void> {
         if (!OversightWebhook.isOversight(req.template)) return Uni.createFrom().voidItem()

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/NotificationDeduplication.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/NotificationDeduplication.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence
+
+import java.sql.SQLException
+
+/**
+ * Recognises the one database error that means "this notification fact is already recorded".
+ *
+ * Behaviour is unchanged from #8953, which fixed it; this only moves the predicate out of a private
+ * method of [com.openbank.notification.application.NotificationConsumer] so a unit test can reach
+ * it. That unreachability is not a style point — it is why the original defect survived review. The
+ * check matched the pgjdbc `PSQLException`, which never appears here, so it could never fire; the
+ * only test that could have caught it was an integration test, and that test was passing vacuously
+ * because a duplicate V14 migration meant the unique index was never created.
+ *
+ * Hibernate Reactive adapts the Vert.x `PgException` into a plain [java.sql.SQLException]
+ * (sqlState 23505, the server message naming the constraint) beneath its
+ * `ConstraintViolationException`. Matching any other exception class here — pgjdbc's or the Vert.x
+ * client's own — reintroduces the original defect in a new disguise.
+ *
+ * Narrow on purpose: it is not enough that SOME unique index was violated. Only this index means
+ * "already recorded"; any other 23505 is a genuine fault and must keep failing loudly rather than
+ * being silently acked as a duplicate, which would drop a notification without trace.
+ */
+object NotificationDeduplication {
+    /** The partial unique index on `notifications(deduplication_key)`. */
+    const val CONSTRAINT = "uq_notifications_deduplication_key"
+
+    /** PostgreSQL `unique_violation`, as surfaced by the reactive stack. */
+    const val SQLSTATE_UNIQUE_VIOLATION = "23505"
+
+    /** True iff [error]'s cause chain carries the deduplication index violation. */
+    fun isConflict(error: Throwable?): Boolean = generateSequence(error) { it.cause }
+        .filterIsInstance<SQLException>()
+        .any {
+            it.sqlState == SQLSTATE_UNIQUE_VIOLATION &&
+                it.message?.contains(CONSTRAINT) == true
+        }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/persistence/NotificationDeduplicationTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/persistence/NotificationDeduplicationTest.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.sql.SQLException
+
+/**
+ * Pins the deduplication predicate, which has no other unit-level cover.
+ *
+ * Both directions matter and neither is theoretical. Too permissive and an unrelated fault is acked
+ * as a duplicate, dropping a notification with no trace. Too strict — what #8334 shipped — and every
+ * duplicate is nacked and redelivered forever.
+ *
+ * **What these tests do NOT prove.** They construct the exception, so they pin the type the code
+ * expects rather than the type Hibernate Reactive actually produces. That is exactly the gap that
+ * let the original defect through: a unit test written against `PSQLException` would have passed
+ * just as confidently. The type below is the one #8953 established against the running stack, and
+ * `NotificationConsumerIT` — which drives a real database — remains the check that keeps it honest.
+ * These tests protect the surrounding logic, not the premise.
+ */
+class NotificationDeduplicationTest {
+    private fun sqlException(state: String, message: String) = SQLException(message, state)
+
+    private fun dedupViolation() = sqlException(
+        NotificationDeduplication.SQLSTATE_UNIQUE_VIOLATION,
+        "duplicate key value violates unique constraint \"${NotificationDeduplication.CONSTRAINT}\"",
+    )
+
+    @Test
+    fun `the deduplication index violation is recognised`() {
+        assertThat(NotificationDeduplication.isConflict(dedupViolation())).isTrue()
+    }
+
+    @Test
+    fun `it is recognised through a wrapping cause chain`() {
+        // Hibernate wraps the driver's exception; the predicate walks causes for that reason.
+        val wrapped = RuntimeException("could not execute statement", dedupViolation())
+        assertThat(NotificationDeduplication.isConflict(wrapped)).isTrue()
+    }
+
+    @Test
+    fun `a different unique index is NOT a duplicate fact`() {
+        // Must keep failing loudly. Acking someone else's constraint violation as "already
+        // recorded" drops a notification and leaves nothing to explain why.
+        assertThat(
+            NotificationDeduplication.isConflict(
+                sqlException(
+                    NotificationDeduplication.SQLSTATE_UNIQUE_VIOLATION,
+                    "duplicate key value violates unique constraint \"uq_notifications_reference\"",
+                ),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `another sqlstate naming the same constraint is not a duplicate`() {
+        // 23503 is a foreign-key violation. The constraint name alone must not be enough.
+        assertThat(
+            NotificationDeduplication.isConflict(
+                sqlException(
+                    "23503",
+                    "insert violates foreign key constraint \"${NotificationDeduplication.CONSTRAINT}\"",
+                ),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `a unique violation with no message is not a duplicate`() {
+        assertThat(
+            NotificationDeduplication.isConflict(
+                SQLException(null, NotificationDeduplication.SQLSTATE_UNIQUE_VIOLATION),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `null and unrelated failures are not duplicates`() {
+        assertThat(NotificationDeduplication.isConflict(null)).isFalse()
+        assertThat(NotificationDeduplication.isConflict(IllegalStateException("boom"))).isFalse()
+    }
+}


### PR DESCRIPTION
**No behaviour change.** #8953 fixed the predicate; this moves it out of a `private` method of
`NotificationConsumer` into `NotificationDeduplication` at the persistence boundary — mirroring
product-catalog's `PostgresConflicts` — and adds the unit tests it currently has none of.

## Why the unreachability is the point

The original defect matched pgjdbc's `PSQLException` while this service persists **reactively**, so
the guard could never fire. Nothing could catch that except an integration test — and that test was
itself passing **vacuously**, because a duplicate `V14` migration meant the unique index was never
created.

Two defects covering for each other, with no unit-level cover anywhere between them. On current
main the predicate is still private and still has no unit test.

## Falsified in both directions

This predicate can fail either way, so both were tested:

| break | goes red |
|---|---|
| drop the constraint-name check (**too permissive**) | `a different unique index is NOT a duplicate fact`, `a unique violation with no message` |
| match a different exception class (**the original defect's shape**) | `the deduplication index violation is recognised`, `it is recognised through a wrapping cause chain` |

Each direction reddens exactly the tests that describe it and leaves the others green — so the suite
isolates as well as fails.

## What these tests do NOT prove

Stated in the test KDoc rather than left implied: they **construct** the exception, so they pin the
type the code expects, not the type Hibernate Reactive produces. A unit test written against
`PSQLException` would have passed just as confidently as this one does.

`NotificationConsumerIT`, which drives a real database, remains the check that keeps the premise
honest. This suite protects the surrounding logic — that a foreign-key violation naming the same
constraint is not a duplicate, that another index's `23505` is not swallowed, that the cause chain
is walked.

## Verified

- 6 tests, 0 skipped, 0 failures, read from the JUnit XML
- ktlint + detekt clean
- exit code measured on the command, not a pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)