### PR TITLE
fix(admin-ui): harden consent lookup lifecycle

### DIFF
--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
+import { InvalidConsentPayloadError, parseConsentList, type Consent } from '@/lib/consents/consentLookup'
 
 // consent-service (ADR-0126) exposes NO "list all consents" endpoint — every read is keyed by
 // consentId, partyId or granteeId. So this is deliberately a LOOKUP page, not a table of everything:
@@ -21,20 +22,6 @@ import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
 // `party-service:marketing-comms` (ADR-0205 D3's fixed internal grantee) answers "who has an ACTIVE
 // marketing consent right now" straight from the owning service, with no projection to drift.
 const MARKETING_GRANTEE = 'party-service:marketing-comms'
-
-interface Consent {
-  id: string
-  partyId: string
-  granteeId: string
-  granteeType: string
-  granteeName: string
-  scopes: string[]
-  accountIbans: string[] | null
-  status: string
-  validFrom: string
-  validTo: string
-  createdAt: string
-}
 
 type Lens = 'party' | 'grantee'
 
@@ -75,21 +62,34 @@ export default function ConsentsPage() {
       // The lens is read ONCE, at request time — never from the closure after the await, where it
       // may already describe a different query.
       const path = lensAtRequest === 'party' ? `party/${encodeURIComponent(q)}` : `grantee/${encodeURIComponent(q)}`
-      const res = await fetch(`/api/svc/consent-service/api/v1/consents/${path}`, { cache: 'no-store' })
+      const res = await fetch(`/api/svc/consent-service/api/v1/consents/${path}`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(12_000),
+      })
       if (gen !== generation.current) return // superseded — a newer lookup or a lens switch won
       if (!res.ok) {
-        setFailure(await classifyBffFailure(res))
+        const nextFailure = await classifyBffFailure(res)
+        // A snapshot may survive a transient service failure, but never an authentication or
+        // authorization failure. Once access is gone, previously rendered customer consent data
+        // is removed in the same request cycle instead of lingering behind an error panel.
+        if (res.status === 401 || res.status === 403) {
+          setRows(null)
+          setLoadedQuery(null)
+        }
+        setFailure(res.status === 403 ? 'unauthorized' : nextFailure)
         return
       }
-      const data = (await res.json()) as Consent[]
+      const data = parseConsentList(await res.json())
       if (gen !== generation.current) return
       setRows(data)
       setLoadedQuery(queryKey)
       // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
       // said "the data source contains no records yet", which an operator cannot tell apart from a
       // broken page — and was false whenever any other party had a consent. Rendered below instead.
-    } catch {
-      if (gen === generation.current) setFailure('unreachable')
+    } catch (error) {
+      if (gen === generation.current) {
+        setFailure(error instanceof InvalidConsentPayloadError ? 'error' : 'unreachable')
+      }
     } finally {
       if (gen === generation.current) setLoading(false)
     }
@@ -210,9 +210,18 @@ export default function ConsentsPage() {
       )}
 
       {loading && (
-        <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>
+        <div role="status" aria-live="polite" style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>
           {t('Načítám…', 'Loading…')}
         </div>
+      )}
+
+      {!loading && failure && rows !== null && (
+        <p role="alert" style={{ margin: '0 0 12px', color: 'var(--warning)', fontSize: '12px', fontWeight: 600 }}>
+          {t(
+            'Aktualizace selhala. Níže zůstává poslední ověřený výsledek pro stejný dotaz; nejde o živý stav.',
+            'Refresh failed. The last verified result for this exact query remains below; it is not live state.',
+          )}
+        </p>
       )}
 
       {!loading && failure && (

--- a/openbank-admin-ui/src/lib/consents/consentLookup.ts
+++ b/openbank-admin-ui/src/lib/consents/consentLookup.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface Consent {
+  id: string
+  partyId: string
+  granteeId: string
+  granteeType: string
+  granteeName: string
+  scopes: string[]
+  accountIbans: string[] | null
+  status: string
+  validFrom: string
+  validTo: string
+  createdAt: string
+}
+
+export class InvalidConsentPayloadError extends Error {
+  constructor() {
+    super('invalid consent lookup payload')
+    this.name = 'InvalidConsentPayloadError'
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isDate(value: unknown): value is string {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value))
+}
+
+function isConsent(value: unknown): value is Consent {
+  if (!value || typeof value !== 'object') return false
+  const consent = value as Partial<Consent>
+  return isNonEmptyString(consent.id)
+    && isNonEmptyString(consent.partyId)
+    && isNonEmptyString(consent.granteeId)
+    && isNonEmptyString(consent.granteeType)
+    && isNonEmptyString(consent.granteeName)
+    && Array.isArray(consent.scopes)
+    && consent.scopes.every(isNonEmptyString)
+    && (consent.accountIbans === null
+      || (Array.isArray(consent.accountIbans) && consent.accountIbans.every(isNonEmptyString)))
+    && isNonEmptyString(consent.status)
+    && isDate(consent.validFrom)
+    && isDate(consent.validTo)
+    && Date.parse(consent.validFrom) <= Date.parse(consent.validTo)
+    && isDate(consent.createdAt)
+}
+
+/** Validate the consent-service response before it can become operator-visible evidence. */
+export function parseConsentList(value: unknown): Consent[] {
+  if (!Array.isArray(value) || !value.every(isConsent)) {
+    throw new InvalidConsentPayloadError()
+  }
+  return value
+}

--- a/openbank-admin-ui/src/test/consent-lookup-contract.test.ts
+++ b/openbank-admin-ui/src/test/consent-lookup-contract.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseConsentList } from '@/lib/consents/consentLookup'
+
+const validConsent = {
+  id: 'consent-1',
+  partyId: 'party-1',
+  granteeId: 'grantee-1',
+  granteeType: 'INTERNAL_SERVICE',
+  granteeName: 'Marketing communications',
+  scopes: ['MARKETING_COMMS_EMAIL'],
+  accountIbans: null,
+  status: 'ACTIVE',
+  validFrom: '2026-06-01T00:00:00Z',
+  validTo: '2026-12-01T00:00:00Z',
+  createdAt: '2026-05-31T10:00:00Z',
+}
+
+describe('consent lookup contract', () => {
+  it('accepts the complete service contract', () => {
+    expect(parseConsentList([validConsent])).toEqual([validConsent])
+  })
+
+  it.each([
+    ['non-array envelope', { items: [validConsent] }],
+    ['invalid validity date', [{ ...validConsent, validTo: 'not-a-date' }]],
+    ['reversed validity window', [{ ...validConsent, validFrom: '2027-01-01T00:00:00Z' }]],
+    ['non-string scope', [{ ...validConsent, scopes: ['PAYMENTS', 7] }]],
+    ['non-string account IBAN', [{ ...validConsent, accountIbans: ['CZ1200', null] }]],
+  ])('rejects %s before it reaches the table', (_label, payload) => {
+    expect(() => parseConsentList(payload)).toThrow('invalid consent lookup payload')
+  })
+})

--- a/openbank-admin-ui/src/test/consents-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/consents-recovery.test.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ConsentsPage from '@/app/consents/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const consent = {
+  id: 'consent-1',
+  partyId: 'party-visible-only-while-authorized',
+  granteeId: 'party-service:marketing-comms',
+  granteeType: 'INTERNAL_SERVICE',
+  granteeName: 'Marketing communications',
+  scopes: ['MARKETING_COMMS_EMAIL'],
+  accountIbans: null,
+  status: 'ACTIVE',
+  validFrom: '2026-06-01T00:00:00Z',
+  validTo: '2026-12-01T00:00:00Z',
+  createdAt: '2026-05-31T10:00:00Z',
+}
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mount() {
+  render(<LanguageProvider><ConsentsPage /></LanguageProvider>)
+  fireEvent.change(screen.getByRole('combobox', { name: 'Consent lookup lens' }), { target: { value: 'grantee' } })
+}
+
+async function lookup() {
+  fireEvent.click(screen.getByRole('button', { name: 'Look up' }))
+  await waitFor(() => expect(screen.queryByText('Loading…')).not.toBeInTheDocument())
+}
+
+beforeEach(() => vi.unstubAllGlobals())
+afterEach(() => cleanup())
+
+describe('consent lookup recovery', () => {
+  it('retains and labels the last verified result after a transient refresh failure', async () => {
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(response(200, [consent]))
+      .mockRejectedValueOnce(new Error('network down'))
+    vi.stubGlobal('fetch', fetchSpy)
+    mount()
+
+    await lookup()
+    expect(screen.getByText(consent.partyId)).toBeVisible()
+    await lookup()
+
+    expect(screen.getByText(consent.partyId)).toBeVisible()
+    expect(screen.getByRole('alert')).toHaveTextContent('last verified result')
+  })
+
+  it('rejects a malformed service response as invalid data, not a network outage', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(200, [{ ...consent, validTo: 'invalid' }])))
+    mount()
+
+    await lookup()
+
+    expect(screen.getByText('Failed to load: Consents')).toBeVisible()
+    expect(screen.queryByText('Consent-service is not responding')).not.toBeInTheDocument()
+    expect(screen.queryByText(consent.partyId)).not.toBeInTheDocument()
+  })
+
+  it.each([401, 403])('removes protected consent data immediately after HTTP %s', async status => {
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(response(200, [consent]))
+      .mockResolvedValueOnce(response(status, { error: status === 401 ? 'unauthorized' : 'forbidden' }))
+    vi.stubGlobal('fetch', fetchSpy)
+    mount()
+
+    await lookup()
+    expect(screen.getByText(consent.partyId)).toBeVisible()
+    await lookup()
+
+    expect(screen.queryByText(consent.partyId)).not.toBeInTheDocument()
+    expect(screen.queryByText(/last verified result/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Session expired')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Harden consent lookup response validation, bounded loading, and rendered-data lifecycle behavior. Detailed security review notes are intentionally not published here.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #9359
Refs #3965

## Changes

- validate the consent lookup contract before rendering
- distinguish invalid payloads from transport failures
- bound lookup duration and announce loading state
- align rendered data with the current request and access lifecycle
- add focused contract and recovery tests

## Verification

- focused Vitest: 4 files, 12 tests passed
- TypeScript: passed
- scoped ESLint: passed
- production Next build: passed, 97/97 pages

## Security and compliance

- [x] `security-review-required`
- [x] `gdpr-review-required`
- [x] No secrets, real PII, suppressions, or new dependencies

## Rollout / Rollback

- Deployment: existing rolling Admin UI GitOps rollout
- Rollback: revert the single commit and redeploy the previous Admin UI image
- Data migration: N/A

## Reviewer notes

Review through the repository security process; do not discuss sensitive findings in public comments.