### PR TITLE
fix(ci): scope threat-model-diff's boundary classifier to the Deployment's own YAML document

### DIFF
--- a/openbank-infra/scripts/check-threat-model-diff.py
+++ b/openbank-infra/scripts/check-threat-model-diff.py
@@ -42,6 +42,7 @@ Modes (ADR-0144 gate graduation):
 from __future__ import annotations
 
 import argparse
+import difflib
 import importlib.util
 import pathlib
 import re
@@ -174,6 +175,40 @@ def hunk_moves_boundary(diff_text: str) -> bool:
     return False
 
 
+def split_yaml_documents(text: str) -> list[str]:
+    """Split a multi-document gitops manifest on its `---` document separators."""
+    docs: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.strip() == "---":
+            docs.append([])
+            continue
+        docs[-1].append(line)
+    return ["\n".join(d) for d in docs]
+
+
+# Kinds whose document is itself a trust boundary (NetworkPolicy: reach by construction;
+# Deployment/Rollout: gated by hunk_moves_boundary). Matches GITOPS_KIND above.
+BOUNDARY_DOC_KIND = re.compile(r"^kind:\s*(NetworkPolicy|Deployment|Rollout)\s*$", re.MULTILINE)
+
+
+def boundary_docs_text(full_text: str) -> str:
+    """The boundary-relevant YAML documents in a (possibly multi-document) manifest file,
+    concatenated -- never the whole file.
+
+    A component manifest here routinely bundles a Deployment with a Service, a ServiceAccount,
+    and a PodMonitor/ServiceMonitor as separate `---`-separated documents in ONE file (see
+    billing-service.yaml, document-service-service.yaml, statement-service.yaml). Without this,
+    hunk_moves_boundary sees the WHOLE FILE'S diff text, so a deleted PodMonitor's
+    `podMetricsEndpoints: - port: management` matches the `ports?` boundary key exactly as if it
+    were the Deployment's own `containerPort` -- flagging a scrape-config removal as a
+    trust-boundary move on the workload it shares a file with (#9071: the PodMonitor-dedup PR
+    tripped this on billing-service.yaml with no Deployment change at all).
+    """
+    return "\n---\n".join(
+        doc for doc in split_yaml_documents(full_text) if BOUNDARY_DOC_KIND.search(doc)
+    )
+
+
 def file_diff(base: str | None, head: str, rel: str) -> str | None:
     """Unified diff of one path, or None when it cannot be inspected."""
     if base is None:
@@ -209,6 +244,17 @@ def adapter_is_client(rel: str) -> bool:
         return False
 
 
+def read_at_ref(ref: str, rel: str) -> str | None:
+    """Content of `rel` at `ref`, or None when it cannot be read (path did not exist there,
+    or `ref` cannot be resolved)."""
+    res = subprocess.run(
+        ["git", "show", f"{ref}:{rel}"], capture_output=True, text=True, cwd=REPO,
+    )
+    if res.returncode != 0:
+        return None
+    return res.stdout
+
+
 def gitops_hit(
     service: str, comp: str, fname: str, base: str | None = None, head: str = "HEAD",
 ) -> str | None:
@@ -230,12 +276,27 @@ def gitops_hit(
         except OSError:
             return None
         if GITOPS_KIND.search(text) and token_in(tokens, text):
-            diff_text = file_diff(base, head, rel)
-            if diff_text is None:
+            if base is None:
                 # Cannot inspect hunks (synthetic --changed-files list): stay conservative,
                 # same contract as yaml_security_keys_changed.
                 return f"{rel} (Deployment/Rollout)"
-            if not hunk_moves_boundary(diff_text):
+            base_text = read_at_ref(base, rel)
+            if base_text is None:
+                # New file, or base ref cannot be read -- nothing to scope the diff against,
+                # stay conservative rather than assume it is boundary-irrelevant.
+                return f"{rel} (Deployment/Rollout)"
+            # Scope the diff to just the Deployment/Rollout/NetworkPolicy documents, not the
+            # whole file -- see boundary_docs_text. A component manifest here routinely bundles
+            # those with a Service/PodMonitor/ServiceMonitor as separate `---` documents, and a
+            # hunk in one of THOSE must never be read as a change to another.
+            base_scoped = boundary_docs_text(base_text)
+            head_scoped = boundary_docs_text(text)
+            if base_scoped == head_scoped:
+                return None
+            scoped_diff = "\n".join(
+                difflib.unified_diff(base_scoped.splitlines(), head_scoped.splitlines(), lineterm=""),
+            )
+            if not hunk_moves_boundary(scoped_diff):
                 return None
             return f"{rel} (Deployment/Rollout)"
     return None
@@ -311,6 +372,50 @@ SELF_TEST_CASES: list[tuple[str, str, bool]] = [
 ]
 
 
+# Multi-document gitops manifest cases (#9071): boundary_docs_text must scope the diff to
+# just the Deployment/Rollout/NetworkPolicy documents in the file, so a hunk in a sibling
+# PodMonitor/Service document sharing the same file is never read as a change to the
+# workload's own boundary. These exercise the actual gitops_hit code path (document split +
+# difflib), not just hunk_moves_boundary on a hand-written diff -- the earlier SELF_TEST_CASES
+# above would all still pass even if the document-scoping were missing entirely.
+DOC_SELF_TEST_CASES: list[tuple[str, str, str, bool]] = [
+    (
+        "a removed PodMonitor's scrape port must NOT flag the Deployment sharing its file",
+        "apiVersion: apps/v1\nkind: Deployment\nspec:\n  ports:\n    - port: 8085\n"
+        "---\n"
+        "apiVersion: monitoring.coreos.com/v1\nkind: PodMonitor\nspec:\n"
+        "  podMetricsEndpoints:\n    - port: management\n",
+        "apiVersion: apps/v1\nkind: Deployment\nspec:\n  ports:\n    - port: 8085\n",
+        False,
+    ),
+    (
+        "a real Deployment containerPort change in the SAME multi-doc file must still flag",
+        "apiVersion: apps/v1\nkind: Deployment\nspec:\n  ports:\n    - port: 8085\n"
+        "---\n"
+        "apiVersion: monitoring.coreos.com/v1\nkind: PodMonitor\nspec:\n"
+        "  podMetricsEndpoints:\n    - port: management\n",
+        "apiVersion: apps/v1\nkind: Deployment\nspec:\n  ports:\n    - port: 8085\n"
+        "    - port: 9443\n"
+        "---\n"
+        "apiVersion: monitoring.coreos.com/v1\nkind: PodMonitor\nspec:\n"
+        "  podMetricsEndpoints:\n    - port: management\n",
+        True,
+    ),
+]
+
+
+def doc_scoped_flags(before: str, after: str) -> bool:
+    """Same comparison gitops_hit makes: scope both sides to boundary docs, diff, classify."""
+    base_scoped = boundary_docs_text(before)
+    head_scoped = boundary_docs_text(after)
+    if base_scoped == head_scoped:
+        return False
+    diff_text = "\n".join(
+        difflib.unified_diff(base_scoped.splitlines(), head_scoped.splitlines(), lineterm=""),
+    )
+    return hunk_moves_boundary(diff_text)
+
+
 def self_test() -> int:
     """Feed the classifier diffs it MUST flag and diffs it MUST NOT.
 
@@ -321,6 +426,12 @@ def self_test() -> int:
     ok = True
     for name, diff_text, expected in SELF_TEST_CASES:
         got = hunk_moves_boundary(diff_text)
+        mark = "ok" if got == expected else "FAIL"
+        if got != expected:
+            ok = False
+        print(f"  [{mark}] {name}: flagged={got} expected={expected}")
+    for name, before, after, expected in DOC_SELF_TEST_CASES:
+        got = doc_scoped_flags(before, after)
         mark = "ok" if got == expected else "FAIL"
         if got != expected:
             ok = False


### PR DESCRIPTION
## Summary

`check-threat-model-diff.py`'s `hunk_moves_boundary` scans a Deployment/Rollout file's WHOLE
diff text for a boundary key. Several gitops component manifests bundle a Deployment with a
Service, ServiceAccount, and PodMonitor/ServiceMonitor as separate `---` documents in one file,
and the gate could not tell them apart — a hunk in a sibling document read as a change to the
Deployment itself. This scopes the classifier to just the Deployment/Rollout/NetworkPolicy
document(s) in the file.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [x] security (private until disclosed) — this is a security-enforced gate; the change narrows a false-positive, it does not weaken real detection (see verification below)
- [ ] breaking change

## Linked issues

Closes #9113. Found getting #9071 (dedup redundant scrape pools) past this required check;
sibling of the same observability audit as #9070/#9071/#9072/#9112.

## The measurement

PR #9071 deleted a PodMonitor whose `podMetricsEndpoints: - port: management` matched the
`ports?` boundary key. The gate demanded a `docs/threat-models/openbank-billing-service.md`
update for a diff that never touches the Deployment:

```
::error::threat-model-diff gate: openbank-billing-service: trust-boundary change without a
docs/threat-models/openbank-billing-service.md update —
openbank-infra/gitops/components/billing/billing-service.yaml (Deployment/Rollout) (ADR-0030 D2)
```

`git diff origin/main...9071-head -- billing-service.yaml` shows the entire hunk sits inside the
deleted `kind: PodMonitor` document — zero relation to the `kind: Deployment` document that
shares the file.

## Changes

- `split_yaml_documents` / `boundary_docs_text`: split a manifest on `---`, keep only the
  documents whose `kind:` is `Deployment`, `Rollout`, or `NetworkPolicy`.
- `read_at_ref`: read a file's content at an arbitrary ref (`git show ref:path`), needed to
  scope the BASE side the same way the HEAD side already was.
- `gitops_hit` now diffs `boundary_docs_text(base)` vs `boundary_docs_text(head)` — not the
  whole file — before calling `hunk_moves_boundary`.
- `DOC_SELF_TEST_CASES` + `doc_scoped_flags`: exercises the actual `gitops_hit` code path
  (document split + `difflib`), not just `hunk_moves_boundary` on a hand-written diff string —
  the pre-existing `SELF_TEST_CASES` would all still pass even if document-scoping were
  entirely absent.

## Verified both directions, not just the false positive

Fixing a false positive without checking the true positive is how a gate quietly loses its
teeth. Both checked, against real files, not synthetic snippets:

- **The actual #9071 diff no longer flags.** `check-threat-model-diff.py --base origin/main
  --head origin/fix/observability-duplicate-scrape-monitors --enforce` → RC=0 (was RC=1).
- **A real Deployment boundary change in the SAME multi-doc file still flags.** Added a fake
  `containerPort: 9443` to `billing-service.yaml`'s own Deployment port list (not the Service,
  not the PodMonitor — the actual container's own listener), committed it in a throwaway
  worktree, ran the gate against `origin/main`: `RC=1`, correctly named
  `billing-service.yaml (Deployment/Rollout)`. Reverted; `git log --all` confirms no trace of
  the throwaway commit survives.
- `--self-test`: 9/9, including the two new `DOC_SELF_TEST_CASES` (PodMonitor-only change must
  not flag; Deployment change in the same file must still flag).
- `ruff check --select E9,F,B` (the gate's own CI select set) on the touched file: clean.

## Definition of Done

- [ ] Hexagonal layering preserved. — N/A, CI script
- [x] Unit tests added/updated. — the gate's own `--self-test`, extended (see above)
- [ ] Integration tests added/updated. — N/A
- [ ] Contract tests updated. — N/A
- [ ] `./gradlew ...` — N/A, no Kotlin touched
- [x] No new lint warnings. (`ruff --select E9,F,B` clean)
- [ ] OpenAPI / Flyway / Avro — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress`/equivalent without justification. — N/A, Python
- [x] No new third-party dependency. (`difflib` is stdlib)
- [x] Auth / crypto / payment code changed? → tag `security-review-required` — yes, this is the
  gate that enforces threat-model currency for money-path services (ADR-0030 D2). Please verify
  the "still flags" case independently rather than trusting the self-test alone — the whole
  point of this PR is that a self-test can pass while the real classifier is wrong (that is
  exactly how the original bug shipped).
- [ ] PII / cardholder data path — no.

## Compliance impact

- [x] None on its own — this corrects a CI gate's precision. It does not change what the gate
  is allowed to require, only which hunks it looks at when deciding.

## Rollout / Rollback

- Deployment strategy: merges into `.github`-adjacent tooling; takes effect on the next PR
  this gate runs against. No service deploy involved.
- Rollback plan: revert the commit. The gate returns to whole-file scanning (the pre-existing,
  over-broad but not under-broad behavior) — a regression to false positives, not to missed
  real changes.
- Data migration reversible: N/A

## Reviewer notes

The risk to focus on: does the document split correctly identify the Deployment/Rollout
document in every shape this repo's manifests actually use? I did not special-case anything —
`split_yaml_documents` is a plain `---`-line splitter and `BOUNDARY_DOC_KIND` reuses the exact
same regex as the pre-existing `GITOPS_KIND`. The only structural assumption is that `---` on
its own line is the document separator, which is universal in this repo's gitops tree (grep
confirms no manifest here uses an inline `---` inside a scalar block without it being its own
line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
