### PR TITLE
fix(admin-ui): make upgrade feedback actionable

### DIFF
--- a/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
+++ b/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
@@ -52,12 +52,23 @@ function fmtDate(iso: string, locale: string): string {
   return new Date(iso).toLocaleDateString(locale, { year: 'numeric', month: 'short' })
 }
 
+function safeReleaseNotesUrl(candidate: string | null): string | null {
+  if (!candidate) return null
+  try {
+    const url = new URL(candidate)
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
 export function LifecycleStrip({ data, name, t, dateLocale = 'en-GB' }: { data: CompLifecycle; name: string; t: T; dateLocale?: string }) {
   const [draft, setDraft] = useState<'idle' | 'busy' | 'done' | 'err'>('idle')
   const u = URGENCY[data.urgency]
   const lc = data.lifecycle
   const has = lc.available
   const running = data.running.version
+  const releaseNotesUrl = safeReleaseNotesUrl(data.upgrade.releaseNotesUrl)
 
   const planUpgrade = async () => {
     setDraft('busy')
@@ -158,10 +169,10 @@ export function LifecycleStrip({ data, name, t, dateLocale = 'en-GB' }: { data: 
       </div>
 
       {/* actions */}
-      {(showUpgrade || data.upgrade.releaseNotesUrl) && (
+      {(showUpgrade || releaseNotesUrl) && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 2 }}>
-          {data.upgrade.releaseNotesUrl && (
-            <a href={data.upgrade.releaseNotesUrl} target="_blank" rel="noreferrer"
+          {releaseNotesUrl && (
+            <a href={releaseNotesUrl} target="_blank" rel="noreferrer"
               style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: 'var(--accent)', textDecoration: 'none' }}>
               <ExternalLink size={12} /> {data.upgrade.target ? `${t('Co je nového v', "What's new in")} ${data.upgrade.target}` : t('Release notes', 'Release notes')}
             </a>

--- a/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
+++ b/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
@@ -167,12 +167,17 @@ export function LifecycleStrip({ data, name, t, dateLocale = 'en-GB' }: { data: 
             </a>
           )}
           {showUpgrade && (
-            <button onClick={planUpgrade} disabled={draft === 'busy' || draft === 'done'}
-              style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11, fontWeight: 600, padding: '4px 10px', borderRadius: 6, cursor: draft === 'done' ? 'default' : 'pointer',
-                border: `1px solid ${draft === 'done' ? '#6ee7b7' : 'var(--border)'}`, background: draft === 'done' ? '#ecfdf5' : 'var(--surface)', color: draft === 'done' ? '#059669' : draft === 'err' ? '#dc2626' : 'var(--text-primary)' }}>
-              {draft === 'busy' ? <Loader2 size={12} className="animate-spin" /> : draft === 'done' ? <Check size={12} /> : <ClipboardPlus size={12} />}
-              {draft === 'done' ? t('Návrh ve frontě', 'Queued') : draft === 'err' ? t('Chyba', 'Error') : <><ArrowUpCircle size={12} style={{ display: 'none' }} />{t('Naplánovat upgrade', 'Plan upgrade')}</>}
-            </button>
+            <>
+              <button type="button" onClick={planUpgrade} disabled={draft === 'busy' || draft === 'done'} aria-busy={draft === 'busy'}
+                style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11, fontWeight: 600, padding: '4px 10px', borderRadius: 6, cursor: draft === 'done' ? 'default' : 'pointer',
+                  border: `1px solid ${draft === 'done' ? '#6ee7b7' : 'var(--border)'}`, background: draft === 'done' ? '#ecfdf5' : 'var(--surface)', color: draft === 'done' ? '#059669' : draft === 'err' ? '#dc2626' : 'var(--text-primary)' }}>
+                {draft === 'busy' ? <Loader2 aria-hidden="true" size={12} className="animate-spin" /> : draft === 'done' ? <Check aria-hidden="true" size={12} /> : <ClipboardPlus aria-hidden="true" size={12} />}
+                {draft === 'busy' ? t('Připravuji…', 'Drafting…') : draft === 'done' ? t('Návrh ve frontě', 'Queued') : draft === 'err' ? t('Zkusit znovu', 'Try again') : <><ArrowUpCircle aria-hidden="true" size={12} style={{ display: 'none' }} />{t('Naplánovat upgrade', 'Plan upgrade')}</>}
+              </button>
+              <span role="status" aria-live="polite" className="sr-only">
+                {draft === 'busy' ? t('Připravuji návrh upgradu.', 'Drafting upgrade proposal.') : draft === 'done' ? t('Návrh upgradu čeká na nezávislé schválení.', 'Upgrade proposal is queued for independent review.') : draft === 'err' ? t('Návrh upgradu se nepodařilo zařadit. Zkuste to znovu.', 'Upgrade proposal could not be queued. Try again.') : ''}
+              </span>
+            </>
           )}
         </div>
       )}

--- a/openbank-admin-ui/src/test/lifecycle-upgrade-feedback.test.tsx
+++ b/openbank-admin-ui/src/test/lifecycle-upgrade-feedback.test.tsx
@@ -71,4 +71,14 @@ describe('lifecycle upgrade proposal feedback', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'Queued' })).toBeDisabled())
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('does not render an unsafe release-notes protocol', () => {
+    render(<LifecycleStrip
+      data={{ ...data, upgrade: { ...data.upgrade, patchAvailable: false, target: null, releaseNotesUrl: 'javascript:alert(1)' } }}
+      name="PostgreSQL"
+      t={t}
+    />)
+
+    expect(screen.queryByRole('link', { name: /Release notes/ })).not.toBeInTheDocument()
+  })
 })

--- a/openbank-admin-ui/src/test/lifecycle-upgrade-feedback.test.tsx
+++ b/openbank-admin-ui/src/test/lifecycle-upgrade-feedback.test.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LifecycleStrip, type CompLifecycle } from '@/components/infra/LifecycleStrip'
+
+const data: CompLifecycle = {
+  id: 'postgres',
+  running: { version: '17.4', source: 'runtime' },
+  lifecycle: {
+    available: true,
+    product: 'postgresql',
+    cycle: '17',
+    isLts: false,
+    eol: '2029-11-08',
+    eolPassed: false,
+    eolDaysLeft: 900,
+    support: true,
+    latestInCycle: '17.6',
+    newestVersion: '18.0',
+    newestCycle: '18',
+  },
+  upgrade: { patchAvailable: true, majorAvailable: false, target: '17.6', releaseNotesUrl: null },
+  cve: { scanned: true, critical: 0, high: 0, medium: 0, low: 0, total: 0, top: [] },
+  urgency: 'patch-available',
+}
+
+const t = (_cs: string, en: string) => en
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('lifecycle upgrade proposal feedback', () => {
+  it('announces progress and success while preventing a duplicate request', async () => {
+    let resolveRequest: ((value: Response) => void) | undefined
+    const fetchMock = vi.fn(() => new Promise<Response>(resolve => { resolveRequest = resolve }))
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+    render(<LifecycleStrip data={data} name="PostgreSQL" t={t} />)
+
+    const button = screen.getByRole('button', { name: 'Plan upgrade' })
+    expect(button).toHaveAttribute('type', 'button')
+    await user.click(button)
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('status')).toHaveTextContent('Drafting upgrade proposal.')
+    await user.click(button)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveRequest?.(new Response(JSON.stringify({ result: { content: [] } }), { status: 200 }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Queued' })).toBeDisabled())
+    expect(screen.getByRole('status')).toHaveTextContent('queued for independent review')
+  })
+
+  it('turns a failed request into a clear retry action', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ result: { content: [] } }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+    render(<LifecycleStrip data={data} name="PostgreSQL" t={t} />)
+
+    await user.click(screen.getByRole('button', { name: 'Plan upgrade' }))
+    const retry = await screen.findByRole('button', { name: 'Try again' })
+    expect(retry).toBeEnabled()
+    expect(screen.getByRole('status')).toHaveTextContent('could not be queued')
+
+    await user.click(retry)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Queued' })).toBeDisabled())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

- make infrastructure upgrade planning an explicit non-submit, busy-aware action
- replace the ambiguous terminal `Error` label with a clear retry affordance
- announce drafting, queued-for-independent-review and retry states to assistive technology
- preserve the existing proposal payload while preventing duplicate requests during flight
- allow release-note links only after parsing and validating an HTTP(S) protocol

## Verification

- TypeScript check passed
- focused ESLint passed
- lifecycle feedback and locale guards: 5 tests passed
- unsafe `javascript:` release-note protocol has a regression test
- production build: 97/97 routes generated

Refs #7654
