### PR TITLE
fix(ci): guarantee PR_DIFF_BASE is diffable, not merely fetched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,30 @@ jobs:
             echo "::warning::merge-base against origin/${BASE_REF} did not resolve after deepening; falling back to the event base.sha, which is stale for a PR that has absorbed main since opening"
             base="${EVENT_BASE_SHA}"
           fi
+          # Every gate runs `git diff "${PR_DIFF_BASE}...HEAD"`, and the THREE-DOT form needs the
+          # merge-base of the two — not merely the base object. In a shallow checkout those are
+          # different properties: measured 2026-09-07 against this remote, with the base fetched by
+          # sha and `git cat-file -e` answering yes, `git diff A...HEAD` still exits 128 while
+          # `A..HEAD` works, because the shared history is cut. Deepening is what fixes it: after
+          # `--deepen`, merge-base resolves and the three-dot diff succeeds.
+          #
+          # So the invariant to guarantee here is `git merge-base <base> HEAD` resolving, and the
+          # bug this replaces is that the fallback above sets a base without re-checking it. Three
+          # gates then died with `exit status 128` and the runner rendered each as that gate's
+          # FINDING rather than an error — credential-deadline-ratchet, adversarial-contract-test
+          # and security-checklist-money-path all reported plausible, actionable defects on
+          # #9077/#9086/#9098 having evaluated nothing (issue #9100).
+          if ! git merge-base "${base}" HEAD >/dev/null 2>&1; then
+            echo "merge-base ${base}..HEAD does not resolve yet — unshallowing so gates can diff."
+            git fetch -q --unshallow origin 2>/dev/null || git fetch -q --deepen=2000 origin 2>/dev/null || true
+          fi
+          if ! git merge-base "${base}" HEAD >/dev/null 2>&1; then
+            echo "::error::No merge-base between ${base} and HEAD in this checkout, so every gate that"
+            echo "::error::diffs against PR_DIFF_BASE would exit 128 and be reported as a FINDING."
+            echo "::error::This is a checkout/fetch failure, not a policy violation. Re-run the job, or"
+            echo "::error::merge origin/${BASE_REF} into the branch so the base is in its own history."
+            exit 1
+          fi
           echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           echo "PR_DIFF_BASE=${base}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
fix(ci): guarantee PR_DIFF_BASE is diffable, not merely fetched

Three gates reported substantive findings today having evaluated nothing:
`credential-deadline-ratchet`, `adversarial-contract-test` and
`security-checklist-money-path`, on #9077, #9086 and #9098. Each runs
`git diff "${PR_DIFF_BASE}...HEAD"`, each died with

  subprocess.CalledProcessError: ... returned non-zero exit status 128

and the runner rendered the non-zero exit as that gate's finding: a missing
rotation deadline, a contract test with no negative case, a PR body missing its
Security checklist. All three were false, and all three named a plausible fix,
which is what makes this expensive — I rewrote a PR body to satisfy one of them
before reading the job log (#9100).

The cause is in the fallback here. When the deepen loop cannot resolve a
merge-base it sets `base="${EVENT_BASE_SHA}"` and never re-checks it; #9077's log
shows exactly that, `PR diff base` equal to `event base.sha`.

What the guard has to assert took a falsification to get right. The obvious check
— is the base object present — is the WRONG property, measured against this remote
in a depth-1 clone:

  git fetch --depth=1 origin <sha>   -> object arrives
  git cat-file -e <sha>^{commit}     -> yes
  git diff <sha>...HEAD              -> STILL exit 128
  git diff <sha>..HEAD               -> works

Three-dot needs the merge-base of the two commits, not the base object, and in a
shallow checkout the shared history is cut. Deepening is what fixes it: after
`--deepen`, `git merge-base` resolves and the three-dot diff succeeds. My first
version of this patch asserted object presence and would have passed while every
gate still crashed.

So: assert `git merge-base <base> HEAD` resolves, unshallow if it does not, and
fail the step with an explicit "checkout/fetch failure, not a policy violation"
if it still cannot — once, here, rather than as N mystery findings downstream.

Refs #9100

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## How the mechanism was established

All of it measured against this remote, in a throwaway `--depth=1` clone, not reasoned:

| step | result |
|---|---|
| `git cat-file -e <base>^{commit}` before fetch | no |
| `git fetch --depth=1 origin <base>` | object arrives (GitHub allows reachable-SHA1-in-want) |
| `git cat-file -e <base>^{commit}` after | **yes** |
| `git diff <base>...HEAD` | **exit 128** |
| `git diff <base>..HEAD` | works |
| `git merge-base <base> HEAD` | empty |
| `git fetch --deepen=400 origin` | — |
| `git merge-base <base> HEAD` | resolves |
| `git diff <base>...HEAD` | **OK** |

The row that matters is the fourth: the base object being present does not make the three-dot diff
work, so a presence check is a guard that passes while every gate still crashes.

## Verified by effect, on real PRs

The workaround this replaces — merging `origin/main` into the branch, which puts the base in the
branch's own history — cleared all three gates on both of my affected PRs: #9086 went from two
crashing gates to `fail=0`, #9098 from `credential-deadline-ratchet` to only the quota-limited
`dependency-review`. That is the same invariant this patch establishes in the workflow instead of by
hand, per PR.

## Not covered here

The per-script half of #9100 still stands: `credential-inventory.py` and the two checkers should
catch `CalledProcessError` and exit with a message that says the base is unreachable, so a future
cause cannot render as a finding either. This PR removes today's cause; that would remove the
class. `check-fleet-attestations.sh` is the model — it already separates "registry/credential/tooling
failure — this says NOTHING about whether these images are attested" from a real finding.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. None.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. None.
- [x] No new third-party dependency. None.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. **No.** One workflow
      step; no service code. It makes gates *more* likely to run rather than less: the step now fails
      closed when no gate could have evaluated anything, where before it handed them an unusable base.
- [x] PII path changed? → tag `gdpr-review-required`. **No.**
- [x] Cardholder data path changed? → tag `pci-review-required`. **No.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
