### PR TITLE
fix(lending): correct the 44 epoch-stamped outbox rows and guard the column

### DIFF
--- a/openbank-lending-service/src/main/resources/db/migration/V16__outbox_created_at_plausible.sql
+++ b/openbank-lending-service/src/main/resources/db/migration/V16__outbox_created_at_plausible.sql
@@ -1,0 +1,24 @@
+-- #9003: 44 of 45 lending_outbox rows on the sandbox carry created_at/updated_at/sent_at of
+-- 1970-01-01 — the #3272 defect class (toEntity() assigning over the column DEFAULT) from before
+-- OutboxMessage.createdAt gained its Instant.now() default. No src/main construction site passes
+-- an explicit createdAt today (grep-verified), so this migration is the data half plus the guard.
+--
+-- Data: the rows are all SENT, so correcting them changes no pending dispatch order; leaving them
+-- would keep 44 epoch rows sorting ahead of real work forever (dispatcher claims ORDER BY
+-- created_at ASC) and landing in the 1970-01 bronze_events partition if ever replayed into the
+-- warehouse. Their true business time is unrecoverable — the honest value is the correction
+-- instant, and this UPDATE is itself the audit trail of that.
+UPDATE lending_outbox
+SET created_at = NOW(),
+    updated_at = NOW(),
+    sent_at = NOW()
+WHERE created_at < TIMESTAMPTZ '2020-01-01';
+
+-- Guard (the issue's suggested work item 3): no outbox row may be inserted with a created_at
+-- older than any plausible service lifetime. Decidable, cheap, and would have caught both this
+-- and #3272 at INSERT time instead of in a warehouse partition.
+--
+-- Rollback: ALTER TABLE lending_outbox DROP CONSTRAINT IF EXISTS lending_outbox_created_at_plausible;
+ALTER TABLE lending_outbox
+    ADD CONSTRAINT lending_outbox_created_at_plausible
+    CHECK (created_at >= TIMESTAMPTZ '2020-01-01');

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/LendingOutboxWriteIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/LendingOutboxWriteIT.kt
@@ -159,13 +159,18 @@ class LendingOutboxWriteIT {
 
         dataSource.connection.use { conn ->
             conn.prepareStatement(
-                "SELECT event_type, payload FROM lending_outbox WHERE aggregate_id = ?",
+                "SELECT event_type, payload, created_at FROM lending_outbox WHERE aggregate_id = ?",
             ).use { ps ->
                 ps.setObject(1, UUID.fromString(loanId))
                 ps.executeQuery().use { rs ->
                     assertThat(rs.next()).describedAs("a lending_outbox row for loan $loanId").isTrue()
                     assertThat(rs.getString("event_type")).isEqualTo("loan.disbursed")
                     assertThat(rs.getString("payload")).contains(loanId)
+                    // #9003 falsification: do not accept "the default is Instant.now()" as proof —
+                    // assert the row that lands through the REAL emitter is not epoch-stamped
+                    // (44 of 45 sandbox rows carried 1970-01-01, the #3272 defect class).
+                    assertThat(rs.getTimestamp("created_at").toInstant())
+                        .isAfter(java.time.Instant.parse("2020-01-01T00:00:00Z"))
                 }
             }
         }


### PR DESCRIPTION
Refs #9003 (closes the code+data half; the sandbox row correction lands with the deploy).

## What
44 of 45 `lending_outbox` rows carried 1970-01-01 — the #3272 defect class recurring in lending. Two consequences the issue names: epoch rows sort permanently ahead of real work in dispatcher claims (`ORDER BY created_at ASC`), and a replay would land them in the 1970-01 `bronze_events` partition, 56 years from where the provisioning events belong.

## Verified first: the live half is closed
No `src/main` construction site of `OutboxMessage` passes an explicit `createdAt` anywhere in the fleet (grep-verified); `LendingOutboxMessage` is a typealias of the shared `OutboxMessage` whose default is now `Instant.now()` with the #3272 KDoc.

## Fix (V16)
- `UPDATE` the epoch rows to the correction instant (they are all `SENT`; true business time is unrecoverable and the UPDATE is itself the audit trail).
- `CHECK (created_at >= 2020-01-01)` — the issue's suggested guard, turning a future epoch row into an INSERT-time error.

## Falsification honoured (not "the default is now()")
`LendingOutboxWriteIT` now asserts the row written through the real emitter has `created_at > 2020-01-01`. Migration validated standalone on a fresh PostgreSQL 16 container: all 16 migrations apply cleanly, the CHECK rejects a 1970 insert, accepts the default `now()` insert.

## Local-env caveat
The lending IT suite could not finish locally: this machine runs ~8 Gradle daemons for parallel sessions and Quarkus boot died on OIDC/Vert.x timeouts twice (Flyway connected and applied without error). CI runs the real gate.

## Security checklist
- [x] No secrets, credentials, or PII added
- [x] No validation loosened — a DB constraint added
- [x] No new outbound edges
- [x] Data correction touches only demonstrably-wrong rows (created_at < 2020), all SENT
