### PR TITLE
docs(delegation): track remaining D3 rollout

### DIFF
--- a/docs/adr/0232-delegated-access-customer-to-party-sharing-with-granular-capabilities.md
+++ b/docs/adr/0232-delegated-access-customer-to-party-sharing-with-granular-capabilities.md
@@ -2,7 +2,7 @@
 date: 2026-07-31
 decision-status: proposed
 delivery-status: partial
-followup: "complete D3 rail rollout beyond domestic payment and reconcile reservations to final clearing outcomes"
+followup: "#9355 — complete D3 rail rollout beyond domestic payment and reconcile reservations to final clearing outcomes"
 authors: [Jiri Raska]
 supersedes: []
 superseded-by: []


### PR DESCRIPTION
## Summary

- restore the required `<refs> — <reason>` metadata shape for partial ADR-0232
- link the newly filed actionable follow-up for remaining delegated rails and clearing reconciliation
- unblock the enforced `adr-partial-followup` gate without weakening or baselining it

## Verification

- `check-adr-partial-followup.py --self-test` passed
- `check-adr-partial-followup.py --enforce` passed
- `check-adr-registry.sh` passed for all 287 ADRs

Closes #9355
Refs #3965
