### PR TITLE
fix(analytics): attribute kyb events to "kyb-service", matching what the service emits

### DIFF
--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/KybAnalyticsIngestTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/KybAnalyticsIngestTest.kt
@@ -36,7 +36,10 @@ class KybAnalyticsIngestTest {
     fun `a kyb record attributes to the kyb service without an override`() {
         assertThat(TopicAttribution.domainOf("openbank.kyb.events")).isEqualTo("kyb")
         assertThat(TopicAttribution.aggregateType("openbank.kyb.events")).isEqualTo("KYB")
-        assertThat(TopicAttribution.sourceService("openbank.kyb.events")).isEqualTo("openbank-kyb-service")
+        // Stripped, matching KybEvent.SOURCE_SERVICE — the value the service actually emits. The
+        // fallback must agree with the producer, or an event missing the field is attributed
+        // under a second spelling.
+        assertThat(TopicAttribution.sourceService("openbank.kyb.events")).isEqualTo("kyb-service")
     }
 
     @Test

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/analytics/TopicProducers.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/analytics/TopicProducers.kt
@@ -132,11 +132,12 @@ object TopicProducers {
         // openbank-engagement-service/src/main/resources/application.yaml -> engagement-events-out.
         "openbank.engagement.events" to "engagement-service",
         // ADR-0284 D8: openbank-kyb-service/src/main/resources/application.yaml -> kyb-events-out.
-        // Kept WITH the "openbank-" prefix, unlike every row above, because
-        // KybAnalyticsIngestTest.kt already pins this exact value ("a kyb record attributes to
-        // the kyb service without an override") and that test predates this table -- matching it
-        // here is correct, not a case of the stripped-prefix rule being violated by accident.
-        "openbank.kyb.events" to "openbank-kyb-service",
+        // Stripped like every row above. This row briefly carried the "openbank-" prefix, justified
+        // by KybAnalyticsIngestTest pinning that spelling -- but the justification had the facts
+        // backwards: the service itself emits KybEvent.SOURCE_SERVICE = "kyb-service", so the
+        // prefixed fallback would have attributed the SAME producer under a second spelling on any
+        // event that arrived without the field. That split is the whole reason this table exists.
+        "openbank.kyb.events" to "kyb-service",
     )
 
     /** Topics with a verified producer entry. Visible for coverage tests. */


### PR DESCRIPTION
**main is red** on `openbank-libs-domain`: `TopicProducersTest > no row carries the openbank- prefix`
fails on the one row that does. Every PR touching libs-domain inherits it — #8909 is stuck behind
this and the delegation clock bomb (#9093).

## Two same-day changes, each green alone

| | |
|---|---|
| **#8880** | added `"openbank.kyb.events" to "openbank-kyb-service"`, with a comment defending the prefix because `KybAnalyticsIngestTest` pinned that spelling |
| **#8920** | gave the table one definition and added the test forbidding the prefix outright |

## The defence had the facts backwards

That is why this is a fix rather than an exemption:

- the service emits **`KybEvent.SOURCE_SERVICE = "kyb-service"`** — stripped, like the other 31 rows
  and like `check-source-service-convention.py` requires (#5256, #5902);
- the table is only the **fallback**, used when an event arrives without the field
  (`AnalyticsConsumer:240`).

So the prefixed row could only ever attribute the **same producer under a second spelling** — exactly
the split this table exists to end, and which `bronze_events` already carries evidence of.

## Alternatives considered and rejected

- **Exempt the row in `TopicProducersTest`.** Smallest diff, and my first instinct — but it makes the
  split permanent and leaves the fallback disagreeing with the producer's own data.
- **Change the test alone.** Leaves the table wrong.

`ADR-0284` names `openbank-kyb-service` as the module / bounded context, never as the attribution
value. The fleet's one documented deviation (lending emits `"lending"`) concerns an *emitted* value
and is recorded in that service's `CLAUDE.md`; kyb's emitted value already follows the convention, so
there is nothing to preserve.

## Not claimed

That no `openbank-kyb-service` rows exist in ClickHouse. Only events missing the field could have
taken the fallback and #8880 merged hours ago — but if any exist, that is a data clean-up, not a
reason to keep the code inconsistent.

## Falsified

Restoring the prefix reddens **exactly two** tests, one from each side of the coupling:

```
FAIL  [openbank-libs-domain]    no row carries the openbank- prefix()
FAIL  [openbank-analytics-sink] a kyb record attributes to the kyb service without an override()
```

Nothing else moves.

## Verified

libs-domain **511 tests / 0 failures**, analytics-sink **115 tests / 0 failures**, ktlint clean,
exit code measured on the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The change is a service
      NAME in an attribution table — no customer data of any kind.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification. None added.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → **No.** `TopicProducers` is a reporting-attribution
      lookup: it labels which service produced an event. It authorises nothing, moves nothing, and
      is not read on any payment path.
- [x] PII path changed? → No. `source_service` is a service name, not a subject.
- [x] Cardholder data path changed? → No.

**Stated rather than ticked away:** this does change a value written to ClickHouse
(`source_service`) for kyb events that arrive without the field. That is the point — the value it
wrote was inconsistent with what the service itself emits. Whether any such rows already exist is
not something this PR can see; if they do, it is a data clean-up, and leaving the code inconsistent
would keep producing them.
