### PR TITLE
fix(ledger): guard ledger_outbox created_at plausibility at INSERT

### DIFF
--- a/openbank-ledger-service/src/main/resources/db/migration/V28__outbox_created_at_plausible.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V28__outbox_created_at_plausible.sql
@@ -1,0 +1,12 @@
+-- #9081: fleet sweep of the guard proven on lending_outbox (#9003) and called for by #3272 —
+-- an outbox row stamped 1970-01-01 (toEntity() assigning over the column DEFAULT) sorts ahead of
+-- all real work in the dispatcher's ORDER BY created_at ASC and lands in the 1970-01 warehouse
+-- partition. This service has no reported epoch-stamped rows (#3272 hit ledger, #9003 lending),
+-- so this migration is the guard only; if the SELECT below ever answers non-zero, correct those
+-- rows to NOW() before adding the constraint:
+--   SELECT count(*) FROM ledger_outbox WHERE created_at < TIMESTAMPTZ '2020-01-01';
+--
+-- Rollback: ALTER TABLE ledger_outbox DROP CONSTRAINT IF EXISTS ledger_outbox_created_at_plausible;
+ALTER TABLE ledger_outbox
+    ADD CONSTRAINT ledger_outbox_created_at_plausible
+    CHECK (created_at >= TIMESTAMPTZ '2020-01-01');


### PR DESCRIPTION
Refs #9081

Fleet sweep of the outbox `created_at` plausibility guard proven on `lending_outbox` (#9003, defect class #3272): no outbox row may be inserted with `created_at < 2020-01-01`, turning an epoch-stamped row into an INSERT-time error instead of a warehouse-partition discovery months later.

- Migration-only: `ALTER TABLE … ADD CONSTRAINT …_created_at_plausible CHECK (created_at >= TIMESTAMPTZ '2020-01-01')`.
- No data UPDATE: this service has no reported epoch-stamped rows (#3272 hit ledger, fixed; #9003 lending, fixed in #9079). The migration file carries the SELECT to run before deploy; a non-zero answer means correcting those rows to `NOW()` first.
- Full migration chain V1..Vn verified on clean Postgres 16 in docker, constraint present.

## Security checklist

- [x] Žádná změna kódu, pouze aditivní DB constraint
- [x] Rollback zdokumentován v migraci (DROP CONSTRAINT)
- [x] Žádný dopad na money-flow logiku — guard jen odmítne neplatný INSERT
- [x] Idempotence N/A (DDL), constraint je deterministický
- [x] Threat model beze změny — žádný nový trust boundary
