### PR TITLE
fix(campaign): ask for credit consent under the grantee the customer granted it to

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/consent/ConsentClient.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/consent/ConsentClient.kt
@@ -77,10 +77,36 @@ class LiveConsentCheckAdapter(
     @RestClient private val client: ConsentServiceClient,
     @ConfigProperty(name = "openbank.campaign.consent-grantee", defaultValue = "party-service:marketing-comms")
     private val grantee: String,
+    @ConfigProperty(name = "openbank.campaign.credit-consent-grantee", defaultValue = "openbank")
+    private val creditGrantee: String,
 ) : ConsentCheckPort {
 
+    /**
+     * The grantee is a property of WHOM the customer granted the consent to, so it follows the
+     * scope rather than the caller.
+     *
+     * Marketing scopes are granted to the comms service (`party-service:marketing-comms`). The
+     * ADR-0269 credit scopes are not: the customer grants those to the BANK, and customer-edge
+     * writes them under `BANK_GRANTEE = "openbank"` (CustomerEdgeResource). This adapter asked
+     * for every scope under the marketing grantee, so the CREDIT_OFFERS lookup queried a
+     * (party, grantee, scope) triple that customer-edge never writes and consent-service will
+     * never hold.
+     *
+     * The rule 1 enrolment gate therefore could not see the switch the customer actually flips.
+     * It failed closed, so it never surfaced as a customer harm — it surfaced as a credit
+     * campaign that enrols nobody, `{"enrolled":0}`, which is indistinguishable from an empty
+     * segment. Verified in sandbox: every CREDIT_* row in consent-service carries
+     * `grantee_id = openbank`, and none carries the marketing grantee.
+     */
+    private fun granteeFor(scope: String): String =
+        if (scope.startsWith(CREDIT_SCOPE_PREFIX)) creditGrantee else grantee
+
     override suspend fun hasActiveConsent(partyId: UUID, scope: String): Boolean =
-        client.hasActiveConsent(partyId, grantee, scope).awaitSuspending().granted
+        client.hasActiveConsent(partyId, granteeFor(scope), scope).awaitSuspending().granted
+
+    private companion object {
+        const val CREDIT_SCOPE_PREFIX = "CREDIT_"
+    }
 }
 
 /**

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/consent/ConsentClientTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/consent/ConsentClientTest.kt
@@ -23,7 +23,7 @@ class ConsentClientTest {
         val client = mockk<ConsentServiceClient>()
         every { client.hasActiveConsent(partyId, "campaign", "MARKETING_COMMS_EMAIL") } returns
             Uni.createFrom().failure(IllegalStateException("consent unavailable"))
-        val adapter = LiveConsentCheckAdapter(client, "campaign")
+        val adapter = LiveConsentCheckAdapter(client, "campaign", "openbank")
 
         assertThatThrownBy {
             runBlocking { adapter.hasActiveConsent(partyId, "MARKETING_COMMS_EMAIL") }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/consent/LiveConsentCheckAdapterTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/consent/LiveConsentCheckAdapterTest.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.consent
+
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The consent grantee must follow the SCOPE, not the caller.
+ *
+ * customer-edge writes the ADR-0269 credit consents under the bank grantee (`openbank`), because
+ * that is who the customer grants them to. This adapter asked for every scope under the marketing
+ * grantee, so the CREDIT_OFFERS lookup queried a (party, grantee, scope) triple that is never
+ * written. The rule 1 enrolment gate could not see the switch the customer flips; it failed
+ * closed, so it read as a credit campaign enrolling nobody rather than as an error.
+ *
+ * These tests assert the grantee actually SENT to consent-service, because that is the thing that
+ * was wrong. Asserting only the boolean would have passed throughout the defect.
+ */
+class LiveConsentCheckAdapterTest {
+
+    private val asked = mutableListOf<Triple<UUID, String, String>>()
+
+    private val client = object : ConsentServiceClient {
+        override fun hasActiveConsent(partyId: UUID, granteeId: String, scope: String): Uni<ConsentCheckResponse> {
+            asked += Triple(partyId, granteeId, scope)
+            // Granted only for the triple customer-edge actually writes.
+            val real = granteeId == BANK && scope.startsWith("CREDIT_")
+            return Uni.createFrom().item(ConsentCheckResponse(granted = real || granteeId == MARKETING))
+        }
+    }
+
+    private val adapter = LiveConsentCheckAdapter(client, MARKETING, BANK)
+
+    @Test
+    fun `credit scopes are asked under the bank grantee`() = runBlocking<Unit> {
+        val party = UUID.randomUUID()
+        val granted = adapter.hasActiveConsent(party, "CREDIT_OFFERS")
+
+        assertThat(asked).singleElement()
+            .describedAs("CREDIT_OFFERS must be looked up under the grantee customer-edge writes")
+            .isEqualTo(Triple(party, BANK, "CREDIT_OFFERS"))
+        assertThat(granted)
+            .describedAs("a consent the customer actually holds must read as granted")
+            .isTrue()
+    }
+
+    @Test
+    fun `marketing scopes keep the marketing grantee`() = runBlocking<Unit> {
+        val party = UUID.randomUUID()
+        adapter.hasActiveConsent(party, "MARKETING_EMAIL")
+
+        assertThat(asked).singleElement()
+            .describedAs("non-credit scopes must not be moved onto the bank grantee")
+            .isEqualTo(Triple(party, MARKETING, "MARKETING_EMAIL"))
+    }
+
+    private companion object {
+        const val MARKETING = "party-service:marketing-comms"
+        const val BANK = "openbank"
+    }
+}


### PR DESCRIPTION
## The defect

ADR-0269 rule 1 gates credit enrolment on the customer's `CREDIT_OFFERS` consent. **It could not see that consent**, because the two sides disagreed about the grantee:

- **customer-edge writes** the credit scopes under `BANK_GRANTEE = "openbank"` — the customer grants them to the *bank* (`CustomerEdgeResource.grantCreditScope`)
- **campaign-service asked** for every scope under `"party-service:marketing-comms"`

The `CREDIT_OFFERS` lookup therefore queried a `(party, grantee, scope)` triple that customer-edge never writes and consent-service will never hold.

Verified live in sandbox — one party, one scope, one instant:

```
grantee=openbank                      -> {"granted":true}
grantee=party-service:marketing-comms -> {"granted":false}
```

## Why nobody noticed

The gate **failed closed**, so this was never a customer harm. It presented as a credit campaign that enrols nobody — `{"enrolled":0}` — indistinguishable from an empty segment.

It was also hidden behind a second defect: #9095, where the REST client URLs sat on config keys Quarkus does not read, so the consent call could not complete at all. With that fixed, this became the remaining reason rule 1 refused everyone.

## The fix

The grantee is a property of **whom the consent was granted to**, so it follows the *scope*, not the caller. Marketing scopes keep the comms grantee; `CREDIT_*` resolves to a new `openbank.campaign.credit-consent-grantee`, defaulting to the bank grantee customer-edge already uses.

## Falsification

The tests assert the grantee **actually sent** to consent-service, not the returned boolean — a boolean assertion passes throughout this defect, because a lookup against the wrong grantee legitimately returns `false`.

Collapsing `granteeFor()` back to a single grantee fails with:

```
[CREDIT_OFFERS must be looked up under the grantee customer-edge writes]
expected: (…, openbank, CREDIT_OFFERS)
 but was: (…, party-service:marketing-comms, CREDIT_OFFERS)
```

The class also had to be checked for *collection*: written first as `fun x() = runBlocking { … }`, JUnit 5 never ran it and the suite reported green with no XML for the class.

Module suite: **278 tests, 0 failures**; `ktlintCheck` and `detekt` clean.

## End-to-end, live

Run in sandbox with this grantee applied as a config override on the running service (see #8918 for the full trace):

| product_kind | enrolled | send_log outcome |
|---|---|---|
| `UNSECURED` | **1** of 8 in segment | `SUPPRESSED_CREDIT_DISTRESS`, `channel` empty — nothing sent |
| `NONE` | **8** | `SUPPRESSED_QUIET_HOURS` |

8 vs 1 is rule 1 working positively: only one party in the segment holds `CREDIT_OFFERS`. The differing outcome shows the rule 2 gate is scoped to credit rather than a blanket refusal.

Honest limits of that run: the consent row was seeded directly into consent-service's database (the grant ceremony via the edge is **not** part of this evidence — OPA correctly refuses `consent.grant` on the bank grantee to any identity but the edge), and the lending gate answered `SIGNALS_UNAVAILABLE`, not `ARREARS` — so it demonstrates fail-closed, **not** the decision table.

Refs #8918