### PR TITLE
fix(admin-ui): distinguish corporate mandate delivery

### DIFF
--- a/openbank-admin-ui/src/components/delegations/DelegationEducation.tsx
+++ b/openbank-admin-ui/src/components/delegations/DelegationEducation.tsx
@@ -102,8 +102,8 @@ export const DELEGATION_SCENARIOS: readonly Scenario[] = [
     label: { cs: 'Korporace', en: 'Corporate' },
     eyebrow: { cs: 'Řízení přístupů ve velkém', en: 'Access governance at scale' },
     summary: {
-      cs: 'Jemnozrnné granty jsou společný základ; organizační mandáty a portfoliové řízení jsou zatím cílový model.',
-      en: 'Fine-grained grants are the common foundation; organisational mandates and portfolio governance remain a target model.',
+      cs: 'Jemnozrnné granty a ověřené statutární mandáty jsou společný základ; portfoliové řízení zůstává cílový model.',
+      en: 'Fine-grained grants and verified statutory mandates are the common foundation; portfolio governance remains a target model.',
     },
     example: {
       cs: 'Cílový model: korporace → treasury tým → portfolio účtů → oddělené navržení a schválení',
@@ -118,11 +118,15 @@ export const DELEGATION_SCENARIOS: readonly Scenario[] = [
         cs: 'Vlastní kombinace práv zůstává viditelná bez domýšlení firemní role z pouhého názvu.',
         en: 'A custom rights set stays visible without inferring a company role from its name.',
       },
+      {
+        cs: 'Přepnutí na firemní profil ověří aktivní mandát; neznámý, neplatný nebo nedostupný důkaz přístup odmítne.',
+        en: 'Switching to a company profile verifies an active mandate; an unknown, invalid or unavailable proof refuses access.',
+      },
     ],
     next: [
       {
-        cs: 'Autoritativní vazba organizace → člen → statutární nebo interní mandát.',
-        en: 'An authoritative organisation → member → statutory or internal mandate relationship.',
+        cs: 'Spravované interní mandáty a členství vedle již ověřených statutárních mandátů.',
+        en: 'Managed internal mandates and membership alongside the already verified statutory mandates.',
       },
       {
         cs: 'Skupiny účtů, pravidla oddělení povinností a vynucené schválení N-z-M.',

--- a/openbank-admin-ui/src/test/delegation-education.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-education.test.tsx
@@ -48,6 +48,7 @@ describe('delegation education', () => {
     expect(corporate).not.toBeNull()
     fireEvent.click(within(corporate!).getByText('Corporate'))
     expect(within(corporate!).getByRole('region', { name: 'Corporate: What the console can explain today' })).toBeVisible()
+    expect(within(corporate!).getByRole('region', { name: 'Corporate: What the console can explain today' })).toHaveTextContent('Switching to a company profile verifies an active mandate')
     expect(within(corporate!).getByRole('region', { name: 'Corporate: Next control layer — not active' })).toHaveTextContent('N-of-M approval')
     expect(within(corporate!).getByText(/Target model:/)).toBeVisible()
   })


### PR DESCRIPTION
## Summary\n\nCorrects the delegated-access corporate education: verified statutory mandates and fail-closed company-profile switching are delivered; portfolio governance, internal mandates, account groups, segregation of duties and N-of-M remain unavailable.\n\n## Verification\n\n-  — 3 passed.\n\n## Scope\n\nThis is an educational truthfulness repair, not a claim that portfolio governance exists. The E2E portfolio slice is tracked in #9280.\n\nRefs #9280