### PR TITLE
feat(admin-ui): unify operator loading states

### DIFF
--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -10,7 +10,7 @@ import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { LoadingState, PageHeader } from '@/components/ui'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { Fingerprint, RefreshCw, ShieldAlert, Users, Check, Search } from 'lucide-react'
 
@@ -408,13 +408,10 @@ export default function IdentityCasesPage() {
         </button>}
       />
       {loading && cases.length === 0 ? (
-        <div className="card" role="status" aria-live="polite" style={{ padding: '28px', display: 'flex', gap: 12, alignItems: 'center' }}>
-          <RefreshCw size={18} aria-hidden="true" className="animate-spin" />
-          <div>
-            <div style={{ fontWeight: 650 }}>{t('Načítám frontu případů…', 'Loading the case queue…')}</div>
-            <div style={{ marginTop: 3, fontSize: 12, color: 'var(--text-secondary)' }}>{t('Ověřuji otevřené případy a pořadí druhých hlasů.', 'Checking active cases and second-vote priority.')}</div>
-          </div>
-        </div>
+        <LoadingState
+          label={t('Načítám frontu případů…', 'Loading the case queue…')}
+          description={t('Ověřuji otevřené případy a pořadí druhých hlasů.', 'Checking active cases and second-vote priority.')}
+        />
       ) : unavail ? (
         <DataUnavailable kind={unavail} service="pid-service" feature={t('ověření identity', 'identity verification')} lang={language} />
       ) : cases.length === 0 && !loading ? (

--- a/openbank-admin-ui/src/app/system/readiness/page.tsx
+++ b/openbank-admin-ui/src/app/system/readiness/page.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useState, useEffect } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { ClipboardCheck, RefreshCw, Star, CheckCircle2, XCircle, CircleSlash } from 'lucide-react'
-import { PageHeader, StatCard, StatusBadge, SWATCH_CLASS, type Tone } from '@/components/ui'
+import { LoadingState, PageHeader, StatCard, StatusBadge, SWATCH_CLASS, type Tone } from '@/components/ui'
 
 interface ReadinessService {
   service: string
@@ -162,7 +162,12 @@ export default function ReadinessPage() {
         />
       </div>
 
-      {loading && <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>{t('Načítám…', 'Loading…')}</div>}
+      {loading && (
+        <LoadingState
+          label={t('Načítám připravenost služeb…', 'Loading service readiness…')}
+          description={t('Sestavuji důkazy napříč všemi dimenzemi produkční připravenosti.', 'Assembling evidence across every production-readiness dimension.')}
+        />
+      )}
 
       {!loading && !unavailable && services.length === 0 && (
         <div style={{ padding: '40px', textAlign: 'center', border: '1px dashed var(--border)', borderRadius: '12px', color: 'var(--text-secondary)' }}>

--- a/openbank-admin-ui/src/components/ui/LoadingState.tsx
+++ b/openbank-admin-ui/src/components/ui/LoadingState.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { LoaderCircle } from 'lucide-react'
+
+type LoadingStateProps = {
+  label: string
+  description?: string
+  className?: string
+}
+
+/**
+ * An announced, page-section loading state for operator workflows.
+ *
+ * The visible explanation tells an operator what is being assembled; `role=status` and
+ * `aria-live=polite` expose the same progress without stealing focus. The spinner is decorative
+ * because the copy already carries the meaning.
+ */
+export function LoadingState({ label, description, className }: LoadingStateProps) {
+  return (
+    <div
+      className={['card', className].filter(Boolean).join(' ')}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      style={{ padding: 28, display: 'flex', gap: 12, alignItems: 'center' }}
+    >
+      <LoaderCircle size={18} aria-hidden="true" className="animate-spin" style={{ flexShrink: 0 }} />
+      <div>
+        <div style={{ fontWeight: 650, color: 'var(--text-primary)' }}>{label}</div>
+        {description && (
+          <div style={{ marginTop: 3, fontSize: 12, color: 'var(--text-secondary)' }}>
+            {description}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/ui/index.ts
+++ b/openbank-admin-ui/src/components/ui/index.ts
@@ -17,6 +17,7 @@
  */
 export { PageHeader } from './PageHeader'
 export { Drawer } from './Drawer'
+export { LoadingState } from './LoadingState'
 export { StatCard } from './StatCard'
 export { StatusBadge } from './StatusBadge'
 export { Tabs, type TabItem } from './Tabs'

--- a/openbank-admin-ui/src/test/loading-state.test.tsx
+++ b/openbank-admin-ui/src/test/loading-state.test.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { LoadingState } from '@/components/ui'
+
+describe('LoadingState', () => {
+  it('announces meaningful progress without exposing its decorative spinner', () => {
+    const { container } = render(
+      <LoadingState label="Loading service readiness…" description="Assembling current evidence." />,
+    )
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveAttribute('aria-busy', 'true')
+    expect(status).toHaveTextContent('Loading service readiness…')
+    expect(status).toHaveTextContent('Assembling current evidence.')
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('keeps the description optional', () => {
+    render(<LoadingState label="Loading…" />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading…')
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared accessible `LoadingState` primitive with meaningful operator context
- migrate identity-case triage and production-readiness workflows from local loading treatments
- preserve RBAC, four-eyes decisions, last-known readiness evidence, retry behavior, and backend contracts

## Accessibility and UX
- polite live-region announcement without moving focus
- explicit busy semantics and decorative spinner hidden from assistive technology
- bilingual, workflow-specific label and explanation instead of a generic loading message

## Verification
- focused Vitest: 7 files / 11 tests
- new component behavior: 2/2
- TypeScript type-check
- changed-file ESLint: zero errors (one pre-existing identity lifecycle warning)
- production build: 97/97 routes
- Chromium E2E: 2/2 (narrow identity triage; readiness outage/retry preservation)

Refs #7654