### PR TITLE
feat(admin-ui): unify accessible tabs

### DIFF
--- a/openbank-admin-ui/e2e/tabs-keyboard.spec.ts
+++ b/openbank-admin-ui/e2e/tabs-keyboard.spec.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps horizontal document tabs operable and panel-linked from the keyboard', async ({ page }) => {
+  await page.route('**/api/svc/document-service/api/v1/documents/templates?limit=200', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.goto('/document-templates')
+
+  const tablist = page.getByRole('tablist', { name: /Document template content|Obsah šablon dokumentů/ })
+  const templates = tablist.getByRole('tab', { name: /Templates|Šablony/ })
+  const documents = tablist.getByRole('tab', { name: /Documents|Dokumenty/ })
+  await expect(templates).toHaveAttribute('aria-selected', 'true')
+  await templates.focus()
+  await page.keyboard.press('ArrowRight')
+
+  await expect(documents).toBeFocused()
+  await expect(documents).toHaveAttribute('aria-selected', 'true')
+  await expect(page.locator('#document-documents-panel')).toBeVisible()
+})
+
+test('keeps vertical settings tabs wrapping and automatically activated', async ({ page }) => {
+  await page.goto('/settings')
+
+  const tablist = page.getByRole('tablist', { name: /Settings sections|Sekce nastavení/ })
+  const profile = tablist.getByRole('tab', { name: /Profile|Profil/ })
+  const language = tablist.getByRole('tab', { name: /Language|Jazyk/ })
+  await profile.focus()
+  await page.keyboard.press('ArrowUp')
+
+  await expect(language).toBeFocused()
+  await expect(language).toHaveAttribute('aria-selected', 'true')
+  await expect(page.locator('#settings-panel-regional')).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -18,7 +18,7 @@ import { hasPermission } from '@/lib/auth/roles'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { looksLikeUuid } from '@/lib/validation/iban'
-import { PageHeader, StatusBadge, type Tone } from '@/components/ui'
+import { PageHeader, StatusBadge, Tabs, type TabItem, type Tone } from '@/components/ui'
 
 // Go through the BFF proxy directly (svcUrl → /api/svc/document-service/...), the
 // same pattern product-catalog/standing-orders/kyc now use — NOT a dedicated
@@ -34,7 +34,6 @@ const PREVIEW_PATH = `${TEMPLATES_PATH}/preview`
 const DOCUMENTS_PATH = '/api/v1/documents'
 
 const PAGE_SIZE = 25
-const CONTENT_TABS = ['templates', 'documents'] as const
 
 type TemplateStatus = 'DRAFT' | 'PUBLISHED' | 'RETIRED'
 
@@ -197,19 +196,6 @@ export default function DocumentTemplatesPage() {
   const canEdit = hasPermission(roles, 'templates:edit')
 
   const [tab, setTab] = useState<'templates' | 'documents'>('templates')
-  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
-
-  const moveTabFocus = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-    let nextIndex: number | null = null
-    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') nextIndex = (index + 1) % CONTENT_TABS.length
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') nextIndex = (index - 1 + CONTENT_TABS.length) % CONTENT_TABS.length
-    if (event.key === 'Home') nextIndex = 0
-    if (event.key === 'End') nextIndex = CONTENT_TABS.length - 1
-    if (nextIndex === null) return
-    event.preventDefault()
-    setTab(CONTENT_TABS[nextIndex])
-    requestAnimationFrame(() => tabRefs.current[nextIndex]?.focus())
-  }
 
   // ── Templates list ──────────────────────────────────────────────────────────
   const [templates, setTemplates] = useState<DocumentTemplate[]>([])
@@ -476,21 +462,17 @@ export default function DocumentTemplatesPage() {
             </button>
           </div>} />
 
-        <div role="tablist" aria-label={t('Obsah šablon dokumentů', 'Document template content')} style={{ display: 'flex', gap: '4px', marginBottom: '18px', borderBottom: '1px solid var(--border)' }}>
-          {([
-            { id: 'templates' as const, label: t('Šablony', 'Templates'), icon: <FileSignature size={13} /> },
-            { id: 'documents' as const, label: t('Dokumenty', 'Documents'), icon: <FileText size={13} /> },
-          ]).map((tb, index) => (
-            <button key={tb.id} ref={element => { tabRefs.current[index] = element }} id={`document-${tb.id}-tab`} role="tab" tabIndex={tab === tb.id ? 0 : -1} aria-selected={tab === tb.id} aria-controls={`document-${tb.id}-panel`} onKeyDown={event => moveTabFocus(event, index)} onClick={() => setTab(tb.id)}
-              style={{
-                display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 14px', fontSize: '13px', fontWeight: 600,
-                border: 'none', borderBottom: tab === tb.id ? '2px solid var(--accent)' : '2px solid transparent',
-                background: 'none', cursor: 'pointer', color: tab === tb.id ? 'var(--accent)' : 'var(--text-secondary)',
-              }}>
-              <span aria-hidden="true">{tb.icon}</span>{tb.label}
-            </button>
-          ))}
-        </div>
+        <Tabs
+          items={[
+            { id: 'templates' as const, label: t('Šablony', 'Templates'), icon: <FileSignature size={13} />, tabId: 'document-templates-tab', panelId: 'document-templates-panel' },
+            { id: 'documents' as const, label: t('Dokumenty', 'Documents'), icon: <FileText size={13} />, tabId: 'document-documents-tab', panelId: 'document-documents-panel' },
+          ] satisfies readonly TabItem<typeof tab>[]}
+          value={tab}
+          onChange={setTab}
+          label={t('Obsah šablon dokumentů', 'Document template content')}
+          idPrefix="document"
+          style={{ marginBottom: 18, borderBottom: '1px solid var(--border)' }}
+        />
 
         <section id="document-templates-panel" role="tabpanel" aria-labelledby="document-templates-tab" hidden={tab !== 'templates'}>
             {unavailable && (

--- a/openbank-admin-ui/src/app/settings/page.tsx
+++ b/openbank-admin-ui/src/app/settings/page.tsx
@@ -3,40 +3,26 @@
 
 'use client'
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { User, Bell, Shield, Globe, Key, Info } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { ROLE_LABELS } from '@/lib/auth/roles'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, Tabs, type TabItem } from '@/components/ui'
 
 type Tab = 'profile' | 'notifications' | 'security' | 'api' | 'regional'
 
 export default function SettingsPage() {
   const [tab, setTab] = useState<Tab>('profile')
-  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
   const { t } = useLanguage()
-  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+  const tabs: TabItem<Tab>[] = [
     { id: 'profile', label: t('Profil', 'Profile'), icon: <User size={14} aria-hidden="true" /> },
     { id: 'notifications', label: t('Oznámení', 'Notifications'), icon: <Bell size={14} aria-hidden="true" /> },
     { id: 'security', label: t('Zabezpečení', 'Security'), icon: <Shield size={14} aria-hidden="true" /> },
     { id: 'api', label: t('API klíče', 'API Keys'), icon: <Key size={14} aria-hidden="true" /> },
     { id: 'regional', label: t('Jazyk', 'Language'), icon: <Globe size={14} aria-hidden="true" /> },
   ]
-
-  const moveTabFocus = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-    const next = event.key === 'ArrowDown' || event.key === 'ArrowRight'
-      ? (index + 1) % tabs.length
-      : event.key === 'ArrowUp' || event.key === 'ArrowLeft'
-        ? (index - 1 + tabs.length) % tabs.length
-        : event.key === 'Home' ? 0
-          : event.key === 'End' ? tabs.length - 1 : -1
-    if (next < 0) return
-    event.preventDefault()
-    setTab(tabs[next].id)
-    tabRefs.current[next]?.focus()
-  }
 
   return <AuthGuard permission="settings:view"><div>
     <PageHeader
@@ -46,9 +32,9 @@ export default function SettingsPage() {
       subtitle={t('Skutečné předvolby a přístup k účtu', 'Actual account preferences and access')}
     />
     <div style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
-      <div role="tablist" aria-label={t('Sekce nastavení', 'Settings sections')} className="card" style={{ width: '200px', flexShrink: 0, padding: '8px' }}>
-        {tabs.map((item, index) => <button key={item.id} ref={element => { tabRefs.current[index] = element }} id={`settings-tab-${item.id}`} role="tab" type="button" tabIndex={tab === item.id ? 0 : -1} onKeyDown={event => moveTabFocus(event, index)} onClick={() => setTab(item.id)} aria-selected={tab === item.id} aria-controls={`settings-panel-${item.id}`} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '9px', padding: '8px 10px', borderRadius: '6px', border: 'none', borderLeft: tab === item.id ? '2px solid var(--accent)' : '2px solid transparent', background: tab === item.id ? 'var(--accent-light)' : 'transparent', color: tab === item.id ? 'var(--accent)' : 'var(--text-secondary)', fontWeight: tab === item.id ? 600 : 400, fontSize: '13px', cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit' }}>{item.icon}{item.label}</button>)}
-      </div>
+      <Tabs items={tabs} value={tab} onChange={setTab} label={t('Sekce nastavení', 'Settings sections')}
+        idPrefix="settings" orientation="vertical" variant="rail" className="card"
+        style={{ width: 200, flexShrink: 0, padding: 8 }} />
       <div style={{ flex: 1 }}>
         <div id="settings-panel-profile" role="tabpanel" aria-labelledby="settings-tab-profile" hidden={tab !== 'profile'}><ProfileTab /></div>
         <div id="settings-panel-notifications" role="tabpanel" aria-labelledby="settings-tab-notifications" hidden={tab !== 'notifications'}><UnavailableSettings title={t('Předvolby oznámení', 'Notification preferences')} detail={t('Osobní předvolby zatím nemají podporovaný backendový kontrakt. Konzole proto nezobrazuje falešné přepínače ani neukládá zdánlivé změny.', 'Personal notification preferences do not yet have a supported backend contract. This console therefore does not show fake switches or pretend to save changes.')} /></div>

--- a/openbank-admin-ui/src/components/ui/Tabs.tsx
+++ b/openbank-admin-ui/src/components/ui/Tabs.tsx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import { useRef, type CSSProperties, type KeyboardEvent, type ReactNode } from 'react'
+
+export type TabItem<Id extends string> = {
+  id: Id
+  label: string
+  icon?: ReactNode
+  /** Preserve an existing tab/panel address when migrating a public or tested surface. */
+  tabId?: string
+  panelId?: string
+}
+
+type TabsProps<Id extends string> = {
+  items: readonly TabItem<Id>[]
+  value: Id
+  onChange: (value: Id) => void
+  label: string
+  idPrefix: string
+  orientation?: 'horizontal' | 'vertical'
+  variant?: 'underline' | 'rail'
+  className?: string
+  style?: CSSProperties
+}
+
+/** WAI-ARIA automatic-activation tabs with wrapping arrow, Home and End navigation. */
+export function Tabs<Id extends string>({
+  items,
+  value,
+  onChange,
+  label,
+  idPrefix,
+  orientation = 'horizontal',
+  variant = 'underline',
+  className,
+  style,
+}: TabsProps<Id>) {
+  const refs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const moveFocus = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const next = event.key === 'ArrowRight' || event.key === 'ArrowDown'
+      ? (index + 1) % items.length
+      : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+        ? (index - 1 + items.length) % items.length
+        : event.key === 'Home' ? 0
+          : event.key === 'End' ? items.length - 1 : -1
+    if (next < 0) return
+    event.preventDefault()
+    onChange(items[next].id)
+    refs.current[next]?.focus()
+  }
+
+  const rail = variant === 'rail'
+  return (
+    <div
+      role="tablist"
+      aria-label={label}
+      aria-orientation={orientation}
+      className={className}
+      style={{
+        display: 'flex',
+        flexDirection: orientation === 'vertical' ? 'column' : 'row',
+        gap: rail ? 2 : 4,
+        ...style,
+      }}
+    >
+      {items.map((item, index) => {
+        const selected = value === item.id
+        return (
+          <button
+            key={item.id}
+            ref={element => { refs.current[index] = element }}
+            id={item.tabId ?? `${idPrefix}-tab-${item.id}`}
+            role="tab"
+            type="button"
+            tabIndex={selected ? 0 : -1}
+            aria-selected={selected}
+            aria-controls={item.panelId ?? `${idPrefix}-panel-${item.id}`}
+            onKeyDown={event => moveFocus(event, index)}
+            onClick={() => onChange(item.id)}
+            style={{
+              width: rail ? '100%' : undefined,
+              display: 'flex',
+              alignItems: 'center',
+              gap: rail ? 9 : 6,
+              padding: rail ? '8px 10px' : '8px 14px',
+              borderRadius: rail ? 6 : 0,
+              border: 'none',
+              borderLeft: rail ? `2px solid ${selected ? 'var(--accent)' : 'transparent'}` : undefined,
+              borderBottom: rail ? undefined : `2px solid ${selected ? 'var(--accent)' : 'transparent'}`,
+              background: rail && selected ? 'var(--accent-light)' : 'transparent',
+              color: selected ? 'var(--accent)' : 'var(--text-secondary)',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 13,
+              fontWeight: selected ? 600 : rail ? 400 : 600,
+              textAlign: 'left',
+            }}
+          >
+            {item.icon && <span aria-hidden="true">{item.icon}</span>}
+            {item.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/ui/index.ts
+++ b/openbank-admin-ui/src/components/ui/index.ts
@@ -18,6 +18,7 @@
 export { PageHeader } from './PageHeader'
 export { StatCard } from './StatCard'
 export { StatusBadge } from './StatusBadge'
+export { Tabs, type TabItem } from './Tabs'
 export {
   BADGE_CLASS,
   DOT_CLASS,

--- a/openbank-admin-ui/src/test/document-template-status-tone.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-template-status-tone.guard.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, it } from 'vitest'
 describe('document template status presentation', () => {
   it('uses the shared semantic badge rather than a page-local colour map', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
+    const uiImports = source.match(/import \{([^}]*)\} from '@\/components\/ui'/)?.[1] ?? ''
 
-    expect(source).toContain("import { PageHeader, StatusBadge, type Tone } from '@/components/ui'")
+    expect(uiImports).toMatch(/\bPageHeader\b/)
+    expect(uiImports).toMatch(/\bStatusBadge\b/)
+    expect(uiImports).toMatch(/\btype Tone\b/)
     expect(source).toContain("DRAFT: 'warning'")
     expect(source).toContain("PUBLISHED: 'success'")
     expect(source).toContain("RETIRED: 'neutral'")

--- a/openbank-admin-ui/src/test/document-templates-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-templates-accessibility.guard.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const page = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
+const tabs = readFileSync(path.resolve(__dirname, '../components/ui/Tabs.tsx'), 'utf8')
 
 describe('document template authoring accessibility', () => {
   it('exposes the authoring modal as a labelled modal dialog', () => {
@@ -25,14 +26,15 @@ describe('document template authoring accessibility', () => {
   })
 
   it('uses an accessible roving-focus tab pattern with permanently addressable panels', () => {
-    expect(page).toContain('role="tablist"')
-    expect(page).toContain('role="tab"')
+    expect(page).toContain('<Tabs')
+    expect(tabs).toContain('role="tablist"')
+    expect(tabs).toContain('role="tab"')
     expect(page).toContain('role="tabpanel"')
-    expect(page).toContain('tabIndex={tab === tb.id ? 0 : -1}')
-    expect(page).toContain("event.key === 'ArrowRight'")
-    expect(page).toContain("event.key === 'ArrowLeft'")
-    expect(page).toContain("event.key === 'Home'")
-    expect(page).toContain("event.key === 'End'")
+    expect(tabs).toContain('tabIndex={selected ? 0 : -1}')
+    expect(tabs).toContain("event.key === 'ArrowRight'")
+    expect(tabs).toContain("event.key === 'ArrowLeft'")
+    expect(tabs).toContain("event.key === 'Home'")
+    expect(tabs).toContain("event.key === 'End'")
     expect(page).toContain('hidden={tab !== \'templates\'}')
     expect(page).toContain('hidden={tab !== \'documents\'}')
     expect(page).toContain('id="template-status-filter"')

--- a/openbank-admin-ui/src/test/settings-tabs-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/settings-tabs-a11y.guard.test.ts
@@ -3,17 +3,19 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const page = fs.readFileSync(path.join(process.cwd(), 'src/app/settings/page.tsx'), 'utf8')
+const tabs = fs.readFileSync(path.join(process.cwd(), 'src/components/ui/Tabs.tsx'), 'utf8')
 
 describe('settings tabs accessibility', () => {
   it('keeps every tab target mounted and keyboard navigable', () => {
-    expect(page).toContain('role="tablist"')
-    expect(page).toContain('role="tab"')
+    expect(page).toContain('<Tabs')
+    expect(tabs).toContain('role="tablist"')
+    expect(tabs).toContain('role="tab"')
     expect(page).toContain('role="tabpanel"')
-    expect(page).toContain('tabIndex={tab === item.id ? 0 : -1}')
-    expect(page).toContain("event.key === 'ArrowDown'")
-    expect(page).toContain("event.key === 'ArrowUp'")
-    expect(page).toContain("event.key === 'Home'")
-    expect(page).toContain("event.key === 'End'")
+    expect(tabs).toContain('tabIndex={selected ? 0 : -1}')
+    expect(tabs).toContain("event.key === 'ArrowDown'")
+    expect(tabs).toContain("event.key === 'ArrowUp'")
+    expect(tabs).toContain("event.key === 'Home'")
+    expect(tabs).toContain("event.key === 'End'")
     for (const id of ['profile', 'notifications', 'security', 'api', 'regional']) {
       expect(page).toContain(`id="settings-panel-${id}"`)
       expect(page).toContain(`hidden={tab !== '${id}'}`)

--- a/openbank-admin-ui/src/test/tabs.test.tsx
+++ b/openbank-admin-ui/src/test/tabs.test.tsx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import { Tabs } from '@/components/ui'
+
+function Harness() {
+  const [value, setValue] = useState<'queue' | 'history'>('queue')
+  return <Tabs items={[{ id: 'queue', label: 'Queue', tabId: 'legacy-queue-tab', panelId: 'legacy-queue-panel' }, { id: 'history', label: 'History' }]}
+    value={value} onChange={setValue} label="Cases" idPrefix="cases" />
+}
+
+describe('Tabs', () => {
+  it('links tabs to panels and exposes exactly one roving tab stop', () => {
+    render(<Harness />)
+
+    const [queue, history] = screen.getAllByRole('tab')
+    expect(screen.getByRole('tablist', { name: 'Cases' })).toHaveAttribute('aria-orientation', 'horizontal')
+    expect(queue).toHaveAttribute('id', 'legacy-queue-tab')
+    expect(queue).toHaveAttribute('aria-controls', 'legacy-queue-panel')
+    expect(history).toHaveAttribute('id', 'cases-tab-history')
+    expect(history).toHaveAttribute('aria-controls', 'cases-panel-history')
+    expect(queue).toHaveAttribute('aria-selected', 'true')
+    expect(queue).toHaveAttribute('tabindex', '0')
+    expect(history).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('wraps arrows, activates the focused tab, and supports Home and End', () => {
+    render(<Harness />)
+    const [queue, history] = screen.getAllByRole('tab')
+
+    queue.focus()
+    fireEvent.keyDown(queue, { key: 'ArrowLeft' })
+    expect(history).toHaveFocus()
+    expect(history).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(history, { key: 'Home' })
+    expect(queue).toHaveFocus()
+    fireEvent.keyDown(queue, { key: 'End' })
+    expect(history).toHaveFocus()
+  })
+})


### PR DESCRIPTION
## Summary
- add one shared typed Tabs primitive for horizontal and vertical operator navigation
- centralize automatic activation, roving focus, wrapping arrows, Home/End, panel linkage, and semantic orientation
- migrate document templates and settings while preserving their existing addressable tab/panel IDs
- remove duplicated page-local keyboard implementations without changing RBAC, publishing, or settings ownership

## Verification
- pre/post accessibility guards: 3 files / 7 tests
- component interaction tests: 2/2, including wrap, focus, activation, default and compatibility IDs
- TypeScript type-check
- changed-file ESLint: zero errors (one pre-existing document load lifecycle warning)
- production build: 97/97 routes
- Chromium E2E: 4/4 (horizontal and vertical keyboard tabs, publication lifecycle, outage recovery)

Refs #7654