### PR TITLE
fix(admin-ui): unify process status presentation

### DIFF
--- a/openbank-admin-ui/src/app/docs/sensors/page.tsx
+++ b/openbank-admin-ui/src/app/docs/sensors/page.tsx
@@ -72,7 +72,7 @@ export default async function SensorsIndexPage() {
       <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 18 }}>
         {(['live', 'partial', 'planned'] as Status[]).map(s => (
           <div key={s} className="card" style={{ padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ width: 9, height: 9, borderRadius: '50%', background: STATUS_META[s].color }} />
+            <span aria-hidden="true" style={{ width: 9, height: 9, borderRadius: '50%', background: STATUS_META[s].text }} />
             <span style={{ fontSize: 18, fontWeight: 650 }}>{counts[s]}</span>
             <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{STATUS_META[s].label[lang]}</span>
           </div>

--- a/openbank-admin-ui/src/components/docs/ProcessView.tsx
+++ b/openbank-admin-ui/src/components/docs/ProcessView.tsx
@@ -14,43 +14,30 @@
 
 import { useState } from 'react'
 import type { ElementType } from 'react'
-import { ShieldCheck, Info, CheckCircle2, CircleDashed, Circle, X } from 'lucide-react'
+import { ShieldCheck, Info, X } from 'lucide-react'
 import { Mermaid } from '@/components/docs/Mermaid'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { StatusBadge } from '@/components/ui/StatusBadge'
+import { TONE_BORDER_LEFT_CLASS, TONE_TEXT_CLASS } from '@/components/ui/tone'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { overallScore, type Process, type Status, type TechNode } from '@/lib/docs/process/schema'
+import { STATUS_META, StatusDot } from '@/lib/docs/status'
 
 type Mode = 'reality' | 'target'
 type Lens = 'story' | 'token' | 'tech'
 
-const STATUS_META: Record<Status, { label: string; color: string; bg: string; border: string; Icon: ElementType }> = {
-  live:    { label: 'Live (dev sandbox)',             color: '#059669', bg: '#ecfdf5', border: '#6ee7b7', Icon: CheckCircle2 },
-  partial: { label: 'Partial (deployed, incomplete)', color: '#d97706', bg: '#fffbeb', border: '#fcd34d', Icon: CircleDashed },
-  planned: { label: 'Planned (roadmap)',              color: '#94a3b8', bg: '#f8fafc', border: '#cbd5e1', Icon: Circle },
-}
-
 // Title icons a manifest may name (lucide-react). Extend as new processes need.
 const ICON_MAP: Record<string, ElementType> = { ShieldCheck }
 
-function StatusDot({ status }: { status: Status }) {
-  const m = STATUS_META[status]
-  return <m.Icon size={13} aria-hidden="true" style={{ color: m.color, flexShrink: 0 }} />
-}
-
-function StatusChip({ status }: { status: Status }) {
+function StatusChip({ status, label }: { status: Status; label: string }) {
   const m = STATUS_META[status]
   return (
-    <span style={{
-      display: 'inline-flex', alignItems: 'center', gap: '4px', fontSize: '11px', fontWeight: 600,
-      padding: '2px 8px', borderRadius: '20px', background: m.bg, color: m.color, border: `1px solid ${m.border}`,
-    }}>
-      <StatusDot status={status} />{m.label}
-    </span>
+    <StatusBadge status={status} tone={m.tone} label={label} leading={<m.Icon size={12} />} className="badge-sm" />
   )
 }
 
 export function ProcessView({ proc }: { proc: Process }) {
-  const { t } = useLanguage()
+  const { language, t } = useLanguage()
   const [mode, setMode] = useState<Mode>('reality')
   const [lens, setLens] = useState<Lens>('story')
   const [selected, setSelected] = useState<TechNode | null>(null)
@@ -58,7 +45,7 @@ export function ProcessView({ proc }: { proc: Process }) {
   const TitleIcon = ICON_MAP[proc.icon] ?? ShieldCheck
   const overall = overallScore(proc.controls)
   const visibleStory = mode === 'reality' ? proc.story.filter(s => s.status === 'live') : proc.story
-  const gaugeColor = overall < 40 ? '#dc2626' : overall < 70 ? '#d97706' : '#059669'
+  const gaugeTone = overall < 40 ? 'danger' : overall < 70 ? 'warning' : 'success'
 
   return (
     <div>
@@ -88,7 +75,7 @@ export function ProcessView({ proc }: { proc: Process }) {
         {(Object.keys(STATUS_META) as Status[]).map(s => (
           <div key={s} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <StatusDot status={s} />
-            <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--text-primary)' }}>{STATUS_META[s].label}</span>
+            <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--text-primary)' }}>{STATUS_META[s].label[language]}</span>
           </div>
         ))}
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginLeft: 'auto', fontSize: '11px', color: 'var(--text-secondary)' }}>
@@ -117,7 +104,7 @@ export function ProcessView({ proc }: { proc: Process }) {
               {visibleStory.map((s, i) => (
                 <li key={i} style={{ fontSize: '14px', color: 'var(--text-primary)', lineHeight: 1.5 }}>
                   <span style={{ marginRight: '8px' }}>{s.text}</span>
-                  {s.status !== 'live' && <StatusChip status={s.status} />}
+                  {s.status !== 'live' && <StatusChip status={s.status} label={STATUS_META[s.status].label[language]} />}
                 </li>
               ))}
             </ol>
@@ -157,8 +144,8 @@ export function ProcessView({ proc }: { proc: Process }) {
                       return (
                         <button key={n.id} type="button" aria-label={n.name} aria-pressed={active} onClick={() => setSelected(active ? null : n)} title={n.desc} style={{
                           display: 'flex', alignItems: 'center', gap: '6px', padding: '6px 10px', borderRadius: '8px',
-                          cursor: 'pointer', background: m.bg, border: `1px solid ${active ? m.color : m.border}`,
-                          boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none',
+                          cursor: 'pointer', background: m.background, border: `1px solid ${active ? m.text : m.border}`,
+                          boxShadow: active ? `0 0 0 2px var(--focus-ring)` : 'none',
                           color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, fontFamily: 'inherit', textAlign: 'left',
                         }}>
                           <StatusDot status={n.status} />{n.name}
@@ -169,12 +156,12 @@ export function ProcessView({ proc }: { proc: Process }) {
                 </div>
               ))}
               {selected && (
-                <div className="card" style={{ padding: '14px 16px', borderLeft: `3px solid ${STATUS_META[selected.status].color}` }}>
+                <div className={`card tone-border-left ${TONE_BORDER_LEFT_CLASS[STATUS_META[selected.status].tone]}`} style={{ padding: '14px 16px' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
                     <span style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{selected.name}</span>
                     <button type="button" aria-label={t('Zavřít technologické detaily', 'Close technology details')} onClick={() => setSelected(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 0 }}><X size={15} aria-hidden="true" /></button>
                   </div>
-                  <div style={{ marginBottom: '8px' }}><StatusChip status={selected.status} /></div>
+                  <div style={{ marginBottom: '8px' }}><StatusChip status={selected.status} label={STATUS_META[selected.status].label[language]} /></div>
                   <p style={{ fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.6, margin: 0 }}>{selected.desc}</p>
                 </div>
               )}
@@ -191,7 +178,7 @@ export function ProcessView({ proc }: { proc: Process }) {
             Compliance (produkční cíl)
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '14px', marginBottom: '16px' }}>
-            <div style={{ fontSize: '40px', fontWeight: 800, color: gaugeColor, lineHeight: 1 }}>{overall}%</div>
+            <div className={TONE_TEXT_CLASS[gaugeTone]} style={{ fontSize: '40px', fontWeight: 800, lineHeight: 1 }}>{overall}%</div>
             <div style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.4 }}>
               vážený compliance score vůči CNB/EBA/PSD2/DORA. Cíl: 100 %.
             </div>
@@ -201,10 +188,10 @@ export function ProcessView({ proc }: { proc: Process }) {
               <div key={c.name} title={c.why}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '8px', marginBottom: '3px' }}>
                   <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--text-primary)' }}>{c.name}</span>
-                  <span style={{ fontSize: '12px', fontWeight: 700, color: STATUS_META[c.status].color }}>{c.pct}%</span>
+                  <span className={TONE_TEXT_CLASS[STATUS_META[c.status].tone]} style={{ fontSize: '12px', fontWeight: 700 }}>{c.pct}%</span>
                 </div>
                 <div style={{ height: '6px', borderRadius: '3px', background: 'var(--surface-2)', overflow: 'hidden', marginBottom: '3px' }}>
-                  <div style={{ width: `${c.pct}%`, height: '100%', background: STATUS_META[c.status].color }} />
+                  <div style={{ width: `${c.pct}%`, height: '100%', background: STATUS_META[c.status].text }} />
                 </div>
                 <div style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>{c.regulation}</div>
                 <div style={{ fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.4, marginTop: '2px' }}>{c.why}</div>

--- a/openbank-admin-ui/src/components/docs/SensorFamilyView.tsx
+++ b/openbank-admin-ui/src/components/docs/SensorFamilyView.tsx
@@ -11,18 +11,13 @@
 // a field is added to SensorEntry.
 
 import Link from 'next/link'
-import { ChevronLeft, CheckCircle2, CircleDashed, Circle, Apple, Smartphone } from 'lucide-react'
+import { ChevronLeft, Apple, Smartphone } from 'lucide-react'
 import {
   FAMILY_META, sensorsByFamily, statusCounts,
   type SensorFamily, type SensorEntry, type Platform,
 } from '@/lib/docs/sensors'
 import { STATUS_META, type Status } from '@/lib/docs/status'
-
-const STATUS_ICON: Record<Status, React.ElementType> = {
-  live: CheckCircle2,
-  partial: CircleDashed,
-  planned: Circle,
-}
+import { StatusBadge } from '@/components/ui/StatusBadge'
 
 const PLATFORM_LABEL: Record<Platform, { label: string; Icon: React.ElementType }> = {
   ios: { label: 'iOS', Icon: Apple },
@@ -31,18 +26,14 @@ const PLATFORM_LABEL: Record<Platform, { label: string; Icon: React.ElementType 
 
 function StatusPill({ status, lang }: { status: Status; lang: 'cs' | 'en' }) {
   const meta = STATUS_META[status]
-  const Icon = STATUS_ICON[status]
   return (
-    <span
-      style={{
-        display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 9px',
-        borderRadius: 20, fontSize: 11, fontWeight: 600,
-        color: meta.color, background: meta.bg, border: `1px solid ${meta.border}`,
-      }}
-    >
-      <Icon size={12} />
-      {meta.label[lang]}
-    </span>
+    <StatusBadge
+      status={status}
+      tone={meta.tone}
+      label={meta.label[lang]}
+      leading={<meta.Icon size={12} />}
+      className="badge-sm"
+    />
   )
 }
 

--- a/openbank-admin-ui/src/lib/docs/status.tsx
+++ b/openbank-admin-ui/src/lib/docs/status.tsx
@@ -13,6 +13,7 @@
 // encoding is what this module exists to keep from drifting.
 
 import { CheckCircle2, CircleDashed, Circle } from 'lucide-react'
+import type { Tone } from '@/components/ui/tone'
 
 export type Status = 'live' | 'partial' | 'planned'
 
@@ -23,19 +24,20 @@ export interface StatusLabel {
 
 export interface StatusMeta {
   label: StatusLabel
-  color: string
-  bg: string
+  tone: Tone
+  text: string
+  background: string
   border: string
   Icon: React.ElementType
 }
 
 export const STATUS_META: Record<Status, StatusMeta> = {
-  live:    { label: { cs: 'Live (běží dnes)',             en: 'Live (running today)' },         color: '#059669', bg: '#ecfdf5', border: '#6ee7b7', Icon: CheckCircle2 },
-  partial: { label: { cs: 'Částečně (nasazeno, neúplné)', en: 'Partial (deployed, incomplete)' }, color: '#d97706', bg: '#fffbeb', border: '#fcd34d', Icon: CircleDashed },
-  planned: { label: { cs: 'Plánováno',                    en: 'Planned' },                      color: '#94a3b8', bg: '#f8fafc', border: '#cbd5e1', Icon: Circle },
+  live:    { label: { cs: 'Live (běží dnes)',             en: 'Live (running today)' },           tone: 'success', text: 'var(--success-text)', background: 'var(--success-bg)', border: 'var(--success-border)', Icon: CheckCircle2 },
+  partial: { label: { cs: 'Částečně (nasazeno, neúplné)', en: 'Partial (deployed, incomplete)' }, tone: 'warning', text: 'var(--warning-text)', background: 'var(--warning-bg)', border: 'var(--warning-border)', Icon: CircleDashed },
+  planned: { label: { cs: 'Plánováno',                    en: 'Planned' },                        tone: 'neutral', text: 'var(--text-secondary)', background: 'var(--surface-2)', border: 'var(--border-strong)', Icon: Circle },
 }
 
 export function StatusDot({ status, size = 13 }: { status: Status; size?: number }) {
   const m = STATUS_META[status]
-  return <m.Icon size={size} style={{ color: m.color, flexShrink: 0 }} />
+  return <m.Icon size={size} aria-hidden="true" style={{ color: m.text, flexShrink: 0 }} />
 }

--- a/openbank-admin-ui/src/test/process-status-presentation.guard.test.ts
+++ b/openbank-admin-ui/src/test/process-status-presentation.guard.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relative: string) => fs.readFileSync(path.join(process.cwd(), relative), 'utf8')
+
+describe('docs process status presentation', () => {
+  const processView = read('src/components/docs/ProcessView.tsx')
+  const sensorView = read('src/components/docs/SensorFamilyView.tsx')
+  const status = read('src/lib/docs/status.tsx')
+
+  it('uses the shared status badge and localized plan-vs-reality labels', () => {
+    expect(processView).toContain("import { StatusBadge } from '@/components/ui/StatusBadge'")
+    expect(sensorView).toContain("import { StatusBadge } from '@/components/ui/StatusBadge'")
+    expect(processView).toContain('STATUS_META[s].label[language]')
+    expect(status).toContain("cs: 'Částečně (nasazeno, neúplné)'")
+    expect(status).toContain("en: 'Partial (deployed, incomplete)'")
+  })
+
+  it('keeps status colours themeable and removes the duplicated raw palette', () => {
+    expect(status).toContain("text: 'var(--success-text)'")
+    expect(status).toContain("background: 'var(--warning-bg)'")
+    expect(status).not.toMatch(/#[0-9a-f]{3,8}/i)
+    expect(processView).not.toMatch(/#(?:059669|d97706|94a3b8|ecfdf5|fffbeb|f8fafc|6ee7b7|fcd34d|cbd5e1)/i)
+    expect(sensorView).not.toMatch(/#(?:059669|d97706|94a3b8|ecfdf5|fffbeb|f8fafc|6ee7b7|fcd34d|cbd5e1)/i)
+  })
+})


### PR DESCRIPTION
## Summary
- replace duplicated process and sensor status colours with shared semantic theme tokens
- render plan-vs-reality states through the common StatusBadge primitive
- localize ProcessView status labels consistently for Czech and English
- preserve process data, scoring, selection, and interaction behavior

## Verification
- focused Vitest guard suite: 10/10 passed
- `npm run type-check`
- changed-file ESLint
- raw-colour ratchet: 1672 literals, below the current ceiling
- `git diff --check`

Refs #7654