### PR TITLE
perf(admin-ui): defer advisory test agent

### DIFF
--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -136,6 +136,31 @@ test('never paints an unavailable evidence bundle healthy', async ({ page }) => 
   await expect(assurance).not.toContainText('passed')
 })
 
+test('defers advisory agent code and network work until the panel approaches view', async ({ page }) => {
+  let agentRequests = 0
+  await page.unroute('**/api/test-intelligence/agents')
+  await page.route('**/api/test-intelligence/agents', route => {
+    agentRequests += 1
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ findings: [], available: true }),
+    })
+  })
+
+  await page.goto('/system/tests')
+  await expect(page.getByRole('region', { name: 'Testing assurance map' })).toBeVisible()
+  await page.waitForTimeout(300)
+  expect(agentRequests).toBe(0)
+
+  const agent = page.getByRole('region', { name: 'Advisory test agent' })
+  await agent.scrollIntoViewIfNeeded()
+  // The Playwright server runs React in development Strict Mode, which may remount an effect;
+  // the performance contract is zero eager requests and a request only after intersection.
+  await expect.poll(() => agentRequests).toBeGreaterThan(0)
+  await expect(agent.getByText(/AI AGENT/)).toBeVisible()
+})
+
 test('keeps the evidence flow usable at the mobile breakpoint', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 })
   await page.goto('/system/tests')

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -17,7 +17,7 @@ import type {
 import {
   TestIntelligenceFlow, testIntelligenceCollectionUnavailable,
 } from '@/components/testing/TestIntelligenceFlow'
-import { TestAgentPanel } from '@/components/testing/TestAgentPanel'
+import { LazyTestAgentPanel } from '@/components/testing/LazyTestAgentPanel'
 import { PageHeader, StatusBadge as SharedStatusBadge, TONE_TEXT_CLASS, type Tone } from '@/components/ui'
 
 type Tab = 'posture' | 'tests' | 'history' | 'execution' | 'runtime' | 'coverage' | 'contracts' | 'mutation' | 'performance' | 'synthetic' | 'clients' | 'ai-assurance'
@@ -559,7 +559,7 @@ export default function TestIntelligencePage() {
       {tab === 'clients' && <ClientExperiences report={report} />}
       {tab === 'ai-assurance' && <AiAssurance report={report} />}
     </> : <div style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Report není dostupný.', 'Report is unavailable.')}</div>}
-    {report && <TestAgentPanel />}
+    {report && <LazyTestAgentPanel />}
     {report && <div style={{ marginTop: 18, color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Schéma', 'Schema')} v{report.schemaVersion} · {t('sesbíráno', 'collected')} {new Intl.DateTimeFormat(dateLocale, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(report.collectedAt))} · {t('absence se nikdy nevykresluje jako nula', 'absence is never rendered as zero')}</div>}
   </div>
 }

--- a/openbank-admin-ui/src/components/testing/LazyTestAgentPanel.tsx
+++ b/openbank-admin-ui/src/components/testing/LazyTestAgentPanel.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+const TestAgentPanel = dynamic(
+  () => import('./TestAgentPanel').then(module => module.TestAgentPanel),
+  { loading: () => <div className="skeleton" style={{ height: 150 }} aria-hidden="true" /> },
+)
+
+/** Defers advisory AI code and its API request until the below-fold panel approaches view. */
+export function LazyTestAgentPanel() {
+  const { t } = useLanguage()
+  const boundary = useRef<HTMLElement>(null)
+  const [nearViewport, setNearViewport] = useState(false)
+
+  useEffect(() => {
+    const element = boundary.current
+    if (!element) return
+    const supportsIntersectionObserver = typeof window.IntersectionObserver === 'function'
+    if (!supportsIntersectionObserver) {
+      const timer = setTimeout(() => setNearViewport(true), 0)
+      return () => clearTimeout(timer)
+    }
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) return
+      setNearViewport(true)
+      observer.disconnect()
+    }, { rootMargin: '600px 0px' })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <section ref={boundary} aria-label={t('Poradní agent testů', 'Advisory test agent')} style={{ minHeight: 150 }}>
+      {nearViewport
+        ? <TestAgentPanel />
+        : <p style={{ margin: '20px 0 0', padding: 18, color: 'var(--text-secondary)', fontSize: 12, border: '1px dashed var(--border-strong)', borderRadius: 12 }}>
+            {t('Analýza poradního agenta se načte při přiblížení této sekce.', 'Advisory agent analysis loads when this section approaches the viewport.')}
+          </p>}
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/lazy-test-agent-panel.guard.test.ts
+++ b/openbank-admin-ui/src/test/lazy-test-agent-panel.guard.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'src/components/testing/LazyTestAgentPanel.tsx'), 'utf8')
+const page = fs.readFileSync(path.join(process.cwd(), 'src/app/system/tests/page.tsx'), 'utf8')
+
+describe('lazy Test Intelligence agent panel', () => {
+  it('splits the advisory panel and waits for a viewport boundary before mounting it', () => {
+    expect(source).toContain("dynamic(")
+    expect(source).toContain("import('./TestAgentPanel')")
+    expect(source).toContain("new IntersectionObserver")
+    expect(source).toContain("rootMargin: '600px 0px'")
+    expect(source).toContain('nearViewport\n        ? <TestAgentPanel />')
+  })
+
+  it('keeps the evidence page on the deferred seam', () => {
+    expect(page).toContain("import { LazyTestAgentPanel } from '@/components/testing/LazyTestAgentPanel'")
+    expect(page).toContain('{report && <LazyTestAgentPanel />}')
+    expect(page).not.toContain("from '@/components/testing/TestAgentPanel'")
+  })
+})


### PR DESCRIPTION
## Summary
- split the below-fold Test Intelligence advisory agent from the initial route bundle
- delay its code and API request until the panel approaches the viewport
- preserve accessible bilingual loading context and environments without IntersectionObserver

## Performance evidence
- `/system/tests` route-owned initial JS: 96,814 B → 92,070 B (-4,744 B / 4.9%)
- advisory agent emitted as a deferred 10,383 B chunk
- E2E proves zero agent API requests before viewport proximity and loading after intersection

## Verification
- focused Vitest: 4/4
- TypeScript type-check
- changed-file ESLint
- production build: 97/97 routes
- Chromium `e2e/test-intelligence.spec.ts`: 7/7 (desktop, mobile, WCAG A/AA, reduced motion)

Refs #7654