### PR TITLE
ci: restore edge dispatch license header

### DIFF
--- a/.github/workflows/edge-openapi-dispatch.yml
+++ b/.github/workflows/edge-openapi-dispatch.yml
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) OpenBank contributors. Licensed under the Mozilla Public License 2.0.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License 2.0.
 #
 # Tells the mobile app that the customer-edge contract moved, the moment it moves.
 #


### PR DESCRIPTION
## Summary

- align the edge OpenAPI dispatch workflow with the repository-root Apache-2.0 license
- restore the enforced license-header-consistency gate on current main and unblock unrelated PRs
- leave workflow behavior unchanged

## Verification

- license header checker self-test passed
- license header consistency gate passed
- independent exact-diff review: no blocker
- diff check clean

Closes #9156
