### PR TITLE
feat(admin-ui): unify accessible detail drawers

### DIFF
--- a/openbank-admin-ui/e2e/drawer-a11y.spec.ts
+++ b/openbank-admin-ui/e2e/drawer-a11y.spec.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const ONBOARDING_RECORD = {
+  partyId: '00000000-1111-0000-0000-000000000001',
+  legalName: 'Ada Banking s.r.o.',
+  email: 'ada@example.test',
+  partyStatus: 'ACTIVE',
+  kycCaseId: null,
+  kycStatus: 'APPROVED',
+  scaEnrolled: true,
+  deviceCount: 1,
+  funnelStage: 'ACTIVE',
+  blockedReason: null,
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-02T10:00:00Z',
+}
+
+const PRODUCT = {
+  id: '00000000-2222-0000-0000-000000000002',
+  code: 'TERM_DEPOSIT_6M_CZK',
+  name: 'Term Deposit 6M',
+  type: 'TERM_DEPOSIT',
+  currency: 'CZK',
+  status: 'ACTIVE',
+  isPublic: true,
+  version: '1.0.0',
+  revision: 4,
+  baseRate: 0.058,
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('onboarding drawer is modal, keyboard-dismissable and restores row focus', async ({ page }) => {
+  await page.route('**/api/svc/onboarding-service/api/v1/onboarding/funnel', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ACTIVE: 1 }) }))
+  await page.route('**/api/svc/onboarding-service/api/v1/onboarding/records?**', route =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [ONBOARDING_RECORD], total: 1, page: 0, size: 20 }),
+    }))
+
+  await page.goto('/onboarding')
+  const trigger = page.getByRole('row', { name: /Select onboarding party Ada Banking|Vybrat onboarding subjekt Ada Banking/ })
+  await trigger.focus()
+  await page.keyboard.press('Enter')
+
+  const dialog = page.getByRole('dialog', { name: /Onboarding details for Ada Banking|Detail onboardingu Ada Banking/ })
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toHaveAttribute('aria-modal', 'true')
+  await expect(page.getByRole('button', { name: /Close onboarding details|Zavřít detail onboardingu/ })).toBeFocused()
+
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await expect(trigger).toBeFocused()
+})
+
+test('product drawer supports keyboard activation and restores product-row focus', async ({ page }) => {
+  await page.route('**/api/svc/product-catalog/api/v1/products', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify([PRODUCT]) }))
+
+  await page.goto('/product-catalog')
+  const trigger = page.getByRole('row', { name: /Open product details for Term Deposit 6M|Otevřít detail produktu Term Deposit 6M/ })
+  await trigger.focus()
+  await page.keyboard.press(' ')
+
+  const dialog = page.getByRole('dialog', { name: /Product details for Term Deposit 6M|Detail produktu Term Deposit 6M/ })
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toHaveAttribute('aria-modal', 'true')
+  await expect(dialog).toContainText(PRODUCT.code)
+
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await expect(trigger).toBeFocused()
+})

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -10,7 +10,7 @@ import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ClipboardList, RefreshCw, ChevronRight, X, TrendingUp } from 'lucide-react'
 import Link from 'next/link'
-import { PageHeader } from '@/components/ui'
+import { Drawer, PageHeader } from '@/components/ui'
 import { Can } from '@/components/auth/AuthGuard'
 
 const SVC = 'onboarding-service'
@@ -369,19 +369,13 @@ function RecordDrawer({
   const stageColor = STAGE_COLOR[record.funnelStage as Stage] ?? 'var(--text-muted)'
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        onClick={onClose}
-        style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', zIndex: 40 }}
-      />
-      {/* Drawer */}
-      <div style={{
-        position: 'fixed', top: 0, right: 0, bottom: 0, width: '420px',
-        background: 'var(--surface)', borderLeft: '1px solid var(--border)',
-        zIndex: 50, overflowY: 'auto', padding: '24px',
-        boxShadow: '-4px 0 24px rgba(0,0,0,0.15)',
-      }}>
+    <Drawer
+      title={t(`Detail onboardingu ${record.legalName ?? record.partyId}`, `Onboarding details for ${record.legalName ?? record.partyId}`)}
+      description={t('Stav onboardingu, identity a související bankovní odkazy.', 'Onboarding, identity and related banking status.')}
+      onClose={onClose}
+      width={420}
+    >
+      <div style={{ padding: 24 }}>
         {/* Header */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '20px' }}>
           <div>
@@ -390,8 +384,8 @@ function RecordDrawer({
               {record.partyId}
             </div>
           </div>
-          <button onClick={onClose} className="btn btn-secondary" style={{ padding: '4px 8px' }} aria-label={t('Zavřít', 'Close')}>
-            <X size={14} />
+          <button type="button" onClick={onClose} className="btn btn-secondary" style={{ padding: '4px 8px' }} aria-label={t('Zavřít detail onboardingu', 'Close onboarding details')}>
+            <X size={14} aria-hidden="true" />
           </button>
         </div>
 
@@ -440,7 +434,7 @@ function RecordDrawer({
           )}
         </div>
       </div>
-    </>
+    </Drawer>
   )
 }
 

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -16,7 +16,7 @@ import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { BADGE_CLASS, PageHeader, StatusBadge, statusTone } from '@/components/ui'
+import { BADGE_CLASS, Drawer, PageHeader, StatusBadge, statusTone } from '@/components/ui'
 
 const TYPE_ICON: Record<string, React.ReactNode> = {
   SAVINGS:      <Banknote size={13} />,
@@ -130,7 +130,13 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
   ].filter(tab => tab.show)
 
   return (
-    <div style={{ position: 'fixed', top: 0, right: 0, width: '520px', height: '100vh', background: 'var(--surface-1)', borderLeft: '1px solid var(--border)', zIndex: 900, display: 'flex', flexDirection: 'column', boxShadow: '-8px 0 32px rgba(0,0,0,0.18)', animation: 'slideInRight 0.2s ease-out' }}>
+    <Drawer
+      title={t(`Detail produktu ${product.name}`, `Product details for ${product.name}`)}
+      description={t('Konfigurace produktu, sazby, poplatky a řízený životní cyklus.', 'Product configuration, rates, fees and governed lifecycle.')}
+      onClose={onClose}
+      width={520}
+    >
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexShrink: 0 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px', flexWrap: 'wrap' }}>
@@ -419,6 +425,7 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
         )}
       </div>
     </div>
+    </Drawer>
   )
 }
 
@@ -675,6 +682,14 @@ export default function ProductCatalogPage() {
                 {!loading && filtered.map(p => (
                   <tr key={p.id}
                     onClick={() => setSelectedProduct(selectedProduct?.id === p.id ? null : p)}
+                    onKeyDown={event => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        setSelectedProduct(selectedProduct?.id === p.id ? null : p)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={t(`Otevřít detail produktu ${p.name}`, `Open product details for ${p.name}`)}
                     style={{ cursor: 'pointer', background: selectedProduct?.id === p.id ? 'var(--accent)0d' : undefined, borderLeft: selectedProduct?.id === p.id ? '3px solid var(--accent)' : '3px solid transparent' }}>
                     <td style={{ fontFamily: 'var(--font-mono)', fontWeight: 700, fontSize: '11px', color: 'var(--text-primary)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>

--- a/openbank-admin-ui/src/components/ui/Drawer.tsx
+++ b/openbank-admin-ui/src/components/ui/Drawer.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import * as Dialog from '@radix-ui/react-dialog'
+import { useEffect, useRef, type ReactNode } from 'react'
+
+type DrawerProps = {
+  title: string
+  description?: string
+  onClose: () => void
+  children: ReactNode
+  width?: number
+}
+
+/** Modal side panel with focus containment, Escape/outside dismissal and focus restoration. */
+export function Drawer({ title, description, onClose, children, width = 480 }: DrawerProps) {
+  const returnFocusRef = useRef<HTMLElement | null>(
+    typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  )
+
+  useEffect(() => {
+    const returnFocus = returnFocusRef.current
+    return () => {
+      queueMicrotask(() => {
+        if (returnFocus?.isConnected) returnFocus.focus()
+      })
+    }
+  }, [])
+
+  return (
+    <Dialog.Root open onOpenChange={open => { if (!open) onClose() }}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{ position: 'fixed', inset: 0, zIndex: 899, background: 'rgba(2, 6, 23, 0.56)' }}
+        />
+        <Dialog.Content
+          aria-modal="true"
+          style={{
+            position: 'fixed',
+            insetBlock: 0,
+            right: 0,
+            zIndex: 900,
+            width,
+            maxWidth: '100vw',
+            overflowY: 'auto',
+            background: 'var(--surface-1)',
+            borderLeft: '1px solid var(--border)',
+            boxShadow: '-8px 0 32px rgba(0,0,0,0.18)',
+            animation: 'slideInRight 0.2s ease-out',
+          }}
+        >
+          <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          {description && <Dialog.Description className="sr-only">{description}</Dialog.Description>}
+          {children}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/openbank-admin-ui/src/components/ui/index.ts
+++ b/openbank-admin-ui/src/components/ui/index.ts
@@ -16,6 +16,7 @@
  * tranche and removed again for exactly that reason: nothing consumed them yet.)
  */
 export { PageHeader } from './PageHeader'
+export { Drawer } from './Drawer'
 export { StatCard } from './StatCard'
 export { StatusBadge } from './StatusBadge'
 export {

--- a/openbank-admin-ui/src/test/drawer.test.tsx
+++ b/openbank-admin-ui/src/test/drawer.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { Drawer } from '@/components/ui'
+
+describe('Drawer', () => {
+  it('exposes a named modal dialog and closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<Drawer title="Product details for Current Account" description="Rates and lifecycle"
+      onClose={onClose}><button type="button">Close</button></Drawer>)
+
+    const dialog = screen.getByRole('dialog', { name: 'Product details for Current Account' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAccessibleDescription('Rates and lifecycle')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('contains its content in a body-level portal', () => {
+    render(<Drawer title="Onboarding details" onClose={vi.fn()}><p>Verified identity</p></Drawer>)
+
+    expect(document.body).toContainElement(screen.getByRole('dialog', { name: 'Onboarding details' }))
+    expect(screen.getByText('Verified identity')).toBeVisible()
+  })
+
+  it('restores focus to the external control that opened it', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return <>
+        <button type="button" onClick={() => setOpen(true)}>Open details</button>
+        {open && <Drawer title="Details" onClose={() => setOpen(false)}><button type="button">Close</button></Drawer>}
+      </>
+    }
+
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'Open details' })
+    trigger.focus()
+    fireEvent.click(trigger)
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+})


### PR DESCRIPTION
## Summary

- add one shared Radix-based detail drawer with modal semantics, focus containment, Escape/outside dismissal, and focus restoration
- migrate onboarding and product-catalog detail panels to the shared primitive
- make product rows keyboard-operable with Enter and Space
- add component and Chromium accessibility regression coverage

## Verification

- `npm run type-check`
- focused ESLint (0 errors; existing page warnings only)
- `npm test` — 450 files, 2460 passed, 1 skipped
- `npm run build` — 97/97 pages
- `OPENBANK_E2E_PORT=3058 npx playwright test e2e/drawer-a11y.spec.ts e2e/product-catalog-recovery.spec.ts e2e/product-lifecycle.spec.ts --project=chromium` — 4 passed

Refs #7654
