### PR TITLE
fix(admin-ui): unify BPMN service status presentation

### DIFF
--- a/openbank-admin-ui/src/components/docs/BpmnView.tsx
+++ b/openbank-admin-ui/src/components/docs/BpmnView.tsx
@@ -23,6 +23,7 @@ import { useState } from 'react'
 import { GitBranch, RefreshCw, CheckCircle2, XCircle, AlertCircle } from 'lucide-react'
 import type { BpmnProcess, BpmnStep } from '@/lib/docs/bpmn/schema'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { StatusBadge } from '@/components/ui'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 const LANE_BG: Record<string, string> = {
@@ -272,10 +273,10 @@ function ProcessLayerMap({ process }: { process: BpmnProcess }) {
                   return (
                     <div key={svc} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
                       <div style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text-secondary)' }}>{svc}</div>
-                      {status === 'up' && <span style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: '#16a34a', fontWeight: 600, background: '#dcfce7', padding: '2px 6px', borderRadius: '4px' }}><CheckCircle2 size={12} aria-hidden="true" /> {t('AKTIVNÍ', 'UP')}</span>}
-                      {status === 'down' && <span style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: '#dc2626', fontWeight: 600, background: '#fee2e2', padding: '2px 6px', borderRadius: '4px' }}><XCircle size={12} aria-hidden="true" /> {t('NEDOSTUPNÉ', 'DOWN')}</span>}
-                      {status === 'loading' && <span style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: '#d97706', fontWeight: 600, background: '#fef3c7', padding: '2px 6px', borderRadius: '4px' }}><RefreshCw size={12} aria-hidden="true" className="animate-spin" /> {t('OVĚŘUJI', 'CHECKING')}</span>}
-                      {status === 'unknown' && <span style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: '#6b7280', fontWeight: 600, background: '#f3f4f6', padding: '2px 6px', borderRadius: '4px' }}><AlertCircle size={12} aria-hidden="true" /> {t('N/A', 'N/A')}</span>}
+                      {status === 'up' && <StatusBadge status="up" label={t('AKTIVNÍ', 'UP')} leading={<CheckCircle2 size={12} />} className="badge-sm" />}
+                      {status === 'down' && <StatusBadge status="down" label={t('NEDOSTUPNÉ', 'DOWN')} leading={<XCircle size={12} />} className="badge-sm" />}
+                      {status === 'loading' && <StatusBadge status="loading" tone="warning" label={t('OVĚŘUJI', 'CHECKING')} leading={<RefreshCw size={12} className="animate-spin" />} className="badge-sm" />}
+                      {status === 'unknown' && <StatusBadge status="unknown" label={t('N/A', 'N/A')} leading={<AlertCircle size={12} />} className="badge-sm" />}
                     </div>
                   )
                 }) : <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('Služba není namapována', 'No service mapped')}</div>}
@@ -370,8 +371,8 @@ export function BpmnView({ processes }: { processes: BpmnProcess[] }) {
             { shape: 'rect', color: '#fde68a', label: 'Task (PSD2)' },
             { shape: 'event', color: ASYNC_COLOR, label: 'Message event (catch/throw)' },
             { shape: 'async', color: ASYNC_COLOR, label: 'Async event / outbox (Kafka)' },
-            { shape: 'status-up', color: '#16a34a', label: 'Service UP' },
-            { shape: 'status-down', color: '#dc2626', label: 'Service DOWN' },
+            { shape: 'status-up', color: 'var(--success-text)', label: 'Service UP' },
+            { shape: 'status-down', color: 'var(--danger-text)', label: 'Service DOWN' },
           ].map((item) => (
             <div key={item.label} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '11px', color: 'var(--text-secondary)' }}>
               {item.shape.startsWith('status-') ? (

--- a/openbank-admin-ui/src/test/bpmn-status-presentation.guard.test.ts
+++ b/openbank-admin-ui/src/test/bpmn-status-presentation.guard.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = () => readFileSync(path.resolve(__dirname, '../components/docs/BpmnView.tsx'), 'utf8')
+
+describe('BPMN service status presentation', () => {
+  it('uses the shared semantic status system without changing operator labels', () => {
+    const component = source()
+
+    expect(component).toContain("import { StatusBadge } from '@/components/ui'")
+    expect(component).toContain('<StatusBadge status="up" label={t(\'AKTIVNÍ\', \'UP\')}')
+    expect(component).toContain('<StatusBadge status="down" label={t(\'NEDOSTUPNÉ\', \'DOWN\')}')
+    expect(component).toContain('<StatusBadge status="loading" tone="warning" label={t(\'OVĚŘUJI\', \'CHECKING\')}')
+    expect(component).toContain('<StatusBadge status="unknown" label={t(\'N/A\', \'N/A\')}')
+    expect(component).toContain("{ shape: 'status-up', color: 'var(--success-text)'")
+    expect(component).toContain("{ shape: 'status-down', color: 'var(--danger-text)'")
+    expect(component).not.toContain("color: '#16a34a', fontWeight: 600, background: '#dcfce7'")
+    expect(component).not.toContain("color: '#dc2626', fontWeight: 600, background: '#fee2e2'")
+  })
+})


### PR DESCRIPTION
## Summary

Move the shared BPMN educational viewer's live service-health states onto the ADR-0208 semantic status system. Every process explainer now uses the same accessible, theme-aware status badges as operator workflows instead of four hand-rolled raw-colour variants.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #7654

## Changes

- Render UP, DOWN, CHECKING and unknown states with `StatusBadge`, preserving bilingual labels and icons.
- Use semantic theme tokens for matching legend symbols and add a focused regression guard.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated.
- [x] Integration and contract tests N/A; no service or API boundary changed.
- [x] 27 focused BPMN, tone and contrast tests pass.
- [x] TypeScript and changed-file ESLint pass.
- [x] No database, event, RBAC, maker-checker, payload or financial behavior changed.

## Security checklist

- [x] No secrets, tokens, passwords or PII.
- [x] No suppressions or unsafe casts.
- [x] No dependency change.
- [x] Auth, crypto, payment, PII and cardholder paths unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: normal rolling Admin UI deployment
- Rollback plan: revert the single commit
- Data migration reversible: N/A

## Screenshots / demo

The visual geometry and wording are preserved; only status palette ownership changes to the already browser-tested shared primitive.

## Reviewer notes

The raw-colour scanner falls by ten literals on this branch. Please verify that service-health semantics remain UP=success, DOWN=danger, CHECKING=warning and unknown=neutral; diagram node/lane colours are intentionally unchanged because they encode process geometry rather than runtime status.
