### PR TITLE
feat(transaction): serve merchant logos from this bank's own origin

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -153,7 +153,7 @@ line and needs its own review.
 | **I**nfo disclosure | Enrichment leaks a *cardholder's* whereabouts rather than a shop's | The catalogue has no customer-, card- or transaction-scoped column; a row is per merchant descriptor and identical for every customer who shopped there. Nothing customer-derived is written back |
 | **T**ampering | A wrong or planted catalogue row attributes a payment to the wrong business — a lever for social engineering ("your payment to X") or for hiding one | Rows arrive only by migration, never from a request. Lookup is an **exact** match on the normalised key: no fuzzy or prefix matching, so a near-name cannot inherit another merchant's identity. `description` is passed through unmodified, so the raw acquirer text remains available and authoritative |
 | **R**epudiation | A dispute is raised against a prettified name that does not appear on the acquirer record | Enrichment is display-only and additive. Disputes and SPAYD consume `description`, which this change does not touch; `source: ENRICHED` labels anything the bank resolved |
-| **S**poofing | `logoUrl` points at attacker-controlled content rendered inside the bank app | URLs are catalogue-controlled and expected to be on a bank-controlled CDN; there is no request path that can set one |
+| **S**poofing | `logoUrl` points at attacker-controlled content rendered inside the bank app | Since §4e the field is DERIVED and origin-relative — it can only ever address this service's own logo route, and the catalogue column an operator writes is provenance that customers never receive. The mitigation is now structural rather than an expectation about what operators type |
 | **D**oS | Enrichment adds a per-row query to every statement page | One query per page: descriptors are normalised, de-duplicated and fetched together, so cost is bounded by distinct merchants on the page, not row count |
 
 **DFD update:** none. Same caller, same endpoint, same authorisation; one additional read of a
@@ -178,6 +178,36 @@ lie about who the customer paid.
 | **I**nfo disclosure | The catalogue becomes a record of where a cardholder was | The table is keyed by acquirer descriptor and holds public business data only — nothing in it is keyed by customer, card or transaction, stated in both `V16__create_merchant_catalog.sql` and the entity KDoc. `GET /unmatched` returns raw descriptors and their counts, never the transactions or accounts they came from |
 | **D**oS | `GET /unmatched` scans the whole transactions table on every operator refresh | `recentDescriptions` is a bounded, ordered window — `scan` is clamped to `MAX_SCAN` (20 000) and page size to `MAX_PAGE_SIZE`, both server-side via `coerceIn`, so a caller cannot widen the query. It lives in `TransactionDescriptorRepository` rather than the domain repository, keeping catalogue curation off the transaction persistence port |
 | **E**oP | A viewer edits the catalogue | Read and write roles are separate: `list`/`unmatched` admit `VIEWER`, `upsert`/`delete` do not, and the OPA action differs too, so a viewer is denied at both layers |
+
+## 4e. Self-hosted merchant logos — STRIDE supplement
+
+`merchant_logo` stores the logo bitmaps and `GET|PUT|DELETE /api/v1/merchants/{descriptorKey}/logo`
+serves and maintains them. Two boundaries move: an operator can now upload **binary content that a
+customer's banking app renders**, and the statement response gained a URL that clients dereference.
+
+**The privacy decision this exists to implement.** The obvious alternative — putting a logo CDN's
+URL in the statement response — would make every render tell that host the customer's IP address
+and which merchant they paid, at the moment they open their transaction list. That is a spending
+profile reconstructable from a third party's access log, outside any consent or processor
+agreement, and it needs no compromise of anything: it is what the feature would do while working
+correctly. Serving the bytes from this origin removes the third party from the request path.
+
+| STRIDE | Threat | Mitigation |
+| --- | --- | --- |
+| **I**nfo disclosure | A logo request tells an external host who a customer paid | `MerchantResponse.logoUrl` is derived and origin-relative; it cannot be set from a request and cannot address another host. `merchant_catalog.logo_url` keeps the upstream URL for licence evidence and is returned only on the operator API |
+| **I**nfo disclosure | The stored image leaks whoever produced it — EXIF, GPS, embedded thumbnails | Only decoded pixels are kept. Re-encoding to a fresh PNG drops every metadata segment, because nothing but the raster is carried across |
+| **T**ampering | An upload carries script into an app that renders it — an SVG, or a polyglot with a payload appended after a valid image | Format is sniffed by magic number, so SVG and HTML are refused as not raster; anything after the image data does not survive the decode/re-encode. `LogoImagesTest` asserts each refusal, not the happy path |
+| **D**oS | A small upload declares an enormous canvas (a decompression bomb) and the decode allocates gigabytes, killing the pod | Dimensions are read from the header **before** any pixel buffer exists and refused above 4096 per side; uploads are capped at 512 kB; the served variants are pre-rendered, and `size` is an enumeration, so a caller cannot make the service resize on the request path |
+| **S**poofing | A planted logo attributes a payment to the wrong business more convincingly than a name alone | Write requires `Roles.OPERATOR`/`ADMIN` and OPA `merchant.update`; the row records `uploaded_by`, `source_url` and `licence`, which the catalogue text rows still do not (§4d's residual repudiation gap is narrower here, not closed elsewhere) |
+| **T**ampering | A cached wrong logo persists after correction, since the response is cached for a year | The URL carries a prefix of the content hash and the ETag is the hash, so replaced bytes are a different URL. Immutability is safe *because* of that, not despite it |
+| **E**oP | A viewer replaces a logo | Read and write split as in §4d: `merchant.list` for the GET, `merchant.update` / `merchant.delete` for the writes, and `VIEWER` holds only the first |
+
+**DFD update:** one new inbound binary write (operator → service) and one new authenticated read of
+static content. No new outbound edge — this service fetches nothing from the internet; bytes arrive
+only from an operator request.
+**Risk class:** content integrity of what a banking app renders, plus the privacy boundary above.
+**Rollback:** revert; `logoUrl` returns to null and the route disappears. The migration is additive,
+so the previous release runs unchanged against the new schema.
 
 ## 5. Residual risks / assumptions
 
@@ -216,6 +246,8 @@ lie about who the customer paid.
   this change is inert until a separately-approved cutover.
 
 ## 6. Change log
+
+- **2026-09-07** — Merchant logos are stored and served by this service (`merchant_logo`, `GET|PUT|DELETE /api/v1/merchants/{descriptorKey}/logo`), and `merchant.logoUrl` became a derived origin-relative path instead of a catalogue-controlled URL (§4e). Two boundaries moved: operator-uploaded binary content that a customer app renders, and a URL clients dereference. The design point is privacy — an external logo host would have learned each customer's IP together with the merchant they paid, every statement render. Uploads are re-encoded rather than stored, which is what refuses SVG/polyglots and strips EXIF; header dimensions are checked before any pixel buffer is allocated. Rollback: revert; the field returns to null and the additive migration can stay or be dropped.
 
 - **2026-09-05** — New inbound REST surface `MerchantCatalogResource` (`/api/v1/merchants`): list, an unmatched-descriptor worklist, upsert and delete, so the D5 catalogue §4c reads can actually be filled (#8573). New trust boundary crossing, hence §4d. No money path touched and no cardholder data added — the table stays keyed by acquirer descriptor. Residual gap recorded rather than papered over: the row records `updated_at` but not who edited it. Rollback: revert the commit; §4c degrades to the empty catalogue it reads today, which already renders the raw descriptor.
 

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -16,8 +16,8 @@
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, Store, Trash2, Plus } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -29,7 +29,10 @@ const CATALOGUE = '/api/v1/merchants'
 type Merchant = {
   descriptorKey: string
   cleanName: string
+  /** Provenance — where the stored bitmap came from. NOT the URL a customer app is given. */
   logoUrl?: string | null
+  /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
+  logoContentHash?: string | null
   category?: string | null
   lat?: number | null
   lon?: number | null
@@ -63,6 +66,7 @@ export default function MerchantsPage() {
   const [draft, setDraft] = useState<Draft | null>(null)
   const [saving, setSaving] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -132,6 +136,61 @@ export default function MerchantsPage() {
       })
       if (!res.ok && res.status !== 404) {
         setActionError(t('Smazání selhalo', 'Delete failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  // Client-side limits mirroring LogoImages on the service. Duplicated deliberately: the server
+  // is the enforcement point and rejects the same cases, but a 512 kB round trip to be told "too
+  // big" is a worse answer than an immediate one, and the operator is picking a file, not
+  // debugging an API.
+  const MAX_UPLOAD_BYTES = 512 * 1024
+  const ACCEPTED = 'image/png,image/jpeg,image/gif'
+
+  const uploadLogo = async (descriptorKey: string, file: File) => {
+    setActionError(null)
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setActionError(t(
+        `Soubor má ${Math.round(file.size / 1024)} kB, limit je ${MAX_UPLOAD_BYTES / 1024} kB.`,
+        `The file is ${Math.round(file.size / 1024)} kB; the limit is ${MAX_UPLOAD_BYTES / 1024} kB.`,
+      ))
+      return
+    }
+    setUploading(descriptorKey)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`, { licence: 'trademark' }),
+        { method: 'PUT', headers: { 'Content-Type': 'application/octet-stream' }, body: file },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { message?: string } | null
+        // The service says WHY it refused — not a raster format, implausible dimensions, no
+        // catalogue row. Passing that through is the difference between a fixable message and
+        // "upload failed".
+        setActionError(body?.message ?? t('Nahrání loga selhalo', 'The logo upload failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    } finally {
+      setUploading(null)
+    }
+  }
+
+  const removeLogo = async (descriptorKey: string) => {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`),
+        { method: 'DELETE' },
+      )
+      if (!res.ok && res.status !== 404) {
+        setActionError(t('Smazání loga selhalo', 'Deleting the logo failed'))
         return
       }
       await load()
@@ -246,6 +305,7 @@ export default function MerchantsPage() {
           <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
             <thead>
               <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
+                <th style={th} aria-label={t('Logo', 'Logo')} />
                 <th style={th}>{t('Descriptor', 'Descriptor')}</th>
                 <th style={th}>{t('Obchodní jméno', 'Trading name')}</th>
                 <th style={th}>{t('Kategorie', 'Category')}</th>
@@ -257,6 +317,7 @@ export default function MerchantsPage() {
             <tbody>
               {rows.map(m => (
                 <tr key={m.descriptorKey} style={{ borderTop: '1px solid var(--border)' }}>
+                  <td style={{ ...td, width: 44 }}><MerchantLogo merchant={m} /></td>
                   <td style={{ ...td, fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.descriptorKey}</td>
                   <td style={td}>{m.cleanName}</td>
                   <td style={td}>{m.category ?? '—'}</td>
@@ -280,6 +341,23 @@ export default function MerchantsPage() {
                     >
                       {t('Upravit', 'Edit')}
                     </button>{' '}
+                    <LogoButton
+                      merchant={m}
+                      busy={uploading === m.descriptorKey}
+                      accept={ACCEPTED}
+                      label={m.logoContentHash
+                        ? t(`Nahradit logo ${m.descriptorKey}`, `Replace the logo for ${m.descriptorKey}`)
+                        : t(`Nahrát logo ${m.descriptorKey}`, `Upload a logo for ${m.descriptorKey}`)}
+                      onPick={file => void uploadLogo(m.descriptorKey, file)}
+                    />{' '}
+                    {m.logoContentHash && <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => void removeLogo(m.descriptorKey)}
+                      aria-label={t(`Smazat logo ${m.descriptorKey}`, `Delete the logo for ${m.descriptorKey}`)}
+                    >
+                      <ImageOff size={12} aria-hidden="true" />
+                    </button>}{' '}
                     <button
                       type="button"
                       className="btn btn-secondary btn-sm"
@@ -292,7 +370,7 @@ export default function MerchantsPage() {
                 </tr>
               ))}
               {!loading && rows.length === 0 && (
-                <tr><td colSpan={6} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+                <tr><td colSpan={7} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                   {t('Katalog je prázdný', 'The catalogue is empty')}
                 </td></tr>
               )}
@@ -323,5 +401,90 @@ function Field({ label, value, onChange, mono }: {
         }}
       />
     </label>
+  )
+}
+
+/**
+ * The stored logo, or a monogram standing in for one that has not been ingested.
+ *
+ * The monogram is a UI affordance and NOT a fallback the customer app gets: absence stays absence
+ * on the wire (`merchant.logoUrl` is simply missing), because a placeholder rendered next to a
+ * payment reads as "this is the merchant's mark" when it is really "we have nothing". Here, on an
+ * operator screen whose whole purpose is to find the gaps, a monogram is exactly the right thing —
+ * it makes a missing logo visible at a glance instead of leaving an empty cell.
+ */
+function MerchantLogo({ merchant }: { merchant: Merchant }) {
+  const box = {
+    width: 32, height: 32, borderRadius: 8, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', border: '1px solid var(--border)', background: 'var(--surface-2)',
+    overflow: 'hidden', flexShrink: 0,
+  } as const
+  if (!merchant.logoContentHash) {
+    return (
+      <div style={box} aria-label={`${merchant.cleanName} — no logo`} title={`${merchant.cleanName} — no logo`}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-tertiary)' }}>
+          {merchant.cleanName.trim().charAt(0).toUpperCase() || '?'}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div style={box}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- the BFF proxies bytes from the
+          service; next/image would need a remote-pattern allowlist for a same-origin path it
+          cannot optimise anyway. */}
+      <img
+        src={svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(merchant.descriptorKey)}/logo`, {
+          size: '64',
+          // Same cache-busting token the service puts in the customer-facing URL: the browser may
+          // cache hard, and a replaced logo is a different URL rather than a stale one.
+          v: merchant.logoContentHash.slice(0, 16),
+        })}
+        alt={merchant.cleanName}
+        width={32}
+        height={32}
+        style={{ objectFit: 'contain' }}
+      />
+    </div>
+  )
+}
+
+/** A file picker dressed as a button — the row already has three, and a bare input breaks the row. */
+function LogoButton({ merchant, busy, accept, label, onPick }: {
+  merchant: Merchant
+  busy: boolean
+  accept: string
+  label: string
+  onPick: (file: File) => void
+}) {
+  const input = useRef<HTMLInputElement>(null)
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        disabled={busy}
+        aria-busy={busy}
+        aria-label={label}
+        title={label}
+        onClick={() => input.current?.click()}
+      >
+        <ImageUp size={12} aria-hidden="true" />
+      </button>
+      <input
+        ref={input}
+        type="file"
+        accept={accept}
+        data-testid={`logo-input-${merchant.descriptorKey}`}
+        style={{ display: 'none' }}
+        onChange={e => {
+          const file = e.target.files?.[0]
+          // Reset the input so picking the SAME file twice fires change again — an operator who
+          // re-crops and re-picks would otherwise get silence.
+          e.target.value = ''
+          if (file) onPick(file)
+        }}
+      />
+    </>
   )
 }

--- a/openbank-admin-ui/src/test/merchants-logo.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo.test.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import MerchantsPage from '@/app/merchants/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const HASH = 'a'.repeat(64)
+
+const withLogo = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: HASH }
+const withoutLogo = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+/**
+ * A fetch stub that records every call, so a test can assert what the page did NOT send — which is
+ * the only way to see a client-side guard working. One that merely checks the error message would
+ * pass just as well against a page that uploaded the file and rendered the server's complaint.
+ */
+function stubFetch(rows: unknown[], onWrite: () => Response = () => json({ contentHash: HASH }, 201)) {
+  const calls: Array<{ url: string; method: string }> = []
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), method: init?.method ?? 'GET' })
+    if (init?.method && init.method !== 'GET') return Promise.resolve(onWrite())
+    if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+    return Promise.resolve(json({ data: rows, total: rows.length }))
+  }))
+  return calls
+}
+
+const renderPage = () => render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+const pngFile = (bytes: number, name = 'logo.png') =>
+  new File([new Uint8Array(bytes)], name, { type: 'image/png' })
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('merchant logos', () => {
+  it('renders the stored logo through the BFF, cache-busted by the content hash', async () => {
+    stubFetch([withLogo])
+
+    renderPage()
+
+    const img = await screen.findByAltText('Billa') as HTMLImageElement
+    expect(img.src).toContain('/api/svc/transaction-service/api/v1/merchants/BILLA/logo')
+    expect(img.src).toContain('size=64')
+    // The token is what makes a year-long immutable cache safe: replaced bytes are a new URL.
+    expect(img.src).toContain(`v=${HASH.slice(0, 16)}`)
+  })
+
+  /**
+   * A merchant with no logo gets a monogram HERE and nothing at all on the customer path. The
+   * distinction is the point: on an operator screen whose job is to find the gaps a placeholder
+   * makes the gap visible, while next to a real payment it would read as the merchant's actual
+   * mark.
+   */
+  it('shows a monogram, not an image, for a merchant with no stored logo', async () => {
+    stubFetch([withoutLogo])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    expect(screen.queryByAltText('Alza.cz')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Alza.cz — no logo')).toBeInTheDocument()
+  })
+
+  it('uploads a picked file as raw bytes to the logo route', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(1024)] } })
+
+    await waitFor(() => expect(calls.some(c => c.method === 'PUT')).toBe(true))
+    const put = calls.find(c => c.method === 'PUT')!
+    expect(put.url).toContain('/api/v1/merchants/ALZACZ/logo')
+    // Reloaded afterwards, or the row would keep showing the monogram it just replaced.
+    expect(calls.filter(c => c.method === 'GET').length).toBeGreaterThan(2)
+  })
+
+  it('refuses an oversized file without sending it', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), {
+      target: { files: [pngFile(512 * 1024 + 1)] },
+    })
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('the limit is 512 kB'))
+    expect(calls.some(c => c.method === 'PUT')).toBe(false)
+  })
+
+  /**
+   * The service says WHY it refused — not a raster format, implausible dimensions, no catalogue
+   * row. Swallowing that for a generic "upload failed" would leave an operator with a file they
+   * cannot fix.
+   */
+  it('surfaces the service’s own rejection reason', async () => {
+    stubFetch([withoutLogo], () => json({ message: 'logo upload is not a PNG, JPEG or GIF image' }, 400))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(64)] } })
+
+    await waitFor(() => expect(screen.getByRole('alert'))
+      .toHaveTextContent('logo upload is not a PNG, JPEG or GIF image'))
+  })
+
+  it('offers logo removal only where a logo exists', async () => {
+    stubFetch([withLogo, withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Billa')).toBeInTheDocument())
+
+    expect(screen.getByLabelText('Delete the logo for BILLA')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete the logo for ALZACZ')).not.toBeInTheDocument()
+  })
+})

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/image/LogoImages.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/image/LogoImages.kt
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.image
+
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+import java.util.HexFormat
+import javax.imageio.ImageIO
+import javax.imageio.stream.MemoryCacheImageInputStream
+
+/**
+ * Turns an uploaded logo into the two square PNGs this service serves, or refuses it.
+ *
+ * **Re-encoding is the security control, not a convenience.** Bytes an operator supplies are
+ * rendered later inside a banking app next to a real transaction, so passing them through
+ * untouched would mean serving whatever was uploaded: an SVG (script-bearing), an HTML polyglot, a
+ * file with a PNG header and a payload after `IEND`, or an image carrying EXIF GPS from whoever
+ * photographed it. Decoding to pixels and writing a fresh PNG keeps only what an image actually
+ * is — a grid of colours — and drops every byte that was not part of it.
+ *
+ * **Dimensions are checked before the pixels are allocated.** A 40 kB PNG can declare
+ * 30000x30000, which is 3.6 GB of `int[]` the moment it is decoded — the classic decompression
+ * bomb, and an out-of-memory kill of the whole pod rather than a rejected request. The header is
+ * read on its own first, so an oversized declaration is a 400 that allocates nothing.
+ *
+ * Deliberately not in `domain`: this is I/O-shaped work over an image codec, and the domain layer
+ * here holds no framework or platform machinery (ADR-0002).
+ */
+object LogoImages {
+    /** The rendered variants, keyed by the pixel size a client asks for. */
+    const val SIZE_SMALL = 64
+    const val SIZE_LARGE = 128
+
+    /** Largest upload accepted. A brand logo that needs more than this is the wrong asset. */
+    const val MAX_UPLOAD_BYTES = 512 * 1024
+
+    /** Largest source dimension accepted, checked from the header before any decode. */
+    const val MAX_SOURCE_PIXELS = 4096
+
+    /** What a browser is told these bytes are, and what [render] always produces. */
+    const val CONTENT_TYPE = "image/png"
+
+    // Written as hex strings rather than byte literals so the signatures stay readable against the
+    // format specifications they come from.
+    private val PNG_MAGIC = HexFormat.of().parseHex("89504E470D0A1A0A")
+    private val JPEG_MAGIC = HexFormat.of().parseHex("FFD8FF")
+    private val GIF_MAGIC = HexFormat.of().parseHex("47494638")
+
+    /** A rejected upload and why, in a sentence an operator can act on. */
+    class RejectedException(message: String, cause: Throwable? = null) : IllegalArgumentException(message, cause)
+
+    /** The two variants plus the hash that identifies them. */
+    data class Rendered(val small: ByteArray, val large: ByteArray, val contentHash: String) {
+        // Data class over ByteArray: the generated equals/hashCode compare by reference, which is
+        // never what a caller means. Both are defined over contentHash, which identifies the
+        // pixels exactly and is what every other part of the system compares by.
+        override fun equals(other: Any?): Boolean = other is Rendered && other.contentHash == contentHash
+
+        override fun hashCode(): Int = contentHash.hashCode()
+    }
+
+    /**
+     * Decode [upload], scale it into both variants, and re-encode as PNG.
+     *
+     * @throws RejectedException when the upload is too large, is not one of the accepted raster
+     *   formats, declares implausible dimensions, or cannot be decoded as an image at all.
+     */
+    // Each throw below is a distinct, separately actionable rejection reason, and collapsing them
+    // into one would tell an operator only that the upload was refused.
+    @Suppress("ThrowsCount")
+    fun render(upload: ByteArray): Rendered {
+        if (upload.isEmpty()) throw RejectedException("logo upload is empty")
+        if (upload.size > MAX_UPLOAD_BYTES) {
+            throw RejectedException("logo upload is ${upload.size} bytes; the limit is $MAX_UPLOAD_BYTES")
+        }
+        // Sniff the real format rather than trusting a declared content type. SVG is refused here
+        // by construction: it is not a raster format, so it matches no magic number, and its
+        // scripting is why it must never reach a client.
+        if (!startsWith(upload, PNG_MAGIC) && !startsWith(upload, JPEG_MAGIC) && !startsWith(upload, GIF_MAGIC)) {
+            throw RejectedException("logo upload is not a PNG, JPEG or GIF image")
+        }
+        requirePlausibleDimensions(upload)
+
+        // A malformed or truncated file fails inside the codec as an IIOException. Left to
+        // propagate it is a 500 for what is plainly a bad upload, so it is translated here — the
+        // same reason the header check above translates its own IOException.
+        val source = try {
+            ImageIO.read(upload.inputStream())
+        } catch (e: java.io.IOException) {
+            throw RejectedException("logo upload could not be decoded as an image: ${e.message}", e)
+        } ?: throw RejectedException("logo upload could not be decoded as an image")
+
+        val large = encodePng(square(source, SIZE_LARGE))
+        val small = encodePng(square(source, SIZE_SMALL))
+        return Rendered(small = small, large = large, contentHash = sha256Hex(large))
+    }
+
+    /** Lower-case hex SHA-256, the form used for both the ETag and the URL cache-busting token. */
+    fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    /**
+     * Reads just the image header to learn the declared dimensions, and refuses an implausible one.
+     *
+     * `getWidth`/`getHeight` on a reader parse the header only — no pixel buffer is allocated —
+     * which is the entire point: the check has to happen before the decode it is protecting.
+     */
+    @Suppress("ThrowsCount")
+    private fun requirePlausibleDimensions(upload: ByteArray) {
+        MemoryCacheImageInputStream(upload.inputStream()).use { stream ->
+            val readers = ImageIO.getImageReaders(stream)
+            if (!readers.hasNext()) throw RejectedException("no image decoder recognises this upload")
+            val reader = readers.next()
+            try {
+                reader.setInput(stream, true, true)
+                val width = reader.getWidth(0)
+                val height = reader.getHeight(0)
+                if (width <= 0 || height <= 0) throw RejectedException("image declares a zero dimension")
+                if (width > MAX_SOURCE_PIXELS || height > MAX_SOURCE_PIXELS) {
+                    throw RejectedException(
+                        "image declares ${width}x$height; the limit is " +
+                            "${MAX_SOURCE_PIXELS}x$MAX_SOURCE_PIXELS",
+                    )
+                }
+            } catch (e: java.io.IOException) {
+                throw RejectedException("image header could not be read: ${e.message}", e)
+            } finally {
+                reader.dispose()
+            }
+        }
+    }
+
+    /**
+     * Fits [source] inside a transparent [size]x[size] canvas, preserving its aspect ratio.
+     *
+     * Fitting rather than cropping or stretching: a logo is a trademark, and a client renders these
+     * at icon size where a squashed or clipped wordmark is both ugly and, for the merchant, wrong.
+     * The padding is transparent so the icon sits on whatever background the app uses, in either
+     * theme.
+     */
+    private fun square(source: BufferedImage, size: Int): BufferedImage {
+        val scale = minOf(size.toDouble() / source.width, size.toDouble() / source.height)
+        val width = maxOf(1, Math.round(source.width * scale).toInt())
+        val height = maxOf(1, Math.round(source.height * scale).toInt())
+        val canvas = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
+        val g = canvas.createGraphics()
+        try {
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            g.drawImage(source, (size - width) / 2, (size - height) / 2, width, height, null)
+        } finally {
+            g.dispose()
+        }
+        return canvas
+    }
+
+    private fun encodePng(image: BufferedImage): ByteArray {
+        val out = ByteArrayOutputStream()
+        if (!ImageIO.write(image, "png", out)) throw RejectedException("PNG encoder is unavailable")
+        return out.toByteArray()
+    }
+
+    private fun startsWith(bytes: ByteArray, magic: ByteArray): Boolean =
+        bytes.size >= magic.size && magic.indices.all { bytes[it] == magic[it] }
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantCatalogEntity.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantCatalogEntity.kt
@@ -50,6 +50,16 @@ class MerchantCatalogEntity : PanacheEntityBase {
     @Column(name = "country")
     var country: String? = null
 
+    /**
+     * [MerchantLogoEntity.contentHash] when a logo has been ingested for this merchant, else null.
+     *
+     * Denormalised so the per-page enrichment read can decide whether to emit a logo URL without a
+     * join, and doubles as the cache-busting token in that URL — a corrected logo changes the hash,
+     * so clients pick it up immediately instead of after a cache TTL.
+     */
+    @Column(name = "logo_etag")
+    var logoEtag: String? = null
+
     @Column(name = "updated_at", nullable = false)
     var updatedAt: Instant = Instant.now()
 }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantLogoEntity.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantLogoEntity.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+/**
+ * The stored bitmaps for one merchant's logo, in the two sizes a client renders.
+ *
+ * Separate from [MerchantCatalogEntity] on purpose: the catalogue row is read for every statement
+ * page, and a `SELECT *` that drags a few kB of image bytes per merchant along with it would put
+ * the images on the enrichment critical path for the benefit of nobody — the page renders names
+ * and categories, and fetches each logo once, cached, over its own request.
+ *
+ * Whether a logo exists at all is answered without touching this table, by
+ * [MerchantCatalogEntity.logoEtag].
+ */
+@Entity
+@Table(name = "merchant_logo")
+class MerchantLogoEntity : PanacheEntityBase {
+    @Id
+    @Column(name = "descriptor_key")
+    var descriptorKey: String = ""
+
+    @Column(name = "bytes_64", nullable = false)
+    var bytes64: ByteArray = ByteArray(0)
+
+    @Column(name = "bytes_128", nullable = false)
+    var bytes128: ByteArray = ByteArray(0)
+
+    @Column(name = "content_type", nullable = false)
+    var contentType: String = ""
+
+    @Column(name = "content_hash", nullable = false)
+    var contentHash: String = ""
+
+    /** Where the bytes came from — provenance, never served to a customer client. */
+    @Column(name = "source_url")
+    var sourceUrl: String? = null
+
+    @Column(name = "licence")
+    var licence: String? = null
+
+    @Column(name = "attribution")
+    var attribution: String? = null
+
+    @Column(name = "uploaded_by")
+    var uploadedBy: String? = null
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.EPOCH
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantLogoEntity.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantLogoEntity.kt
@@ -55,5 +55,5 @@ class MerchantLogoEntity : PanacheEntityBase {
     var uploadedBy: String? = null
 
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: Instant = Instant.EPOCH
+    var updatedAt: Instant = Instant.now()
 }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/MerchantLogoRepository.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/MerchantLogoRepository.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.persistence.repository
+
+import com.openbank.transaction.infrastructure.persistence.entity.MerchantCatalogEntity
+import com.openbank.transaction.infrastructure.persistence.entity.MerchantLogoEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Stores and serves the merchant logo bitmaps.
+ *
+ * Every write also maintains [MerchantCatalogEntity.logoEtag], in the SAME transaction. That
+ * denormalised marker is what the enrichment read path consults, so letting the two drift would
+ * make the statement advertise a logo that 404s (or hide one that exists) — the marker is not a
+ * cache that can be rebuilt later, it is the only thing the hot path looks at.
+ */
+@ApplicationScoped
+class MerchantLogoRepository : PanacheRepositoryBase<MerchantLogoEntity, String> {
+
+    suspend fun findByKey(descriptorKey: String): MerchantLogoEntity? = Panache.withSession {
+        find("descriptorKey", descriptorKey).firstResult()
+    }.awaitSuspending()
+
+    /**
+     * Insert or replace one merchant's logo, returning true when it was newly created.
+     *
+     * Returns null when there is no catalogue row to attach it to. A logo for a merchant the
+     * catalogue does not know is unreachable — nothing would ever look it up — and the foreign key
+     * would reject it anyway; answering 404 says which of the two things to fix.
+     *
+     * The catalogue row is loaded through the same session rather than through
+     * `MerchantCatalogRepository`, whose methods open their own `Panache.withSession`. Managed here,
+     * the marker update is part of this transaction and flushes with it; routed through a second
+     * repository call it would be a separate unit of work that can succeed while this one rolls
+     * back.
+     */
+    suspend fun upsert(entity: MerchantLogoEntity): Boolean? = Panache.withTransaction {
+        Panache.getSession().flatMap { session ->
+            session.find(MerchantCatalogEntity::class.java, entity.descriptorKey).flatMap { merchant ->
+                if (merchant == null) {
+                    Uni.createFrom().nullItem()
+                } else {
+                    merchant.logoEtag = entity.contentHash
+                    find("descriptorKey", entity.descriptorKey).firstResult().flatMap { existing ->
+                        if (existing == null) {
+                            persist(entity).map { true }
+                        } else {
+                            existing.bytes64 = entity.bytes64
+                            existing.bytes128 = entity.bytes128
+                            existing.contentType = entity.contentType
+                            existing.contentHash = entity.contentHash
+                            existing.sourceUrl = entity.sourceUrl
+                            existing.licence = entity.licence
+                            existing.attribution = entity.attribution
+                            existing.uploadedBy = entity.uploadedBy
+                            existing.updatedAt = entity.updatedAt
+                            Uni.createFrom().item(false)
+                        }
+                    }
+                }
+            }
+        }
+    }.awaitSuspending()
+
+    /** Remove a merchant's logo and clear the catalogue marker with it, in one transaction. */
+    suspend fun deleteByKey(descriptorKey: String): Boolean = Panache.withTransaction {
+        Panache.getSession().flatMap { session ->
+            session.find(MerchantCatalogEntity::class.java, descriptorKey).flatMap { merchant ->
+                merchant?.logoEtag = null
+                delete("descriptorKey", descriptorKey).map { it > 0 }
+            }
+        }
+    }.awaitSuspending()
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/MerchantCatalogResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/MerchantCatalogResource.kt
@@ -7,8 +7,11 @@ package com.openbank.transaction.infrastructure.rest
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.security.Roles
 import com.openbank.transaction.domain.model.MerchantDescriptor
+import com.openbank.transaction.infrastructure.image.LogoImages
 import com.openbank.transaction.infrastructure.persistence.entity.MerchantCatalogEntity
+import com.openbank.transaction.infrastructure.persistence.entity.MerchantLogoEntity
 import com.openbank.transaction.infrastructure.persistence.repository.MerchantCatalogRepository
+import com.openbank.transaction.infrastructure.persistence.repository.MerchantLogoRepository
 import com.openbank.transaction.infrastructure.persistence.repository.TransactionDescriptorRepository
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
@@ -20,8 +23,13 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.CacheControl
+import jakarta.ws.rs.core.Context
+import jakarta.ws.rs.core.EntityTag
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Request
 import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.SecurityContext
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import java.time.Instant
@@ -52,6 +60,7 @@ import java.time.Instant
 class MerchantCatalogResource(
     private val catalog: MerchantCatalogRepository,
     private val transactions: TransactionDescriptorRepository,
+    private val logos: MerchantLogoRepository,
 ) {
 
     @GET
@@ -139,12 +148,133 @@ class MerchantCatalogResource(
         }
     }
 
+    /**
+     * The merchant's logo, as a square PNG.
+     *
+     * **Why this bank serves the bytes itself.** The alternative — putting a logo CDN's URL in the
+     * statement response and letting the app load it — hands that CDN the customer's IP address
+     * together with the merchant they paid, every time they open their transaction list. That is a
+     * spending profile leaving the bank through an `<img>` tag, with no consent and no contract
+     * covering it. The bytes are ingested once and served from here, so a logo tells nobody
+     * anything.
+     *
+     * Cached hard and keyed by content: the URL carries the content hash, so a corrected logo is a
+     * different URL and reaches clients immediately, and `If-None-Match` makes the repeat request a
+     * 304 with no body.
+     */
+    @GET
+    @Path("/{descriptorKey}/logo")
+    @Produces(LogoImages.CONTENT_TYPE)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "merchant.list", resource = "")
+    @Operation(summary = "The merchant's logo as a square PNG")
+    suspend fun logo(
+        @PathParam("descriptorKey") descriptorKey: String,
+        @QueryParam("size") @DefaultValue("64") size: Int,
+        @Context request: Request,
+    ): Response {
+        val key = MerchantDescriptor.normalise(descriptorKey)
+            ?: return badRequest("descriptorKey normalises to nothing identifying")
+        if (size != LogoImages.SIZE_SMALL && size != LogoImages.SIZE_LARGE) {
+            return badRequest("size must be ${LogoImages.SIZE_SMALL} or ${LogoImages.SIZE_LARGE}")
+        }
+        val logo = logos.findByKey(key) ?: return Response.status(Response.Status.NOT_FOUND).build()
+        val tag = EntityTag(logo.contentHash)
+        // Conditional first: an unchanged logo is by far the common case once an app has rendered
+        // the statement once, and a 304 costs no bytes on the wire.
+        request.evaluatePreconditions(tag)?.let { return it.cacheControl(immutable()).tag(tag).build() }
+        val bytes = if (size == LogoImages.SIZE_LARGE) logo.bytes128 else logo.bytes64
+        return Response.ok(bytes, logo.contentType)
+            .tag(tag)
+            .cacheControl(immutable())
+            .header("Content-Length", bytes.size)
+            .build()
+    }
+
+    /**
+     * Store or replace one merchant's logo from raw image bytes.
+     *
+     * The upload is decoded and re-encoded rather than stored as sent — see [LogoImages] for why
+     * that is the security boundary and not a nicety. Provenance travels with it: `sourceUrl`,
+     * `licence` and `attribution` record where a trademark came from and on what terms this bank
+     * may show it, which is the paperwork a logo needs and an image file does not carry.
+     */
+    @PUT
+    @Path("/{descriptorKey}/logo")
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "merchant.update", resource = "")
+    @Operation(summary = "Store or replace a merchant logo from raw image bytes")
+    @Suppress("LongParameterList")
+    suspend fun putLogo(
+        @PathParam("descriptorKey") descriptorKey: String,
+        @QueryParam("sourceUrl") sourceUrl: String?,
+        @QueryParam("licence") licence: String?,
+        @QueryParam("attribution") attribution: String?,
+        @Context security: SecurityContext,
+        upload: ByteArray?,
+    ): Response {
+        val key = MerchantDescriptor.normalise(descriptorKey)
+            ?: return badRequest("descriptorKey normalises to nothing identifying")
+        // Nullable on purpose: JAX-RS injects null for an absent body, and a non-nullable parameter
+        // would make that a 500 instead of the 400 it is (fleet rule, see the root CLAUDE.md).
+        val bytes = upload ?: return badRequest("request body is required and must be image bytes")
+        val rendered = try {
+            LogoImages.render(bytes)
+        } catch (e: LogoImages.RejectedException) {
+            return badRequest(e.message ?: "logo upload was rejected")
+        }
+        val entity = MerchantLogoEntity().also {
+            it.descriptorKey = key
+            it.bytes64 = rendered.small
+            it.bytes128 = rendered.large
+            it.contentType = LogoImages.CONTENT_TYPE
+            it.contentHash = rendered.contentHash
+            it.sourceUrl = sourceUrl?.trim()?.ifBlank { null }
+            it.licence = licence?.trim()?.ifBlank { null }
+            it.attribution = attribution?.trim()?.ifBlank { null }
+            it.uploadedBy = security.userPrincipal?.name
+            it.updatedAt = Instant.now()
+        }
+        val created = logos.upsert(entity)
+            ?: return Response.status(Response.Status.NOT_FOUND)
+                .entity(mapOf("message" to "no catalogue entry under key '$key' to attach a logo to"))
+                .build()
+        val status = if (created) Response.Status.CREATED else Response.Status.OK
+        return Response.status(status).entity(MerchantLogoResponse(key, rendered.contentHash)).build()
+    }
+
+    @DELETE
+    @Path("/{descriptorKey}/logo")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "merchant.delete", resource = "")
+    @Operation(summary = "Remove a merchant logo")
+    suspend fun deleteLogo(@PathParam("descriptorKey") descriptorKey: String): Response {
+        val key = MerchantDescriptor.normalise(descriptorKey)
+            ?: return badRequest("descriptorKey normalises to nothing identifying")
+        return if (logos.deleteByKey(key)) {
+            Response.noContent().build()
+        } else {
+            Response.status(Response.Status.NOT_FOUND).build()
+        }
+    }
+
+    /**
+     * A year, immutable. Safe only because the URL the client follows carries the content hash:
+     * new bytes are a new URL, so nothing cached can ever be stale.
+     */
+    private fun immutable(): CacheControl = CacheControl().also {
+        it.isPrivate = false
+        it.maxAge = LOGO_MAX_AGE_SECONDS
+    }
+
     private fun badRequest(message: String): Response =
         Response.status(Response.Status.BAD_REQUEST).entity(mapOf("message" to message)).build()
 
     private companion object {
         const val MAX_PAGE_SIZE = 200
         const val MAX_SCAN = 20_000
+        const val LOGO_MAX_AGE_SECONDS = 31_536_000
     }
 }
 
@@ -158,10 +288,19 @@ data class MerchantUpsertRequest(
     val country: String? = null,
 )
 
+/**
+ * One catalogue row as an operator sees it.
+ *
+ * [logoUrl] is PROVENANCE — where the stored bitmap was obtained — and is deliberately not what a
+ * customer client receives; that one is derived from [logoContentHash] and points at this service.
+ * [logoContentHash] is null exactly when no logo has been ingested, which is how the operator
+ * screen knows whether to offer "upload" or "replace".
+ */
 data class MerchantAdminResponse(
     val descriptorKey: String,
     val cleanName: String,
     val logoUrl: String?,
+    val logoContentHash: String?,
     val category: String?,
     val lat: Double?,
     val lon: Double?,
@@ -173,6 +312,9 @@ data class MerchantAdminResponse(
 data class MerchantPage(val data: List<MerchantAdminResponse>, val total: Long)
 
 data class UnmatchedDescriptor(val descriptorKey: String, val occurrences: Int)
+
+/** What a logo write returns: the key it landed under and the hash that now identifies its bytes. */
+data class MerchantLogoResponse(val descriptorKey: String, val contentHash: String)
 
 private fun MerchantUpsertRequest.toEntity(key: String) = MerchantCatalogEntity().also {
     it.descriptorKey = key
@@ -190,6 +332,7 @@ private fun MerchantCatalogEntity.toAdminResponse() = MerchantAdminResponse(
     descriptorKey = descriptorKey,
     cleanName = cleanName,
     logoUrl = logoUrl,
+    logoContentHash = logoEtag,
     category = category,
     lat = lat,
     lon = lon,

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
@@ -349,6 +349,13 @@ data class TransactionResponse(
  * and a head-office pin on a "where you spent" map would be fiction. [source] is always `ENRICHED`
  * here; the field exists so a client never has to infer whether a name is the bank's or the
  * acquirer's.
+ *
+ * [logoUrl] is ORIGIN-RELATIVE and always points back at whichever host served this response. That
+ * is the whole design: the catalogue also records where a logo was obtained from, and putting THAT
+ * URL here instead would make every statement render fire a request at a third-party CDN carrying
+ * the customer's IP address and the merchant they paid — a spending profile leaving the bank
+ * through an `<img>` tag. The bytes are ingested once and served from this bank's own origin, so
+ * the field is a path and never an external link.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class MerchantResponse(
@@ -361,9 +368,20 @@ data class MerchantResponse(
 
 data class MerchantGeoResponse(val lat: Double, val lon: Double, val city: String?, val country: String?)
 
+/**
+ * How much of the content hash goes in the logo URL. A 64-bit prefix: the token only has to
+ * distinguish one merchant's successive logos from each other, and a full hash makes every
+ * statement row longer for nothing.
+ */
+private const val LOGO_VERSION_CHARS = 16
+
 private fun MerchantCatalogEntity.toResponse() = MerchantResponse(
     cleanName = cleanName,
-    logoUrl = logoUrl,
+    // Null when no logo has been ingested — absence stays absence, and a client renders whatever
+    // it renders today. The hash makes the URL change whenever the bytes do, which is what lets
+    // the logo route answer with a year-long immutable cache and still correct a wrong logo the
+    // moment it is replaced.
+    logoUrl = logoEtag?.let { "/api/v1/merchants/$descriptorKey/logo?size=64&v=${it.take(LOGO_VERSION_CHARS)}" },
     category = category,
     // Both coordinates or neither — the column constraint enforces it, and this mirrors it so a
     // half-populated row can never become a pin at latitude 0.

--- a/openbank-transaction-service/src/main/resources/db/migration/V18__merchant_logo.sql
+++ b/openbank-transaction-service/src/main/resources/db/migration/V18__merchant_logo.sql
@@ -1,0 +1,50 @@
+-- Self-hosted merchant logos for transaction enrichment.
+--
+-- WHY THE BYTES LIVE HERE AND NOT AS A LINK TO SOMEBODY ELSE'S CDN.
+-- `merchant_catalog.logo_url` has been a nullable column since V16 and was never populated. The
+-- obvious way to populate it — point it at a logo CDN and let the customer's app load the image —
+-- is the one thing this must not do. Every such request tells that CDN the customer's IP address
+-- and which merchant they transacted with, at the moment they open their statement: the third
+-- party reconstructs a spending profile from nothing but its access log, and no consent covers it.
+-- So the bytes are ingested once, server-side, and served from this bank's own origin.
+--
+-- `logo_url` therefore changes meaning rather than getting populated: it records WHERE a logo was
+-- obtained (provenance and licence evidence), and is operator-facing only. The customer-facing
+-- `merchant.logoUrl` is derived from `logo_etag` below and always points at this service.
+CREATE TABLE merchant_logo (
+    descriptor_key VARCHAR(120) PRIMARY KEY REFERENCES merchant_catalog (descriptor_key) ON DELETE CASCADE,
+    -- Two pre-rendered square variants. A statement row renders at 64 CSS px (128 on a 2x screen),
+    -- and both are a few kB, so storing them beats resizing per request or shipping one large
+    -- image the client scales down.
+    bytes_64       BYTEA NOT NULL,
+    bytes_128      BYTEA NOT NULL,
+    -- Always image/png today. Carried explicitly rather than assumed, so adding a second output
+    -- format later is a value change and not a migration of every reader.
+    content_type   VARCHAR(40) NOT NULL,
+    -- SHA-256 (hex) of bytes_128. Serves as the HTTP ETag and as the cache-busting token in the
+    -- derived logoUrl, so a corrected logo reaches clients without any TTL having to expire.
+    content_hash   CHAR(64) NOT NULL,
+    -- Provenance. `source_url` is where the bytes came from, `licence` how they may be used, and
+    -- `attribution` the credit line a licence may require (ODbL and CC-BY sources do). A logo with
+    -- no recorded licence is a trademark this bank is republishing on nothing but hope.
+    source_url     VARCHAR(400),
+    licence        VARCHAR(60),
+    attribution    VARCHAR(200),
+    uploaded_by    VARCHAR(120),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT merchant_logo_bytes_64_size CHECK (octet_length(bytes_64) BETWEEN 1 AND 65536),
+    CONSTRAINT merchant_logo_bytes_128_size CHECK (octet_length(bytes_128) BETWEEN 1 AND 262144)
+);
+
+COMMENT ON TABLE merchant_logo IS
+    'Self-hosted merchant logo bitmaps. Served from this origin so no third party learns who a customer paid.';
+
+-- Presence marker on the catalogue row, so the enrichment read path — one query per statement
+-- page — never needs a join or a second round trip to decide whether a logo exists. NULL means no
+-- logo; the value is merchant_logo.content_hash and is maintained by the same write.
+ALTER TABLE merchant_catalog ADD COLUMN logo_etag CHAR(64);
+
+COMMENT ON COLUMN merchant_catalog.logo_url IS
+    'Provenance only: where the logo was obtained. Operator-facing, never sent to a customer client.';
+COMMENT ON COLUMN merchant_catalog.logo_etag IS
+    'merchant_logo.content_hash when a logo exists, else NULL. Denormalised for the per-page enrichment read.';

--- a/openbank-transaction-service/src/main/resources/db/migration/V18__merchant_logo.sql
+++ b/openbank-transaction-service/src/main/resources/db/migration/V18__merchant_logo.sql
@@ -1,3 +1,8 @@
+-- Rollback: DROP TABLE merchant_logo; ALTER TABLE merchant_catalog DROP COLUMN logo_etag;
+-- Both are additive, so the previous release runs unchanged against this schema and the rollback
+-- loses only the ingested bitmaps — every one of which can be re-uploaded, since the catalogue row
+-- and its provenance (merchant_catalog.logo_url) survive.
+--
 -- Self-hosted merchant logos for transaction enrichment.
 --
 -- WHY THE BYTES LIVE HERE AND NOT AS A LINK TO SOMEBODY ELSE'S CDN.

--- a/openbank-transaction-service/src/main/resources/openapi.yaml
+++ b/openbank-transaction-service/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   # Minor bump (1.11.0 -> 1.12.0): additive only — GET /approvals (the checker's queue, issue
   # #5679, mirroring sanctions' #3472) plus two additive fields on the PATCH .../approvals/{id}
   # response (makerId, createdAt). No breaking change.
-  version: 1.14.0
+  version: 1.15.0
   description: BIAN-aligned transaction history, search and retrieval.
   license:
     name: Apache-2.0
@@ -332,6 +332,100 @@ paths:
       responses:
         '204': {description: Entry removed}
         '404': {description: No entry under that key}
+  /api/v1/merchants/{descriptorKey}/logo:
+    get:
+      tags: [Merchant catalogue]
+      summary: The merchant's logo as a square PNG
+      description: >-
+        Served from this bank's own origin, which is the point of the endpoint existing at all: the
+        alternative — a logo CDN's URL in the statement response — tells that CDN the customer's IP
+        address and the merchant they paid, every time a transaction list renders. Cached for a
+        year and immutable, which is safe only because the URL clients follow carries the content
+        hash; new bytes are a new URL. Supports If-None-Match.
+      operationId: getMerchantLogo
+      parameters:
+        - name: descriptorKey
+          in: path
+          required: true
+          description: Raw or normalised acquirer descriptor; it is normalised the same way the lookup does.
+          schema: {type: string}
+        - name: size
+          in: query
+          description: Pixel size of the square variant. An enumeration, not a free number - the variants are pre-rendered.
+          schema: {type: integer, enum: [64, 128], default: 64}
+        - name: v
+          in: query
+          description: Cache-busting token echoed from the logoUrl the service issued. Ignored by the server.
+          schema: {type: string}
+      responses:
+        '200':
+          description: The logo bitmap
+          headers:
+            ETag: {schema: {type: string}}
+            Cache-Control: {schema: {type: string}}
+          content:
+            image/png:
+              schema: {type: string, format: binary}
+        '304': {description: The client's cached copy is current}
+        '400': {description: Key normalises to nothing, or an unsupported size}
+        '404': {description: No logo stored for this merchant}
+    put:
+      tags: [Merchant catalogue]
+      summary: Store or replace a merchant logo from raw image bytes
+      description: >-
+        The upload is decoded and re-encoded as PNG rather than stored as sent. That is a security
+        boundary, not a resize: it drops anything that was not part of the image — an appended
+        payload, embedded metadata — and refuses formats that can carry script (SVG) or that
+        declare implausible dimensions (a decompression bomb). Provenance query parameters record
+        where a trademark came from and on what terms it may be shown.
+      operationId: putMerchantLogo
+      parameters:
+        - name: descriptorKey
+          in: path
+          required: true
+          schema: {type: string}
+        - name: sourceUrl
+          in: query
+          description: Where the bytes were obtained. Recorded, never served to a customer client.
+          schema: {type: string}
+        - name: licence
+          in: query
+          description: Terms the logo may be shown under, e.g. "trademark", "CC-BY-4.0".
+          schema: {type: string}
+        - name: attribution
+          in: query
+          description: Credit line a licence requires, where it requires one.
+          schema: {type: string}
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema: {type: string, format: binary}
+      responses:
+        '200':
+          description: Logo replaced
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/MerchantLogoWritten'}
+        '201':
+          description: Logo stored
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/MerchantLogoWritten'}
+        '400': {description: Missing body, unsupported format, oversized upload, or implausible dimensions}
+        '404': {description: No catalogue entry under that key to attach a logo to}
+    delete:
+      tags: [Merchant catalogue]
+      summary: Remove a merchant logo
+      operationId: deleteMerchantLogo
+      parameters:
+        - name: descriptorKey
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        '204': {description: Logo removed}
+        '404': {description: No logo stored for this merchant}
   /api/v1/transactions/approvals:
     get:
       tags: [Transactions]
@@ -425,13 +519,30 @@ components:
       properties:
         descriptorKey: {type: string}
         cleanName: {type: string}
-        logoUrl: {type: string, nullable: true}
+        logoUrl:
+          type: string
+          nullable: true
+          description: >-
+            PROVENANCE — where the stored logo bitmap was obtained, for licence evidence. Operator
+            facing; this is not the URL a customer client receives.
+        logoContentHash:
+          type: string
+          nullable: true
+          description: >-
+            SHA-256 of the stored logo, or null when none has been ingested. Null is how the
+            operator screen knows to offer "upload" rather than "replace".
         category: {type: string, nullable: true}
         lat: {type: number, format: double, nullable: true}
         lon: {type: number, format: double, nullable: true}
         city: {type: string, nullable: true}
         country: {type: string, nullable: true}
         updatedAt: {type: string, format: date-time}
+    MerchantLogoWritten:
+      type: object
+      description: The key the logo landed under and the hash that now identifies its bytes.
+      properties:
+        descriptorKey: {type: string}
+        contentHash: {type: string}
     MerchantUpsert:
       type: object
       required: [cleanName]
@@ -610,7 +721,14 @@ components:
         logoUrl:
           type: string
           nullable: true
-          description: Bank-controlled CDN URL. Never a third-party hotlink (privacy + availability).
+          description: >
+            ORIGIN-RELATIVE path to the logo this bank serves itself, e.g.
+            "/api/v1/merchants/ALZACZ/logo?size=64&v=<hash>". Never a third-party URL: an external
+            logo host would learn the customer's IP address and the merchant they paid every time a
+            statement renders, which is a spending profile leaving the bank through an img tag. The
+            v token is a prefix of the image content hash, so replacing a logo changes the URL and
+            the response may be cached immutably. Absent when no logo has been ingested — render
+            what you render today, never a placeholder.
         category:
           type: string
           nullable: true

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/image/LogoImagesTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/image/LogoImagesTest.kt
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.image
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+/**
+ * These assert what [LogoImages] REFUSES, not what it accepts.
+ *
+ * The accept path is trivially visible — an image goes in, two PNGs come out — and would pass just
+ * as happily if every guard were deleted. What makes re-encoding a security control rather than a
+ * resize is that an SVG, a polyglot and a decompression bomb do not get through it, so each of
+ * those is a test that fails the moment the corresponding guard stops working.
+ */
+class LogoImagesTest {
+
+    private fun png(width: Int, height: Int, colour: Color = Color.RED): ByteArray {
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val g = image.createGraphics()
+        g.color = colour
+        g.fillRect(0, 0, width, height)
+        g.dispose()
+        val out = ByteArrayOutputStream()
+        ImageIO.write(image, "png", out)
+        return out.toByteArray()
+    }
+
+    @Test
+    fun `an SVG is refused, because a logo a client renders must not be able to carry script`() {
+        val svg = """<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>"""
+            .toByteArray(Charsets.UTF_8)
+
+        assertThatThrownBy { LogoImages.render(svg) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+            .hasMessageContaining("not a PNG, JPEG or GIF")
+    }
+
+    @Test
+    fun `an HTML file named as an image is refused`() {
+        val html = "<html><body><img src=x onerror=alert(1)></body></html>".toByteArray(Charsets.UTF_8)
+
+        assertThatThrownBy { LogoImages.render(html) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+    }
+
+    /**
+     * A polyglot: a real PNG with a payload appended after the image data. It decodes fine, which
+     * is exactly why storing the upload verbatim would serve the payload along with the logo.
+     */
+    @Test
+    fun `bytes appended after a valid image do not survive re-encoding`() {
+        val payload = "<script>alert('polyglot')</script>".toByteArray(Charsets.UTF_8)
+        val polyglot = png(64, 64) + payload
+
+        val rendered = LogoImages.render(polyglot)
+
+        assertThat(String(rendered.large, Charsets.ISO_8859_1)).doesNotContain("polyglot")
+        assertThat(String(rendered.small, Charsets.ISO_8859_1)).doesNotContain("polyglot")
+    }
+
+    /**
+     * The decompression-bomb guard. A header declaring a huge canvas is refused BEFORE the pixels
+     * are allocated — decoding one would be gigabytes of `int[]` and an out-of-memory kill of the
+     * pod, which is a denial of service rather than a rejected request.
+     */
+    @Test
+    fun `an image declaring implausible dimensions is refused without being decoded`() {
+        val oversized = png(LogoImages.MAX_SOURCE_PIXELS + 1, 8)
+
+        assertThatThrownBy { LogoImages.render(oversized) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+            .hasMessageContaining("the limit is")
+    }
+
+    @Test
+    fun `an upload over the byte limit is refused`() {
+        val tooBig = png(8, 8) + ByteArray(LogoImages.MAX_UPLOAD_BYTES)
+
+        assertThatThrownBy { LogoImages.render(tooBig) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+            .hasMessageContaining("bytes; the limit is")
+    }
+
+    @Test
+    fun `an empty upload is refused`() {
+        assertThatThrownBy { LogoImages.render(ByteArray(0)) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+    }
+
+    @Test
+    fun `a truncated PNG is refused rather than stored half-decoded`() {
+        val truncated = png(64, 64).copyOfRange(0, 40)
+
+        assertThatThrownBy { LogoImages.render(truncated) }
+            .isInstanceOf(LogoImages.RejectedException::class.java)
+    }
+
+    @Test
+    fun `both variants are produced at the sizes clients request`() {
+        val rendered = LogoImages.render(png(200, 200))
+
+        val small = ImageIO.read(rendered.small.inputStream())
+        val large = ImageIO.read(rendered.large.inputStream())
+        assertThat(small.width).isEqualTo(LogoImages.SIZE_SMALL)
+        assertThat(small.height).isEqualTo(LogoImages.SIZE_SMALL)
+        assertThat(large.width).isEqualTo(LogoImages.SIZE_LARGE)
+        assertThat(large.height).isEqualTo(LogoImages.SIZE_LARGE)
+    }
+
+    /**
+     * A wide wordmark keeps its proportions and is centred in a transparent square. Stretching it
+     * to fill would misrepresent a trademark, and cropping would cut it in half.
+     */
+    @Test
+    fun `a non-square source is fitted, not stretched, and padded transparently`() {
+        val rendered = LogoImages.render(png(400, 100))
+
+        val large = ImageIO.read(rendered.large.inputStream())
+        assertThat(large.width).isEqualTo(LogoImages.SIZE_LARGE)
+        assertThat(large.height).isEqualTo(LogoImages.SIZE_LARGE)
+        // The source is 4:1, so the drawn band is a quarter of the canvas high and the corners are
+        // padding. Alpha 0 there proves the padding is transparent rather than black or white.
+        assertThat(Color(large.getRGB(2, 2), true).alpha).isZero()
+        assertThat(Color(large.getRGB(LogoImages.SIZE_LARGE / 2, LogoImages.SIZE_LARGE / 2), true).alpha)
+            .isEqualTo(255)
+    }
+
+    /**
+     * The hash is the ETag and the cache-busting token in the URL a client follows, so identical
+     * pixels must hash identically (or every deploy would look like a changed logo) and different
+     * pixels must not (or a corrected logo would never reach anyone).
+     */
+    @Test
+    fun `the content hash is stable for the same pixels and differs for different ones`() {
+        val first = LogoImages.render(png(120, 120, Color.RED))
+        val same = LogoImages.render(png(120, 120, Color.RED))
+        val other = LogoImages.render(png(120, 120, Color.BLUE))
+
+        assertThat(first.contentHash).isEqualTo(same.contentHash)
+        assertThat(first.contentHash).isNotEqualTo(other.contentHash)
+        assertThat(first.contentHash).hasSize(64)
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MerchantCatalogResourceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MerchantCatalogResourceTest.kt
@@ -4,18 +4,29 @@
 
 package com.openbank.transaction.infrastructure.rest
 
+import com.openbank.transaction.infrastructure.image.LogoImages
 import com.openbank.transaction.infrastructure.persistence.entity.MerchantCatalogEntity
+import com.openbank.transaction.infrastructure.persistence.entity.MerchantLogoEntity
 import com.openbank.transaction.infrastructure.persistence.repository.MerchantCatalogRepository
+import com.openbank.transaction.infrastructure.persistence.repository.MerchantLogoRepository
 import com.openbank.transaction.infrastructure.persistence.repository.TransactionDescriptorRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import jakarta.ws.rs.core.Request
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.SecurityContext
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
 import java.time.Instant
+import javax.imageio.ImageIO
 
 /**
  * The catalogue is only useful if what an operator writes is what the lookup later reads, and if
@@ -26,13 +37,15 @@ class MerchantCatalogResourceTest {
 
     private lateinit var catalog: MerchantCatalogRepository
     private lateinit var transactions: TransactionDescriptorRepository
+    private lateinit var logos: MerchantLogoRepository
     private lateinit var resource: MerchantCatalogResource
 
     @BeforeEach
     fun setUp() {
         catalog = mockk()
         transactions = mockk()
-        resource = MerchantCatalogResource(catalog, transactions)
+        logos = mockk()
+        resource = MerchantCatalogResource(catalog, transactions, logos)
         coEvery { catalog.upsert(any()) } returns true
         coEvery { catalog.findByKey(any()) } returns null
         coEvery { catalog.deleteByKey(any()) } returns true
@@ -157,5 +170,175 @@ class MerchantCatalogResourceTest {
         runBlocking { resource.unmatchedDescriptors(10_000, 999_999) }
 
         coVerify { transactions.recentDescriptions(20_000) }
+    }
+
+    private fun pngBytes(colour: Color = Color.RED): ByteArray {
+        val image = BufferedImage(80, 80, BufferedImage.TYPE_INT_ARGB)
+        val g = image.createGraphics()
+        g.color = colour
+        g.fillRect(0, 0, 80, 80)
+        g.dispose()
+        val out = ByteArrayOutputStream()
+        ImageIO.write(image, "png", out)
+        return out.toByteArray()
+    }
+
+    private fun logoEntity(key: String, hash: String) = MerchantLogoEntity().also {
+        it.descriptorKey = key
+        it.bytes64 = byteArrayOf(1, 2, 3)
+        it.bytes128 = byteArrayOf(4, 5, 6, 7)
+        it.contentType = LogoImages.CONTENT_TYPE
+        it.contentHash = hash
+        it.updatedAt = Instant.parse("2026-09-06T08:00:00Z")
+    }
+
+    private fun unconditionalRequest(): Request = mockk {
+        every { evaluatePreconditions(any<jakarta.ws.rs.core.EntityTag>()) } returns null
+    }
+
+    private fun operator(name: String = "op-1"): SecurityContext = mockk {
+        every { userPrincipal } returns mockk { every { this@mockk.name } returns name }
+    }
+
+    /**
+     * The same normalisation the catalogue write applies, on the read side. An app follows the URL
+     * this service put in its own response, but an operator (or a support tool) pastes a raw
+     * descriptor, and a route that only accepted the normalised form would 404 on the merchant it
+     * was just shown.
+     */
+    @Test
+    fun `a raw descriptor resolves to the same logo as its normalised key`() {
+        coEvery { logos.findByKey("ALZACZ") } returns logoEntity("ALZACZ", "a".repeat(64))
+
+        val response = runBlocking { resource.logo("ALZA.CZ A.S. PRAHA 4", 64, unconditionalRequest()) }
+
+        assertThat(response.status).isEqualTo(200)
+        coVerify { logos.findByKey("ALZACZ") }
+    }
+
+    /**
+     * Size is an enumeration, not a number. Left open, a client could ask for 4096 and the service
+     * would either serve a stored variant that does not exist or start rendering on the request
+     * path — a resize per request, chosen by the caller, is a denial of service with a friendly
+     * name.
+     */
+    @Test
+    fun `an unsupported size is a 400, not a served variant`() {
+        val response = runBlocking { resource.logo("ALZACZ", 512, unconditionalRequest()) }
+
+        assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `the two supported sizes serve the two stored variants`() {
+        coEvery { logos.findByKey("ALZACZ") } returns logoEntity("ALZACZ", "b".repeat(64))
+
+        val small = runBlocking { resource.logo("ALZACZ", 64, unconditionalRequest()) }
+        val large = runBlocking { resource.logo("ALZACZ", 128, unconditionalRequest()) }
+
+        assertThat(small.entity as ByteArray).hasSize(3)
+        assertThat(large.entity as ByteArray).hasSize(4)
+    }
+
+    /**
+     * The conditional path carries the cache directives too. Without them a 304 would tell the
+     * client the bytes are unchanged and simultaneously that it may not keep them, so the next
+     * render asks again — the revalidation would never stop.
+     */
+    @Test
+    fun `a matching If-None-Match answers 304 with no body and keeps the cache directives`() {
+        val hash = "c".repeat(64)
+        coEvery { logos.findByKey("ALZACZ") } returns logoEntity("ALZACZ", hash)
+        val conditional: Request = mockk {
+            every { evaluatePreconditions(any<jakarta.ws.rs.core.EntityTag>()) } returns
+                Response.notModified()
+        }
+
+        val response = runBlocking { resource.logo("ALZACZ", 64, conditional) }
+
+        assertThat(response.status).isEqualTo(304)
+        assertThat(response.entity).isNull()
+        assertThat(response.headers.getFirst("Cache-Control").toString()).contains("max-age=31536000")
+        assertThat(response.entityTag?.value).isEqualTo(hash)
+    }
+
+    @Test
+    fun `a merchant with no stored logo is a 404, never a placeholder image`() {
+        coEvery { logos.findByKey(any()) } returns null
+
+        val response = runBlocking { resource.logo("ALZACZ", 64, unconditionalRequest()) }
+
+        assertThat(response.status).isEqualTo(404)
+    }
+
+    /**
+     * The upload is re-encoded, so what is stored is never the bytes that arrived. Asserting the
+     * stored bytes DIFFER from the upload is the only way to see that from outside: an
+     * implementation that passed the file through would still produce a 201 and a plausible hash.
+     */
+    @Test
+    fun `an uploaded image is re-encoded before it is stored`() {
+        val upload = pngBytes()
+        val saved = slot<MerchantLogoEntity>()
+        coEvery { logos.upsert(capture(saved)) } returns true
+
+        val response = runBlocking {
+            resource.putLogo("ALZA.CZ A.S.", null, "trademark", null, operator(), upload)
+        }
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(saved.captured.descriptorKey).isEqualTo("ALZACZ")
+        assertThat(saved.captured.bytes64).isNotEqualTo(upload)
+        assertThat(saved.captured.bytes128).isNotEqualTo(upload)
+        assertThat(saved.captured.contentType).isEqualTo(LogoImages.CONTENT_TYPE)
+        assertThat(saved.captured.licence).isEqualTo("trademark")
+        assertThat(saved.captured.uploadedBy).isEqualTo("op-1")
+    }
+
+    /**
+     * An absent body must be the caller's error. JAX-RS injects null for one, so a non-nullable
+     * parameter would make the commonest mistake — `curl -X PUT` with no file — a 500 (root
+     * CLAUDE.md: a non-nullable JAX-RS parameter is a 500 and a body guard is dead code).
+     */
+    @Test
+    fun `a missing request body is a 400, not a 500`() {
+        val response = runBlocking { resource.putLogo("ALZACZ", null, null, null, operator(), null) }
+
+        assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `an upload that is not a raster image is refused with the reason`() {
+        val response = runBlocking {
+            resource.putLogo("ALZACZ", null, null, null, operator(), "<svg/>".toByteArray())
+        }
+
+        assertThat(response.status).isEqualTo(400)
+        @Suppress("UNCHECKED_CAST")
+        assertThat((response.entity as Map<String, String>)["message"]).contains("not a PNG, JPEG or GIF")
+    }
+
+    /**
+     * A logo for a merchant the catalogue does not hold is unreachable — nothing would ever look it
+     * up — so it is a 404 about the missing catalogue entry rather than a silently orphaned row.
+     */
+    @Test
+    fun `a logo for an unknown merchant is a 404`() {
+        coEvery { logos.upsert(any()) } returns null
+
+        val response = runBlocking {
+            resource.putLogo("NEVERSEEN", null, null, null, operator(), pngBytes())
+        }
+
+        assertThat(response.status).isEqualTo(404)
+    }
+
+    @Test
+    fun `deleting a logo that is not there is a 404`() {
+        coEvery { logos.deleteByKey(any()) } returns false
+
+        val response = runBlocking { resource.deleteLogo("ALZACZ") }
+
+        assertThat(response.status).isEqualTo(404)
     }
 }

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MerchantLogoUrlTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MerchantLogoUrlTest.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import com.openbank.libs.api.pagination.CursorPage
+import com.openbank.libs.api.pagination.PageInfo
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
+import com.openbank.transaction.application.port.`in`.TransactionUseCase
+import com.openbank.transaction.domain.model.Transaction
+import com.openbank.transaction.domain.model.TransactionStatus
+import com.openbank.transaction.domain.model.TransactionType
+import com.openbank.transaction.infrastructure.persistence.entity.MerchantCatalogEntity
+import com.openbank.transaction.infrastructure.persistence.repository.MerchantCatalogRepository
+import com.openbank.transaction.infrastructure.persistence.repository.PanacheTransactionRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * What a customer's client is told about a merchant's logo.
+ *
+ * The catalogue holds TWO different URLs and only one of them may leave the bank. `logo_url` is
+ * provenance — where the bitmap was obtained, typically a third-party host — and returning it here
+ * would make every statement render tell that host the customer's IP address and which merchant
+ * they paid. The field a client receives is derived, origin-relative, and content-hashed. These
+ * tests hold that apart, because both are strings on the same object and swapping them back is a
+ * one-word edit that nothing else would notice.
+ */
+class MerchantLogoUrlTest {
+
+    private lateinit var useCase: TransactionUseCase
+    private lateinit var repository: PanacheTransactionRepository
+    private lateinit var catalog: MerchantCatalogRepository
+    private lateinit var resource: TransactionResource
+
+    private val accountId: UUID = UUID.randomUUID()
+    private val hash = "0123456789abcdef" + "f".repeat(48)
+
+    @BeforeEach
+    fun setUp() {
+        useCase = mockk()
+        repository = mockk()
+        catalog = mockk()
+        resource = TransactionResource(useCase, repository, catalog)
+    }
+
+    private fun transaction() = Transaction(
+        id = UUID.randomUUID(),
+        referenceNumber = "REF-1",
+        type = TransactionType.DEBIT,
+        sourceAccountId = accountId,
+        targetAccountId = null,
+        amount = Money(BigDecimal("249.00"), CurrencyCode.CZK),
+        fxRate = null,
+        baseAmount = Money(BigDecimal("249.00"), CurrencyCode.CZK),
+        status = TransactionStatus.COMPLETED,
+        description = "ALZA.CZ A.S. PRAHA 4",
+        valueDate = LocalDate.parse("2026-09-07"),
+        bookingDate = LocalDate.parse("2026-09-07"),
+        initiatedAt = Instant.parse("2026-09-07T10:00:00Z"),
+        completedAt = Instant.parse("2026-09-07T10:00:01Z"),
+        failedAt = null,
+        failureReason = null,
+        idempotencyKey = "idem-1",
+        version = 1,
+    )
+
+    private fun alza(logoEtag: String?) = MerchantCatalogEntity().also {
+        it.descriptorKey = "ALZACZ"
+        it.cleanName = "Alza.cz"
+        // Provenance: a third-party host. It must never reach a client.
+        it.logoUrl = "https://logo.example.com/alza.cz.png"
+        it.logoEtag = logoEtag
+        it.category = "SHOPPING"
+    }
+
+    private suspend fun merchantOf(entity: MerchantCatalogEntity): MerchantResponse? {
+        coEvery { useCase.listTransactions(any()) } returns
+            CursorPage(listOf(transaction()), PageInfo(limit = 20, hasNextPage = false))
+        coEvery { catalog.findByDescriptors(any()) } returns mapOf("ALZACZ" to entity)
+
+        val response = resource.listTransactions(accountId, 20, null)
+
+        @Suppress("UNCHECKED_CAST")
+        val page = response.entity as CursorPage<TransactionResponse>
+        return page.data.single().merchant
+    }
+
+    @Test
+    fun `the logo URL points at this bank, carries the size and is versioned by the content hash`() {
+        val merchant = runBlocking { merchantOf(alza(hash)) }
+
+        assertThat(merchant?.logoUrl).isEqualTo("/api/v1/merchants/ALZACZ/logo?size=64&v=0123456789abcdef")
+    }
+
+    /**
+     * The one that matters. A client that received the provenance URL would fetch the logo from a
+     * third party, and the privacy property the whole design exists for would be gone — silently,
+     * with the image still rendering correctly.
+     */
+    @Test
+    fun `the provenance URL is never what a client receives`() {
+        val merchant = runBlocking { merchantOf(alza(hash)) }
+
+        assertThat(merchant?.logoUrl).doesNotContain("logo.example.com")
+        assertThat(merchant?.logoUrl).startsWith("/")
+    }
+
+    /** No ingested logo means no field. Absence stays absence; there is no placeholder to send. */
+    @Test
+    fun `a merchant with no ingested logo carries no logo URL`() {
+        val merchant = runBlocking { merchantOf(alza(null)) }
+
+        assertThat(merchant?.cleanName).isEqualTo("Alza.cz")
+        assertThat(merchant?.logoUrl).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Merchant logos are now stored and served by this bank, not linked from somebody else's CDN, and the
enrichment response carries an origin-relative, content-hashed URL for them. This is the first slice
of the merchant-enrichment programme (logos → honest geo → the card path → automated ingest).

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8573

## Changes

- `V18__merchant_logo.sql` — `merchant_logo` (two pre-rendered square PNGs, content type, SHA-256,
  provenance: source URL, licence, attribution, uploader) plus `merchant_catalog.logo_etag`, the
  denormalised presence marker the per-page enrichment read consults so it never needs a join.
- `merchant_catalog.logo_url` changes meaning rather than getting populated: it is now the
  **provenance** record (where a logo was obtained), operator-facing, never sent to a customer.
- `LogoImages` — decode, dimension-check, fit into a transparent square, re-encode as PNG.
- `GET|PUT|DELETE /api/v1/merchants/{descriptorKey}/logo`, operator-write / reader-read, reusing the
  existing `merchant.list` / `merchant.update` / `merchant.delete` authz actions.
- `MerchantResponse.logoUrl` is now derived: `/api/v1/merchants/{key}/logo?size=64&v=<hash prefix>`,
  or absent when no logo has been ingested.
- OpenAPI 1.14.0 → 1.15.0 (additive).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved). Deliberately not: the routes
      are exercised at the resource layer, and the reactive repository's session behaviour is the
      part a real-DB IT would add value for — that arrives with the geo/terminal slice, which
      changes the same read path.
- [ ] Contract tests updated (if public API changed). No consumer pact covers `merchant`; the edge
      forwards it byte-for-byte and gains the route in a follow-up PR.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed). No event changed.
- [x] Docs updated (README, ADR if architectural). `docs/threat-models/openbank-transaction-service.md`
      §4e, plus the §4c spoofing row, which claimed `logoUrl` was expected to be bank-controlled and
      is now structurally unable to be anything else.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in
      this PR). Two `@Suppress("ThrowsCount")` in `LogoImages`: each throw is a distinct,
      separately actionable rejection reason, and collapsing them would tell an operator only that
      the upload was refused. One `@Suppress("LongParameterList")` on `putLogo`, whose parameters
      are the path key, three provenance fields, the security context and the body.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). None —
      image decoding is `javax.imageio` from the JDK.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. Considered and the
      answer is **no**: no authentication, cryptographic or payment-execution code is touched. The
      new routes reuse the catalogue's existing roles and OPA actions, and the SHA-256 here is a
      content identifier for caching, not a security primitive. No tag.
- [x] PII path changed? → tag `gdpr-review-required`. The change **removes** an exposure that had
      not shipped yet rather than adding one; see below.
- [x] Cardholder data path changed? → tag `pci-review-required`. Considered and the answer is
      **no**: nothing added is keyed by card, customer or transaction. `merchant_logo` hangs off the
      acquirer descriptor, exactly as the catalogue it belongs to does. No tag.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The design decision this PR exists to make: a third-party logo URL in the statement response would
have meant every render telling that host the customer's IP address and which merchant they paid, at
the moment they opened their transaction list — a spending profile reconstructable from an access
log, outside any consent or processor agreement. Serving the bytes from this origin removes the
third party from the request path entirely. Nothing customer-derived is stored: `merchant_logo` is
keyed by acquirer descriptor, like the catalogue it hangs off.

Logo bytes are re-encoded rather than stored as uploaded. That is a security control:

- SVG and HTML are refused (a logo a banking app renders must not be able to carry script);
- bytes appended after a valid image do not survive the re-encode (polyglot files);
- embedded metadata (EXIF, including GPS) is dropped, because pixels are all that is kept;
- a header declaring implausible dimensions is refused **before** any pixel buffer is allocated — a
  40 kB PNG can declare 30000×30000, which is 3.6 GB of `int[]` and an OOM kill of the pod.

`LogoImagesTest` asserts each of those refusals rather than the happy path, which would pass just as
well with every guard deleted.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the service. The route disappears and `logoUrl` goes back to null; nothing
  else reads `merchant_logo` or `logo_etag`, and no other service's response shape changes.
- Data migration reversible: yes — `DROP TABLE merchant_logo;` and
  `ALTER TABLE merchant_catalog DROP COLUMN logo_etag;`. Both are additive, so the previous release
  runs unchanged against the new schema.

## Reviewer notes

- **The catalogue marker is maintained in the same transaction as the bytes**, through the same
  Hibernate session rather than a second repository call, because the hot path reads only the marker
  — a drift would advertise a logo that 404s or hide one that exists.
- The customer-facing URL is deliberately **origin-relative**, so whichever host served the statement
  serves the logo. customer-edge forwards `merchant` byte-for-byte, so exposing the same path there
  is what makes it resolve for the mobile app; that is a follow-up PR, together with the spec change
  on the edge side.
- Still to come in this programme, in order: geo honesty (today's seed pins a whole chain at one
  Prague coordinate, and per-store location properly comes from the POS terminal / ATM identifier,
  which nothing in the fleet currently carries); the card path (`MerchantDescriptor` into
  `openbank-libs-domain`, MCC fallback); SSRF-hardened automated ingest with per-source licence
  recording; the admin-ui upload screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
