### PR TITLE
feat(admin-ui): manage merchant logos from the catalogue screen

### DIFF
--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -16,8 +16,8 @@
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, Store, Trash2, Plus } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -29,7 +29,10 @@ const CATALOGUE = '/api/v1/merchants'
 type Merchant = {
   descriptorKey: string
   cleanName: string
+  /** Provenance — where the stored bitmap came from. NOT the URL a customer app is given. */
   logoUrl?: string | null
+  /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
+  logoContentHash?: string | null
   category?: string | null
   lat?: number | null
   lon?: number | null
@@ -63,6 +66,7 @@ export default function MerchantsPage() {
   const [draft, setDraft] = useState<Draft | null>(null)
   const [saving, setSaving] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -132,6 +136,61 @@ export default function MerchantsPage() {
       })
       if (!res.ok && res.status !== 404) {
         setActionError(t('Smazání selhalo', 'Delete failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  // Client-side limits mirroring LogoImages on the service. Duplicated deliberately: the server
+  // is the enforcement point and rejects the same cases, but a 512 kB round trip to be told "too
+  // big" is a worse answer than an immediate one, and the operator is picking a file, not
+  // debugging an API.
+  const MAX_UPLOAD_BYTES = 512 * 1024
+  const ACCEPTED = 'image/png,image/jpeg,image/gif'
+
+  const uploadLogo = async (descriptorKey: string, file: File) => {
+    setActionError(null)
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setActionError(t(
+        `Soubor má ${Math.round(file.size / 1024)} kB, limit je ${MAX_UPLOAD_BYTES / 1024} kB.`,
+        `The file is ${Math.round(file.size / 1024)} kB; the limit is ${MAX_UPLOAD_BYTES / 1024} kB.`,
+      ))
+      return
+    }
+    setUploading(descriptorKey)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`, { licence: 'trademark' }),
+        { method: 'PUT', headers: { 'Content-Type': 'application/octet-stream' }, body: file },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { message?: string } | null
+        // The service says WHY it refused — not a raster format, implausible dimensions, no
+        // catalogue row. Passing that through is the difference between a fixable message and
+        // "upload failed".
+        setActionError(body?.message ?? t('Nahrání loga selhalo', 'The logo upload failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    } finally {
+      setUploading(null)
+    }
+  }
+
+  const removeLogo = async (descriptorKey: string) => {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`),
+        { method: 'DELETE' },
+      )
+      if (!res.ok && res.status !== 404) {
+        setActionError(t('Smazání loga selhalo', 'Deleting the logo failed'))
         return
       }
       await load()
@@ -246,6 +305,7 @@ export default function MerchantsPage() {
           <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
             <thead>
               <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
+                <th style={th} aria-label={t('Logo', 'Logo')} />
                 <th style={th}>{t('Descriptor', 'Descriptor')}</th>
                 <th style={th}>{t('Obchodní jméno', 'Trading name')}</th>
                 <th style={th}>{t('Kategorie', 'Category')}</th>
@@ -257,6 +317,7 @@ export default function MerchantsPage() {
             <tbody>
               {rows.map(m => (
                 <tr key={m.descriptorKey} style={{ borderTop: '1px solid var(--border)' }}>
+                  <td style={{ ...td, width: 44 }}><MerchantLogo merchant={m} /></td>
                   <td style={{ ...td, fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.descriptorKey}</td>
                   <td style={td}>{m.cleanName}</td>
                   <td style={td}>{m.category ?? '—'}</td>
@@ -280,6 +341,23 @@ export default function MerchantsPage() {
                     >
                       {t('Upravit', 'Edit')}
                     </button>{' '}
+                    <LogoButton
+                      merchant={m}
+                      busy={uploading === m.descriptorKey}
+                      accept={ACCEPTED}
+                      label={m.logoContentHash
+                        ? t(`Nahradit logo ${m.descriptorKey}`, `Replace the logo for ${m.descriptorKey}`)
+                        : t(`Nahrát logo ${m.descriptorKey}`, `Upload a logo for ${m.descriptorKey}`)}
+                      onPick={file => void uploadLogo(m.descriptorKey, file)}
+                    />{' '}
+                    {m.logoContentHash && <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => void removeLogo(m.descriptorKey)}
+                      aria-label={t(`Smazat logo ${m.descriptorKey}`, `Delete the logo for ${m.descriptorKey}`)}
+                    >
+                      <ImageOff size={12} aria-hidden="true" />
+                    </button>}{' '}
                     <button
                       type="button"
                       className="btn btn-secondary btn-sm"
@@ -292,7 +370,7 @@ export default function MerchantsPage() {
                 </tr>
               ))}
               {!loading && rows.length === 0 && (
-                <tr><td colSpan={6} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+                <tr><td colSpan={7} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                   {t('Katalog je prázdný', 'The catalogue is empty')}
                 </td></tr>
               )}
@@ -323,5 +401,90 @@ function Field({ label, value, onChange, mono }: {
         }}
       />
     </label>
+  )
+}
+
+/**
+ * The stored logo, or a monogram standing in for one that has not been ingested.
+ *
+ * The monogram is a UI affordance and NOT a fallback the customer app gets: absence stays absence
+ * on the wire (`merchant.logoUrl` is simply missing), because a placeholder rendered next to a
+ * payment reads as "this is the merchant's mark" when it is really "we have nothing". Here, on an
+ * operator screen whose whole purpose is to find the gaps, a monogram is exactly the right thing —
+ * it makes a missing logo visible at a glance instead of leaving an empty cell.
+ */
+function MerchantLogo({ merchant }: { merchant: Merchant }) {
+  const box = {
+    width: 32, height: 32, borderRadius: 8, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', border: '1px solid var(--border)', background: 'var(--surface-2)',
+    overflow: 'hidden', flexShrink: 0,
+  } as const
+  if (!merchant.logoContentHash) {
+    return (
+      <div style={box} aria-label={`${merchant.cleanName} — no logo`} title={`${merchant.cleanName} — no logo`}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-tertiary)' }}>
+          {merchant.cleanName.trim().charAt(0).toUpperCase() || '?'}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div style={box}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- the BFF proxies bytes from the
+          service; next/image would need a remote-pattern allowlist for a same-origin path it
+          cannot optimise anyway. */}
+      <img
+        src={svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(merchant.descriptorKey)}/logo`, {
+          size: '64',
+          // Same cache-busting token the service puts in the customer-facing URL: the browser may
+          // cache hard, and a replaced logo is a different URL rather than a stale one.
+          v: merchant.logoContentHash.slice(0, 16),
+        })}
+        alt={merchant.cleanName}
+        width={32}
+        height={32}
+        style={{ objectFit: 'contain' }}
+      />
+    </div>
+  )
+}
+
+/** A file picker dressed as a button — the row already has three, and a bare input breaks the row. */
+function LogoButton({ merchant, busy, accept, label, onPick }: {
+  merchant: Merchant
+  busy: boolean
+  accept: string
+  label: string
+  onPick: (file: File) => void
+}) {
+  const input = useRef<HTMLInputElement>(null)
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        disabled={busy}
+        aria-busy={busy}
+        aria-label={label}
+        title={label}
+        onClick={() => input.current?.click()}
+      >
+        <ImageUp size={12} aria-hidden="true" />
+      </button>
+      <input
+        ref={input}
+        type="file"
+        accept={accept}
+        data-testid={`logo-input-${merchant.descriptorKey}`}
+        style={{ display: 'none' }}
+        onChange={e => {
+          const file = e.target.files?.[0]
+          // Reset the input so picking the SAME file twice fires change again — an operator who
+          // re-crops and re-picks would otherwise get silence.
+          e.target.value = ''
+          if (file) onPick(file)
+        }}
+      />
+    </>
   )
 }

--- a/openbank-admin-ui/src/test/merchants-logo.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo.test.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import MerchantsPage from '@/app/merchants/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const HASH = 'a'.repeat(64)
+
+const withLogo = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: HASH }
+const withoutLogo = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+/**
+ * A fetch stub that records every call, so a test can assert what the page did NOT send — which is
+ * the only way to see a client-side guard working. One that merely checks the error message would
+ * pass just as well against a page that uploaded the file and rendered the server's complaint.
+ */
+function stubFetch(rows: unknown[], onWrite: () => Response = () => json({ contentHash: HASH }, 201)) {
+  const calls: Array<{ url: string; method: string }> = []
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), method: init?.method ?? 'GET' })
+    if (init?.method && init.method !== 'GET') return Promise.resolve(onWrite())
+    if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+    return Promise.resolve(json({ data: rows, total: rows.length }))
+  }))
+  return calls
+}
+
+const renderPage = () => render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+const pngFile = (bytes: number, name = 'logo.png') =>
+  new File([new Uint8Array(bytes)], name, { type: 'image/png' })
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('merchant logos', () => {
+  it('renders the stored logo through the BFF, cache-busted by the content hash', async () => {
+    stubFetch([withLogo])
+
+    renderPage()
+
+    const img = await screen.findByAltText('Billa') as HTMLImageElement
+    expect(img.src).toContain('/api/svc/transaction-service/api/v1/merchants/BILLA/logo')
+    expect(img.src).toContain('size=64')
+    // The token is what makes a year-long immutable cache safe: replaced bytes are a new URL.
+    expect(img.src).toContain(`v=${HASH.slice(0, 16)}`)
+  })
+
+  /**
+   * A merchant with no logo gets a monogram HERE and nothing at all on the customer path. The
+   * distinction is the point: on an operator screen whose job is to find the gaps a placeholder
+   * makes the gap visible, while next to a real payment it would read as the merchant's actual
+   * mark.
+   */
+  it('shows a monogram, not an image, for a merchant with no stored logo', async () => {
+    stubFetch([withoutLogo])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    expect(screen.queryByAltText('Alza.cz')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Alza.cz — no logo')).toBeInTheDocument()
+  })
+
+  it('uploads a picked file as raw bytes to the logo route', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(1024)] } })
+
+    await waitFor(() => expect(calls.some(c => c.method === 'PUT')).toBe(true))
+    const put = calls.find(c => c.method === 'PUT')!
+    expect(put.url).toContain('/api/v1/merchants/ALZACZ/logo')
+    // Reloaded afterwards, or the row would keep showing the monogram it just replaced.
+    expect(calls.filter(c => c.method === 'GET').length).toBeGreaterThan(2)
+  })
+
+  it('refuses an oversized file without sending it', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), {
+      target: { files: [pngFile(512 * 1024 + 1)] },
+    })
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('the limit is 512 kB'))
+    expect(calls.some(c => c.method === 'PUT')).toBe(false)
+  })
+
+  /**
+   * The service says WHY it refused — not a raster format, implausible dimensions, no catalogue
+   * row. Swallowing that for a generic "upload failed" would leave an operator with a file they
+   * cannot fix.
+   */
+  it('surfaces the service’s own rejection reason', async () => {
+    stubFetch([withoutLogo], () => json({ message: 'logo upload is not a PNG, JPEG or GIF image' }, 400))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(64)] } })
+
+    await waitFor(() => expect(screen.getByRole('alert'))
+      .toHaveTextContent('logo upload is not a PNG, JPEG or GIF image'))
+  })
+
+  it('offers logo removal only where a logo exists', async () => {
+    stubFetch([withLogo, withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Billa')).toBeInTheDocument())
+
+    expect(screen.getByLabelText('Delete the logo for BILLA')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete the logo for ALZACZ')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

The merchant catalogue screen could write every field of a merchant except the one a customer sees
first. Each row now shows its stored logo and offers upload / replace / remove, against the routes
added in the parent PR.

**Stacked on #9108** — based on `feat/merchant-logo-enrichment`, so this PR's diff is the admin-ui
change alone once the parent lands.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8573

## Changes

- Logo column on the catalogue table, rendered through the BFF and cache-busted by the content hash.
- Upload / replace from a file picker (`PUT .../logo`, raw bytes), and removal where a logo exists.
- Client-side size and format limits mirroring `LogoImages`, with the service's own rejection reason
  passed through verbatim when it refuses anyway.
- `merchants-logo.test.tsx` — 6 tests.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). N/A — UI only.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved). The boundary is the BFF proxy,
      which forwards bytes and content type unchanged; the routes it reaches are tested in #9108.
- [ ] Contract tests updated (if public API changed). No API change here.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. N/A for admin-ui; `npm test` is green
      (448 files, 2449 tests) and `npm run lint` reports 0 errors.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). No REST API change.
- [ ] Flyway migration added + rollback note (if DB changed). No DB change.
- [ ] Avro schema versioned backward-compatibly (if event changed). No event change.
- [x] Docs updated (README, ADR if architectural). The design note lives with the code; the threat
      model for the surface is in #9108 §4e.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. One
      `eslint-disable-next-line @next/next/no-img-element`: the image is a same-origin BFF path
      `next/image` cannot optimise and would need a remote-pattern allowlist for.
- [x] No new third-party dependency, OR: dependency review attached. None.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. Considered: no. The
      calls go through the existing BFF proxy with the operator's session, unchanged.
- [x] PII path changed? → tag `gdpr-review-required`. Considered: no. Public business data only,
      keyed by acquirer descriptor.
- [x] Cardholder data path changed? → tag `pci-review-required`. Considered: no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert; the column and the buttons disappear and the rest of the screen is unchanged.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

Table gains a 32px logo cell as the first column; rows without a logo show a monogram (an operator
affordance — the customer path still sends nothing when there is no logo).

## Reviewer notes

- **The monogram is deliberately operator-only.** `merchant.logoUrl` stays absent on the wire when
  no logo exists, because a placeholder rendered next to a payment reads as "this is the merchant's
  mark" when it really means "we have nothing".
- **The oversized-file test asserts no request was sent**, not that a message appeared. A page that
  uploaded the file and rendered the server's complaint would pass the message assertion and fail
  this one — which is the only way to see a client-side guard actually guarding.
- The `v=` token on the `<img>` is the same content-hash prefix the service puts in the
  customer-facing URL, so the browser may cache hard and a replaced logo is still a different URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
