### PR TITLE
fix(infra): accept cosign's buildInvocationID casing in the SLSA Kyverno policy

### DIFF
--- a/openbank-infra/gitops/components/kyverno/verify-slsa-provenance-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/verify-slsa-provenance-policy.yaml
@@ -93,6 +93,18 @@ spec:
                     # and unguessable from the image, so NotEquals empty is the decidable check;
                     # per-run binding is the deploy pipeline's job (post-attest verify), not
                     # admission's.
-                    - key: "{{ metadata.buildInvocationId }}"
+                    # CASING (2026-09-07, sandbox): cosign does not embed the SLSA predicate
+                    # verbatim — it parses it into its Go struct and re-marshals, and the
+                    # struct's json tag is `buildInvocationID` (capital D), not the SLSA v0.2
+                    # spec spelling `buildInvocationId`. Verified with
+                    # `cosign download attestation` on a live image: metadata keys are exactly
+                    # [buildInvocationID, completeness, reproducible]. The CI-side verify
+                    # binding learned this in #8892; this policy did not, so its JMESPath
+                    # answered "failed to resolve metadata.buildInvocationId" for EVERY
+                    # correctly-attested image (admin-ui sandbox-8adcc1946 included) and the
+                    # policy could never have graduated to Enforce. The `||` fallback keeps
+                    # the spec-spelled key accepted for any future producer that embeds the
+                    # predicate verbatim; same fallback idiom as tool-ingress-gate-policy.yaml.
+                    - key: "{{ metadata.buildInvocationID || metadata.buildInvocationId }}"
                       operator: NotEquals
                       value: ""


### PR DESCRIPTION
## Defect 1 (fixed here) — SLSA provenance policy JMESPath casing

`verify-slsa-provenance-policy.yaml` keyed its invocation-identity condition on
`{{ metadata.buildInvocationId }}` (SLSA v0.2 spec spelling). Live verification on
sandbox today against admin-ui `sandbox-8adcc1946`:

```
cosign download attestation …/openbank-admin-ui:sandbox-8adcc1946
→ predicate.metadata keys = ["buildInvocationID", "completeness", "reproducible"]
```

cosign does not embed the predicate verbatim: it parses it into its Go struct and
re-marshals, and the struct's json tag is `buildInvocationID` (capital D). Kyverno's
JMESPath therefore answered "failed to resolve metadata.buildInvocationId" for EVERY
correctly-attested image — the policy is Audit-only so it only poisoned PolicyReports,
but it could never have graduated to Enforce. Commit 1ef14c5a4 (#8892) fixed the
CI-side verify binding for exactly this casing; the Kyverno policy was missed.

Fix: `{{ metadata.buildInvocationID || metadata.buildInvocationId }}` — the `||`
fallback idiom already used in `tool-ingress-gate-policy.yaml`, and mirroring the
CI side's jq `(.buildInvocationId // .buildInvocationID)`. The comment above the
condition now documents the casing lesson.

## Defect 2 (no change needed in git — drift suspected live) — negative-result cache poisoning

Read both Enforce policies fully before touching anything, per the task. **Both already
carry `useCache: false`** with the race documented:

- `verify-images-policy.yaml` (verify-openbank-image-signatures): `useCache: false` since
  the 2026-07-09 incident — concurrent verifyImages goroutines racing on the ECR credential
  temp file, loser's transient failure cached as a real result.
- `verify-sbom-attestation-policy.yaml` (verify-openbank-image-sbom-attestation): same-day
  mirror fix, `useCache: false`, with the billing-service repeat-denial documented.

So the 2026-09-07 admin-ui `sandbox-8adcc1946` "cache entry found" / "unverified image"
sequence happened **despite git carrying the fix** — which means the live ClusterPolicy
objects in the cluster do not match git (the `useCache` field was added after those objects
were last applied, or ArgoCD drifted them). The remediation there is operational, not a code
change: force a sync/refresh of the kyverno policies application (or `kubectl apply` the two
files) and confirm `kubectl get clusterpolicy … -o jsonpath='{…useCache}'` reads false on both
Enforce policies. Worth a one-line runbook note; I have no cluster access from this session to
verify the drift directly.

## Verification

- YAML parse of all three kyverno policy files: OK
- `check-gitops-duplicate-resources.py --enforce`: OK (723 manifests)
- Casing evidence: `cosign download attestation` metadata keys quoted above; CI-side dual-casing
  handling already exists in `openbank-infra/scripts/lib/cosign-attest.sh` (#8892)

Refs #8590
