### PR TITLE
fix(admin-ui): use native regulatory disclosures

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -123,6 +123,12 @@ test('regulatory preview blocks fiction: it shows real FINREP cells and no submi
 
   await page.goto('/regulatory')
   const finrep = page.locator('.card').filter({ hasText: 'CNB — Finanční výkazy (FINREP)' })
+  const disclosure = finrep.locator('button[aria-controls="regulatory-report-cnb-finrep"]')
+  await expect(disclosure).toHaveAccessibleName(/CNB — Finanční výkazy.*(?:Rozbalit detail|Expand details)/)
+  await disclosure.focus()
+  await page.keyboard.press('Enter')
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+  await expect(finrep.getByText(/Datový zdroj:|Data source:/)).toBeVisible()
   await finrep.getByRole('button', { name: /Náhled exportu|Preview export/ }).click()
   await expect(page.getByText('Celková aktiva')).toBeVisible()
   await expect(page.getByTestId('export-readiness')).toContainText(/Připraveno pro interní export|Ready for internal export/)

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -525,11 +525,11 @@ export default function RegulatoryPage() {
           const isSelected = selected === report.id
           return (
             <div key={report.id} className="card" style={{ overflow: 'hidden', borderLeft: `3px solid ${cfg.color}` }}>
-              <div role="button" tabIndex={0} aria-expanded={isSelected}
-                aria-label={`${report.name} — ${isSelected ? t('Sbalit detail', 'Collapse details') : t('Rozbalit detail', 'Expand details')}`}
-                style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: '12px', cursor: 'pointer', flexWrap: 'wrap' }}
-                onClick={() => setSelected(s => s === report.id ? null : report.id)}
-                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(s => s === report.id ? null : report.id) } }}>
+              <div style={{ display: 'flex', alignItems: 'stretch', flexWrap: 'wrap' }}>
+                <button type="button" aria-expanded={isSelected} aria-controls={`regulatory-report-${report.id}`}
+                  aria-label={`${report.name} — ${isSelected ? t('Sbalit detail', 'Collapse details') : t('Rozbalit detail', 'Expand details')}`}
+                  style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: '12px', cursor: 'pointer', flex: '1 1 520px', minWidth: 0, flexWrap: 'wrap', border: 0, background: 'transparent', color: 'inherit', font: 'inherit', textAlign: 'left' }}
+                  onClick={() => setSelected(s => s === report.id ? null : report.id)}>
                 {/* Status */}
                 <span style={{ color: cfg.color, flexShrink: 0 }}>{cfg.icon}</span>
 
@@ -554,10 +554,12 @@ export default function RegulatoryPage() {
                   </div>
                 </div>
 
-                {/* Actions */}
-                <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }} onClick={e => e.stopPropagation()}>
+                </button>
+
+                {/* Actions remain a sibling of the disclosure button, never a nested interactive control. */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0, padding: '10px 16px 10px 0' }}>
                   {source === 'implemented' ? (
-                    <button className="btn btn-secondary" style={{ fontSize: '11px', padding: '5px 10px' }}
+                    <button type="button" className="btn btn-secondary" style={{ fontSize: '11px', padding: '5px 10px' }}
                       onClick={(e) => openPreview(report.id, e)}>
                       {downloadMessage === report.id ? <><Check size={11} style={{ color: '#16a34a' }} /> {t('Staženo', 'Downloaded')}</> : <><Eye size={11} /> {t('Náhled exportu', 'Preview export')}</>}
                     </button>
@@ -571,7 +573,7 @@ export default function RegulatoryPage() {
 
               {/* Detail */}
               {isSelected && (
-                <div style={{ padding: '16px', borderTop: '1px solid var(--border)', background: 'var(--surface-2)' }}>
+                <div id={`regulatory-report-${report.id}`} style={{ padding: '16px', borderTop: '1px solid var(--border)', background: 'var(--surface-2)' }}>
                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', marginBottom: '12px' }}>
                     <div>
                       <div style={{ fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-tertiary)', marginBottom: '6px' }}>{t('Popis', 'Description')}</div>

--- a/openbank-admin-ui/src/test/inline-navigation-keyboard-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/inline-navigation-keyboard-a11y.guard.test.ts
@@ -6,12 +6,13 @@ const root = path.resolve(process.cwd(), 'src')
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
 
 describe('inline navigation keyboard contract', () => {
-  it('keeps custom expandable rows and lineage links keyboard accessible', () => {
+  it('keeps native expandable rows and lineage links keyboard accessible', () => {
     const regulatory = read('app/regulatory/page.tsx')
     const lineage = read('app/docs/lineage/page.tsx')
-    expect(regulatory).toContain('role="button" tabIndex={0} aria-expanded={isSelected}')
-    expect(regulatory).toContain("e.key === 'Enter'")
-    expect(regulatory).toContain("e.key === ' '")
+    expect(regulatory).toContain('<button type="button" aria-expanded={isSelected}')
+    expect(regulatory).toContain('aria-controls={`regulatory-report-${report.id}`}')
+    expect(regulatory).toContain('id={`regulatory-report-${report.id}`}')
+    expect(regulatory).not.toContain('<div role="button" tabIndex={0}')
     expect(lineage).toContain('<button type="button" disabled={!known.has(')
     expect(lineage).toContain('disabled={!known.has(')
     expect(lineage).toContain('is not loaded')

--- a/openbank-admin-ui/src/test/regulatory-report-disclosure.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-report-disclosure.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('regulatory report disclosure contract', () => {
+  it('uses a native disclosure button without nesting the export action', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/regulatory/page.tsx'), 'utf8')
+
+    expect(source).toContain('<button type="button" aria-expanded={isSelected}')
+    expect(source).toContain('aria-controls={`regulatory-report-${report.id}`}')
+    expect(source).toContain('id={`regulatory-report-${report.id}`}')
+    expect(source).not.toContain('<div role="button" tabIndex={0}')
+    expect(source).toContain('Actions remain a sibling of the disclosure button')
+  })
+})


### PR DESCRIPTION
## Summary

- replace the simulated regulatory report row control with a native disclosure button
- connect every disclosure to its detail region through stable `aria-controls` / `id` semantics
- keep export preview as an independent sibling action instead of mixing interactive targets
- preserve report data, FINREP loading, export readiness and regulator-submission truthfulness

## Verification

- TypeScript check passed
- focused ESLint passed
- regulatory disclosure and preview guards: 3 tests passed
- Chromium keyboard disclosure plus live FINREP preview flow: 1 test passed
- production build: 97/97 routes generated

Refs #7654
