### PR TITLE
fix(admin-ui): announce screen recovery state

### DIFF
--- a/openbank-admin-ui/src/app/error.tsx
+++ b/openbank-admin-ui/src/app/error.tsx
@@ -37,9 +37,14 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
 
   return (
     <div style={{ minHeight: '60vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px' }}>
-      <div className="card" style={{ maxWidth: '440px', textAlign: 'center', padding: '32px' }}>
-        <AlertTriangle size={32} style={{ color: 'var(--warning)', margin: '0 auto 16px' }} />
-        <h2 style={{ fontSize: '16px', marginBottom: '8px' }}>
+      <div
+        className="card"
+        role="alert"
+        aria-labelledby="screen-error-title"
+        style={{ maxWidth: '440px', textAlign: 'center', padding: '32px' }}
+      >
+        <AlertTriangle aria-hidden="true" size={32} style={{ color: 'var(--warning)', margin: '0 auto 16px' }} />
+        <h2 id="screen-error-title" style={{ fontSize: '16px', marginBottom: '8px' }}>
           {t('Tuto obrazovku se nepodařilo zobrazit', 'This screen failed to render')}
         </h2>
         <p style={{ color: 'var(--text-muted)', fontSize: '13px', marginBottom: '20px', lineHeight: 1.5 }}>
@@ -49,8 +54,8 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
           )}
         </p>
         <div style={{ display: 'flex', gap: '8px', justifyContent: 'center' }}>
-          <button className="btn btn-primary" onClick={() => reset()}>
-            <RotateCw size={13} /> {t('Zkusit znovu', 'Try again')}
+          <button type="button" className="btn btn-primary" onClick={() => reset()}>
+            <RotateCw aria-hidden="true" size={13} /> {t('Zkusit znovu', 'Try again')}
           </button>
           <Link href="/dashboard" className="btn btn-secondary">{t('Na přehled', 'Dashboard')}</Link>
         </div>

--- a/openbank-admin-ui/src/app/global-error.tsx
+++ b/openbank-admin-ui/src/app/global-error.tsx
@@ -14,7 +14,7 @@ import * as Sentry from '@sentry/nextjs'
  * fallback (never Next's bare default, per CLAUDE.md rule #1). The richer [error.tsx]
  * handles everything below the root layout.
  */
-export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     console.error('[admin-ui] root layout error:', error)
     Sentry.captureException(error)
@@ -24,19 +24,19 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
     <html lang="en">
       <body style={{ fontFamily: 'system-ui, sans-serif', margin: 0 }}>
         <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-          <div style={{ maxWidth: 420, textAlign: 'center' }}>
-            <h2 style={{ fontSize: 16, marginBottom: 8 }}>
+          <div role="alert" aria-labelledby="global-error-title" style={{ maxWidth: 420, textAlign: 'center' }}>
+            <h2 id="global-error-title" style={{ fontSize: 16, marginBottom: 8 }}>
               The console failed to load · Konzoli se nepodařilo načíst
             </h2>
             <p style={{ color: '#6b7280', fontSize: 13, lineHeight: 1.5, marginBottom: 20 }}>
-              An unexpected error occurred. Please reload the page.<br />
-              Došlo k neočekávané chybě. Načtěte prosím stránku znovu.
+              An unexpected error occurred. It is safe to try loading the console again.<br />
+              Došlo k neočekávané chybě. Konzoli můžete bezpečně zkusit načíst znovu.
             </p>
-            <button type="button" aria-label="Reload admin console / Načíst konzoli"
-              onClick={() => window.location.reload()}
+            <button type="button" aria-label="Try loading the admin console again / Zkusit znovu načíst konzoli"
+              onClick={reset}
               style={{ padding: '8px 16px', borderRadius: 6, border: '1px solid #d1d5db', background: '#fff', cursor: 'pointer' }}
             >
-              Reload · Načíst znovu
+              Try again · Zkusit znovu
             </button>
             {error?.digest && (
               <p style={{ color: '#9ca3af', fontSize: 11, marginTop: 16, fontFamily: 'monospace' }}>ref: {error.digest}</p>

--- a/openbank-admin-ui/src/test/app-error-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/app-error-recovery.test.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import Error from '@/app/error'
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+
+vi.mock('@sentry/nextjs', () => ({ captureException }))
+
+describe('app error recovery', () => {
+  beforeEach(() => {
+    captureException.mockClear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('announces the failure, reports it, and offers explicit recovery', async () => {
+    const reset = vi.fn()
+    const error = Object.assign(new globalThis.Error('render failed'), { digest: 'safe-ref-42' })
+
+    render(
+      <LanguageProvider initialLanguage="en">
+        <Error error={error} reset={reset} />
+      </LanguageProvider>,
+    )
+
+    const alert = screen.getByRole('alert', { name: 'This screen failed to render' })
+    expect(alert).toHaveTextContent('safe-ref-42')
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard')
+    const retry = screen.getByRole('button', { name: 'Try again' })
+    expect(retry).toHaveAttribute('type', 'button')
+    fireEvent.click(retry)
+    expect(reset).toHaveBeenCalledOnce()
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(error))
+  })
+})

--- a/openbank-admin-ui/src/test/app-error-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/app-error-recovery.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import Error from '@/app/error'
+import GlobalError from '@/app/global-error'
 
 const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
 
@@ -35,6 +36,19 @@ describe('app error recovery', () => {
     const retry = screen.getByRole('button', { name: 'Try again' })
     expect(retry).toHaveAttribute('type', 'button')
     fireEvent.click(retry)
+    expect(reset).toHaveBeenCalledOnce()
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(error))
+  })
+
+  it('retries a root-layout failure without forcing a full-page reload', async () => {
+    const reset = vi.fn()
+    const error = Object.assign(new globalThis.Error('root failed'), { digest: 'root-ref-7' })
+
+    render(<GlobalError error={error} reset={reset} />)
+
+    const alert = screen.getByRole('alert', { name: /The console failed to load/ })
+    expect(alert).toHaveTextContent('root-ref-7')
+    fireEvent.click(screen.getByRole('button', { name: /Try loading the admin console again/ }))
     expect(reset).toHaveBeenCalledOnce()
     await waitFor(() => expect(captureException).toHaveBeenCalledWith(error))
   })

--- a/openbank-admin-ui/src/test/global-error-reload.guard.test.ts
+++ b/openbank-admin-ui/src/test/global-error-reload.guard.test.ts
@@ -4,9 +4,11 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 describe('global error recovery contract', () => {
-  it('keeps reload recovery an explicit accessible button', () => {
+  it('keeps in-place recovery explicit and accessible', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/global-error.tsx'), 'utf8')
-    expect(source).toContain('<button type="button" aria-label="Reload admin console / Načíst konzoli"')
-    expect(source).toContain('window.location.reload()')
+    expect(source).toContain('role="alert" aria-labelledby="global-error-title"')
+    expect(source).toContain('<button type="button" aria-label="Try loading the admin console again / Zkusit znovu načíst konzoli"')
+    expect(source).toContain('onClick={reset}')
+    expect(source).not.toContain('window.location.reload()')
   })
 })


### PR DESCRIPTION
## Summary

- expose route-level and root-layout render failures as named alerts so assistive technology announces them
- keep retry actions explicit non-submit buttons and hide decorative icons from the accessibility tree
- use the framework recovery callback for root failures instead of forcing a full-page reload
- preserve Sentry reporting, safe diagnostic references, dashboard escape and exact retry behavior
- update the recovery guard so a hard-reload regression fails alongside focused behavior coverage

## Verification

- TypeScript check passed
- focused ESLint passed
- app recovery, root recovery guard and section-boundary suites: 5 tests passed
- production build: 97/97 routes generated

Refs #7654
