### PR TITLE
fix(campaign): configure REST client URLs under quarkus.rest-client

### DIFF
--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -46,6 +46,36 @@ quarkus:
     credentials:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
 
+  # REST clients. The URL MUST live under `quarkus.rest-client.<configKey>.url` — this is the
+  # only key `@RegisterRestClient(configKey = ...)` reads.
+  #
+  # This service previously declared the URLs as bare top-level keys (`consent-service.url`,
+  # `incentive-service.url`). Quarkus does not read those for a REST client, so every client here
+  # was built with no base URL and threw from `RestClientCDIDelegateBuilder.configureBaseUrl` on
+  # first use. Both call sites catch broadly and fail closed, so the failure surfaced as
+  # "credit consent unreadable for party … treating as absent" for EVERY party, and an enrolment
+  # sweep reporting `{"enrolled":0}` — indistinguishable from an empty segment. Found by running a
+  # real campaign in sandbox, not by any test: the tests inject the ports directly and never
+  # exercise this configuration.
+  #
+  # The env var names are unchanged, so the Deployment needs no edit; only the key they land on
+  # moves. lending-service's own application.yaml already uses this shape.
+  rest-client:
+    consent-service:
+      url: ${CONSENT_SERVICE_URL:http://localhost:8106}
+      connect-timeout: 2000
+      read-timeout: 3000
+    incentive-service:
+      url: ${INCENTIVE_SERVICE_URL:http://localhost:8156}
+      connect-timeout: 2000
+      read-timeout: 3000
+    # ADR-0269 rule 2 (#8918). Short read timeout: this sits in the send path and a slow refusal
+    # must not hold a journey open.
+    lending-service:
+      url: ${LENDING_SERVICE_URL:http://lending-service.lending.svc:8126}
+      connect-timeout: 2000
+      read-timeout: 3000
+
   # Health probes and the Prometheus scrape live on the management interface, not the
   # application port — the Deployment probes /q/health/{live,ready} on 8085 and the
   # PodMonitor scrapes the same port. Without this block nothing listens there, so the
@@ -108,16 +138,6 @@ openbank:
     quiet-hours-start: ${CAMPAIGN_QUIET_HOURS_START:21}
     quiet-hours-end: ${CAMPAIGN_QUIET_HOURS_END:8}
     consent-grantee: party-service:marketing-comms
-
-consent-service:
-  url: http://localhost:8106
-
-incentive-service:
-  url: ${INCENTIVE_SERVICE_URL:http://localhost:8156}
-
-# ADR-0269 rule 2 (#8918): the credit distress floor, asked per credit send.
-lending-service:
-  url: ${LENDING_SERVICE_URL:http://lending-service.lending.svc:8126}
 
 analytics:
   clickhouse-url: ${CLICKHOUSE_URL:http://localhost:8123}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/RestClientUrlConfiguredTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/RestClientUrlConfiguredTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.yaml.snakeyaml.Yaml
+import java.io.File
+
+/**
+ * Every `@RegisterRestClient(configKey = "x")` must have `quarkus.rest-client.x.url` configured.
+ *
+ * ## Why this exists
+ *
+ * This service declared its client URLs as BARE TOP-LEVEL keys — `consent-service.url`,
+ * `incentive-service.url`. Quarkus does not read those for a REST client; it reads only
+ * `quarkus.rest-client.<configKey>.url`. So every client was built with no base URL and threw from
+ * `RestClientCDIDelegateBuilder.configureBaseUrl` the first time it was used.
+ *
+ * Both call sites catch broadly and fail closed, which is right — and which is exactly why nothing
+ * went red. The failure surfaced in production as `credit consent unreadable for party …; treating
+ * as absent` for EVERY party, and an enrolment sweep answering `{"enrolled":0}`: indistinguishable
+ * from an empty segment unless you read the logs.
+ *
+ * No existing test could have caught it. They all inject the ports directly, so the Quarkus
+ * configuration is never exercised — the seam that broke is the one the tests replace. This test
+ * therefore checks the CONFIGURATION rather than the behaviour, because that is where the defect
+ * lives.
+ */
+class RestClientUrlConfiguredTest {
+
+    /** Gradle runs tests with the module as the working directory; a root-level run needs the suffix. */
+    private val moduleRoot = File("").absoluteFile.let { cwd ->
+        if (cwd.name == MODULE) cwd else File(cwd, MODULE)
+    }
+
+    @Test
+    fun `every RegisterRestClient configKey has a quarkus rest-client url`() {
+        val configKeys = File(moduleRoot, "src/main/kotlin").walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { CONFIG_KEY.findAll(it.readText()).map { m -> m.groupValues[1] } }
+            .toSortedSet()
+
+        // Guard the guard: if the scan finds nothing, the assertion below passes vacuously and this
+        // test would report success while checking no clients at all.
+        assertThat(configKeys)
+            .describedAs("no @RegisterRestClient(configKey=...) found — the scan is broken, not the config")
+            .isNotEmpty()
+
+        @Suppress("UNCHECKED_CAST")
+        val yaml = Yaml().load<Map<String, Any?>>(File(moduleRoot, "src/main/resources/application.yaml").readText())
+        val restClient = ((yaml["quarkus"] as? Map<String, Any?>)?.get("rest-client") as? Map<String, Any?>).orEmpty()
+
+        val missing = configKeys.filter { key ->
+            val entry = restClient[key] as? Map<*, *>
+            entry?.get("url")?.toString().isNullOrBlank()
+        }
+
+        assertThat(missing)
+            .describedAs(
+                "these REST clients have no `quarkus.rest-client.<key>.url`, so they build with no base " +
+                    "URL and throw on first use — a bare top-level `<key>.url` does NOT count",
+            )
+            .isEmpty()
+    }
+
+    private companion object {
+        const val MODULE = "openbank-campaign-service"
+        val CONFIG_KEY = Regex("""@RegisterRestClient\s*\(\s*configKey\s*=\s*"([^"]+)"""")
+    }
+}


### PR DESCRIPTION
## What broke

Campaign-service declared its REST client URLs as **bare top-level keys** — `consent-service.url`, `incentive-service.url`, `lending-service.url`.

Quarkus does not read those for a REST client. `@RegisterRestClient(configKey = "x")` reads **only** `quarkus.rest-client.x.url`. Every client in this service was built with no base URL and threw from `RestClientCDIDelegateBuilder.configureBaseUrl` on first use.

`consent-service` was doubly broken: besides the wrong key, its URL was hardcoded to `http://localhost:8106` and ignored the `CONSENT_SERVICE_URL` the Deployment has been setting all along.

## Why nothing went red

Both call sites catch broadly and **fail closed** — which is the correct behaviour, and exactly why this stayed invisible. It surfaced only as:

```
WARN  credit consent unreadable for party 5e3d6411-…; treating as absent
POST /api/v1/campaigns/{id}/enrol  ->  {"enrolled":0,"failed":0}
```

`{"enrolled":0}` is indistinguishable from an empty segment unless you read the service logs. Found by running a real campaign in sandbox, not by any test.

This is what blocked the ADR-0269 rule 2 end-to-end verification (#8918): no party could clear the rule 1 enrolment gate, so the delivery-time distress gate was never reached.

## Blast radius

Env var names are unchanged, so **the Deployment needs no edit and no NetworkPolicy edge moves** — only the config key they land on. `lending-service`'s own `application.yaml` already uses this shape.

## The guard

`RestClientUrlConfiguredTest` scans the sources for every `@RegisterRestClient(configKey = ...)` and asserts each has a `quarkus.rest-client.<key>.url`.

It checks the **configuration**, not the behaviour, because that is where the defect lives: the existing tests inject the ports directly, so the seam that broke is precisely the one they replace. No behavioural test in this module could have caught this.

## Falsification

Not just observed green — both failure modes were forced:

| Sabotage | Result |
|---|---|
| drop `lending-service.url` from the yaml | `AssertionError: … Expecting empty but was: ["lending-service"]` |
| break the source-scan regex | `AssertionError: no @RegisterRestClient(configKey=...) found — the scan is broken, not the config` |

The second matters most: without that emptiness assertion the test would pass vacuously at exactly the moment it stopped working.

Module suite: **277 tests, 0 failures**; `ktlintCheck` and `detekt` clean.

## Follow-up, not in this PR

`INCENTIVE_SERVICE_URL` is **not set in the campaign Deployment at all**, so the incentive client falls back to `localhost:8156` in-cluster. Pre-existing and not regressed here; fixing it needs a NetworkPolicy edge plus a regen, so it gets its own issue.

Refs #8918