### PR TITLE
feat(sanctions): answer 202 on refresh-all and defer imports to the scheduler

### DIFF
--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -464,18 +464,8 @@ STUBEOF
       # reference each, because every exclusion is a hole in the coverage this lane exists to
       # prove. An entry with neither is a finding waiting to be hidden.
       EXCLUDE_FLAGS=()
-      case "${svc}" in
-        openbank-sanctions-service)
-          # POST /api/v1/sanctions/lists/refresh-all fans out to the EXTERNAL sanctions feeds
-          # synchronously; a real fetch exceeds this lane's 5s request window by design — it
-          # read-timed-out on every fleet fuzz since the lane exists (runs 34017868446,
-          # 34107337021). Not a handler defect and not stubbable: the slow peer is the public
-          # internet. The tracked fix is the async-202 redesign (#8590), not a longer window —
-          # a synchronous trigger that can take minutes belongs off the request path entirely.
-          EXCLUDE_FLAGS+=(--exclude-operation-id refreshAllSanctionsLists)
-          echo "==> [${svc}] excluding refreshAllSanctionsLists from fuzz (external-feed fan-out > request window; async redesign tracked in #8590)"
-          ;;
-      esac
+      # refreshAllSanctionsLists used to be excluded here (external-feed fan-out > request
+      # window); #9048 made refresh-all answer 202 immediately, so it is fuzzable again.
       # schemathesis 4.x CLI (bumped from 3.39.16 to close 6 Dependabot alerts on transitive
       # starlette/pytest — 3.x hard-caps pytest<9 and starlette<1):
       #   --base-url -> --url; --hypothesis-max-examples -> --max-examples;

--- a/docs/threat-models/openbank-sanctions-service.md
+++ b/docs/threat-models/openbank-sanctions-service.md
@@ -196,6 +196,23 @@ and nothing alerts on a queue that fails to drain (the same class as #3273).
   interceptor case in #3349 (an approval for resource A must not unlock resource B).
   Risk class = **elevation of privilege** (narrowed). Rollback: revert to `resource = ""`, which
   restores the over-broad grant — the two tests would go red first.
+- **2026-09-08** — **New inbound REST surface: `POST /api/v2/sanctions/lists/refresh-all`** (issue
+  #9048), and the v1 operation's semantics change under its unchanged shape. The old v1 behaviour
+  was itself a D1-class hazard: it ran the entire external-feed fan-out synchronously inside the
+  HTTP request, so any slow feed turned a compliance-data refresh into an opaque proxy 502/504 and
+  the fuzz lane had to exclude the operation outright. Both URL majors now set a
+  `refresh_requested_at` flag (V12, additive column) on every enabled list and return immediately —
+  v2 with 202 + `{requested: N}` and a **required `Idempotency-Key` header** (#8351), v1 with its
+  legacy 200 + array of pre-refresh lists for the deprecation window. The 60s scheduler treats a
+  flagged list as due, runs the real imports one list at a time, and `markUpdated` clears the flag
+  at commit, so a flag cannot cause re-import on every tick. Risk class = **denial of service**
+  (a refreshed-all trigger is an expensive-batch amplifier): mitigated by `ROLE_OPERATOR`/
+  `ROLE_ADMIN` + `@Authorize(sanctions.trigger)` on BOTH URL majors (regression guard extended to
+  the v2 resource class), by the flag being idempotent by construction (repeated triggers converge,
+  no dedup store needed), and by `ConcurrentExecution.SKIP` on the scheduler. No new egress — the
+  same feeds the cron already fetches. Rollback: revert; V12 is a nullable additive column and the
+  v1 path is untouched in shape.
+
 - **2026-09-04** — Issue #8362: first-party EU consolidated-list adapter + import outcomes.
   The EU list import switches its default source from the OpenSanctions-normalised CSV mirror
   (migration V7's workaround for a then-redirecting endpoint) to the official EU FSF XML feed,

--- a/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
@@ -11,6 +11,8 @@ export async function GET() {
 }
 
 export async function POST() {
-  // Refreshing every enabled list re-downloads and re-indexes the upstream feeds.
-  return forwardToSanctionsService('/api/v1/sanctions/lists/refresh-all', 'POST', {}, 20_000)
+  // Refreshing every enabled list re-downloads and re-indexes the upstream feeds — since #9048
+  // the v2 endpoint answers 202 immediately and the scheduler runs the imports off the request
+  // path, so the BFF no longer needs to hold a long upstream request open.
+  return forwardToSanctionsService('/api/v2/sanctions/lists/refresh-all', 'POST', {}, 20_000)
 }

--- a/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
@@ -14,5 +14,10 @@ export async function POST() {
   // Refreshing every enabled list re-downloads and re-indexes the upstream feeds — since #9048
   // the v2 endpoint answers 202 immediately and the scheduler runs the imports off the request
   // path, so the BFF no longer needs to hold a long upstream request open.
-  return forwardToSanctionsService('/api/v2/sanctions/lists/refresh-all', 'POST', {}, 20_000)
+  return forwardToSanctionsService('/api/v2/sanctions/lists/refresh-all', 'POST', {}, 20_000, {
+    // #9048: the v2 contract requires an Idempotency-Key on money-path POSTs (#8351). A fresh
+    // key per operator click is correct here — the flag update is idempotent by construction,
+    // so a retry with the same or a new key converges to the same state.
+    'Idempotency-Key': crypto.randomUUID(),
+  })
 }

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
@@ -88,6 +88,19 @@ class SanctionsListService(
     }
 
     /**
+     * Legacy v1 variant of the same request: flags the lists exactly like [requestRefreshAll] but
+     * returns the enabled lists (200 + array) so the v1 contract SHAPE survives the deprecation
+     * window (docs/03-api: a breaking change moves to /api/v2 while v1 runs in parallel). The
+     * returned lists are the PRE-refresh state — v1 could no longer keep its old post-refresh
+     * semantics anyway, because those semantics were the defect: they required the imports to
+     * finish inside the request.
+     */
+    suspend fun requestRefreshAllLegacy(): List<SanctionsList> {
+        requestRefreshAll()
+        return repo.listSanctionsLists().filter { it.enabled }
+    }
+
+    /**
      * Scheduled refresh: checks cron schedule per list, calls the real importer.
      * Runs every 60s but only triggers a list when its cron time matches.
      *

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
@@ -72,11 +72,19 @@ class SanctionsListService(
             ?: throw IllegalStateException("Failed to persist sanctions list refresh for $listType")
     }
 
-    suspend fun refreshAll(): List<SanctionsList> {
-        Log.info("Refreshing all enabled sanctions lists")
-        return repo.listSanctionsLists()
-            .filter { list -> list.enabled }
-            .map { list -> refresh(list.listType) }
+    /**
+     * #9048: request a refresh of every enabled list and answer immediately. The endpoint cannot
+     * afford to run the imports synchronously — a full sweep of all feeds can take far longer
+     * than any sane HTTP timeout, so the request used to hang until the proxy gave up while the
+     * imports kept running in the background, and the caller could not tell whether anything had
+     * happened. Instead we set a `refreshRequestedAt` flag on every enabled list; the scheduled
+     * loop treats a flagged list as due and runs the real imports one list at a time, clearing the
+     * flag via markUpdated as each completes. Per-list progress stays queryable through each
+     * list's lastUpdatedAt.
+     */
+    suspend fun requestRefreshAll(): Int {
+        Log.info("Refresh requested for all enabled sanctions lists (deferred to scheduler)")
+        return repo.requestRefreshAll()
     }
 
     /**
@@ -146,6 +154,9 @@ class SanctionsListService(
 
     private fun SanctionsList.isDueForScheduledRefresh(now: ZonedDateTime): Boolean {
         if (!enabled) return false
+        // #9048: an explicit refresh request overrides the cron schedule — the operator asked for
+        // this list now, so the next tick picks it up regardless of hour/day.
+        if (refreshRequestedAt != null) return true
         val currentDay = now.dayOfWeek.name.take(3)
         if (currentDay !in cronDays.split(',').filter { it.isNotBlank() }) return false
         if (now.hour != cronHour || now.minute != cronMinute) return false

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/domain/model/SanctionsList.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/domain/model/SanctionsList.kt
@@ -20,6 +20,8 @@ data class SanctionsList(
     val cronDays: String,
     val createdAt: Instant,
     val updatedAt: Instant,
+    /** #9048: an operator-requested refresh pending the scheduler tick; null when none is owed. */
+    val refreshRequestedAt: Instant? = null,
 )
 
 data class UpdateSanctionsListRequest(

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/entity/SanctionsListEntity.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/entity/SanctionsListEntity.kt
@@ -48,10 +48,14 @@ class SanctionsListEntity {
     @field:Column(name = "updated_at")
     var updatedAt: Instant = Instant.now()
 
+    /** #9048: operator asked for a refresh off-request; the scheduler does the work. */
+    @field:Column(name = "refresh_requested_at")
+    var refreshRequestedAt: Instant? = null
+
     fun toDomain() = SanctionsList(
         id = id, listType = listType, displayName = displayName, sourceUrl = sourceUrl,
         enabled = enabled, lastUpdatedAt = lastUpdatedAt, lastEntryCount = lastEntryCount,
         cronHour = cronHour, cronMinute = cronMinute, cronDays = cronDays,
-        createdAt = createdAt, updatedAt = updatedAt,
+        createdAt = createdAt, updatedAt = updatedAt, refreshRequestedAt = refreshRequestedAt,
     )
 }

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsListRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsListRepositoryImpl.kt
@@ -35,9 +35,23 @@ class SanctionsListRepositoryImpl(private val clock: Clock) : PanacheRepository<
                 entity.lastUpdatedAt = updatedAt
                 entity.lastEntryCount = entryCount
                 entity.updatedAt = updatedAt
+                // #9048: the refresh the flag asked for has now run — clear it, or the scheduler
+                // would re-import the list on every tick forever.
+                entity.refreshRequestedAt = null
             }
         }
     }.map { it?.toDomain() }
+
+    /**
+     * #9048: flag every enabled list for refresh, returning how many were flagged. The actual
+     * imports run on the scheduler ticks, one list per unit of work — never inside the HTTP
+     * request that asked.
+     */
+    suspend fun requestRefreshAll(): Int = Panache.withTransaction {
+        // `now` must be computed in the body, never as a default parameter — a default arg is
+        // evaluated at the call site even on a mockk mock (whose clock is null → NPE in tests).
+        update("refreshRequestedAt = ?1, updatedAt = ?1 WHERE enabled = true", Instant.now(clock))
+    }.awaitSuspending()
 
     suspend fun listSanctionsLists(): List<SanctionsList> = listSanctionsListsUni().awaitSuspending()
 

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListRefreshV2Resource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListRefreshV2Resource.kt
@@ -8,6 +8,7 @@ import com.openbank.libs.authz.Authorize
 import com.openbank.sanctions.application.usecase.SanctionsListService
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.HeaderParam
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
@@ -30,5 +31,13 @@ class SanctionsListRefreshV2Resource(private val service: SanctionsListService) 
     @Path("/refresh-all")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "sanctions.trigger", resource = "")
-    suspend fun refreshAll(): Response = Response.accepted(mapOf("requested" to service.requestRefreshAll())).build()
+    suspend fun refreshAll(@HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
+        // #8351: money-path POSTs require the key. Nullable + requireNotNull in the BODY — a
+        // non-nullable JAX-RS param NPEs at injection (a 500), and a suspend fun emits no
+        // intrinsic at all (the null flows in silently). libs-runtime maps this to 400.
+        // No dedup store is needed: flagging is `UPDATE ... SET refresh_requested_at = now`,
+        // idempotent by construction — a replayed key converges to the same state.
+        requireNotNull(idempotencyKey) { "Idempotency-Key header is required" }
+        return Response.accepted(mapOf("requested" to service.requestRefreshAll())).build()
+    }
 }

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListRefreshV2Resource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListRefreshV2Resource.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.infrastructure.rest
+
+import com.openbank.libs.authz.Authorize
+import com.openbank.sanctions.application.usecase.SanctionsListService
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+
+/**
+ * v2 of the refresh-all trigger (#9048, ADR-0048): the v1 operation answered 200 only after every
+ * enabled feed had been re-downloaded inside the request — a synchronous external fan-out that
+ * outlived every proxy timeout. The v2 contract is honest about the work being deferred: 202
+ * immediately, the imports run on the scheduler one list at a time, and per-list progress is
+ * observable through each list's `lastUpdatedAt` on GET /api/v1/sanctions/lists.
+ */
+@Path("/api/v2/sanctions/lists")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+class SanctionsListRefreshV2Resource(private val service: SanctionsListService) {
+
+    @POST
+    @Path("/refresh-all")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "sanctions.trigger", resource = "")
+    suspend fun refreshAll(): Response = Response.accepted(mapOf("requested" to service.requestRefreshAll())).build()
+}

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
@@ -55,6 +55,8 @@ class SanctionsListResource(private val service: SanctionsListService) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "sanctions.trigger", resource = "")
     suspend fun refreshAll(): Response =
-        // #9048: 202 Accepted — the imports are queued for the scheduler, not run in-request.
-        Response.accepted(mapOf("requested" to service.requestRefreshAll())).build()
+        // #9048: deprecated in favour of POST /api/v2/sanctions/lists/refresh-all (202). Kept
+        // serving the v1 shape (200 + array) for the deprecation window; the imports are now
+        // deferred to the scheduler here too — the old synchronous fan-out was the defect.
+        Response.ok(service.requestRefreshAllLegacy()).build()
 }

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
@@ -54,5 +54,7 @@ class SanctionsListResource(private val service: SanctionsListService) {
     @Path("/refresh-all")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "sanctions.trigger", resource = "")
-    suspend fun refreshAll(): Response = Response.ok(service.refreshAll()).build()
+    suspend fun refreshAll(): Response =
+        // #9048: 202 Accepted — the imports are queued for the scheduler, not run in-request.
+        Response.accepted(mapOf("requested" to service.requestRefreshAll())).build()
 }

--- a/openbank-sanctions-service/src/main/resources/db/migration/V12__refresh_requested_at.sql
+++ b/openbank-sanctions-service/src/main/resources/db/migration/V12__refresh_requested_at.sql
@@ -1,0 +1,6 @@
+-- #9048: POST /refresh-all moves off the request path (202 + the existing 60s scheduler does the
+-- work). This flag is the hand-off: the endpoint sets it on every enabled list, the scheduler's
+-- due-check treats a set flag as due, and markUpdated clears it when that list's refresh commits.
+--
+-- Rollback: ALTER TABLE sanctions_lists DROP COLUMN IF EXISTS refresh_requested_at;
+ALTER TABLE sanctions_lists ADD COLUMN IF NOT EXISTS refresh_requested_at TIMESTAMPTZ;

--- a/openbank-sanctions-service/src/main/resources/openapi.yaml
+++ b/openbank-sanctions-service/src/main/resources/openapi.yaml
@@ -252,6 +252,15 @@ paths:
         on subsequent scheduler ticks, one list at a time, and per-list progress is observable
         through each list's lastUpdatedAt on GET /api/v1/sanctions/lists.
       operationId: refreshAllSanctionsListsV2
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          description: >-
+            Required on money-path POSTs (#8351). Flagging is idempotent by construction, so a
+            retried key converges to the same state.
+          schema:
+            type: string
       responses:
         '202':
           description: Refresh of all enabled lists queued on the scheduler.

--- a/openbank-sanctions-service/src/main/resources/openapi.yaml
+++ b/openbank-sanctions-service/src/main/resources/openapi.yaml
@@ -6,12 +6,12 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.1 -> 1.2): additive
   # only — GET /approvals (the checker's queue, issue #3472) plus two additive fields on
   # ApprovalResponse (makerId, createdAt). No breaking change.
-  version: 1.5.0
-  # 1.4.0 -> 1.5.0 (#9048): POST /lists/refresh-all now answers 202 and defers the imports to the
-  # scheduler instead of running them inside the request. The success code changed 200 -> 202,
-  # which oasdiff may classify as breaking; the URL major stays 1 (ADR-0048) because the resource
-  # and its semantics (operator triggers a refresh of all enabled lists) are unchanged — the
-  # previous synchronous 200 was itself the defect (request outlived every proxy timeout).
+  version: 2.0.0
+  # 1.4.0 -> 2.0.0 (#9048, ADR-0048): POST /lists/refresh-all could not keep answering 200 — that
+  # required the whole external-feed fan-out to finish inside the request, which was the defect.
+  # oasdiff classifies 200 -> 202 as breaking, and a breaking change here means a new URL major:
+  # /api/v2/sanctions/lists/refresh-all (202) now carries the operation, while the v1 path keeps
+  # its 200 + array shape for the deprecation window (both defer the imports to the scheduler).
   description: >-
     Real-time sanctions screening against EU, UN, OFAC, HM Treasury and CNB lists. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -224,14 +224,37 @@ paths:
   /api/v1/sanctions/lists/refresh-all:
     post:
       tags: [SanctionsLists]
-      summary: Trigger manual refresh of all enabled lists
+      summary: Trigger manual refresh of all enabled lists (deprecated v1 shape)
+      description: >-
+        DEPRECATED — use POST /api/v2/sanctions/lists/refresh-all, which answers 202 (#9048).
+        This v1 operation keeps its 200 + array shape for the deprecation window but no longer
+        performs the imports in-request: it flags every enabled list for the scheduler and
+        returns the enabled lists in their PRE-refresh state immediately. Per-list progress is
+        observable through each list's lastUpdatedAt.
+      deprecated: true
       operationId: refreshAllSanctionsLists
       responses:
+        '200':
+          description: Enabled lists flagged for refresh (pre-refresh state)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SanctionsList'
+
+  /api/v2/sanctions/lists/refresh-all:
+    post:
+      tags: [SanctionsLists]
+      summary: Trigger manual refresh of all enabled lists
+      description: >-
+        Flags every enabled list for refresh and answers immediately (#9048). The imports run
+        on subsequent scheduler ticks, one list at a time, and per-list progress is observable
+        through each list's lastUpdatedAt on GET /api/v1/sanctions/lists.
+      operationId: refreshAllSanctionsListsV2
+      responses:
         '202':
-          description: >-
-            Refresh of all enabled lists queued on the scheduler (#9048). The response returns
-            immediately; the imports run on subsequent scheduler ticks, one list at a time, and
-            per-list progress is observable through each list's lastUpdatedAt.
+          description: Refresh of all enabled lists queued on the scheduler.
           content:
             application/json:
               schema:

--- a/openbank-sanctions-service/src/main/resources/openapi.yaml
+++ b/openbank-sanctions-service/src/main/resources/openapi.yaml
@@ -6,7 +6,12 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.1 -> 1.2): additive
   # only — GET /approvals (the checker's queue, issue #3472) plus two additive fields on
   # ApprovalResponse (makerId, createdAt). No breaking change.
-  version: 1.4.0
+  version: 1.5.0
+  # 1.4.0 -> 1.5.0 (#9048): POST /lists/refresh-all now answers 202 and defers the imports to the
+  # scheduler instead of running them inside the request. The success code changed 200 -> 202,
+  # which oasdiff may classify as breaking; the URL major stays 1 (ADR-0048) because the resource
+  # and its semantics (operator triggers a refresh of all enabled lists) are unchanged — the
+  # previous synchronous 200 was itself the defect (request outlived every proxy timeout).
   description: >-
     Real-time sanctions screening against EU, UN, OFAC, HM Treasury and CNB lists. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -222,14 +227,19 @@ paths:
       summary: Trigger manual refresh of all enabled lists
       operationId: refreshAllSanctionsLists
       responses:
-        '200':
-          description: All enabled lists refreshed
+        '202':
+          description: >-
+            Refresh of all enabled lists queued on the scheduler (#9048). The response returns
+            immediately; the imports run on subsequent scheduler ticks, one list at a time, and
+            per-list progress is observable through each list's lastUpdatedAt.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SanctionsList'
+                type: object
+                properties:
+                  requested:
+                    type: integer
+                    description: How many enabled lists were flagged for refresh.
 
   /api/v1/sanctions/approvals:
     get:

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
@@ -222,31 +222,55 @@ class SanctionsListServiceTest {
             .hasMessageContaining("Failed to persist sanctions list refresh")
     }
 
-    // ──── refreshAll ─────────────────────────────────────────────────────────
+    // ──── requestRefreshAll (#9048) ─────────────────────────────────────────
 
     @Test
-    fun `refreshAll only refreshes enabled lists`(): Unit = runBlocking {
-        val enabled = sampleList(listType = "OFAC_SDN", enabled = true)
-        val disabled = sampleList(listType = "FATF_HIGH_RISK", enabled = false)
-        coEvery { repo.listSanctionsLists() } returns listOf(enabled, disabled)
-        coEvery { repo.findByListType("OFAC_SDN") } returns enabled
-        coEvery { importer.importList(SanctionsListType.OFAC_SDN, any()) } returns ListImportResult.imported(1)
-        coEvery { repo.markUpdated("OFAC_SDN", 1) } returns enabled.copy(lastEntryCount = 1)
+    fun `requestRefreshAll flags enabled lists via repo and returns the count`(): Unit = runBlocking {
+        coEvery { repo.requestRefreshAll() } returns 5
 
-        val result = service.refreshAll()
-
-        assertThat(result).hasSize(1)
-        coVerify(exactly = 0) { repo.findByListType("FATF_HIGH_RISK") }
-    }
-
-    @Test
-    fun `refreshAll returns empty list when nothing is enabled`(): Unit = runBlocking {
-        coEvery { repo.listSanctionsLists() } returns listOf(sampleList(enabled = false))
-
-        assertThat(service.refreshAll()).isEmpty()
+        assertThat(service.requestRefreshAll()).isEqualTo(5)
+        coVerify { repo.requestRefreshAll() }
+        // The endpoint must never touch the importer — the imports belong to the scheduler.
+        coVerify(exactly = 0) { importer.importList(any(), any()) }
     }
 
     // ──── scheduledRefresh ──────────────────────────────────────────────────
+
+    @Test
+    fun `scheduledRefresh refreshes a flagged list even outside its cron window`(): Unit = runBlocking {
+        // clock fixed at 2024-01-15T12:00:00Z (Monday) but this list's cron says 06:00 — without
+        // the #9048 flag it would NOT be due. The refresh-requested flag makes it due.
+        val flagged = sampleList(
+            listType = "OFAC_SDN",
+            sourceUrl = "https://example.com/sdn.xml",
+            cronHour = 6,
+            cronMinute = 0,
+        ).copy(refreshRequestedAt = Instant.parse("2024-01-15T11:58:00Z"))
+        coEvery { repo.listSanctionsLists() } returns listOf(flagged)
+        coEvery { repo.findByListType("OFAC_SDN") } returns flagged
+        coEvery {
+            importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml")
+        } returns ListImportResult.imported(9)
+        coEvery { repo.markUpdated("OFAC_SDN", 9) } returns flagged.copy(lastEntryCount = 9)
+
+        service.scheduledRefresh()
+
+        coVerify { importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml") }
+        // markUpdated is also what clears the flag (repo side), so the list is not re-imported
+        // on every subsequent tick.
+        coVerify { repo.markUpdated("OFAC_SDN", 9) }
+    }
+
+    @Test
+    fun `scheduledRefresh does not refresh a disabled list even when flagged`(): Unit = runBlocking {
+        val flaggedDisabled = sampleList(listType = "OFAC_SDN", enabled = false)
+            .copy(refreshRequestedAt = Instant.parse("2024-01-15T11:58:00Z"))
+        coEvery { repo.listSanctionsLists() } returns listOf(flaggedDisabled)
+
+        service.scheduledRefresh()
+
+        coVerify(exactly = 0) { importer.importList(any(), any()) }
+    }
 
     @Test
     fun `scheduledRefresh skips lists whose cron schedule does not match now`(): Unit = runBlocking {

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
@@ -234,6 +234,19 @@ class SanctionsListServiceTest {
         coVerify(exactly = 0) { importer.importList(any(), any()) }
     }
 
+    @Test
+    fun `requestRefreshAllLegacy flags and returns the enabled lists for the v1 shape`(): Unit = runBlocking {
+        val enabled = sampleList(listType = "OFAC_SDN", enabled = true)
+        coEvery { repo.requestRefreshAll() } returns 1
+        coEvery { repo.listSanctionsLists() } returns listOf(enabled, sampleList(enabled = false))
+
+        val result = service.requestRefreshAllLegacy()
+
+        assertThat(result).containsExactly(enabled)
+        coVerify { repo.requestRefreshAll() }
+        coVerify(exactly = 0) { importer.importList(any(), any()) }
+    }
+
     // ──── scheduledRefresh ──────────────────────────────────────────────────
 
     @Test

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListSecurityTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListSecurityTest.kt
@@ -35,4 +35,23 @@ class SanctionsListSecurityTest {
                 .isNull()
         }
     }
+
+    @Test
+    fun `no SanctionsListRefreshV2Resource endpoint is @PermitAll`() {
+        // Same guard for the v2 refresh-all resource (#9048) — a new URL major must not quietly
+        // drop the role-gating its v1 sibling carries.
+        val methods = SanctionsListRefreshV2Resource::class.java.declaredMethods.filter { m ->
+            m.getAnnotation(GET::class.java) != null ||
+                m.getAnnotation(POST::class.java) != null ||
+                m.getAnnotation(PUT::class.java) != null ||
+                m.getAnnotation(DELETE::class.java) != null ||
+                m.getAnnotation(PATCH::class.java) != null
+        }
+        assertThat(methods).isNotEmpty()
+        methods.forEach { m ->
+            assertThat(m.getAnnotation(PermitAll::class.java))
+                .describedAs("${m.name} must not be @PermitAll — use @RolesAllowed")
+                .isNull()
+        }
+    }
 }


### PR DESCRIPTION
## Proč

`POST /api/v1/sanctions/lists/refresh-all` spouštěl importy všech povolených feedů synchronně v rámci HTTP requestu — sweep přes všechny externí zdroje trvá déle než jakýkoli rozumný proxy timeout (fuzz lane read-timeout 5 s na každém běhu), takže request visel, proxy vzadávala, a volající nemohl poznat, jestli se vůbec něco stalo.

## Co se mění

- Nový sloupec `sanctions_lists.refresh_requested_at` (V12) jako hand-off flag: endpoint flag nastaví na všech enabled listech, scheduler (60 s) považuje flagged list za due bez ohledu na cron okno a `markUpdated` flag při commitu maže.
- **Kontrakt dle ADR-0048:** oasdiff klasifikuje 200 → 202 jako breaking a D2 činí MAJOR bump nesplnitelným bez nového URL majoru — operace proto přechází na **`POST /api/v2/sanctions/lists/refresh-all`** (202 `{requested: N}`), `info.version` 1.4.0 → 2.0.0.
- **v1 cesta zůstává** pro deprecation window (docs/03-api: v1 běží paralelně 6 měsíců): drží tvar 200 + pole listů, ale importy už také deleguje na scheduler a vrací pre-refresh stav okamžitě — staré synchronní chování byl samotný defect, nedalo se zachovat.
- Per-list `/{listType}/refresh` zůstává synchronní záměrně: jeden feed se vejde do request window a operátor čeká na výsledek právě jednoho importu — na rozdíl od fan-outu přes všechny (non-goal v issue).
- admin-ui BFF (`/api/sanctions/lists` POST) přepnuto na v2 cestu; `forwardToSanctionsService` propustí 202 přes `res.ok`, UI po refresh-i jen reloaduje seznamy.
- Fuzz exclusion `refreshAllSanctionsLists` odebrána — v1 i v2 jsou zpátky uvnitř request window.
- Per-feed last-success queryable: `lastUpdatedAt` na GET /api/v1/sanctions/lists (acceptance #2).

## Security checklist

- [x] Žádná změna authn/authz — v2 resource nese stejné role i `@Authorize` jako v1 (regresní guard rozšířen i na v2 třídu)
- [x] Externí fan-out se z request path odstraňuje, nepřidává
- [x] Migrace additivní (`ADD COLUMN IF NOT EXISTS`), rollback v komentáři, ověřena sekvencí V1–V12 na čisté Postgres 16
- [x] Endpoint nejde zneužít k DoS: flag idempotentní, importy mimo request, scheduler má `ConcurrentExecution.SKIP`

## Testy

- Lokálně zelené: `:openbank-sanctions-service:test ktlintCheck detekt`
- Nové unit testy: requestRefreshAll deleguje a netýká se importeru; legacy varianta vrací enabled listy; flagged list je due mimo cron okno; disabled list se i s flagem přeskočí; security guard pro v2 resource

Closes #9048
