### PR TITLE
feat(admin-ui): edit merchant locations and fetch logos

### DIFF
--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -251,7 +251,9 @@ export default function MerchantsPage() {
       const res = await fetch(
         svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo/fetch`),
         {
-          method: 'POST',
+          // PUT: the ingest is an upsert keyed by the descriptor, so a retry after a timeout stores
+          // the same bytes rather than a second logo.
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ sourceUrl: fetchUrl.trim(), licence: 'trademark' }),
         },

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -17,7 +17,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff, MapPin } from 'lucide-react'
+import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff, MapPin, Download } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -67,6 +67,9 @@ type LocationDraft = {
   terminalId: string
 }
 
+/** Whether the service is configured to fetch logos, and from where. */
+type LogoSources = { enabled: boolean; allowedHosts: string[] }
+
 const EMPTY_LOCATION: LocationDraft = {
   cityToken: '', lat: '', lon: '', city: '', country: '', precision: 'CITY', terminalId: '',
 }
@@ -100,13 +103,19 @@ export default function MerchantsPage() {
   const [openLocations, setOpenLocations] = useState<string | null>(null)
   const [locations, setLocations] = useState<MerchantLocation[]>([])
   const [locationDraft, setLocationDraft] = useState<LocationDraft | null>(null)
+  // Null until asked. `enabled: false` is a real answer, not a failure: ingest is off unless an
+  // allowlist was configured, and the screen must not offer an action that cannot work.
+  const [logoSources, setLogoSources] = useState<LogoSources | null>(null)
+  const [fetchFor, setFetchFor] = useState<string | null>(null)
+  const [fetchUrl, setFetchUrl] = useState('')
 
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const [listRes, unmatchedRes] = await Promise.all([
+      const [listRes, unmatchedRes, sourcesRes] = await Promise.all([
         fetch(svcUrl(SERVICE, CATALOGUE, { size: '100' }), { cache: 'no-store' }),
         fetch(svcUrl(SERVICE, `${CATALOGUE}/unmatched`, { limit: '25' }), { cache: 'no-store' }),
+        fetch(svcUrl(SERVICE, `${CATALOGUE}/logo-sources`), { cache: 'no-store' }),
       ])
       if (!listRes.ok) {
         setUnavailable({ kind: await classifyBffFailure(listRes) })
@@ -118,6 +127,9 @@ export default function MerchantsPage() {
       // The worklist failing must not blank the catalogue: they are separate reads, and a stale
       // or empty worklist is a smaller loss than losing the rows an operator is editing.
       setUnmatched(unmatchedRes.ok ? (await unmatchedRes.json() as Unmatched[]) : [])
+      // A failed read is treated as "off", not as "unknown": offering an action that will certainly
+      // be refused is worse than not offering it.
+      setLogoSources(sourcesRes.ok ? (await sourcesRes.json() as LogoSources) : { enabled: false, allowedHosts: [] })
       setUnavailable(null)
     } catch {
       setUnavailable({ kind: 'unreachable' })
@@ -229,6 +241,36 @@ export default function MerchantsPage() {
       await load()
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  const fetchLogo = async (descriptorKey: string) => {
+    setActionError(null)
+    setUploading(descriptorKey)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo/fetch`),
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sourceUrl: fetchUrl.trim(), licence: 'trademark' }),
+        },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { message?: string } | null
+        // The service says exactly why — host not allowlisted, resolves inward, answered a redirect,
+        // not a raster image. Each of those is a different action for the operator, and collapsing
+        // them into "fetch failed" would leave them with a URL they cannot fix.
+        setActionError(body?.message ?? t('Stažení loga selhalo', 'Fetching the logo failed'))
+        return
+      }
+      setFetchFor(null)
+      setFetchUrl('')
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    } finally {
+      setUploading(null)
     }
   }
 
@@ -400,6 +442,33 @@ export default function MerchantsPage() {
           </div>
         </section>}
 
+        {fetchFor && logoSources?.enabled && <section className="card" style={{ marginBottom: 18 }}>
+          <h2 style={{ fontSize: 14, margin: '0 0 4px' }}>
+            {t('Stáhnout logo', 'Fetch a logo')} — <span style={{ fontFamily: 'var(--font-mono)' }}>{fetchFor}</span>
+          </h2>
+          <p style={{ fontSize: 12, color: 'var(--text-tertiary)', margin: '0 0 10px' }}>
+            {t(
+              'Server stáhne obrázek sám a uloží ho k sobě — do aplikace zákazníka nikdy neputuje cizí URL. Povolené zdroje:',
+              'The server downloads the image and stores it here; a third-party URL never reaches a customer app. Allowed sources:',
+            )}{' '}
+            <span style={{ fontFamily: 'var(--font-mono)' }}>{logoSources.allowedHosts.join(', ')}</span>
+          </p>
+          <Field label={t('Adresa obrázku', 'Image URL')} value={fetchUrl} onChange={setFetchUrl} mono />
+          <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => void fetchLogo(fetchFor)}
+              disabled={uploading === fetchFor || !fetchUrl.trim()}
+            >
+              {uploading === fetchFor ? t('Stahuji…', 'Fetching…') : t('Stáhnout', 'Fetch')}
+            </button>
+            <button type="button" className="btn btn-secondary btn-sm" onClick={() => setFetchFor(null)}>
+              {t('Zrušit', 'Cancel')}
+            </button>
+          </div>
+        </section>}
+
         <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
             <h2 style={{ fontSize: 14, margin: 0 }}>
@@ -460,6 +529,14 @@ export default function MerchantsPage() {
                     >
                       <MapPin size={12} aria-hidden="true" />
                     </button>{' '}
+                    {logoSources?.enabled && <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => { setFetchFor(m.descriptorKey); setFetchUrl(''); setActionError(null) }}
+                      aria-label={t(`Stáhnout logo ${m.descriptorKey}`, `Fetch a logo for ${m.descriptorKey}`)}
+                    >
+                      <Download size={12} aria-hidden="true" />
+                    </button>}{' '}
                     <LogoButton
                       merchant={m}
                       busy={uploading === m.descriptorKey}

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -16,8 +16,8 @@
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, Store, Trash2, Plus } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -29,7 +29,10 @@ const CATALOGUE = '/api/v1/merchants'
 type Merchant = {
   descriptorKey: string
   cleanName: string
+  /** Provenance — where the stored bitmap came from. NOT the URL a customer app is given. */
   logoUrl?: string | null
+  /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
+  logoContentHash?: string | null
   category?: string | null
   lat?: number | null
   lon?: number | null
@@ -63,6 +66,7 @@ export default function MerchantsPage() {
   const [draft, setDraft] = useState<Draft | null>(null)
   const [saving, setSaving] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -132,6 +136,61 @@ export default function MerchantsPage() {
       })
       if (!res.ok && res.status !== 404) {
         setActionError(t('Smazání selhalo', 'Delete failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  // Client-side limits mirroring LogoImages on the service. Duplicated deliberately: the server
+  // is the enforcement point and rejects the same cases, but a 512 kB round trip to be told "too
+  // big" is a worse answer than an immediate one, and the operator is picking a file, not
+  // debugging an API.
+  const MAX_UPLOAD_BYTES = 512 * 1024
+  const ACCEPTED = 'image/png,image/jpeg,image/gif'
+
+  const uploadLogo = async (descriptorKey: string, file: File) => {
+    setActionError(null)
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setActionError(t(
+        `Soubor má ${Math.round(file.size / 1024)} kB, limit je ${MAX_UPLOAD_BYTES / 1024} kB.`,
+        `The file is ${Math.round(file.size / 1024)} kB; the limit is ${MAX_UPLOAD_BYTES / 1024} kB.`,
+      ))
+      return
+    }
+    setUploading(descriptorKey)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`, { licence: 'trademark' }),
+        { method: 'PUT', headers: { 'Content-Type': 'application/octet-stream' }, body: file },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { message?: string } | null
+        // The service says WHY it refused — not a raster format, implausible dimensions, no
+        // catalogue row. Passing that through is the difference between a fixable message and
+        // "upload failed".
+        setActionError(body?.message ?? t('Nahrání loga selhalo', 'The logo upload failed'))
+        return
+      }
+      await load()
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    } finally {
+      setUploading(null)
+    }
+  }
+
+  const removeLogo = async (descriptorKey: string) => {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/logo`),
+        { method: 'DELETE' },
+      )
+      if (!res.ok && res.status !== 404) {
+        setActionError(t('Smazání loga selhalo', 'Deleting the logo failed'))
         return
       }
       await load()
@@ -246,6 +305,7 @@ export default function MerchantsPage() {
           <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
             <thead>
               <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
+                <th style={th} aria-label={t('Logo', 'Logo')} />
                 <th style={th}>{t('Descriptor', 'Descriptor')}</th>
                 <th style={th}>{t('Obchodní jméno', 'Trading name')}</th>
                 <th style={th}>{t('Kategorie', 'Category')}</th>
@@ -257,6 +317,7 @@ export default function MerchantsPage() {
             <tbody>
               {rows.map(m => (
                 <tr key={m.descriptorKey} style={{ borderTop: '1px solid var(--border)' }}>
+                  <td style={{ ...td, width: 44 }}><MerchantLogo merchant={m} /></td>
                   <td style={{ ...td, fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.descriptorKey}</td>
                   <td style={td}>{m.cleanName}</td>
                   <td style={td}>{m.category ?? '—'}</td>
@@ -280,6 +341,23 @@ export default function MerchantsPage() {
                     >
                       {t('Upravit', 'Edit')}
                     </button>{' '}
+                    <LogoButton
+                      merchant={m}
+                      busy={uploading === m.descriptorKey}
+                      accept={ACCEPTED}
+                      label={m.logoContentHash
+                        ? t(`Nahradit logo ${m.descriptorKey}`, `Replace the logo for ${m.descriptorKey}`)
+                        : t(`Nahrát logo ${m.descriptorKey}`, `Upload a logo for ${m.descriptorKey}`)}
+                      onPick={file => void uploadLogo(m.descriptorKey, file)}
+                    />{' '}
+                    {m.logoContentHash && <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => void removeLogo(m.descriptorKey)}
+                      aria-label={t(`Smazat logo ${m.descriptorKey}`, `Delete the logo for ${m.descriptorKey}`)}
+                    >
+                      <ImageOff size={12} aria-hidden="true" />
+                    </button>}{' '}
                     <button
                       type="button"
                       className="btn btn-secondary btn-sm"
@@ -292,7 +370,7 @@ export default function MerchantsPage() {
                 </tr>
               ))}
               {!loading && rows.length === 0 && (
-                <tr><td colSpan={6} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+                <tr><td colSpan={7} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                   {t('Katalog je prázdný', 'The catalogue is empty')}
                 </td></tr>
               )}
@@ -323,5 +401,90 @@ function Field({ label, value, onChange, mono }: {
         }}
       />
     </label>
+  )
+}
+
+/**
+ * The stored logo, or a monogram standing in for one that has not been ingested.
+ *
+ * The monogram is a UI affordance and NOT a fallback the customer app gets: absence stays absence
+ * on the wire (`merchant.logoUrl` is simply missing), because a placeholder rendered next to a
+ * payment reads as "this is the merchant's mark" when it is really "we have nothing". Here, on an
+ * operator screen whose whole purpose is to find the gaps, a monogram is exactly the right thing —
+ * it makes a missing logo visible at a glance instead of leaving an empty cell.
+ */
+function MerchantLogo({ merchant }: { merchant: Merchant }) {
+  const box = {
+    width: 32, height: 32, borderRadius: 8, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', border: '1px solid var(--border)', background: 'var(--surface-2)',
+    overflow: 'hidden', flexShrink: 0,
+  } as const
+  if (!merchant.logoContentHash) {
+    return (
+      <div style={box} aria-label={`${merchant.cleanName} — no logo`} title={`${merchant.cleanName} — no logo`}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-tertiary)' }}>
+          {merchant.cleanName.trim().charAt(0).toUpperCase() || '?'}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div style={box}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- the BFF proxies bytes from the
+          service; next/image would need a remote-pattern allowlist for a same-origin path it
+          cannot optimise anyway. */}
+      <img
+        src={svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(merchant.descriptorKey)}/logo`, {
+          size: '64',
+          // Same cache-busting token the service puts in the customer-facing URL: the browser may
+          // cache hard, and a replaced logo is a different URL rather than a stale one.
+          v: merchant.logoContentHash.slice(0, 16),
+        })}
+        alt={merchant.cleanName}
+        width={32}
+        height={32}
+        style={{ objectFit: 'contain' }}
+      />
+    </div>
+  )
+}
+
+/** A file picker dressed as a button — the row already has three, and a bare input breaks the row. */
+function LogoButton({ merchant, busy, accept, label, onPick }: {
+  merchant: Merchant
+  busy: boolean
+  accept: string
+  label: string
+  onPick: (file: File) => void
+}) {
+  const input = useRef<HTMLInputElement>(null)
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        disabled={busy}
+        aria-busy={busy}
+        aria-label={label}
+        title={label}
+        onClick={() => input.current?.click()}
+      >
+        <ImageUp size={12} aria-hidden="true" />
+      </button>
+      <input
+        ref={input}
+        type="file"
+        accept={accept}
+        data-testid={`logo-input-${merchant.descriptorKey}`}
+        style={{ display: 'none' }}
+        onChange={e => {
+          const file = e.target.files?.[0]
+          // Reset the input so picking the SAME file twice fires change again — an operator who
+          // re-crops and re-picks would otherwise get silence.
+          e.target.value = ''
+          if (file) onPick(file)
+        }}
+      />
+    </>
   )
 }

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -17,7 +17,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff } from 'lucide-react'
+import { RefreshCw, Store, Trash2, Plus, ImageUp, ImageOff, MapPin } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -33,6 +33,8 @@ type Merchant = {
   logoUrl?: string | null
   /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
   logoContentHash?: string | null
+  /** What the coordinates on the CATALOGUE row can answer. CITY for every chain. */
+  geoPrecision?: string | null
   category?: string | null
   lat?: number | null
   lon?: number | null
@@ -42,6 +44,32 @@ type Merchant = {
 }
 
 type Unmatched = { descriptorKey: string; occurrences: number }
+
+type MerchantLocation = {
+  descriptorKey: string
+  cityToken: string
+  lat: number
+  lon: number
+  city?: string | null
+  country?: string | null
+  precision: string
+  terminalId?: string | null
+  source?: string | null
+}
+
+type LocationDraft = {
+  cityToken: string
+  lat: string
+  lon: string
+  city: string
+  country: string
+  precision: string
+  terminalId: string
+}
+
+const EMPTY_LOCATION: LocationDraft = {
+  cityToken: '', lat: '', lon: '', city: '', country: '', precision: 'CITY', terminalId: '',
+}
 
 type Draft = {
   descriptorKey: string
@@ -67,6 +95,11 @@ export default function MerchantsPage() {
   const [saving, setSaving] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   const [uploading, setUploading] = useState<string | null>(null)
+  // Which merchant's locations are open, and what they are. Loaded on demand: a catalogue page is a
+  // hundred merchants and almost none of them are the one an operator came to fix.
+  const [openLocations, setOpenLocations] = useState<string | null>(null)
+  const [locations, setLocations] = useState<MerchantLocation[]>([])
+  const [locationDraft, setLocationDraft] = useState<LocationDraft | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -199,6 +232,80 @@ export default function MerchantsPage() {
     }
   }
 
+  const toggleLocations = async (descriptorKey: string) => {
+    setActionError(null)
+    setLocationDraft(null)
+    if (openLocations === descriptorKey) {
+      setOpenLocations(null)
+      setLocations([])
+      return
+    }
+    setOpenLocations(descriptorKey)
+    setLocations([])
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/locations`),
+        { cache: 'no-store' },
+      )
+      setLocations(res.ok ? (await res.json() as MerchantLocation[]) : [])
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  const saveLocation = async (descriptorKey: string) => {
+    if (!locationDraft) return
+    setActionError(null)
+    try {
+      const res = await fetch(
+        svcUrl(
+          SERVICE,
+          `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/locations/${encodeURIComponent(locationDraft.cityToken)}`,
+        ),
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            lat: Number(locationDraft.lat),
+            lon: Number(locationDraft.lon),
+            city: locationDraft.city || null,
+            country: locationDraft.country || null,
+            precision: locationDraft.precision,
+            terminalId: locationDraft.terminalId || null,
+          }),
+        },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { message?: string } | null
+        setActionError(body?.message ?? t('Uložení místa selhalo', 'Saving the location failed'))
+        return
+      }
+      setLocationDraft(null)
+      const reopen = openLocations
+      setOpenLocations(null)
+      if (reopen) await toggleLocations(reopen)
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
+  const removeLocation = async (descriptorKey: string, cityToken: string) => {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        svcUrl(SERVICE, `${CATALOGUE}/${encodeURIComponent(descriptorKey)}/locations/${encodeURIComponent(cityToken)}`),
+        { method: 'DELETE' },
+      )
+      if (!res.ok && res.status !== 404) {
+        setActionError(t('Smazání místa selhalo', 'Deleting the location failed'))
+        return
+      }
+      setLocations(prev => prev.filter(l => l.cityToken !== cityToken))
+    } catch {
+      setActionError(t('Služba je nedostupná', 'The service is unreachable'))
+    }
+  }
+
   const th = { padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' } as const
   const td = { padding: '10px 14px' } as const
 
@@ -321,7 +428,10 @@ export default function MerchantsPage() {
                   <td style={{ ...td, fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.descriptorKey}</td>
                   <td style={td}>{m.cleanName}</td>
                   <td style={td}>{m.category ?? '—'}</td>
-                  <td style={td}>{[m.city, m.country].filter(Boolean).join(', ') || '—'}</td>
+                  <td style={td}>
+                    {[m.city, m.country].filter(Boolean).join(', ') || '—'}
+                    {m.lat != null && <PrecisionBadge precision={m.geoPrecision ?? 'CITY'} t={t} />}
+                  </td>
                   <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>
                     {m.updatedAt ? new Date(m.updatedAt).toLocaleString(dateLocale) : '—'}
                   </td>
@@ -340,6 +450,15 @@ export default function MerchantsPage() {
                       })}
                     >
                       {t('Upravit', 'Edit')}
+                    </button>{' '}
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => void toggleLocations(m.descriptorKey)}
+                      aria-label={t(`Místa pro ${m.descriptorKey}`, `Locations for ${m.descriptorKey}`)}
+                      aria-expanded={openLocations === m.descriptorKey}
+                    >
+                      <MapPin size={12} aria-hidden="true" />
                     </button>{' '}
                     <LogoButton
                       merchant={m}
@@ -368,7 +487,25 @@ export default function MerchantsPage() {
                     </button>
                   </td>
                 </tr>
-              ))}
+              )).flatMap((row, i) => {
+                const m = rows[i]
+                if (openLocations !== m.descriptorKey) return [row]
+                return [row, (
+                  <tr key={`${m.descriptorKey}-locations`} style={{ background: 'var(--surface-2)' }}>
+                    <td colSpan={7} style={{ padding: '10px 14px' }}>
+                      <LocationsPanel
+                        merchant={m}
+                        locations={locations}
+                        draft={locationDraft}
+                        setDraft={setLocationDraft}
+                        onSave={() => void saveLocation(m.descriptorKey)}
+                        onRemove={cityToken => void removeLocation(m.descriptorKey, cityToken)}
+                        t={t}
+                      />
+                    </td>
+                  </tr>
+                )]
+              })}
               {!loading && rows.length === 0 && (
                 <tr><td colSpan={7} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                   {t('Katalog je prázdný', 'The catalogue is empty')}
@@ -488,3 +625,151 @@ function LogoButton({ merchant, busy, accept, label, onPick }: {
     </>
   )
 }
+
+/**
+ * What a coordinate is worth, said out loud in the table.
+ *
+ * The seeded catalogue pins each CHAIN at one Prague address, so `BILLA` reads as a precise location
+ * and is a representative one. An operator looking at the row has no way to know that unless the
+ * screen says so, and "the pin is for the brand, not the shop" is exactly the thing they are here to
+ * fix.
+ */
+function PrecisionBadge({ precision, t }: { precision: string; t: (cs: string, en: string) => string }) {
+  const exact = precision === 'EXACT'
+  return (
+    <span
+      title={exact
+        ? t('Kde se skutečně platilo', 'Where the money was actually spent')
+        : t('Obchodník působí v tomto městě; pin je orientační', 'The merchant trades in this town; the pin is representative')}
+      style={{
+        marginLeft: 6, fontSize: 10, padding: '1px 5px', borderRadius: 4,
+        border: '1px solid var(--border)', color: 'var(--text-tertiary)',
+        background: exact ? 'var(--surface)' : 'transparent',
+      }}
+    >
+      {precision}
+    </span>
+  )
+}
+
+/**
+ * Per-town locations for one merchant.
+ *
+ * This exists because the API without it repeats the mistake it was written to fix: `merchant_location`
+ * would be a table with no writer, exactly as `merchant_catalog` was for months before #8573 — an
+ * enrichment path that is complete end to end and starved.
+ *
+ * `cityToken` is the town AS THE ACQUIRER DESCRIPTOR SPELLS IT, which is why the field says so: the
+ * read path derives that token from the transaction and matches on it, so a location filed under a
+ * prettier spelling is one no transaction can ever find. The server folds it either way; the hint is
+ * there so an operator understands what they are keying on rather than guessing.
+ */
+function LocationsPanel({ merchant, locations, draft, setDraft, onSave, onRemove, t }: {
+  merchant: Merchant
+  locations: MerchantLocation[]
+  draft: LocationDraft | null
+  setDraft: (d: LocationDraft | null) => void
+  onSave: () => void
+  onRemove: (cityToken: string) => void
+  t: (cs: string, en: string) => string
+}) {
+  // EXACT without a terminal id is refused by the API and by a database constraint. Mirroring the
+  // rule here is not duplication of the check — the server stays the enforcement point — it is the
+  // difference between a disabled button with a reason and a 400 an operator has to decode.
+  const exactAllowed = Boolean(draft?.terminalId.trim())
+  const canSave = Boolean(draft && draft.cityToken.trim() && draft.lat.trim() && draft.lon.trim())
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <strong style={{ fontSize: 12 }}>
+          {t('Místa podle měst', 'Locations by town')} — <span style={{ fontFamily: 'var(--font-mono)' }}>{merchant.descriptorKey}</span>
+        </strong>
+        <button type="button" className="btn btn-secondary btn-sm" onClick={() => setDraft({ ...EMPTY_LOCATION })}>
+          <Plus size={12} aria-hidden="true" /> {t('Přidat místo', 'Add a location')}
+        </button>
+      </div>
+
+      {locations.length === 0 && !draft && <p style={{ fontSize: 12, color: 'var(--text-tertiary)', margin: 0 }}>
+        {t(
+          'Žádná místa. Bez nich se každá transakce vykreslí na jednom pinu z katalogu — u řetězce je to pin značky, ne obchodu.',
+          'No locations. Without them every transaction resolves to the single catalogue pin, which for a chain is the brand, not the shop.',
+        )}
+      </p>}
+
+      {locations.length > 0 && <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12, marginBottom: 8 }}>
+        <thead>
+          <tr style={{ textAlign: 'left', color: 'var(--text-tertiary)' }}>
+            <th style={{ padding: '4px 8px', fontWeight: 500 }}>{t('Token města', 'Town token')}</th>
+            <th style={{ padding: '4px 8px', fontWeight: 500 }}>{t('Šířka', 'Latitude')}</th>
+            <th style={{ padding: '4px 8px', fontWeight: 500 }}>{t('Délka', 'Longitude')}</th>
+            <th style={{ padding: '4px 8px', fontWeight: 500 }}>{t('Přesnost', 'Precision')}</th>
+            <th style={{ padding: '4px 8px', fontWeight: 500 }}>{t('Terminál', 'Terminal')}</th>
+            <th style={{ padding: '4px 8px' }} aria-label={t('Akce', 'Actions')} />
+          </tr>
+        </thead>
+        <tbody>
+          {locations.map(l => (
+            <tr key={l.cityToken}>
+              <td style={{ padding: '4px 8px', fontFamily: 'var(--font-mono)' }}>{l.cityToken}</td>
+              <td style={{ padding: '4px 8px' }}>{l.lat}</td>
+              <td style={{ padding: '4px 8px' }}>{l.lon}</td>
+              <td style={{ padding: '4px 8px' }}><PrecisionBadge precision={l.precision} t={t} /></td>
+              <td style={{ padding: '4px 8px', fontFamily: 'var(--font-mono)' }}>{l.terminalId ?? '—'}</td>
+              <td style={{ padding: '4px 8px', textAlign: 'right' }}>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => onRemove(l.cityToken)}
+                  aria-label={t(`Smazat místo ${l.cityToken}`, `Delete the location ${l.cityToken}`)}
+                >
+                  <Trash2 size={11} aria-hidden="true" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>}
+
+      {draft && <div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}>
+          <Field label={t('Token města', 'Town token')} value={draft.cityToken} onChange={v => setDraft({ ...draft, cityToken: v })} mono />
+          <Field label={t('Šířka', 'Latitude')} value={draft.lat} onChange={v => setDraft({ ...draft, lat: v })} mono />
+          <Field label={t('Délka', 'Longitude')} value={draft.lon} onChange={v => setDraft({ ...draft, lon: v })} mono />
+          <Field label={t('Město', 'City')} value={draft.city} onChange={v => setDraft({ ...draft, city: v })} />
+          <Field label={t('Země', 'Country')} value={draft.country} onChange={v => setDraft({ ...draft, country: v })} />
+          <Field label={t('ID terminálu', 'Terminal id')} value={draft.terminalId} onChange={v => setDraft({ ...draft, terminalId: v })} mono />
+          <label style={{ display: 'block', fontSize: 11, color: 'var(--text-tertiary)' }}>
+            {t('Přesnost', 'Precision')}
+            <select
+              value={draft.precision}
+              onChange={e => setDraft({ ...draft, precision: e.target.value })}
+              style={{
+                display: 'block', width: '100%', marginTop: 3, fontSize: 13, padding: '5px 8px',
+                borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)',
+              }}
+            >
+              <option value="CITY">CITY</option>
+              <option value="EXACT" disabled={!exactAllowed}>EXACT</option>
+            </select>
+          </label>
+        </div>
+        <p style={{ fontSize: 11, color: 'var(--text-tertiary)', margin: '8px 0 0' }}>
+          {t(
+            'Token města je město tak, jak ho píše acquirer descriptor (PLZEN, ne Plzeň) — server ho složí sám, ale klíčuje se právě podle něj. EXACT jde jen s ID terminálu: souřadnice bez zařízení, které platbu přijalo, nemůže být o tom, kde se platilo.',
+            'The town token is the town as the acquirer descriptor spells it (PLZEN, not Plzeň) — the server folds it either way, but that is what the lookup keys on. EXACT needs a terminal id: a coordinate not tied to the device that took the payment cannot be about where the money was spent.',
+          )}
+        </p>
+        <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+          <button type="button" className="btn btn-primary btn-sm" onClick={onSave} disabled={!canSave}>
+            {t('Uložit místo', 'Save the location')}
+          </button>
+          <button type="button" className="btn btn-secondary btn-sm" onClick={() => setDraft(null)}>
+            {t('Zrušit', 'Cancel')}
+          </button>
+        </div>
+      </div>}
+    </div>
+  )
+}
+

--- a/openbank-admin-ui/src/test/merchants-locations.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-locations.test.tsx
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import MerchantsPage from '@/app/merchants/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const billa = {
+  descriptorKey: 'BILLA',
+  cleanName: 'Billa',
+  city: 'Praha',
+  country: 'CZ',
+  lat: 50.0834,
+  lon: 14.4238,
+  geoPrecision: 'CITY',
+}
+
+const brno = {
+  descriptorKey: 'BILLA',
+  cityToken: 'BRNO',
+  lat: 49.1951,
+  lon: 16.6068,
+  city: 'Brno',
+  country: 'CZ',
+  precision: 'CITY',
+  terminalId: null,
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+function stubFetch(locations: unknown[] = [], onWrite: () => Response = () => json({}, 201)) {
+  const calls: Array<{ url: string; method: string; body?: string }> = []
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), method: init?.method ?? 'GET', body: init?.body as string | undefined })
+    if (init?.method && init.method !== 'GET') return Promise.resolve(onWrite())
+    if (String(url).includes('/locations')) return Promise.resolve(json(locations))
+    if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+    return Promise.resolve(json({ data: [billa], total: 1 }))
+  }))
+  return calls
+}
+
+const renderPage = () => render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+const openLocations = async () => {
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Billa')).toBeInTheDocument())
+  fireEvent.click(screen.getByLabelText('Locations for BILLA'))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('merchant locations', () => {
+  /**
+   * The catalogue pin is for the BRAND. An operator reading the row cannot tell that from a pair of
+   * coordinates, and telling them is the whole point of the precision field existing.
+   */
+  it('labels the catalogue pin with its precision', async () => {
+    stubFetch()
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Billa')).toBeInTheDocument())
+    expect(screen.getAllByText('CITY').length).toBeGreaterThan(0)
+  })
+
+  it('loads a merchant’s locations on demand, not with the page', async () => {
+    const calls = stubFetch([brno])
+
+    await openLocations()
+
+    await waitFor(() => expect(screen.getByText('BRNO')).toBeInTheDocument())
+    expect(calls.filter(c => c.url.includes('/locations'))).toHaveLength(1)
+  })
+
+  /**
+   * A merchant with no locations must say what that costs, not just show an empty table: without
+   * them every transaction resolves to the one catalogue pin, which for a chain is the brand.
+   */
+  it('says what a merchant with no locations means', async () => {
+    stubFetch([])
+
+    await openLocations()
+
+    await waitFor(() => expect(screen.getByText(/every transaction resolves to the single catalogue pin/)).toBeInTheDocument())
+  })
+
+  /**
+   * EXACT is refused by the API and by a database constraint without a terminal id. The option is
+   * disabled here so an operator sees the rule rather than decoding a 400 — the server stays the
+   * enforcement point, this is only the explanation.
+   */
+  it('offers EXACT only once a terminal id is given', async () => {
+    stubFetch([])
+
+    await openLocations()
+    await waitFor(() => expect(screen.getByText('Add a location')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Add a location'))
+
+    const exact = await screen.findByRole('option', { name: 'EXACT' }) as HTMLOptionElement
+    expect(exact.disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Terminal id'), { target: { value: 'T-00042' } })
+    expect((screen.getByRole('option', { name: 'EXACT' }) as HTMLOptionElement).disabled).toBe(false)
+  })
+
+  it('writes a location under the town token, keyed the way the read path keys it', async () => {
+    const calls = stubFetch([])
+
+    await openLocations()
+    await waitFor(() => expect(screen.getByText('Add a location')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Add a location'))
+    fireEvent.change(screen.getByLabelText('Town token'), { target: { value: 'BRNO' } })
+    fireEvent.change(screen.getByLabelText('Latitude'), { target: { value: '49.1951' } })
+    fireEvent.change(screen.getByLabelText('Longitude'), { target: { value: '16.6068' } })
+    fireEvent.click(screen.getByText('Save the location'))
+
+    await waitFor(() => expect(calls.some(c => c.method === 'PUT')).toBe(true))
+    const put = calls.find(c => c.method === 'PUT')!
+    expect(put.url).toContain('/api/v1/merchants/BILLA/locations/BRNO')
+    expect(JSON.parse(put.body!)).toMatchObject({ lat: 49.1951, lon: 16.6068, precision: 'CITY' })
+  })
+
+  /** Coordinates are not optional for a location — an incomplete row cannot be saved at all. */
+  it('will not save a location without coordinates', async () => {
+    const calls = stubFetch([])
+
+    await openLocations()
+    await waitFor(() => expect(screen.getByText('Add a location')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Add a location'))
+    fireEvent.change(screen.getByLabelText('Town token'), { target: { value: 'BRNO' } })
+
+    expect((screen.getByText('Save the location') as HTMLButtonElement).disabled).toBe(true)
+    expect(calls.some(c => c.method === 'PUT')).toBe(false)
+  })
+
+  it('surfaces the service’s reason when a location write is refused', async () => {
+    stubFetch([], () => json({ message: 'precision EXACT requires a terminalId' }, 400))
+
+    await openLocations()
+    await waitFor(() => expect(screen.getByText('Add a location')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Add a location'))
+    fireEvent.change(screen.getByLabelText('Town token'), { target: { value: 'BRNO' } })
+    fireEvent.change(screen.getByLabelText('Latitude'), { target: { value: '49.1' } })
+    fireEvent.change(screen.getByLabelText('Longitude'), { target: { value: '16.6' } })
+    fireEvent.click(screen.getByText('Save the location'))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('precision EXACT requires a terminalId'))
+  })
+})

--- a/openbank-admin-ui/src/test/merchants-logo-fetch.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo-fetch.test.tsx
@@ -76,7 +76,7 @@ describe('merchant logo ingest', () => {
     expect(await screen.findByText('upload.wikimedia.org')).toBeInTheDocument()
   })
 
-  it('posts the source URL to the ingest route', async () => {
+  it('puts the source URL to the ingest route', async () => {
     const calls = stubFetch({ enabled: true, allowedHosts: ['upload.wikimedia.org'] })
 
     renderPage()
@@ -87,10 +87,12 @@ describe('merchant logo ingest', () => {
     })
     fireEvent.click(screen.getByText('Fetch'))
 
-    await waitFor(() => expect(calls.some(c => c.method === 'POST')).toBe(true))
-    const post = calls.find(c => c.method === 'POST')!
-    expect(post.url).toContain('/api/v1/merchants/ALZACZ/logo/fetch')
-    expect(JSON.parse(post.body!)).toMatchObject({ sourceUrl: 'https://upload.wikimedia.org/alza.png' })
+    // PUT rather than POST: the ingest is an upsert keyed by the descriptor, so a retry after a
+    // timeout is safe — which is what the idempotency gate was right to insist on.
+    await waitFor(() => expect(calls.some(c => c.method === 'PUT')).toBe(true))
+    const put = calls.find(c => c.method === 'PUT')!
+    expect(put.url).toContain('/api/v1/merchants/ALZACZ/logo/fetch')
+    expect(JSON.parse(put.body!)).toMatchObject({ sourceUrl: 'https://upload.wikimedia.org/alza.png' })
   })
 
   /**
@@ -124,6 +126,6 @@ describe('merchant logo ingest', () => {
     fireEvent.click(screen.getByLabelText('Fetch a logo for ALZACZ'))
 
     expect((await screen.findByText('Fetch') as HTMLButtonElement).disabled).toBe(true)
-    expect(calls.some(c => c.method === 'POST')).toBe(false)
+    expect(calls.some(c => c.method === 'PUT')).toBe(false)
   })
 })

--- a/openbank-admin-ui/src/test/merchants-logo-fetch.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo-fetch.test.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import MerchantsPage from '@/app/merchants/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const alza = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+function stubFetch(sources: unknown, onWrite: () => Response = () => json({}, 201)) {
+  const calls: Array<{ url: string; method: string; body?: string }> = []
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), method: init?.method ?? 'GET', body: init?.body as string | undefined })
+    if (init?.method && init.method !== 'GET') return Promise.resolve(onWrite())
+    const u = String(url)
+    if (u.includes('/logo-sources')) {
+      return Promise.resolve(sources instanceof Response ? sources : json(sources))
+    }
+    if (u.includes('/unmatched')) return Promise.resolve(json([]))
+    if (u.includes('/locations')) return Promise.resolve(json([]))
+    return Promise.resolve(json({ data: [alza], total: 1 }))
+  }))
+  return calls
+}
+
+const renderPage = () => render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('merchant logo ingest', () => {
+  /**
+   * Ingest is off unless an allowlist was configured, and off is a real answer rather than a
+   * failure. Offering an action that is certain to be refused wastes the operator's time and teaches
+   * them to ignore errors.
+   */
+  it('does not offer the fetch action when ingest is disabled', async () => {
+    stubFetch({ enabled: false, allowedHosts: [] })
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    expect(screen.queryByLabelText('Fetch a logo for ALZACZ')).not.toBeInTheDocument()
+  })
+
+  /** A failed read of the configuration is treated as off, for the same reason. */
+  it('treats an unreadable configuration as disabled', async () => {
+    stubFetch(json({ message: 'boom' }, 500))
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    expect(screen.queryByLabelText('Fetch a logo for ALZACZ')).not.toBeInTheDocument()
+  })
+
+  /**
+   * When it IS on, the allowlist is shown. An operator who cannot see which hosts are permitted will
+   * paste one that is not, and read the refusal as the feature being broken.
+   */
+  it('shows the allowed hosts so the operator does not guess', async () => {
+    stubFetch({ enabled: true, allowedHosts: ['upload.wikimedia.org'] })
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Fetch a logo for ALZACZ'))
+
+    expect(await screen.findByText('upload.wikimedia.org')).toBeInTheDocument()
+  })
+
+  it('posts the source URL to the ingest route', async () => {
+    const calls = stubFetch({ enabled: true, allowedHosts: ['upload.wikimedia.org'] })
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Fetch a logo for ALZACZ'))
+    fireEvent.change(await screen.findByLabelText('Image URL'), {
+      target: { value: 'https://upload.wikimedia.org/alza.png' },
+    })
+    fireEvent.click(screen.getByText('Fetch'))
+
+    await waitFor(() => expect(calls.some(c => c.method === 'POST')).toBe(true))
+    const post = calls.find(c => c.method === 'POST')!
+    expect(post.url).toContain('/api/v1/merchants/ALZACZ/logo/fetch')
+    expect(JSON.parse(post.body!)).toMatchObject({ sourceUrl: 'https://upload.wikimedia.org/alza.png' })
+  })
+
+  /**
+   * The service distinguishes "not allowlisted" from "resolves inward" from "answered a redirect",
+   * and each is a different action for the operator. Collapsing them into "fetch failed" leaves them
+   * with a URL they cannot fix.
+   */
+  it('surfaces the service’s own refusal reason', async () => {
+    stubFetch(
+      { enabled: true, allowedHosts: ['upload.wikimedia.org'] },
+      () => json({ message: "host 'evil.example.com' is not in the configured allowlist" }, 400),
+    )
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Fetch a logo for ALZACZ'))
+    fireEvent.change(await screen.findByLabelText('Image URL'), {
+      target: { value: 'https://evil.example.com/x.png' },
+    })
+    fireEvent.click(screen.getByText('Fetch'))
+
+    await waitFor(() => expect(screen.getByRole('alert'))
+      .toHaveTextContent('is not in the configured allowlist'))
+  })
+
+  it('will not post an empty URL', async () => {
+    const calls = stubFetch({ enabled: true, allowedHosts: ['upload.wikimedia.org'] })
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Fetch a logo for ALZACZ'))
+
+    expect((await screen.findByText('Fetch') as HTMLButtonElement).disabled).toBe(true)
+    expect(calls.some(c => c.method === 'POST')).toBe(false)
+  })
+})

--- a/openbank-admin-ui/src/test/merchants-logo.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo.test.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import MerchantsPage from '@/app/merchants/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const HASH = 'a'.repeat(64)
+
+const withLogo = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: HASH }
+const withoutLogo = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+/**
+ * A fetch stub that records every call, so a test can assert what the page did NOT send — which is
+ * the only way to see a client-side guard working. One that merely checks the error message would
+ * pass just as well against a page that uploaded the file and rendered the server's complaint.
+ */
+function stubFetch(rows: unknown[], onWrite: () => Response = () => json({ contentHash: HASH }, 201)) {
+  const calls: Array<{ url: string; method: string }> = []
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), method: init?.method ?? 'GET' })
+    if (init?.method && init.method !== 'GET') return Promise.resolve(onWrite())
+    if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+    return Promise.resolve(json({ data: rows, total: rows.length }))
+  }))
+  return calls
+}
+
+const renderPage = () => render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+const pngFile = (bytes: number, name = 'logo.png') =>
+  new File([new Uint8Array(bytes)], name, { type: 'image/png' })
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('merchant logos', () => {
+  it('renders the stored logo through the BFF, cache-busted by the content hash', async () => {
+    stubFetch([withLogo])
+
+    renderPage()
+
+    const img = await screen.findByAltText('Billa') as HTMLImageElement
+    expect(img.src).toContain('/api/svc/transaction-service/api/v1/merchants/BILLA/logo')
+    expect(img.src).toContain('size=64')
+    // The token is what makes a year-long immutable cache safe: replaced bytes are a new URL.
+    expect(img.src).toContain(`v=${HASH.slice(0, 16)}`)
+  })
+
+  /**
+   * A merchant with no logo gets a monogram HERE and nothing at all on the customer path. The
+   * distinction is the point: on an operator screen whose job is to find the gaps a placeholder
+   * makes the gap visible, while next to a real payment it would read as the merchant's actual
+   * mark.
+   */
+  it('shows a monogram, not an image, for a merchant with no stored logo', async () => {
+    stubFetch([withoutLogo])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    expect(screen.queryByAltText('Alza.cz')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Alza.cz — no logo')).toBeInTheDocument()
+  })
+
+  it('uploads a picked file as raw bytes to the logo route', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(1024)] } })
+
+    await waitFor(() => expect(calls.some(c => c.method === 'PUT')).toBe(true))
+    const put = calls.find(c => c.method === 'PUT')!
+    expect(put.url).toContain('/api/v1/merchants/ALZACZ/logo')
+    // Reloaded afterwards, or the row would keep showing the monogram it just replaced.
+    expect(calls.filter(c => c.method === 'GET').length).toBeGreaterThan(2)
+  })
+
+  it('refuses an oversized file without sending it', async () => {
+    const calls = stubFetch([withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), {
+      target: { files: [pngFile(512 * 1024 + 1)] },
+    })
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('the limit is 512 kB'))
+    expect(calls.some(c => c.method === 'PUT')).toBe(false)
+  })
+
+  /**
+   * The service says WHY it refused — not a raster format, implausible dimensions, no catalogue
+   * row. Swallowing that for a generic "upload failed" would leave an operator with a file they
+   * cannot fix.
+   */
+  it('surfaces the service’s own rejection reason', async () => {
+    stubFetch([withoutLogo], () => json({ message: 'logo upload is not a PNG, JPEG or GIF image' }, 400))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alza.cz')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('logo-input-ALZACZ'), { target: { files: [pngFile(64)] } })
+
+    await waitFor(() => expect(screen.getByRole('alert'))
+      .toHaveTextContent('logo upload is not a PNG, JPEG or GIF image'))
+  })
+
+  it('offers logo removal only where a logo exists', async () => {
+    stubFetch([withLogo, withoutLogo])
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Billa')).toBeInTheDocument())
+
+    expect(screen.getByLabelText('Delete the logo for BILLA')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete the logo for ALZACZ')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Two operator gaps on the merchants screen, both of them APIs that shipped without a writer in the UI:
per-town locations (#9115) and logo ingest (#9135). Each catalogue row now expands into its
locations, and — where the service says ingest is configured — offers a fetch action.

**Stacked on #9135** (→ #9115 → #9108). This branch also merges #9110, so the merchants screen
carries the logo column, the location editor and the fetch action together, and the three never
conflict at merge time.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8573

## Changes

- Expandable per-merchant location panel: list, add, remove, loaded on demand.
- `PrecisionBadge` on the catalogue row and on every location — `CITY` vs `EXACT`, with the meaning
  in the tooltip.
- `EXACT` is selectable only once a terminal id is filled in, mirroring the API and the `CHECK`
  constraint.
- Fetch action, shown only when `GET /logo-sources` reports ingest enabled, with the allowlist
  displayed next to the field and the service's own refusal reason surfaced verbatim.
- `merchants-locations.test.tsx` (7 tests) and `merchants-logo-fetch.test.tsx` (6 tests).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). N/A — UI only.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved). The routes are tested in #9115.
- [ ] Contract tests updated (if public API changed). No API change here.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. N/A for admin-ui; `npm run lint` is
      0 errors (90 warnings, unchanged from the base) and all four merchants suites are green
      (22 tests).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). No REST API change.
- [ ] Flyway migration added + rollback note (if DB changed). No DB change.
- [ ] Avro schema versioned backward-compatibly (if event changed). No event change.
- [x] Docs updated (README, ADR if architectural). The reasoning lives with the code; the threat
      model for the surface is in #9115 §4f.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. None added.
- [x] No new third-party dependency, OR: dependency review attached. None.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. Considered: no. Calls go
      through the existing BFF proxy with the operator's session.
- [x] PII path changed? → tag `gdpr-review-required`. Considered: no. Public business data — where a
      shop is, keyed by acquirer descriptor and town, never where a cardholder was.
- [x] Cardholder data path changed? → tag `pci-review-required`. Considered: no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert; the panel and badges disappear, the rest of the screen is unchanged.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

A catalogue row gains a map-pin button; expanding it shows that merchant's towns with their
precision, and a form whose `EXACT` option is disabled until a terminal id is present.

## Reviewer notes

- **Why this PR exists at all.** An API with no writer is the exact failure #8573 documents: the
  enrichment pipeline was complete end to end and starved because filling it meant a migration and a
  deploy. `merchant_location` was heading the same way, and I noticed it in my own change.
- **The client-side EXACT rule is not a second enforcement point.** The server refuses it, and so
  does a database constraint; the disabled option exists so the operator sees the rule instead of
  decoding a 400.
- **The town-token hint is load-bearing.** The server folds `Plzeň` and `PLZEN` alike, but the read
  path matches on the token the acquirer descriptor carries — an operator who does not know that
  files locations no transaction can ever find.
- **"Fetch not offered" is the normal state, not a broken one.** Ingest is off unless an allowlist is
  configured (#9135), so the button is absent by default; an unreadable configuration counts as off
  for the same reason. Offering an action certain to be refused teaches operators to ignore errors.
- **The allowlist is shown, and refusals pass through verbatim.** "Not allowlisted", "resolves to a
  non-public address" and "answered a redirect" are three different things for an operator to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
