### PR TITLE
fix(transaction): reversals record what they reverse

### DIFF
--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/in/TransactionPorts.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/in/TransactionPorts.kt
@@ -33,6 +33,16 @@ data class InitiateTransactionCommand(
     val scaExemption: String? = null,
     /** Rail payment that triggered this booking (ADR-0108); null for operator/system commands. */
     val originatingPaymentId: UUID? = null,
+    /**
+     * The transaction this booking reverses (#8841). Set only by `reverseTransaction`, which
+     * already holds the original's id — without this parameter the id was available at the call
+     * site and dropped one line later, leaving the V2 compliance column `reversal_of` NULL on
+     * every row ever written. Deliberately no ledger-style unique index: `transactions` is
+     * PARTITION BY RANGE (booking_date), and Postgres requires every partitioning column in a
+     * unique constraint — the COMPLETED→REVERSED status transition stays the sole guard against
+     * a double reversal, and the decision is recorded here rather than left by default.
+     */
+    val reversalOf: UUID? = null,
     /** Which scheme carried the money (ADR-0103 D2). Null until stamped at origination. */
     val rail: PaymentRail? = null,
     /** How the movement was instructed (ADR-0103 D2) — orthogonal to [rail]. */

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -209,6 +209,8 @@ class TransactionService(
             scaExemption = command.scaExemption,
             rail = command.rail,
             instructionType = command.instructionType,
+            reversalOf = command.reversalOf,
+            isReversal = command.type == TransactionType.REVERSAL,
         )
 
         val saved = try {
@@ -284,6 +286,7 @@ class TransactionService(
                 description = "Reversal: ${command.reason}",
                 valueDate = java.time.LocalDate.now(clock),
                 initiatedBy = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                reversalOf = original.id,
             ),
         )
     }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/model/Transaction.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/model/Transaction.kt
@@ -43,6 +43,14 @@ data class Transaction(
     val merchantCategory: String? = null,
     /** Rail payment that triggered this transaction; null for operator/system postings (ADR-0108). */
     val originatingPaymentId: UUID? = null,
+    /**
+     * The transaction this one reverses (#8841). Set only on REVERSAL transactions created by
+     * `reverseTransaction`; the V2 compliance column existed unpopulated for the whole life of
+     * the service, so a reversal could not say WHAT it reversed except by parsing `description`.
+     */
+    val reversalOf: UUID? = null,
+    /** True iff this transaction was created as a reversal of another (#8841). */
+    val isReversal: Boolean = false,
 ) {
     fun complete(clock: Clock): Transaction {
         check(status == TransactionStatus.PENDING || status == TransactionStatus.PROCESSING) {

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheTransactionRepository.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheTransactionRepository.kt
@@ -237,6 +237,8 @@ private fun TransactionEntity.toDomain(): com.openbank.transaction.domain.model.
         },
         merchantCategory = merchantCategory,
         originatingPaymentId = originatingPaymentId,
+        reversalOf = reversalOf,
+        isReversal = isReversal,
     )
 }
 
@@ -272,6 +274,8 @@ private fun com.openbank.transaction.domain.model.Transaction.toEntity() = Trans
     instructionType = this@toEntity.instructionType?.name
     merchantCategory = this@toEntity.merchantCategory
     originatingPaymentId = this@toEntity.originatingPaymentId
+    reversalOf = this@toEntity.reversalOf
+    isReversal = this@toEntity.isReversal
 }
 
 /**

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -479,6 +479,9 @@ class TransactionServiceTest {
         assertThat(result.type).isEqualTo(TransactionType.REVERSAL)
         assertThat(result.targetAccountId).isEqualTo(originalSourceId)
         assertThat(result.sourceAccountId).isNull()
+        // #8841: the reversal must say WHAT it reversed — the id is available at the call site.
+        assertThat(result.reversalOf).isEqualTo(original.id)
+        assertThat(result.isReversal).isTrue()
         coVerify { transactionRepository.update(match { it.status == TransactionStatus.REVERSED }) }
     }
 

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionReversalLinkIT.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionReversalLinkIT.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * #8841: a reversal must say WHAT it reversed. The V2 compliance columns `reversal_of` /
+ * `is_reversal` existed — documented, drawn in the ER diagram — with no code path ever assigning
+ * them, so every unit test that never read the row back looked fine. This IT drives the real REST
+ * flow and asserts the linkage on the PERSISTED row with plain JDBC, because the defect is
+ * precisely a field the code never touched.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
+class TransactionReversalLinkIT {
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.url")
+    lateinit var jdbcUrl: String
+
+    @ConfigProperty(name = "quarkus.datasource.username")
+    lateinit var jdbcUser: String
+
+    @ConfigProperty(name = "quarkus.datasource.password")
+    lateinit var jdbcPassword: String
+
+    private val today = LocalDate.now().toString()
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a reversal persists reversal_of and is_reversal on the real row`() {
+        val source = UUID.randomUUID()
+        val target = UUID.randomUUID()
+        val originalId = RestAssured.given()
+            .contentType("application/json")
+            .body(
+                """
+                {
+                  "idempotencyKey": "${UUID.randomUUID()}",
+                  "type": "TRANSFER",
+                  "sourceAccountId": "$source",
+                  "targetAccountId": "$target",
+                  "amount": "150.00",
+                  "currencyCode": "CZK",
+                  "description": "Reversal-link IT transfer",
+                  "valueDate": "$today"
+                }
+                """.trimIndent(),
+            )
+            .post("/api/v1/transactions")
+            .then().statusCode(201)
+            .extract().jsonPath().getString("id")
+
+        val reversalId = RestAssured.given()
+            .contentType("application/json")
+            .body("""{"idempotencyKey": "${UUID.randomUUID()}", "reason": "Reversal-link IT"}""")
+            .post("/api/v1/transactions/$originalId/reverse")
+            .then().statusCode(200)
+            .extract().jsonPath().getString("id")
+
+        DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPassword).use { conn ->
+            conn.createStatement().executeQuery(
+                "SELECT reversal_of, is_reversal FROM transactions WHERE id = '$reversalId'",
+            ).use { rs ->
+                assertThat(rs.next()).describedAs("reversal row exists").isTrue()
+                assertThat(rs.getObject("reversal_of").toString()).isEqualTo(originalId)
+                assertThat(rs.getBoolean("is_reversal")).isTrue()
+            }
+            // The original carries no link in the other direction and is not itself a reversal.
+            conn.createStatement().executeQuery(
+                "SELECT is_reversal FROM transactions WHERE id = '$originalId'",
+            ).use { rs ->
+                assertThat(rs.next()).isTrue()
+                assertThat(rs.getBoolean("is_reversal")).isFalse()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #8841

## Root cause
`reversal_of` / `is_reversal` are V2 **compliance** columns — documented in `docs/04-data.*.md`, drawn as a self-relation in the ER diagram — with no code path ever assigning either. `reverseTransaction` holds the original id in `command.originalTransactionId` and dropped it one line later, because `InitiateTransactionCommand` and the domain `Transaction` had no field for it.

## Fix
- `InitiateTransactionCommand.reversalOf` → domain `Transaction.reversalOf` / `isReversal` → entity mapper both directions.
- `reverseTransaction` passes `original.id`; `isReversal` derives from `type == REVERSAL`.

## Unique index — decision made explicitly (the issue asked)
No `uq_transactions_reversal_of`: `transactions` is `PARTITION BY RANGE (booking_date)` and Postgres requires every partitioning column in a unique constraint (measured — the migration fails at boot). The COMPLETED→REVERSED status transition (+ idempotency key) stays the sole double-reversal guard; recorded in the command KDoc.

## Tests
- `TransactionServiceTest` asserts `reversalOf`/`isReversal` on the reversal result.
- New `TransactionReversalLinkIT`: real REST initiate → reverse, then asserts the link on the **persisted row** via plain JDBC — the defect class is a field no test ever read back.

Local gate green: `test ktlintCheck detekt koverVerify`.

## Follow-up (not in this PR)
`reversalOf` is not yet exposed on the REST response DTO / `transaction.initiated` event payload — that is an additive API change (ADR-0048 versioning) worth its own PR.

## Security checklist
- [x] No secrets, credentials, or PII added to code or logs
- [x] Input validation unchanged; no validation loosened
- [x] No new outbound edges or trust boundaries introduced
- [x] Money-path behaviour strictly gains auditability (compliance linkage); no control removed