### PR TITLE
fix(admin-ui): clarify serverless tier disclosure

### DIFF
--- a/openbank-admin-ui/src/components/finops/ServerlessLegend.tsx
+++ b/openbank-admin-ui/src/components/finops/ServerlessLegend.tsx
@@ -59,25 +59,27 @@ export function ServerlessLegend() {
   return (
     <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 'var(--r-lg)', overflow: 'hidden' }}>
       <button
+        type="button"
         onClick={() => setOpen(o => !o)}
         aria-expanded={open}
+        aria-controls="serverless-tier-explainer"
         style={{
           width: '100%', display: 'flex', alignItems: 'center', gap: '8px',
           padding: '12px 16px', background: 'transparent', border: 'none', cursor: 'pointer',
           color: 'var(--text-primary)', textAlign: 'left',
         }}
       >
-        <Zap size={15} style={{ color: '#059669' }} />
+        <Zap aria-hidden="true" size={15} style={{ color: '#059669' }} />
         <span style={{ fontSize: '13px', fontWeight: 600 }}>
           {t('Serverless tiery a plán (škálování na nulu)', 'Serverless tiers & plan (scale-to-zero)')}
         </span>
         <span style={{ marginLeft: 'auto', display: 'inline-flex' }}>
-          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          {open ? <ChevronDown aria-hidden="true" size={16} /> : <ChevronRight aria-hidden="true" size={16} />}
         </span>
       </button>
 
       {open && (
-        <div style={{ padding: '0 16px 16px' }}>
+        <div id="serverless-tier-explainer" style={{ padding: '0 16px 16px' }}>
           <p style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.5, margin: '0 0 12px' }}>
             {t('Každá služba spadá do jednoho tieru (ADR-0057). Nové služby defaultně do nejnižšího, který jejich trigger dovolí — vždy-běžící je opt-in. Implementováno na stávajícím Kubernetes + KEDA / Karpenter spot, žádný proprietární FaaS (ADR-0027).',
                'Every service falls into one tier (ADR-0057). New services default to the lowest tier their trigger allows — always-on is opt-in. Built on the existing Kubernetes + KEDA / Karpenter spot, no proprietary FaaS (ADR-0027).')}

--- a/openbank-admin-ui/src/test/serverless-legend-disclosure.test.tsx
+++ b/openbank-admin-ui/src/test/serverless-legend-disclosure.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ServerlessLegend } from '@/components/finops/ServerlessLegend'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+afterEach(cleanup)
+
+describe('serverless tier explainer disclosure', () => {
+  it('reveals and hides the educational content from the keyboard', async () => {
+    const user = userEvent.setup()
+    render(<LanguageProvider><ServerlessLegend /></LanguageProvider>)
+
+    const disclosure = screen.getByRole('button', { name: 'Serverless tiers & plan (scale-to-zero)' })
+    expect(disclosure).toHaveAttribute('type', 'button')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+    expect(disclosure).toHaveAttribute('aria-controls', 'serverless-tier-explainer')
+    expect(screen.queryByText(/Every service falls into one tier/)).not.toBeInTheDocument()
+
+    disclosure.focus()
+    await user.keyboard('{Enter}')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText(/Every service falls into one tier/)).toBeVisible()
+
+    await user.keyboard(' ')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(/Every service falls into one tier/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- make the shared serverless tier explainer an explicit non-submit disclosure control
- connect the control to its educational panel with stable expanded/controls semantics
- keep decorative tier-navigation icons out of the accessible name
- prove native Enter and Space interaction plus truthful collapsed/expanded state

## Verification

- TypeScript check passed
- focused ESLint passed
- serverless disclosure behavior test passed
- production build: 97/97 routes generated

Refs #7654
