### PR TITLE
ci(governance): remove stale SCA idempotency baseline

### DIFF
--- a/.github/gates/idempotency-parity-baseline.txt
+++ b/.github/gates/idempotency-parity-baseline.txt
@@ -29,4 +29,3 @@
 # nothing rejects the call — `requestKey` is simply null, both the get and the save are skipped,
 # and every duplicate initiates a fresh challenge. The quiet direction: the protection exists,
 # runs, and can never engage for a spec-conformant caller.
-openbank-sca-service bound-not-published POST /api/v1/sca/challenges


### PR DESCRIPTION
The SCA creation endpoint now satisfies the idempotency contract, but its resolved finding remained in the ratchet baseline and makes `Validate manifests` fail on current `main` and unrelated PRs.

Remove the stale entry so the enforced gate reflects the current zero-finding state.

Validation: `python3 .github/scripts/check-idempotency-contract-parity.py --self-test`; `python3 .github/scripts/check-idempotency-contract-parity.py --enforce --baseline .github/gates/idempotency-parity-baseline.txt`

Refs #8351