### PR TITLE
fix(onboarding): an APPROVED kyc no longer moves the funnel board backwards

### DIFF
--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/OnboardingRecord.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/OnboardingRecord.kt
@@ -63,11 +63,21 @@ enum class FunnelStage {
             party == PartyStage.SUSPENDED || party == PartyStage.CLOSED -> BLOCKED
             party == PartyStage.ACTIVE && scaEnrolled -> ACTIVE
             party == PartyStage.ACTIVE && !scaEnrolled -> SCA_PENDING
-            kyc == KycStage.UNDER_REVIEW -> KYC_UNDER_REVIEW
-            kyc == KycStage.DOCUMENTS_REQUIRED -> KYC_DOCUMENTS_REQUIRED
-            kyc == KycStage.OPEN || kyc == null -> KYC_OPEN
-            kyc == KycStage.REJECTED || kyc == KycStage.EXPIRED -> BLOCKED
-            else -> REGISTERED
+            else ->
+                // Exhaustive on purpose (#8951): the previous catch-all `else -> REGISTERED` is
+                // the actual root cause — APPROVED had no branch and fell through to the FIRST
+                // funnel column, so the board moved a customer backwards at the exact moment
+                // their KYC was approved (APPROVED + not-yet-ACTIVE is the normal ordering:
+                // kyc-service approves, party-service activates afterwards). A new KycStage
+                // value is now a compile error here, not a silent fall-through.
+                when (kyc) {
+                    null, KycStage.OPEN -> KYC_OPEN
+                    KycStage.DOCUMENTS_REQUIRED -> KYC_DOCUMENTS_REQUIRED
+                    // APPROVED stays in the KYC column until party activation — KYC_OPEN would
+                    // lie (the KYC is not open) and there is no KYC_APPROVED board column.
+                    KycStage.UNDER_REVIEW, KycStage.APPROVED -> KYC_UNDER_REVIEW
+                    KycStage.REJECTED, KycStage.EXPIRED -> BLOCKED
+                }
         }
     }
 }

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
@@ -50,6 +50,29 @@ class OnboardingProjectionServiceTest {
     }
 
     @Test
+    fun `an APPROVED kyc on a not-yet-active party stays in the KYC column`(): Unit = runBlocking {
+        // #8951: APPROVED + PENDING_KYC is the NORMAL ordering (kyc-service approves,
+        // party-service activates afterwards) — it used to fall through the catch-all else to
+        // REGISTERED, moving the funnel board BACKWARDS at the moment of approval.
+        assertThat(FunnelStage.derive(PartyStage.PENDING_KYC, KycStage.APPROVED, false))
+            .isEqualTo(FunnelStage.KYC_UNDER_REVIEW)
+        assertThat(FunnelStage.derive(PartyStage.PENDING_KYC, KycStage.APPROVED, true))
+            .isEqualTo(FunnelStage.KYC_UNDER_REVIEW)
+    }
+
+    @Test
+    fun `derive never produces REGISTERED - the funnel only moves forward from it`(): Unit = runBlocking {
+        // REGISTERED is the initial stage written at PartyCreated; no derive() input may map
+        // back onto it. Totality over the three dimensions.
+        val produced = PartyStage.entries.flatMap { party ->
+            (KycStage.entries.toList() + null).flatMap { kyc ->
+                listOf(false, true).map { sca -> FunnelStage.derive(party, kyc, sca) }
+            }
+        }
+        assertThat(produced).doesNotContain(FunnelStage.REGISTERED)
+    }
+
+    @Test
     fun `derive returns SCA_PENDING for ACTIVE party without device`(): Unit = runBlocking {
         assertThat(FunnelStage.derive(PartyStage.ACTIVE, KycStage.APPROVED, false))
             .isEqualTo(FunnelStage.SCA_PENDING)


### PR DESCRIPTION
Closes #8951

## Root cause
`FunnelStage.derive` had branches for five of six `KycStage` values — **APPROVED had none**, so `APPROVED` + not-yet-`ACTIVE` party (the *normal* ordering: kyc-service approves, party-service activates afterwards) fell through `else -> REGISTERED`, the first funnel column. The board moved a customer backwards at the exact moment of approval.

## Fix (issue's option 1)
- `APPROVED → KYC_UNDER_REVIEW`: `KYC_OPEN` would lie (the KYC is not open); a new `KYC_APPROVED` stage is a board/admin-ui change nobody asked for.
- The kyc dimension is now an **exhaustive `when`** — the catch-all `else` on a closed enum was the actual root cause; the next `KycStage` value is a compile error, not a silent fall-through.

## Tests
- APPROVED stays in the KYC column for a non-active party (both `scaEnrolled` states).
- Totality: `derive` never produces `REGISTERED` for any combination of the three dimensions — it is written once at `PartyCreated` and the funnel only moves forward.

Local: unit tests + ktlint + detekt green. IT suite could not finish locally (machine saturated by parallel agent sessions; the single failure is a 58s SocketTimeout in `OnboardingStageFilterIT`, pre-existing env flake) — CI runs the real gate.

## Security checklist
- [x] No secrets, credentials, or PII
- [x] No validation changed; pure domain derivation fix
- [x] No new outbound edges
- [x] Customer-facing correctness fix (board no longer regresses on approval)
