### PR TITLE
fix(libs): strip the openbank- prefix from the kyb topic-producer row

### DIFF
--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/KybAnalyticsIngestTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/KybAnalyticsIngestTest.kt
@@ -36,7 +36,13 @@ class KybAnalyticsIngestTest {
     fun `a kyb record attributes to the kyb service without an override`() {
         assertThat(TopicAttribution.domainOf("openbank.kyb.events")).isEqualTo("kyb")
         assertThat(TopicAttribution.aggregateType("openbank.kyb.events")).isEqualTo("KYB")
-        assertThat(TopicAttribution.sourceService("openbank.kyb.events")).isEqualTo("openbank-kyb-service")
+        // NOT "openbank-kyb-service": TopicProducers.sourceService (delegated to here) strips the
+        // module prefix like every other row, per its own documented rule and per
+        // check-source-service-convention.py -- and KybEvent.SOURCE_SERVICE, what kyb-service
+        // actually stamps in the body, is "kyb-service" too. This test's earlier value was wrong,
+        // and TopicProducersTest's "no row carries the openbank- prefix" was the invariant that
+        // caught it (issue found 2026-09-07).
+        assertThat(TopicAttribution.sourceService("openbank.kyb.events")).isEqualTo("kyb-service")
     }
 
     @Test

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/analytics/TopicProducers.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/analytics/TopicProducers.kt
@@ -132,11 +132,15 @@ object TopicProducers {
         // openbank-engagement-service/src/main/resources/application.yaml -> engagement-events-out.
         "openbank.engagement.events" to "engagement-service",
         // ADR-0284 D8: openbank-kyb-service/src/main/resources/application.yaml -> kyb-events-out.
-        // Kept WITH the "openbank-" prefix, unlike every row above, because
-        // KybAnalyticsIngestTest.kt already pins this exact value ("a kyb record attributes to
-        // the kyb service without an override") and that test predates this table -- matching it
-        // here is correct, not a case of the stripped-prefix rule being violated by accident.
-        "openbank.kyb.events" to "openbank-kyb-service",
+        // This row is pointless in practice, per the rule above: KybEvent.SOURCE_SERVICE stamps
+        // "kyb-service" in every event body, so the fallback below never fires for this topic.
+        // It stays anyway as a documented producer, WITHOUT the prefix like every other row --
+        // an earlier revision kept it WITH the prefix, on the mistaken belief that
+        // KybAnalyticsIngestTest.kt's "a kyb record attributes to the kyb service without an
+        // override" pinned this table. It pins TopicAttribution.sourceService, a different
+        // object (openbank-analytics-sink), which happens to delegate here -- so that test was
+        // itself asserting the wrong value, not evidence for keeping one. Fixed together.
+        "openbank.kyb.events" to "kyb-service",
     )
 
     /** Topics with a verified producer entry. Visible for coverage tests. */


### PR DESCRIPTION
## Summary

`TopicProducersTest`'s own invariant ("no row carries the openbank- prefix") has been red on `main` since #8920 landed both the table and that test in the same commit. Path-scoped CI never caught it because `openbank-libs-domain` only builds when that module's own directory changes or on a code-global (full-fleet) trigger. Found while an unrelated PR touching `openbank-libs-runtime` triggered exactly that full-fleet build.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] chore (build / tooling)
- [ ] docs
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8920

## Changes

- `TopicProducers.kt` — the kyb row loses the `openbank-` prefix, matching every other row and the table's own documented rule (enforced fleet-wide by `check-source-service-convention.py`).
- `KybAnalyticsIngestTest.kt` — its assertion is corrected to match, with the misdiagnosis it was based on rewritten in the comment.

## Why the prefixed value was wrong, not just inconsistent

The row's comment cited `KybAnalyticsIngestTest.kt` as evidence the prefix was correct. That test asserts `TopicAttribution.sourceService` in `openbank-analytics-sink`, a different object that happens to delegate straight through to `TopicProducers.sourceService` — so the two ARE linked, and the comment was right about that, wrong about which side was authoritative.

Checked against the producer itself rather than assumed: `openbank-kyb-service`'s `KybEvent.SOURCE_SERVICE` — what it actually stamps into every event body — is `"kyb-service"`, no prefix. This table's own row is a fallback that never fires for kyb anyway (the body already carries the field), which is exactly the "harmless but pointless" case the table's own KDoc describes for a producer that self-stamps.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — no import added.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural) — comment corrected in place.

`openbank-libs-domain`'s and `openbank-analytics-sink`'s own test suites are the verification; both modules build on this PR.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [x] No auth / crypto / payment code changed: the delegation-service commit is test-only (fixes a wall-clock time bomb in `SpendReservationServiceTest`, cherry-picked from #9086); the kyb-prefix commit touches a fallback-attribution string, never a decision path.
- [x] No PII path changed.
- [x] No cardholder-data path changed.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

This is a fallback-attribution string for analytics/audit event rows, not a new data category or processing purpose.

## Rollout / Rollback

- Deployment strategy: no runtime change — pure library code, exercised only by tests.
- Rollback plan: revert; the table returns to the (broken) prefixed value.
- Data migration reversible: N/A — this fallback has never fired for kyb events, since the producer self-stamps the field.

## Reviewer notes

Found and fixed while unblocking an unrelated PR (#9025) whose full-fleet trigger surfaced this pre-existing red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

