### PR TITLE
fix(dispute): operator update to a terminal status emits dispute.resolved

### DIFF
--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
@@ -119,7 +119,30 @@ class DisputeService(
                     },
                     updatedAt = OffsetDateTime.now(clock),
                 )
-                disputeRepo.update(updated).flatMap { saved ->
+                // #8745 finding 2: this endpoint knowingly handles the three terminal statuses
+                // (it stamps resolvedAt for them), so the same terminal state emitted
+                // dispute.resolved through resolveRemediation and NOTHING through here — an
+                // ADR-0220 exclusion applied on dispute.opened would never lift for a dispute
+                // resolved on this path. Mirror doResolve: the transition INTO a terminal
+                // status carries the event, committed atomically with the row.
+                val terminal = listOf(
+                    DisputeStatus.RESOLVED_CUSTOMER,
+                    DisputeStatus.RESOLVED_MERCHANT,
+                    DisputeStatus.WITHDRAWN,
+                )
+                val messages =
+                    if (updated.status in terminal && dispute.status !in terminal) {
+                        listOf(resolvedOutboxMessage(updated))
+                    } else {
+                        emptyList()
+                    }
+                val write =
+                    if (messages.isEmpty()) {
+                        disputeRepo.update(updated)
+                    } else {
+                        disputeRepo.update(updated, messages)
+                    }
+                write.flatMap { saved ->
                     val event = DisputeTimelineEvent(
                         disputeId = saved.id,
                         eventType = "STATUS_CHANGED",

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
@@ -155,7 +155,13 @@ class DisputeServiceTest {
         )
         val update = UpdateDisputeRequest(status = DisputeStatus.RESOLVED_CUSTOMER, resolvedBy = "caseworker")
         every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
-        every { disputeRepo.update(any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        val outbox = slot<List<OutboxMessage>>()
+        // #8745: the transition INTO a terminal status now commits dispute.resolved atomically —
+        // the same event doResolve emits — instead of the timeline-only write that never left
+        // the service.
+        every { disputeRepo.update(any(), capture(outbox)) } answers {
+            Uni.createFrom().item(firstArg<Dispute>())
+        }
         every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
 
         val result = service.update(id, update).await().indefinitely()
@@ -166,8 +172,41 @@ class DisputeServiceTest {
         assertThat(result.updatedAt).isNotNull()
 
         verify(exactly = 1) { disputeRepo.findById(id) }
-        verify(exactly = 1) { disputeRepo.update(any()) }
+        verify(exactly = 1) { disputeRepo.update(any(), any()) }
         verify(exactly = 1) { timelineRepo.save(any()) }
+        assertThat(outbox.captured.single().payload).contains(""""eventType":"dispute.resolved"""")
+    }
+
+    @Test
+    fun `update to a non-terminal status emits no outbox event`() {
+        val id = UUID.randomUUID()
+        val existing = Dispute(
+            id = id,
+            reference = "DSP-1001",
+            transactionId = UUID.randomUUID(),
+            accountId = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            disputeType = DisputeType.DUPLICATE,
+            amount = BigDecimal("10.00"),
+            transactionDate = today,
+            filingDate = today,
+            resolutionDeadline = today.plusDays(45),
+            createdAt = now,
+            updatedAt = now,
+        )
+        every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
+        every { disputeRepo.update(any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
+
+        val result = service.update(
+            id,
+            UpdateDisputeRequest(status = DisputeStatus.UNDER_REVIEW),
+        ).await().indefinitely()
+
+        assertThat(result.status).isEqualTo(DisputeStatus.UNDER_REVIEW)
+        assertThat(result.resolvedAt).isNull()
+        verify(exactly = 1) { disputeRepo.update(any()) }
+        verify(exactly = 0) { disputeRepo.update(any(), any()) }
     }
 
     @Test
@@ -188,7 +227,9 @@ class DisputeServiceTest {
             updatedAt = now,
         )
         every { disputeRepo.findById(id) } returns Uni.createFrom().item(existing)
-        every { disputeRepo.update(any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        // WITHDRAWN is terminal: withdraw (which delegates to update) now commits
+        // dispute.resolved atomically via the two-arg overload (#8745).
+        every { disputeRepo.update(any(), any()) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
         every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
 
         val result = service.withdraw(id, "customer").await().indefinitely()
@@ -199,7 +240,7 @@ class DisputeServiceTest {
         assertThat(result.updatedAt).isNotNull()
 
         verify(exactly = 1) { disputeRepo.findById(id) }
-        verify(exactly = 1) { disputeRepo.update(any()) }
+        verify(exactly = 1) { disputeRepo.update(any(), any()) }
         verify(exactly = 1) { timelineRepo.save(any()) }
     }
 


### PR DESCRIPTION
Refs #8745 (finding 2 of the outbox-asymmetry sweep).

## Root cause
`DisputeService.update` (operator `PUT /api/v1/disputes/{id}`) knowingly handles the three terminal statuses — it stamps `resolvedAt` for exactly them — yet persisted with the 1-arg `update()`: only a local `dispute_timeline` row. The **same terminal state** emits `dispute.resolved` through `resolveRemediation` and **nothing** through this endpoint. Consumers of `openbank.dispute.events` (audit, engagement) held the dispute open forever; an ADR-0220 marketing exclusion applied on `dispute.opened` would never lift.

## Fix
Transition INTO `RESOLVED_CUSTOMER` / `RESOLVED_MERCHANT` / `WITHDRAWN` commits `dispute.resolved` atomically with the row (2-arg overload, same as `doResolve`). `withdraw()` delegates to `update()`, so withdrawals are announced too. Non-terminal updates unchanged — no status-changed event type exists, deliberately.

## Tests
- `update … RESOLVED_CUSTOMER` now asserts the outbox carries `dispute.resolved`.
- New: non-terminal update (`UNDER_REVIEW`) emits **no** outbox event.
- `withdraw` test updated for the 2-arg write.

Local gate green: `:openbank-dispute-service:test ktlintCheck detekt`.

## Security checklist
- [x] No secrets, credentials, or PII added to code or logs (payload fields mirror doResolve)
- [x] Input validation unchanged
- [x] No new outbound edges — the event goes through the existing outbox/topic
- [x] No money movement; purely closes an observability/audit gap