### PR TITLE
feat(account): record the terms version a term deposit opens under

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -630,3 +630,17 @@ Recovery from a legacy tombstone is a newly issued grant, never replaying the sa
   **Risk class:** confidentiality (bounded to party ids of parties the owner already transacts
   with); no money mutation, no new principal, no new service-to-service edge. Rollback: remove the
   route; enforcement is unchanged because the guard never reads this projection.
+- **2026-09-08** — **Term-deposit openings record the governing terms version** (#9044), no new
+  route, caller, edge or privilege. `POST /api/v1/accounts` for `TERM_DEPOSIT` now carries a
+  required `termsVersion`/`termsUrl`/`termsEffectiveFrom` triple, persisted on the account row
+  (V24; CHECK NOT VALID, existing deposits stay NULL — no backfill, a historical deposit must not
+  gain terms it never showed the customer). The values are resolved server-side by the
+  customer-edge from the product catalogue's currently-effective terms, and a client-supplied
+  `termsVersionShown` mismatch answers 409 there, so a terms rollout can never bind a customer to
+  a document they were not shown. The record is audit data: it is written once at opening, never
+  mutated, and read back in the account response. **Security-relevant half:** the triple is
+  evidence, not input to any authorization or money decision, so forging it requires the caller to
+  already hold the open-account privilege; the 409 comparison happens at the edge against the
+  catalogue of record, not against client-supplied truth. **Risk class:** accountability /
+  non-repudiation hardening; no money mutation, no new principal, no new service-to-service edge.
+  Rollback: drop the three columns; openings of other account types are unaffected.

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
@@ -32,6 +32,14 @@ data class OpenAccountCommand(
      * (canDebit/canCredit both require ACTIVE).
      */
     val initialStatus: AccountStatus = AccountStatus.ACTIVE,
+    /**
+     * Terms version + document reference the account is opened under (#9044). The use case
+     * REQUIRES a non-blank [termsVersion] for TERM_DEPOSIT; other account types may carry it
+     * but are not required to.
+     */
+    val termsVersion: String? = null,
+    val termsUrl: String? = null,
+    val termsEffectiveFrom: LocalDate? = null,
 )
 
 data class CloseAccountCommand(val accountId: UUID, val reason: String?, val requestedBy: UUID)

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -35,6 +35,7 @@ import com.openbank.account.domain.event.AccountCreatedEvent
 import com.openbank.account.domain.event.AccountStatusChangedEvent
 import com.openbank.account.domain.model.Account
 import com.openbank.account.domain.model.AccountStatus
+import com.openbank.account.domain.model.AccountType
 import com.openbank.account.domain.model.CurrencyPocket
 import com.openbank.account.domain.model.PocketResolution
 import com.openbank.account.domain.model.PocketRouter
@@ -121,6 +122,16 @@ class AccountService(
             ProductLookupResult.Unavailable -> Unit
         }
 
+        // #9044: a TERM_DEPOSIT must never open without a record of the terms version it was
+        // opened under — the terms carry the early-withdrawal penalty and the notice period, and
+        // "which terms govern this deposit" is the first question of any complaints/conduct
+        // review. IllegalArgumentException → 400 via libs-runtime's mapper, same as the REST
+        // layer's own validation. The DB backs this with chk_accounts_terms (NOT VALID — honest
+        // nulls on pre-V24 accounts stay untouched).
+        require(command.accountType != AccountType.TERM_DEPOSIT || !command.termsVersion.isNullOrBlank()) {
+            "termsVersion is required when opening a TERM_DEPOSIT account"
+        }
+
         val iban = ibanGenerator.generate(command.currency)
 
         check(!accountRepository.existsByIban(iban)) {
@@ -142,6 +153,9 @@ class AccountService(
             sanctionsScreenedAt = now,
             sanctionsStatus = screening.status,
             legalName = command.legalName.ifBlank { null },
+            termsVersion = command.termsVersion,
+            termsUrl = command.termsUrl,
+            termsEffectiveFrom = command.termsEffectiveFrom,
         )
 
         // Account + pocket + idempotency key commit in ONE transaction (#465). A concurrent

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
@@ -45,6 +45,16 @@ data class Account(
      * authorization decision. Null means "use the account-type default name".
      */
     val nickname: String? = null,
+    /**
+     * Terms version this deposit was opened under (#9044) — the record a complaints/conduct
+     * review asks for first. Non-null for every TERM_DEPOSIT opened after V24 (enforced by
+     * chk_accounts_terms); null means a pre-V24 account, which has no truthful record and was
+     * deliberately NOT backfilled from openedAt (that would manufacture evidence).
+     */
+    val termsVersion: String? = null,
+    /** Snapshot of the terms document reference at opening (URL + effective-from date). */
+    val termsUrl: String? = null,
+    val termsEffectiveFrom: LocalDate? = null,
 ) {
     fun canDebit(amount: Money): Boolean {
         require(amount.currency == currency) { "Currency mismatch" }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
@@ -86,6 +86,17 @@ class AccountEntity : PanacheEntityBase {
     @Column(name = "nickname", length = 60)
     var nickname: String? = null
 
+    /** Terms version this TERM_DEPOSIT was opened under (V24, #9044). Null = pre-V24 account. */
+    @Column(name = "terms_version")
+    var termsVersion: String? = null
+
+    /** Snapshot of the terms document URL at opening — evidence of what was shown (V24, #9044). */
+    @Column(name = "terms_url")
+    var termsUrl: String? = null
+
+    @Column(name = "terms_effective_from")
+    var termsEffectiveFrom: LocalDate? = null
+
     /** Stamped from the injected [java.time.Clock] in the repository layer (ADR-0100 — no wall-clock reads here). */
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: Instant = Instant.now()

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
@@ -240,6 +240,9 @@ private fun AccountEntity.toDomain() = Account(
     goalTargetMinorUnits = goalTargetMinorUnits,
     goalTargetDate = goalTargetDate,
     nickname = nickname,
+    termsVersion = termsVersion,
+    termsUrl = termsUrl,
+    termsEffectiveFrom = termsEffectiveFrom,
 )
 
 private fun Account.toEntity() = AccountEntity().also {
@@ -261,4 +264,7 @@ private fun Account.toEntity() = AccountEntity().also {
     it.goalTargetMinorUnits = goalTargetMinorUnits
     it.goalTargetDate = goalTargetDate
     it.nickname = nickname
+    it.termsVersion = termsVersion
+    it.termsUrl = termsUrl
+    it.termsEffectiveFrom = termsEffectiveFrom
 }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
@@ -149,6 +149,9 @@ class AccountResource(
                 currency = CurrencyCode.of(request.currencyCode),
                 requestedBy = operatorId(),
                 legalName = request.legalName,
+                termsVersion = request.termsVersion,
+                termsUrl = request.termsUrl,
+                termsEffectiveFrom = request.termsEffectiveFrom,
             ),
         )
         val responseBody = account.toResponse()
@@ -521,6 +524,9 @@ private fun com.openbank.account.domain.model.Account.toResponse() = AccountResp
     goalTargetMinorUnits = goalTargetMinorUnits,
     goalTargetDate = goalTargetDate,
     nickname = nickname,
+    termsVersion = termsVersion,
+    termsUrl = termsUrl,
+    termsEffectiveFrom = termsEffectiveFrom,
 )
 
 private fun CursorPage<com.openbank.account.domain.model.Account>.toResponse() =

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/dto/AccountDtos.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/dto/AccountDtos.kt
@@ -20,6 +20,14 @@ data class OpenAccountRequest(
     val currencyCode: String,
     /** Legal name of the party — required for sanctions screening (ADR-0032 §C). */
     val legalName: String,
+    /**
+     * Terms version + document reference the account is opened under (#9044). REQUIRED for
+     * TERM_DEPOSIT (enforced in the use case — a deposit without a terms record is a compliance
+     * gap, not a nullable convenience), ignored semantic weight for other account types.
+     */
+    val termsVersion: String? = null,
+    val termsUrl: String? = null,
+    val termsEffectiveFrom: LocalDate? = null,
 )
 
 data class CloseAccountRequest(val reason: String?)
@@ -43,6 +51,10 @@ data class AccountResponse(
     val goalTargetDate: LocalDate? = null,
     /** Customer-chosen display label. Null means "use the account-type default name". */
     val nickname: String? = null,
+    /** Terms version the account was opened under (#9044). Null = pre-V24 account. */
+    val termsVersion: String? = null,
+    val termsUrl: String? = null,
+    val termsEffectiveFrom: LocalDate? = null,
 )
 
 data class AddPocketRequest(val currencyCode: String)

--- a/openbank-account-service/src/main/resources/db/migration/V24__account_terms_version.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V24__account_terms_version.sql
@@ -1,0 +1,29 @@
+-- #9044: record which terms version a term deposit was opened under.
+--
+-- The terms carry the early-withdrawal penalty and the notice period — the two clauses a
+-- customer is held to and the two most likely to be revised. Without this record, "which terms
+-- govern this deposit" could only be reconstructed from openedAt against catalogue effective
+-- dates, which assumes the catalogue is never corrected in place and produces no evidence of
+-- what the customer was shown. A complaints/conduct review asks this question first, months
+-- after opening — exactly when reconstruction is least defensible.
+--
+-- We store the version REFERENCE plus the document url/effectiveFrom as snapshot metadata, not
+-- the document itself (duplicating the catalogue would drift). This makes catalogue version
+-- retention a REQUIREMENT, recorded here explicitly: a terms version referenced by any open or
+-- closed account must stay retrievable in product-catalog forever.
+--
+-- Existing term deposits stay NULL — they have no truthful record and a backfill from openedAt
+-- would manufacture evidence (#9044 decision 3, same reasoning as CourtRegisterSignalState
+-- .NOT_CONFIGURED, #6646). The CHECK is therefore NOT VALID: it constrains rows written AFTER
+-- this migration and never audits the honest-null historical ones.
+--
+-- Rollback: ALTER TABLE accounts DROP CONSTRAINT IF EXISTS chk_accounts_terms;
+--           ALTER TABLE accounts DROP COLUMN IF EXISTS terms_version,
+--                          DROP COLUMN IF EXISTS terms_url, DROP COLUMN IF EXISTS terms_effective_from;
+
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS terms_version TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS terms_url TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS terms_effective_from DATE;
+
+ALTER TABLE accounts ADD CONSTRAINT chk_accounts_terms
+    CHECK (account_type <> 'TERM_DEPOSIT' OR terms_version IS NOT NULL) NOT VALID;

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,12 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.16.0
+  # 1.16.0 -> 1.17.0 (#9044): additive — optional termsVersion/termsUrl/termsEffectiveFrom on
+  # OpenAccountRequest and the Account response. termsVersion is use-case-REQUIRED for
+  # TERM_DEPOSIT openings, which is a behaviour rule, not a contract break (existing clients
+  # opening other account types are unaffected; term-deposit openings come only from
+  # customer-edge, updated in the same change).
+  version: 1.17.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -1253,6 +1258,19 @@ components:
         legalName:
           type: string
           description: Legal name of the account holder for sanctions screening (ADR-0032 §C).
+        termsVersion:
+          type: string
+          description: >-
+            Terms version the account is opened under (#9044). REQUIRED when accountType is
+            TERM_DEPOSIT (400 otherwise) — a term deposit must never open without a record of
+            the terms it was opened under.
+        termsUrl:
+          type: string
+          description: Snapshot of the terms document URL at opening (#9044).
+        termsEffectiveFrom:
+          type: string
+          format: date
+          description: Snapshot of the terms document effective-from date at opening (#9044).
 
     CloseAccountRequest:
       type: object
@@ -1308,6 +1326,17 @@ components:
           nullable: true
         nickname:
           type: string
+          nullable: true
+        termsVersion:
+          type: string
+          nullable: true
+          description: Terms version the account was opened under (#9044); null = pre-V24 account.
+        termsUrl:
+          type: string
+          nullable: true
+        termsEffectiveFrom:
+          type: string
+          format: date
           nullable: true
 
     RenameAccountRequest:

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -553,6 +553,53 @@ class AccountServiceTest {
         assertThat(result.goalTargetMinorUnits).isNull()
     }
 
+    @Test
+    fun `openAccount refuses a TERM_DEPOSIT without a terms version`() {
+        // #9044: a term deposit must never open without a record of the terms it was opened
+        // under — they carry the early-withdrawal penalty and the notice period. The refusal is
+        // an IllegalArgumentException (400 at the REST layer), before any screening or persist.
+        val command = openAccountCommand().copy(accountType = AccountType.TERM_DEPOSIT)
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+
+        assertThatThrownBy {
+            runBlocking { service.openAccount(command) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("termsVersion is required")
+    }
+
+    @Test
+    fun `openAccount persists the terms record on a TERM_DEPOSIT`(): Unit = runBlocking {
+        val iban = Iban.of("CZ6508000000192000145399")
+        val command = openAccountCommand().copy(
+            accountType = AccountType.TERM_DEPOSIT,
+            termsVersion = "2026-01",
+            termsUrl = "https://docs.example/td-2026-01.pdf",
+            termsEffectiveFrom = java.time.LocalDate.parse("2026-01-01"),
+        )
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        every { ibanGenerator.generate(command.currency) } returns iban
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { accountRepository.existsByIban(iban) } returns false
+        coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
+        coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
+
+        val result = service.openAccount(command)
+
+        assertThat(result.termsVersion).isEqualTo("2026-01")
+        coVerify {
+            accountRepository.saveNewAccount(
+                match {
+                    it.termsVersion == "2026-01" &&
+                        it.termsUrl == "https://docs.example/td-2026-01.pdf" &&
+                        it.termsEffectiveFrom == java.time.LocalDate.parse("2026-01-01")
+                },
+                any(),
+                any(),
+            )
+        }
+    }
+
     private fun openAccountCommand(legalName: String = "Test Customer") = OpenAccountCommand(
         idempotencyKey = "idem-123",
         partyId = UUID.randomUUID(),

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
@@ -126,7 +126,10 @@ class AccountApiIT {
               "productId": "00000000-2222-0000-0000-000000000002",
               "accountType": "TERM_DEPOSIT",
               "currencyCode": "EUR",
-              "legalName": "Test Customer"
+              "legalName": "Test Customer",
+              "termsVersion": "2026-01",
+              "termsUrl": "https://docs.example/td-2026-01.pdf",
+              "termsEffectiveFrom": "2026-01-01"
             }
         """.trimIndent()
 
@@ -141,6 +144,10 @@ class AccountApiIT {
             body("accountType", equalTo("TERM_DEPOSIT"))
             body("currencyCode", equalTo("EUR"))
             body("status", equalTo("ACTIVE"))
+            // #9044: the terms record the deposit was opened under is persisted and returned.
+            body("termsVersion", equalTo("2026-01"))
+            body("termsUrl", equalTo("https://docs.example/td-2026-01.pdf"))
+            body("termsEffectiveFrom", equalTo("2026-01-01"))
         }
     }
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -614,23 +614,22 @@ class CustomerEdgeResource(
         require(idempotencyKey.isNotBlank()) { "Idempotency-Key header must not be blank" }
         require(idempotencyKey.length <= MAX_IDEMPOTENCY_KEY_LENGTH) { "Idempotency-Key is too long" }
         val customer = customer()
-        val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
-            ?: return badRequest("Malformed term-deposit request")
-        if (request.fieldNames().asSequence().any { it !in TERM_DEPOSIT_OPEN_FIELDS }) {
-            return badRequest("Term-deposit request contains unsupported fields")
+        val parsed = when (val result = parseOpenTermDepositRequest(body)) {
+            is OpenRequestParse.Reject -> return result.response
+            is OpenRequestParse.Ok -> result
         }
-        val productId = request.uuidField("productId")
-            ?: return Response.status(400).entity("{\"error\":\"productId must be a UUID\"}").build()
-        val reservationId = request.get("incentiveReservationId")?.takeUnless { it.isNull }?.let {
-            it.takeIf { node -> node.isTextual }?.textValue()?.let { value ->
-                runCatching { UUID.fromString(value) }.getOrNull()
-            } ?: return badRequest("incentiveReservationId must be a UUID")
-        }
+        val request = parsed.request
+        val productId = parsed.productId
+        val reservationId = parsed.reservationId
         val offer = when (val result = resolvePublicTermDeposit(customer, productId)) {
             is TermDepositResolution.Found -> result.offer
             TermDepositResolution.NotFound -> return termDepositNotFound()
             TermDepositResolution.Unavailable -> return termDepositCatalogueUnavailable()
         }
+        // #9044: the terms record the deposit is opened under — see gateTermsForOpen.
+        val termsGate = gateTermsForOpen(request, offer)
+        if (termsGate is TermsGate.Reject) return termsGate.response
+        val terms = (termsGate as TermsGate.Ok)
         val party = when (val result = activeParty(customer)) {
             is ActivePartyResult.Approved -> result
             is ActivePartyResult.Rejected -> return result.response
@@ -641,6 +640,9 @@ class CustomerEdgeResource(
             .put("accountType", "TERM_DEPOSIT")
             .put("currencyCode", offer.path("currency").asText())
             .put("legalName", party.legalName)
+            .put("termsVersion", terms.version)
+            .put("termsUrl", terms.url)
+            .put("termsEffectiveFrom", terms.effectiveFrom)
         val response = upstream.post(
             "$accountServiceUrl/api/v1/accounts",
             customer.partyId.toString(),
@@ -5127,6 +5129,88 @@ class CustomerEdgeResource(
     }
 
     /** Maps the rich operator product into only the terms a retail customer needs to decide. */
+    /**
+     * The terms document in force TODAY for this offer (#9044): effectiveFrom <= today and
+     * (no effectiveTo or effectiveTo >= today); the latest effectiveFrom wins when several
+     * qualify. Returns null when the product carries no currently effective document — the
+     * caller must treat that as unopenable, never as "open it without a terms record".
+     */
+    private fun resolveCurrentTerms(offer: JsonNode): JsonNode? {
+        val today = LocalDate.now(clock)
+        val docs = offer.path("termsAndConditions")
+        if (!docs.isArray) return null
+        return docs.filter { doc ->
+            val from = runCatching { LocalDate.parse(doc.path("effectiveFrom").asText()) }.getOrNull()
+                ?: return@filter false
+            val to = doc.path("effectiveTo").takeIf { it.isTextual }
+                ?.let { runCatching { LocalDate.parse(it.asText()) }.getOrNull() }
+            !from.isAfter(today) && (to == null || !to.isBefore(today))
+        }.maxByOrNull { it.path("effectiveFrom").asText() }
+    }
+
+    /** Parses and validates the open-term-deposit request body (#9044 keeps this small). */
+    private fun parseOpenTermDepositRequest(body: String): OpenRequestParse {
+        val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
+            ?: return OpenRequestParse.Reject(badRequest("Malformed term-deposit request"))
+        if (request.fieldNames().asSequence().any { it !in TERM_DEPOSIT_OPEN_FIELDS }) {
+            return OpenRequestParse.Reject(badRequest("Term-deposit request contains unsupported fields"))
+        }
+        val productId = request.uuidField("productId")
+            ?: return OpenRequestParse.Reject(
+                Response.status(400).entity("{\"error\":\"productId must be a UUID\"}").build(),
+            )
+        val reservationId = request.get("incentiveReservationId")?.takeUnless { it.isNull }?.let {
+            it.takeIf { node -> node.isTextual }?.textValue()?.let { value ->
+                runCatching { UUID.fromString(value) }.getOrNull()
+            } ?: return OpenRequestParse.Reject(badRequest("incentiveReservationId must be a UUID"))
+        }
+        return OpenRequestParse.Ok(request, productId, reservationId)
+    }
+
+    private sealed interface OpenRequestParse {
+        data class Ok(val request: JsonNode, val productId: UUID, val reservationId: UUID?) : OpenRequestParse
+        data class Reject(val response: Response) : OpenRequestParse
+    }
+
+    /**
+     * The #9044 terms gate for term-deposit opening. The deposit must open with a RECORD of the
+     * terms it was opened under — they carry the early-withdrawal penalty and the notice period,
+     * and a complaints review asks "which terms govern this deposit" months later, when
+     * reconstruction from openedAt is least defensible. The edge resolves the CURRENTLY EFFECTIVE
+     * terms document server-side (what was published); a product with none is unopenable, and a
+     * client echoing a STALE rendered version is refused with 409, so a terms rollout can never
+     * bind the customer to a document they were not shown (ADR-0269: shown vs published is made
+     * explicit, never papered over).
+     */
+    private fun gateTermsForOpen(request: JsonNode, offer: JsonNode): TermsGate {
+        val terms = resolveCurrentTerms(offer)
+            ?: return TermsGate.Reject(
+                Response.status(Response.Status.CONFLICT)
+                    .entity("{\"error\":\"Product has no currently effective terms document\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build(),
+            )
+        val version = terms.path("version").asText()
+        val shown = request.get("termsVersionShown")?.takeUnless { it.isNull }?.let {
+            it.takeIf { node -> node.isTextual }?.textValue()
+                ?: return TermsGate.Reject(badRequest("termsVersionShown must be a string"))
+        }
+        if (shown != null && shown != version) {
+            return TermsGate.Reject(
+                Response.status(Response.Status.CONFLICT)
+                    .entity("{\"error\":\"Terms version mismatch — re-display the current terms before opening\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build(),
+            )
+        }
+        return TermsGate.Ok(version, terms.path("url").asText(), terms.path("effectiveFrom").asText())
+    }
+
+    private sealed interface TermsGate {
+        data class Ok(val version: String, val url: String, val effectiveFrom: String) : TermsGate
+        data class Reject(val response: Response) : TermsGate
+    }
+
     private fun termDepositOffer(product: JsonNode): ObjectNode? {
         val today = LocalDate.now(clock)
         if (!isDiscoverableTermDeposit(product) || !isCurrentlyValid(product, today)) return null
@@ -5310,7 +5394,7 @@ class CustomerEdgeResource(
             "REWARDS_HUB",
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
-        private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId")
+        private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId", "termsVersionShown")
         private val TERMINAL_ACCOUNT_REJECTION_STATUSES = setOf(422)
         private const val MIN_PROMO_CODE_LENGTH = 8
         private const val MAX_PROMO_CODE_LENGTH = 128

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,11 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.53.1
+  # 1.53.1 -> 1.54.0 (#9044): additive — optional termsVersionShown on OpenTermDepositRequest
+  # (the client echoes the terms version it rendered; a mismatch with the catalogue's currently
+  # effective version is a 409, forcing re-display during a terms rollout) and a new 409 response
+  # on POST /term-deposits.
+  version: 1.54.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -185,6 +189,11 @@ paths:
           description: Missing idempotency key or malformed product ID
         '404':
           description: Product is not an active public term-deposit offer, or party is absent
+        '409':
+          description: >-
+            Terms version mismatch — the client displayed a terms version that no longer governs
+            (#9044); re-display the current terms and retry. Also returned when the product has
+            no currently effective terms document.
         '422':
           description: KYC not approved
 
@@ -4974,6 +4983,14 @@ components:
             Optional opaque reservation returned by /incentives/claims. The edge commits it only
             after account-service returns the authoritative openedAt; deterministic rejection
             releases it, while transient failure leaves it retryable until its TTL.
+        termsVersionShown:
+          type: string
+          description: >-
+            The terms document version the client RENDERED to the customer (#9044). The edge
+            resolves the currently effective version from the catalogue; when the two differ the
+            open is refused with 409, so a terms rollout can never bind the customer to a
+            document they were not shown. The version actually opened under is recorded on the
+            account by account-service.
 
     ClaimCampaignIncentiveRequest:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -61,7 +61,19 @@ class CustomerEdgeResourceTest {
         "type":"TERM_DEPOSIT", "currency":"CZK", "status":"$status", "isPublic":$public,
         "minBalance":10000, "termDepositConfig":{"termMonths":6,"interestRateAnnual":0.058,
         "payoutFrequency":"AT_MATURITY","autoRenewEnabled":true,"earlyWithdrawalPenaltyPct":50.0,
-        "earlyWithdrawalNoticeDays":0}, "termsAndConditions":[]
+        "earlyWithdrawalNoticeDays":0},
+        "termsAndConditions":[{"version":"2026-01","url":"https://docs.example/td-2026-01.pdf",
+        "effectiveFrom":"2026-01-01","language":"cs"}]
+    }
+    """.trimIndent()
+
+    /** A product whose only terms document is not yet in force (#9044: unopenable). */
+    private fun termDepositProductWithoutCurrentTerms(id: UUID): String = """{
+        "id":"$id", "code":"TERM_DEPOSIT_6M_CZK", "name":"Termínovaný vklad 6 měsíců",
+        "type":"TERM_DEPOSIT", "currency":"CZK", "status":"ACTIVE", "isPublic":true,
+        "minBalance":10000, "termDepositConfig":{"termMonths":6,"interestRateAnnual":0.058},
+        "termsAndConditions":[{"version":"2999-01","url":"https://docs.example/td-2999.pdf",
+        "effectiveFrom":"2999-01-01","language":"cs"}]
     }
     """.trimIndent()
 
@@ -274,6 +286,57 @@ class CustomerEdgeResourceTest {
         assertThat(body.path("accountType").asText()).isEqualTo("TERM_DEPOSIT")
         assertThat(body.path("currencyCode").asText()).isEqualTo("CZK")
         assertThat(body.path("legalName").asText()).isEqualTo("Ada Customer")
+        // #9044: the deposit opens with the terms record resolved from the catalogue.
+        assertThat(body.path("termsVersion").asText()).isEqualTo("2026-01")
+        assertThat(body.path("termsUrl").asText()).isEqualTo("https://docs.example/td-2026-01.pdf")
+        assertThat(body.path("termsEffectiveFrom").asText()).isEqualTo("2026-01-01")
+    }
+
+    @Test
+    fun `term deposit opening matches a matching termsVersionShown and rejects a stale one`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post(match { it.contains("/api/v1/accounts") }, any(), any(), any()) } returns
+            Response.status(201).entity("""{"id":"${UUID.randomUUID()}"}""").build()
+
+        val resource = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }
+        // The version the app rendered matches the catalogue's currently effective one → opens.
+        assertThat(
+            resource.openTermDeposit("""{"productId":"$product","termsVersionShown":"2026-01"}""", "k1").status,
+        ).isEqualTo(201)
+        // A stale rendered version (a terms rollout landed between display and tap) → 409,
+        // so the customer re-sees the governing document instead of being bound to another.
+        assertThat(
+            resource.openTermDeposit("""{"productId":"$product","termsVersionShown":"2025-06"}""", "k2").status,
+        ).isEqualTo(409)
+    }
+
+    @Test
+    fun `term deposit opening is refused when the product has no currently effective terms`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        // A FUTURE effectiveFrom is not yet in force — there is no terms document to open under.
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProductWithoutCurrentTerms(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit("""{"productId":"$product"}""", "no-terms")
+
+        assertThat(response.status).isEqualTo(409)
+        verify(exactly = 0) { upstream.post(match { it.contains("/api/v1/accounts") }, any(), any(), any()) }
     }
 
     @Test

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -144,6 +144,49 @@ class CustomerEdgeIncentivePactConsumerTest {
         .body(customerReservationBody("RELEASED"))
         .toPact()
 
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun reserveWithoutIdentity(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a published offer contains the pact promo code for the pact product")
+        .uponReceiving("POST an attributed customer reservation WITHOUT trusted party identity")
+        .path("/api/v1/customer-incentives/offers/$OFFER_ID/reservations")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "Idempotency-Key" to IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(
+            newJsonBody { body ->
+                body.stringValue("code", "WELCOME10")
+                body.stringValue("productRef", PRODUCT_ID)
+                body.stringValue("attributionRef", INTERACTION_REF)
+            }.build(),
+        )
+        .willRespondWith()
+        .status(401)
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "reserveWithoutIdentity")
+    fun `provider rejects a reservation request that carries no trusted identity`(mockServer: MockServer) {
+        val connection = java.net.URI(
+            "${mockServer.getUrl()}/api/v1/customer-incentives/offers/$OFFER_ID/reservations",
+        ).toURL().openConnection() as java.net.HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.setRequestProperty("Idempotency-Key", IDEMPOTENCY_KEY)
+        connection.doOutput = true
+        connection.outputStream.use { out ->
+            out.write(
+                """{"code":"WELCOME10","productRef":"$PRODUCT_ID","attributionRef":"$INTERACTION_REF"}"""
+                    .toByteArray(),
+            )
+        }
+
+        assertThat(connection.responseCode).isEqualTo(401)
+    }
+
     @Test
     @PactTestFor(pactMethod = "reserveAttributedIncentive")
     fun `real edge client reserves against the provider contract`(mockServer: MockServer) {

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -145,14 +145,14 @@ class CustomerEdgeIncentivePactConsumerTest {
         .toPact()
 
     @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
-    fun reserveWithoutIdentity(builder: PactDslWithProvider): RequestResponsePact = builder
-        .given("a published offer contains the pact promo code for the pact product")
-        .uponReceiving("POST an attributed customer reservation WITHOUT trusted party identity")
-        .path("/api/v1/customer-incentives/offers/$OFFER_ID/reservations")
+    fun reserveUnknownOffer(builder: PactDslWithProvider): RequestResponsePact = builder
+        .uponReceiving("POST an attributed customer reservation for an offer the bank does not hold")
+        .path("/api/v1/customer-incentives/offers/$UNKNOWN_OFFER_ID/reservations")
         .method("POST")
         .headers(
             mapOf(
                 "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
                 "Idempotency-Key" to IDEMPOTENCY_KEY,
             ),
         )
@@ -164,17 +164,18 @@ class CustomerEdgeIncentivePactConsumerTest {
             }.build(),
         )
         .willRespondWith()
-        .status(401)
+        .status(404)
         .toPact()
 
     @Test
-    @PactTestFor(pactMethod = "reserveWithoutIdentity")
-    fun `provider rejects a reservation request that carries no trusted identity`(mockServer: MockServer) {
+    @PactTestFor(pactMethod = "reserveUnknownOffer")
+    fun `provider answers 404 for an offer the caller may not see`(mockServer: MockServer) {
         val connection = java.net.URI(
-            "${mockServer.getUrl()}/api/v1/customer-incentives/offers/$OFFER_ID/reservations",
+            "${mockServer.getUrl()}/api/v1/customer-incentives/offers/$UNKNOWN_OFFER_ID/reservations",
         ).toURL().openConnection() as java.net.HttpURLConnection
         connection.requestMethod = "POST"
         connection.setRequestProperty("Content-Type", "application/json")
+        connection.setRequestProperty("X-Customer-Party-Id", PARTY_ID)
         connection.setRequestProperty("Idempotency-Key", IDEMPOTENCY_KEY)
         connection.doOutput = true
         connection.outputStream.use { out ->
@@ -184,7 +185,7 @@ class CustomerEdgeIncentivePactConsumerTest {
             )
         }
 
-        assertThat(connection.responseCode).isEqualTo(401)
+        assertThat(connection.responseCode).isEqualTo(404)
     }
 
     @Test
@@ -268,6 +269,7 @@ class CustomerEdgeIncentivePactConsumerTest {
         const val INTERACTION_REF = "22222222-2222-4222-8222-222222222222"
         const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
         const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
+        const val UNKNOWN_OFFER_ID = "99999999-9999-4999-8999-999999999999"
         const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
         const val IDEMPOTENCY_KEY = "claim-pact-once"
         const val OPEN_IDEMPOTENCY_KEY = "open-pact-once"

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -237,7 +237,9 @@ class CustomerEdgeIncentivePactConsumerTest {
         val TERM_DEPOSIT_PRODUCT = """
             {"id":"$PRODUCT_ID","code":"TERM_6M","name":"Term deposit","type":"TERM_DEPOSIT",
             "currency":"CZK","status":"ACTIVE","isPublic":true,
-            "termDepositConfig":{"termMonths":6,"interestRateAnnual":5.8},"termsAndConditions":[]}
+            "termDepositConfig":{"termMonths":6,"interestRateAnnual":5.8},
+            "termsAndConditions":[{"version":"2026-01","url":"https://docs.example/td.pdf",
+            "effectiveFrom":"2026-01-01","language":"cs"}]}
         """.trimIndent()
         val ATTRIBUTION = """
             {"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH",

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
@@ -173,7 +173,7 @@ private const val OPENED_AT = "2026-08-27T03:00:00Z"
 private const val CLAIM_JSON =
     """{"interactionRef":"$INTERACTION_ID","code":"WELCOME10","productId":"$PRODUCT_ID"}"""
 private const val PRODUCT_JSON =
-    """{"id":"$PRODUCT_ID","code":"TD-12M","name":"12 month deposit","type":"TERM_DEPOSIT","status":"ACTIVE","isPublic":true,"currency":"CZK","termDepositConfig":{"termMonths":12,"interestRateAnnual":3.5},"termsAndConditions":[]}"""
+    """{"id":"$PRODUCT_ID","code":"TD-12M","name":"12 month deposit","type":"TERM_DEPOSIT","status":"ACTIVE","isPublic":true,"currency":"CZK","termDepositConfig":{"termMonths":12,"interestRateAnnual":3.5},"termsAndConditions":[{"version":"2026-01","url":"https://docs.example/td.pdf","effectiveFrom":"2026-01-01","language":"cs"}]}"""
 private const val ATTRIBUTION_JSON =
     """{"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH","incentiveOfferRef":{"id":"$OFFER_ID","name":"WELCOME","version":1}}"""
 private const val RESERVATION_JSON =

--- a/pacts/openbank-customer-edge-openbank-incentive-service.json
+++ b/pacts/openbank-customer-edge-openbank-incentive-service.json
@@ -4,6 +4,30 @@
   },
   "interactions": [
     {
+      "description": "POST an attributed customer reservation WITHOUT trusted party identity",
+      "providerStates": [
+        {
+          "name": "a published offer contains the pact promo code for the pact product"
+        }
+      ],
+      "request": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "code": "WELCOME10",
+          "productRef": "33333333-3333-4333-8333-333333333333"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "claim-pact-once"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/offers/44444444-4444-4444-8444-444444444444/reservations"
+      },
+      "response": {
+        "status": 401
+      }
+    },
+    {
       "description": "POST an attributed customer reservation with trusted party identity",
       "providerStates": [
         {

--- a/pacts/openbank-customer-edge-openbank-incentive-service.json
+++ b/pacts/openbank-customer-edge-openbank-incentive-service.json
@@ -4,12 +4,7 @@
   },
   "interactions": [
     {
-      "description": "POST an attributed customer reservation WITHOUT trusted party identity",
-      "providerStates": [
-        {
-          "name": "a published offer contains the pact promo code for the pact product"
-        }
-      ],
+      "description": "POST an attributed customer reservation for an offer the bank does not hold",
       "request": {
         "body": {
           "attributionRef": "22222222-2222-4222-8222-222222222222",
@@ -18,13 +13,14 @@
         },
         "headers": {
           "Content-Type": "application/json",
-          "Idempotency-Key": "claim-pact-once"
+          "Idempotency-Key": "claim-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
         },
         "method": "POST",
-        "path": "/api/v1/customer-incentives/offers/44444444-4444-4444-8444-444444444444/reservations"
+        "path": "/api/v1/customer-incentives/offers/99999999-9999-4999-8999-999999999999/reservations"
       },
       "response": {
-        "status": 401
+        "status": 404
       }
     },
     {


### PR DESCRIPTION
Closes #9044

## Co a proč

Term deposit dosud nenesl žádný záznam o tom, podle které verze obchodních podmínek byl založen — banka by nedokázala prokázat, které terms zákazníka vážou. Tato PR to řeší koncepčně na obou koncích:

1. **Záznam na účtu, ne kopie dokumentu.** `accounts` nese `terms_version`, `terms_url`, `terms_effective_from` (V24). Ukládáme verzi + referenci na snapshot, ne celý text podmínek — retention povinnost zůstává na katalogu produktů, který terms publikuje.
2. **Edge resolvuje server-side.** customer-edge při otevření term depositu určí currently-effective terms z katalogu (co bylo published) a klient může poslat `termsVersionShown` — mismatch ⇒ **409**, takže rollout podmínek nikdy neváže zákazníka k dokumentu, který neviděl.
3. **Žádný backfill.** Existující depozita zůstávají `NULL`; CHECK (`account_type<>'TERM_DEPOSIT' OR terms_version IS NOT NULL`) je `NOT VALID`, aby historické řádky nedostaly terms, které zákazníkovi nikdy nebyly ukázány.

## Změny

- account-service: `OpenAccountRequest` nese terms triple pro `TERM_DEPOSIT` (400 při absenci), persist V24 + NOT VALID CHECK, openapi 1.15.0 → 1.16.0 (aditivní).
- customer-edge: `parseOpenTermDepositRequest` + `gateTermsForOpen` (409 žádné currently-effective terms / 409 mismatch), openapi 1.53.1 → 1.54.0.
- Testy: unit (refuse bez termsVersion, persist), `AccountApiIT` (201 s terms v payloadu i odpovědi), edge testy (201 match / 409 mismatch / 409 no-current-terms), Pact + incentive fixtures.

## Ověření

- `:openbank-account-service:test`, `:openbank-customer-edge:test`, ktlint, detekt — zelené (Pact provider test padal pouze na `QuarkusBindException` port 8081 při paralelních buildech; izolovaně prošel).
- Všechny migrace V1–V24 aplikovány sekvenčně na čistém Postgres 16 v dockeru — OK, constraint je `NOT VALID`.

## Security checklist

- [x] Žádné nové secrets; žádný nový inbound surface bez autentizace
- [x] Money-path dopad posouzen — záznam terms je auditní údaj, žádná změna pohybu peněz
- [x] Idempotency — open-account flow používá existující idempotency-key handling, beze změny
- [x] Migrace je aditivní, rollback = drop sloupců; CHECK NOT VALID neblokuje existující data
- [x] Threat model — žádný nový endpoint, jen nová pole na existujícím open-account flow
