### PR TITLE
fix(psd2): declare the default datasource so the api-fuzz harness can provision its DB

### DIFF
--- a/openbank-psd2-service/src/main/resources/application.yaml
+++ b/openbank-psd2-service/src/main/resources/application.yaml
@@ -93,6 +93,21 @@ quarkus:
       connect-timeout: 2000
       read-timeout: 3000
 
+  # Local/default datasource so the service boots outside the cluster and the
+  # api-fuzz harness can derive + provision its DB (issue #9257 — psd2 was the
+  # only in-scope candidate carrying no postgresql:// URL here, which kept it
+  # out of the DAST fleet). GitOps overrides all of these via
+  # QUARKUS_DATASOURCE_* env (psd2-service.yaml); DB name openbank_psd2 matches
+  # postgres.yaml.
+  datasource:
+    db-kind: postgresql
+    username: ${POSTGRES_USER:openbank}
+    password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
+    reactive:
+      url: ${REACTIVE_URL:postgresql://localhost:5432/openbank_psd2}
+    jdbc:
+      url: ${JDBC_URL:jdbc:postgresql://localhost:5432/openbank_psd2}
+
   management:
     enabled: true
     port: 8085


### PR DESCRIPTION
## Proč

Fleet fuzz coverage je 27/27 = 100 %, ale s trvalou exclusion `openbank-psd2-service — no postgresql:// URL — the harness cannot provision its DB`. Příčina: psd2 jako jediná služba nese datasource pouze jako GitOps env (`QUARKUS_DATASOURCE_JDBC_URL`), v `application.yaml` blok chybí, takže scope-derivace v `api-fuzz.yml` ho vyřadí.

## Změna

Standardní fleet datasource blok (stejný pattern jako vop-service): defaultní localhost URL, env override. DB jméno `openbank_psd2` odpovídá `gitops/components/psd2-service/postgres.yaml`. Nasazené chování se nemění — `QUARKUS_DATASOURCE_*` env má přednost před YAML defaultem.

## Ověření

- `check-duplicate-yaml-keys.sh`: clean (81 souborů)
- Simulace scope regexu z `api-fuzz.yml` proti upravenému YAML: DB `openbank_psd2` odvozena → psd2 vstoupí do scope
- Po merge spustím fleet `api-fuzz` a KPI refresh; akceptace dle #9257: `excluded: []`, inScope 28/28, `fuzz.excludedCount: 0`

Closes #9257
Refs #8590

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (N/A — config-only default datasource, no auth/payment path change)
- [x] PII path changed? → tag `gdpr-review-required`. (N/A)
- [x] Cardholder data path changed? → tag `pci-review-required`. (N/A)
