### PR TITLE
fix(admin-ui): contain compliance review focus

### DIFF
--- a/openbank-admin-ui/e2e/compliance-pack-decision-review.spec.ts
+++ b/openbank-admin-ui/e2e/compliance-pack-decision-review.spec.ts
@@ -47,15 +47,26 @@ test('checker reviews exact pack, retains a refusal, and retries the unchanged d
 
   await page.goto('/lending/compliance-packs')
   await page.getByRole('textbox', { name: 'Decision reason' }).fill('independent legal review')
-  await page.getByRole('button', { name: 'Approve' }).click()
+  const approve = page.getByRole('button', { name: 'Approve' })
+  await approve.click()
 
   const dialog = page.getByRole('alertdialog', { name: 'Review pack activation' })
   await expect(dialog).toContainText('immediately governs new lending applications')
   await expect(dialog).toContainText(proposal.contentHash)
   await expect(dialog).toContainText(proposal.id)
   await expect(dialog).toContainText('independent legal review')
+  await expect(dialog.getByRole('button', { name: 'Back' })).toBeFocused()
+  await page.keyboard.press('Shift+Tab')
+  await expect(dialog.getByRole('button', { name: 'Confirm activation' })).toBeFocused()
   expect(attempts).toBe(0)
 
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await expect(approve).toBeFocused()
+  expect(attempts).toBe(0)
+
+  await approve.click()
+  await expect(dialog).toBeVisible()
   await dialog.getByRole('button', { name: 'Confirm activation' }).click()
   await expect(dialog.getByTestId('decision-review-error')).toContainText('Checker must differ from maker')
   await expect(dialog).toBeVisible()

--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -74,6 +74,7 @@ export default function CompliancePacksPage() {
   const [review, setReview] = useState<{ proposal: PackActivationView; approve: boolean } | null>(null)
   const reviewCancelRef = useRef<HTMLButtonElement>(null)
   const reviewConfirmRef = useRef<HTMLButtonElement>(null)
+  const reviewReturnFocusRef = useRef<HTMLElement | null>(null)
   const detailTriggerRef = useRef<HTMLElement | null>(null)
 
   const openDetail = (pack: PackActivationView, event: React.MouseEvent<HTMLElement>) => {
@@ -124,6 +125,17 @@ export default function CompliancePacksPage() {
   const failWith = async (res: Response, fallback: string) => {
     const body = await res.json().catch(() => ({} as { error?: string }))
     setError(body?.error || `${fallback} (HTTP ${res.status})`)
+  }
+
+  const openReview = (event: React.MouseEvent<HTMLButtonElement>, proposal: PackActivationView, approve: boolean) => {
+    reviewReturnFocusRef.current = event.currentTarget
+    setError(null)
+    setReview({ proposal, approve })
+  }
+
+  const closeReview = () => {
+    setReview(null)
+    setError(null)
   }
 
   const propose = async () => {
@@ -237,7 +249,7 @@ export default function CompliancePacksPage() {
         </div>
       )}
 
-      <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <div id="compliance-pack-pending-heading" tabIndex={-1} className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <CheckCircle2 aria-hidden="true" size={15} /> {t('Aktivní packy', 'Active packs')} ({active.length})
       </div>
       <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 24 }}>
@@ -313,10 +325,10 @@ export default function CompliancePacksPage() {
                 onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
                 style={{ fontSize: 12 }}
               />
-              <button type="button" className="btn btn-primary" disabled={busyId === p.id} onClick={() => { setError(null); setReview({ proposal: p, approve: true }) }} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-primary" disabled={busyId === p.id} onClick={event => openReview(event, p, true)} style={{ fontSize: 12 }}>
                 {t('Schválit', 'Approve')}
               </button>
-              <button type="button" className="btn btn-secondary" disabled={busyId === p.id} onClick={() => { setError(null); setReview({ proposal: p, approve: false }) }} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-secondary" disabled={busyId === p.id} onClick={event => openReview(event, p, false)} style={{ fontSize: 12 }}>
                 {t('Zamítnout', 'Reject')}
               </button>
               </Can>
@@ -331,39 +343,35 @@ export default function CompliancePacksPage() {
       </div>
 
       {review && (
-        <div
-          role="alertdialog"
-          aria-modal="true"
-          aria-labelledby="pack-decision-review-title"
-          aria-describedby="pack-decision-review-impact"
-          onKeyDown={event => {
-            if (event.key === 'Escape' && busyId !== review.proposal.id) {
-              setReview(null)
-              setError(null)
-            }
-            if (event.key === 'Tab') {
-              const first = reviewCancelRef.current
-              const last = reviewConfirmRef.current
-              if (event.shiftKey && document.activeElement === first) {
+        <Dialog.Root open onOpenChange={open => { if (!open && busyId !== review.proposal.id) closeReview() }}>
+          <Dialog.Portal>
+            <Dialog.Overlay style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.68)' }} />
+            <Dialog.Content
+              className="card"
+              role="alertdialog"
+              aria-busy={busyId === review.proposal.id}
+              onOpenAutoFocus={event => {
                 event.preventDefault()
-                last?.focus()
-              } else if (!event.shiftKey && document.activeElement === last) {
+                reviewCancelRef.current?.focus()
+              }}
+              onCloseAutoFocus={event => {
                 event.preventDefault()
-                first?.focus()
-              }
-            }
-          }}
-          style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.68)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
-        >
-          <div className="card" style={{ width: 'min(620px, 100%)', maxHeight: '90vh', overflowY: 'auto', padding: 22 }}>
-            <h2 id="pack-decision-review-title" style={{ margin: 0, fontSize: 17 }}>
+                const original = reviewReturnFocusRef.current
+                const fallback = document.getElementById('compliance-pack-pending-heading')
+                ;(original?.isConnected ? original : fallback)?.focus()
+              }}
+              onEscapeKeyDown={event => { if (busyId === review.proposal.id) event.preventDefault() }}
+              onPointerDownOutside={event => { if (busyId === review.proposal.id) event.preventDefault() }}
+              style={{ position: 'fixed', zIndex: 1201, top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: 'min(620px, calc(100% - 40px))', maxHeight: '90vh', overflowY: 'auto', padding: 22 }}
+            >
+            <Dialog.Title style={{ margin: 0, fontSize: 17 }}>
               {review.approve ? t('Zkontrolovat aktivaci packu', 'Review pack activation') : t('Zkontrolovat zamítnutí packu', 'Review pack rejection')}
-            </h2>
-            <p id="pack-decision-review-impact" style={{ color: 'var(--text-secondary)', fontSize: 13, lineHeight: 1.55 }}>
+            </Dialog.Title>
+            <Dialog.Description style={{ color: 'var(--text-secondary)', fontSize: 13, lineHeight: 1.55 }}>
               {review.approve
                 ? t('Po potvrzení začne tento pack okamžitě řídit nové úvěrové žádosti. Není potřeba restart ani release služby.', 'Once confirmed, this pack immediately governs new lending applications. No service restart or release is required.')
                 : t('Po potvrzení bude návrh definitivně zamítnut a nebude ovlivňovat nové úvěrové žádosti.', 'Once confirmed, the proposal is rejected and will not affect new lending applications.')}
-            </p>
+            </Dialog.Description>
             <dl style={{ display: 'grid', gridTemplateColumns: '150px minmax(0, 1fr)', gap: '8px 12px', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}>
               <dt>{t('Jurisdikce', 'Jurisdiction')}</dt><dd>{review.proposal.jurisdiction}</dd>
               <dt>{t('Produkt', 'Product')}</dt><dd>{review.proposal.productType}</dd>
@@ -379,15 +387,16 @@ export default function CompliancePacksPage() {
             </p>
             {error && <div data-testid="decision-review-error" style={{ padding: 10, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 12 }}>{error}</div>}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
-              <button ref={reviewCancelRef} autoFocus type="button" className="btn btn-secondary" disabled={busyId === review.proposal.id} onClick={() => { setReview(null); setError(null) }}>
+              <button ref={reviewCancelRef} type="button" className="btn btn-secondary" disabled={busyId === review.proposal.id} onClick={closeReview}>
                 {t('Zpět', 'Back')}
               </button>
               <button ref={reviewConfirmRef} type="button" className={review.approve ? 'btn btn-primary' : 'btn btn-secondary'} aria-busy={busyId === review.proposal.id} disabled={busyId === review.proposal.id} onClick={() => void decide(review.proposal.id, review.approve)}>
                 {busyId === review.proposal.id ? t('Odesílám…', 'Submitting…') : review.approve ? t('Potvrdit aktivaci', 'Confirm activation') : t('Potvrdit zamítnutí', 'Confirm rejection')}
               </button>
             </div>
-          </div>
-        </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
       )}
 
       <Dialog.Root open={detail !== null} onOpenChange={open => { if (!open) setDetail(null) }}>


### PR DESCRIPTION
## Summary

- replace the hand-built lending compliance decision overlay with the existing Radix modal primitive
- preserve four-eyes `alertdialog` semantics, exact reviewed content, RBAC and service-owned maker/checker enforcement
- trap focus, support safe cancellation, and restore focus to the exact approve/reject trigger
- fall back to the pending-checker heading when a successful decision removes the reviewed row
- prevent dismissal while the decision request is in flight

## Verification

- `npm run type-check`
- focused ESLint (0 errors; one existing effect warning)
- compliance behavior/RBAC/header Vitest — 14 passed
- compliance decision + operator cockpit Chromium E2E — 8 passed
- `npm run build` — 97/97 pages

Refs #7654
