### PR TITLE
fix(transaction): announce the COMPLETED to REVERSED transition

### DIFF
--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/TransactionEventPublisher.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/TransactionEventPublisher.kt
@@ -19,6 +19,9 @@ interface TransactionEventPublisher {
 
     fun failedPayload(transaction: Transaction, reason: String): String
 
+    /** #8745: the COMPLETED → REVERSED terminal transition event. */
+    fun reversedPayload(transaction: Transaction, reason: String): String
+
     /** ADR-0108: settlement proof event with journalId for scheme reconciliation. */
     fun settledPayload(transaction: Transaction, journalId: java.util.UUID): String
 }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -78,6 +78,7 @@ class TransactionService(
 
     companion object {
         private const val TRANSACTION_INITIATED_EVENT = "openbank.transactions.transaction.initiated"
+        private const val TRANSACTION_REVERSED_EVENT = "openbank.transactions.transaction.reversed"
         // The completed/failed event types moved with the terminal write into
         // PaymentActivitiesImpl (#4238) — they are emitted by the workflow, not by this caller.
 
@@ -270,8 +271,20 @@ class TransactionService(
             "Cannot reverse transaction ${original.id}: no source account"
         }
 
-        // Mark original as reversed; no domain event — the reversal transaction carries the audit trail
-        transactionRepository.update(original.reverse())
+        // Mark original as reversed AND announce it (#8745 finding 1): this was the only terminal
+        // transition with no event — the reversal's transaction.initiated announces THAT a reversal
+        // happened, but a consumer projecting status held the ORIGINAL at COMPLETED permanently.
+        // The row and the outbox event commit atomically (update's two-arg overload), the same
+        // transactional-outbox shape the workflow's terminal writes use.
+        val reversed = original.reverse()
+        transactionRepository.update(
+            reversed,
+            OutboxMessage(
+                aggregateId = reversed.id,
+                eventType = TRANSACTION_REVERSED_EVENT,
+                payload = eventPublisher.reversedPayload(reversed, command.reason),
+            ),
+        )
 
         // Initiate reversal credit — flows through the normal saga as an incoming credit
         // (sourceAccountId=null → no balance cover needed; DEBIT cash-clearing, CREDIT deposit-control)

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/event/TransactionEvents.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/event/TransactionEvents.kt
@@ -68,3 +68,23 @@ data class TransactionFailedEvent(
     override val aggregateType = "Transaction"
     override val eventType = "TransactionFailed"
 }
+
+/**
+ * #8745 finding 1: the COMPLETED → REVERSED transition was the only terminal status change with
+ * no event — the reversal's own `transaction.initiated` announces THAT a reversal happened but
+ * (before #8841's linkage) could not say WHAT it reversed, so a consumer projecting status held
+ * the original at COMPLETED permanently. Carries the operator's reason, mirroring
+ * [TransactionFailedEvent].
+ */
+data class TransactionReversedEvent(
+    override val aggregateId: UUID,
+    override val version: Long,
+    val referenceNumber: String,
+    val reason: String,
+    override val occurredAt: Instant,
+    /** See [TransactionInitiatedEvent.sourceService] (#3994/#5256). */
+    val sourceService: String = "transaction-service",
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "Transaction"
+    override val eventType = "TransactionReversed"
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/messaging/LoggingTransactionEventPublisher.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/messaging/LoggingTransactionEventPublisher.kt
@@ -9,6 +9,7 @@ import com.openbank.transaction.application.port.out.TransactionEventPublisher
 import com.openbank.transaction.domain.event.TransactionCompletedEvent
 import com.openbank.transaction.domain.event.TransactionFailedEvent
 import com.openbank.transaction.domain.event.TransactionInitiatedEvent
+import com.openbank.transaction.domain.event.TransactionReversedEvent
 import com.openbank.transaction.domain.event.TransactionSettledEvent
 import com.openbank.transaction.domain.model.Transaction
 import jakarta.enterprise.context.ApplicationScoped
@@ -53,6 +54,17 @@ class LoggingTransactionEventPublisher(private val objectMapper: ObjectMapper, p
 
     override fun failedPayload(transaction: Transaction, reason: String): String = objectMapper.writeValueAsString(
         TransactionFailedEvent(
+            aggregateId = transaction.id,
+            version = transaction.version,
+            referenceNumber = transaction.referenceNumber,
+            reason = reason,
+            occurredAt = Instant.now(clock),
+            sourceService = SOURCE_SERVICE,
+        ),
+    )
+
+    override fun reversedPayload(transaction: Transaction, reason: String): String = objectMapper.writeValueAsString(
+        TransactionReversedEvent(
             aggregateId = transaction.id,
             version = transaction.version,
             referenceNumber = transaction.referenceNumber,

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -465,10 +465,12 @@ class TransactionServiceTest {
 
         coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
         coEvery {
-            transactionRepository.update(match { it.status == TransactionStatus.REVERSED })
+            transactionRepository.update(match { it.status == TransactionStatus.REVERSED }, any())
         } answers { firstArg() }
         coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returnsMany listOf(null, null)
         every { eventPublisher.initiatedPayload(any()) } returns "{}"
+        // #8745: the COMPLETED -> REVERSED transition now carries an outbox event.
+        every { eventPublisher.reversedPayload(any(), any()) } returns "{\"event\":\"reversed\"}"
         stubWorkflowCommitted(TransactionStatus.COMPLETED)
         // The original is read by id too; the reversal credit's own reload comes from the stub above.
         coEvery { transactionRepository.findById(original.id) } returns original
@@ -482,7 +484,12 @@ class TransactionServiceTest {
         // #8841: the reversal must say WHAT it reversed — the id is available at the call site.
         assertThat(result.reversalOf).isEqualTo(original.id)
         assertThat(result.isReversal).isTrue()
-        coVerify { transactionRepository.update(match { it.status == TransactionStatus.REVERSED }) }
+        coVerify {
+            transactionRepository.update(
+                match { it.status == TransactionStatus.REVERSED },
+                match { it.eventType == "openbank.transactions.transaction.reversed" },
+            )
+        }
     }
 
     @Test

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionReversalLinkIT.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionReversalLinkIT.kt
@@ -84,6 +84,18 @@ class TransactionReversalLinkIT {
                 assertThat(rs.next()).isTrue()
                 assertThat(rs.getBoolean("is_reversal")).isFalse()
             }
+            // #8745: the COMPLETED -> REVERSED transition announces itself — the outbox row
+            // committed atomically with the status flip (transactional outbox, ADR-0049).
+            conn.createStatement().executeQuery(
+                "SELECT payload FROM transaction_outbox " +
+                    "WHERE aggregate_id = '$originalId' " +
+                    "AND event_type = 'openbank.transactions.transaction.reversed'",
+            ).use { rs ->
+                assertThat(rs.next())
+                    .describedAs("transaction.reversed outbox row for the original")
+                    .isTrue()
+                assertThat(rs.getString("payload")).contains("TransactionReversed")
+            }
         }
     }
 }


### PR DESCRIPTION
Refs #8745 (finding 1 of the outbox-asymmetry sweep). Stacks on the merged #8841 linkage fix.

## Root cause
`reverseTransaction` flipped the original to REVERSED with the 1-arg `update()` — the only terminal transition with no outbox event (`PaymentActivitiesImpl` emits completed/failed via the 2-arg form). The reversal transaction announces `transaction.initiated`, but nothing announced the **original** leaving COMPLETED, so any consumer projecting status off `openbank.transactions.*` held it at COMPLETED permanently. The in-code justification ("the reversal transaction carries the audit trail") did not hold: `TransactionInitiatedEvent` had no field referencing the original (until #8841) and no `description`.

## Fix
- New `TransactionReversedEvent` (mirrors `TransactionFailedEvent`: aggregateId, version, referenceNumber, reason, occurredAt, sourceService) on `openbank.transactions.transaction.reversed`.
- The flip commits row + outbox atomically via the 2-arg `update()` — the fleet transactional-outbox shape.

## Tests
- Use-case test: verifies the 2-arg update carries the `…transaction.reversed` event type.
- `TransactionReversalLinkIT`: real REST reverse → asserts the outbox row for the original exists with a `TransactionReversed` payload.

Local gate green: `test ktlintCheck detekt koverVerify`.

## Security checklist
- [x] No secrets, credentials, or PII added (reason string mirrors the existing failed-event shape)
- [x] Input validation unchanged
- [x] No new outbound edges — existing outbox topic family
- [x] Money-path change is purely additive observability; no control removed