### PR TITLE
fix(admin-ui): align dispute portfolio contract

### DIFF
--- a/openbank-admin-ui/e2e/disputes-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/disputes-recovery.spec.ts
@@ -3,14 +3,14 @@ import { signInAsOperator } from './helpers/auth'
 
 const dispute = {
   id: 'dispute-001',
-  referenceNumber: 'DSP-2026-0042',
+  reference: 'DSP-2026-0042',
   disputeType: 'CARD_NOT_PRESENT',
   status: 'UNDER_REVIEW',
-  claimantAccountId: 'account-123',
+  accountId: 'account-123',
   transactionId: 'transaction-12345678',
   amount: 2450,
   currency: 'CZK',
-  slaDeadline: '2026-08-01T00:00:00Z',
+  resolutionDeadline: '2026-08-01',
   createdAt: '2026-07-01T09:00:00Z',
 }
 
@@ -33,7 +33,7 @@ test.beforeEach(async ({ context, baseURL, page }) => {
 
 test('keeps dispute and SLA evidence visible after a failed refresh', async ({ page }) => {
   let unavailable = false
-  await page.route('**/api/svc/dispute-service/api/v1/disputes**', route => unavailable
+  await page.route('**/api/disputes', route => unavailable
     ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
     : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([dispute]) }))
 

--- a/openbank-admin-ui/src/app/api/disputes/route.ts
+++ b/openbank-admin-ui/src/app/api/disputes/route.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { hasPermission } from '@/lib/auth/roles'
+import { serverSvcUrl } from '@/lib/services/bff'
+import { DISPUTE_STATUSES, parseDisputeList, type DisputeRecord } from '@/lib/disputes/disputePortfolio'
+
+export const dynamic = 'force-dynamic'
+const TIMEOUT_MS = 8_000
+
+class DisputeHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`dispute-service HTTP ${status}`)
+  }
+}
+
+class InvalidDisputeResponseError extends Error {}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  if (!hasPermission(session.user.roles ?? [], 'compliance:view')) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  try {
+    const pages = await Promise.all(DISPUTE_STATUSES.map(async status => {
+      const response = await fetch(serverSvcUrl(
+        'dispute-service',
+        'dispute',
+        8135,
+        '/api/v1/disputes',
+        { status },
+      ), {
+        cache: 'no-store',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${session.user.accessToken}`,
+        },
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      })
+      if (!response.ok) throw new DisputeHttpError(response.status)
+      let disputes: DisputeRecord[]
+      try {
+        disputes = parseDisputeList(await response.json())
+      } catch {
+        throw new InvalidDisputeResponseError('invalid dispute-service payload')
+      }
+      if (disputes.some(dispute => dispute.status !== status)) {
+        throw new InvalidDisputeResponseError('dispute-service returned a mismatched status page')
+      }
+      return disputes
+    }))
+
+    // Concurrent status reads can observe a transition twice. De-duplicate by aggregate id so one
+    // case never inflates totals; the later status in the canonical lifecycle order wins.
+    const unique = new Map<string, DisputeRecord>()
+    for (const page of pages) for (const dispute of page) unique.set(dispute.id, dispute)
+    return NextResponse.json([...unique.values()])
+  } catch (error) {
+    if (error instanceof DisputeHttpError && (error.status === 401 || error.status === 403)) {
+      return NextResponse.json(
+        { error: error.status === 401 ? 'unauthorized' : 'forbidden' },
+        { status: error.status },
+      )
+    }
+    if (error instanceof InvalidDisputeResponseError) {
+      return NextResponse.json({ error: 'invalid_upstream_response' }, { status: 502 })
+    }
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/app/disputes/page.tsx
+++ b/openbank-admin-ui/src/app/disputes/page.tsx
@@ -7,46 +7,45 @@ import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { MessageSquareWarning, Search, CheckCircle2, Clock, RefreshCw, AlertTriangle, Timer } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
-
-interface Dispute {
-  id: string; referenceNumber: string; disputeType: string; status: string
-  claimantAccountId: string; transactionId: string; amount: number; currency: string
-  slaDeadline: string; createdAt: string
-}
+import {
+  disputeDaysRemaining,
+  isDisputeSlaBreached,
+  isTerminalDispute,
+  parseDisputeList,
+  type DisputeRecord,
+} from '@/lib/disputes/disputePortfolio'
 
 export default function DisputesPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
-  const { data, loading, unavailable, waking, reload } = useServiceResource<Dispute[]>(
-    svcUrl('dispute-service', '/api/v1/disputes'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as Dispute[]) : ((raw as { disputes?: Dispute[] }).disputes ?? [])) },
+  const { data, loading, unavailable, waking, reload } = useServiceResource<DisputeRecord[]>(
+    '/api/disputes',
+    { select: parseDisputeList },
   )
   const disputes = data ?? []
   const hasSnapshot = data !== null
   const showingRetainedSnapshot = unavailable !== null && hasSnapshot
 
   const filtered = disputes.filter(d =>
-    d.referenceNumber?.toLowerCase().includes(search.toLowerCase()) ||
-    d.disputeType?.toLowerCase().includes(search.toLowerCase()) ||
-    d.status?.toLowerCase().includes(search.toLowerCase())
+    d.reference.toLowerCase().includes(search.toLowerCase()) ||
+    d.disputeType.toLowerCase().includes(search.toLowerCase()) ||
+    d.status.toLowerCase().includes(search.toLowerCase())
   )
 
-  const open = disputes.filter(d => ['OPEN', 'UNDER_REVIEW', 'PENDING_EVIDENCE'].includes(d.status))
-  const resolved = disputes.filter(d => ['RESOLVED', 'CLOSED', 'CHARGEBACK_ISSUED'].includes(d.status))
-  const slaBreached = disputes.filter(d => d.slaDeadline && new Date(d.slaDeadline) < new Date() && !['RESOLVED', 'CLOSED'].includes(d.status))
+  const open = disputes.filter(d => !isTerminalDispute(d.status))
+  const resolved = disputes.filter(d => isTerminalDispute(d.status))
+  const now = new Date()
+  const slaBreached = disputes.filter(d => isDisputeSlaBreached(d, now))
 
-  const slaStatus = (deadline: string, status: string) => {
-    if (['RESOLVED', 'CLOSED'].includes(status)) return null
+  const slaStatus = (deadline: string | null, status: DisputeRecord['status']) => {
+    if (isTerminalDispute(status)) return null
     if (!deadline) return null
-    // eslint-disable-next-line react-hooks/purity -- SLA days-remaining display is inherently time-relative; the deadline is stable server data.
-    const now = Date.now()
-    const daysLeft = Math.ceil((new Date(deadline).getTime() - now) / 86400000)
+    const daysLeft = disputeDaysRemaining(deadline, now)
     if (daysLeft < 0) return <span style={{ fontSize: '11px', color: 'var(--danger)', fontWeight: 700 }}>{t('PORUŠENÍ SLA', 'SLA BREACH')}</span>
     if (daysLeft <= 5) return <span style={{ fontSize: '11px', color: 'var(--warning)', fontWeight: 600 }}>{daysLeft}{t('d zbývá', 'd left')}</span>
     return <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{daysLeft}{t('d zbývá', 'd left')}</span>
@@ -57,7 +56,7 @@ export default function DisputesPage() {
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <PageHeader
           title={t('Reklamace & Spory', 'Disputes & Complaints')}
-          subtitle={t('Správa sporů — chargeback · SLA 45 dní · PSD2 čl. 73', 'Dispute management — chargeback · SLA 45 days · PSD2 Art. 73')}
+          subtitle={t('Portfolio všech stavů · lhůta každého případu · PSD2 čl. 73', 'All-status portfolio · each case’s resolution deadline · PSD2 Art. 73')}
           icon={<MessageSquareWarning size={18} aria-hidden="true" />}
           actions={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <ServiceStatusBadge
@@ -95,7 +94,7 @@ export default function DisputesPage() {
             display: 'flex', alignItems: 'center', gap: '10px' }}>
             <AlertTriangle size={16} style={{ color: 'var(--danger)', flexShrink: 0 }} />
             <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--danger-text)' }}>
-              {slaBreached.length} {t(slaBreached.length > 1 ? 'sporů překročilo SLA 45 dní' : 'spor překročil SLA 45 dní', slaBreached.length > 1 ? 'disputes exceeded the 45-day SLA' : 'dispute exceeded the 45-day SLA')} — {t('vyžaduje okamžité řešení', 'requires immediate action')}
+              {slaBreached.length} {t(slaBreached.length > 1 ? 'sporů překročilo lhůtu řešení' : 'spor překročil lhůtu řešení', slaBreached.length > 1 ? 'disputes exceeded their resolution deadline' : 'dispute exceeded its resolution deadline')} — {t('vyžaduje okamžité řešení', 'requires immediate action')}
             </span>
           </div>
         )}
@@ -139,7 +138,7 @@ export default function DisputesPage() {
                 </tr></thead>
                 <tbody>{filtered.map(d => (
                   <tr key={d.id}>
-                    <td className="mono" style={{ fontWeight: 600 }}>{d.referenceNumber}</td>
+                    <td className="mono" style={{ fontWeight: 600 }}>{d.reference}</td>
                     <td style={{ color: 'var(--text-secondary)' }}>{d.disputeType}</td>
                     <td className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{d.transactionId?.slice(0, 8)}…</td>
                     <td style={{ fontWeight: 600 }}>
@@ -148,7 +147,7 @@ export default function DisputesPage() {
                     <td>
                       <StatusBadge status={d.status} />
                     </td>
-                    <td>{slaStatus(d.slaDeadline, d.status)}</td>
+                    <td>{slaStatus(d.resolutionDeadline, d.status)}</td>
                     <td style={{ color: 'var(--text-tertiary)' }}>{d.createdAt ? new Date(d.createdAt).toLocaleString(numberLocale) : '—'}</td>
                   </tr>
                 ))}</tbody>

--- a/openbank-admin-ui/src/lib/disputes/disputePortfolio.ts
+++ b/openbank-admin-ui/src/lib/disputes/disputePortfolio.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const DISPUTE_STATUSES = [
+  'OPEN',
+  'UNDER_REVIEW',
+  'PENDING_CUSTOMER',
+  'PENDING_MERCHANT',
+  'RESOLVED_CUSTOMER',
+  'RESOLVED_MERCHANT',
+  'WITHDRAWN',
+  'ESCALATED',
+] as const
+
+export type DisputeStatus = typeof DISPUTE_STATUSES[number]
+
+export interface DisputeRecord {
+  id: string
+  reference: string
+  disputeType: string
+  status: DisputeStatus
+  accountId: string
+  transactionId: string
+  amount: number
+  currency: string
+  resolutionDeadline: string | null
+  createdAt: string
+}
+
+const STATUS_SET: ReadonlySet<string> = new Set(DISPUTE_STATUSES)
+const TERMINAL_STATUSES: ReadonlySet<DisputeStatus> = new Set([
+  'RESOLVED_CUSTOMER',
+  'RESOLVED_MERCHANT',
+  'WITHDRAWN',
+])
+const LOCAL_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isLocalDate(value: unknown): value is string {
+  if (typeof value !== 'string' || !LOCAL_DATE.test(value)) return false
+  const [year, month, day] = value.split('-').map(Number)
+  const parsed = new Date(Date.UTC(year, month - 1, day))
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day
+}
+
+function isDispute(value: unknown): value is DisputeRecord {
+  if (!value || typeof value !== 'object') return false
+  const dispute = value as Partial<DisputeRecord>
+  return isNonEmptyString(dispute.id)
+    && isNonEmptyString(dispute.reference)
+    && isNonEmptyString(dispute.disputeType)
+    && typeof dispute.status === 'string'
+    && STATUS_SET.has(dispute.status)
+    && isNonEmptyString(dispute.accountId)
+    && isNonEmptyString(dispute.transactionId)
+    && typeof dispute.amount === 'number'
+    && Number.isFinite(dispute.amount)
+    && dispute.amount >= 0
+    && typeof dispute.currency === 'string'
+    && /^[A-Z]{3}$/.test(dispute.currency)
+    && (dispute.resolutionDeadline === null || isLocalDate(dispute.resolutionDeadline))
+    && typeof dispute.createdAt === 'string'
+    && Number.isFinite(Date.parse(dispute.createdAt))
+}
+
+export function parseDisputeList(value: unknown): DisputeRecord[] {
+  if (!Array.isArray(value) || !value.every(isDispute)) {
+    throw new Error('invalid dispute portfolio payload')
+  }
+  return value
+}
+
+export function isTerminalDispute(status: DisputeStatus): boolean {
+  return TERMINAL_STATUSES.has(status)
+}
+
+/** Whole calendar days until an inclusive service-owned LocalDate deadline. */
+export function disputeDaysRemaining(deadline: string, today: Date): number {
+  if (!isLocalDate(deadline)) throw new Error('invalid dispute deadline')
+  const [year, month, day] = deadline.split('-').map(Number)
+  const deadlineDay = Date.UTC(year, month - 1, day)
+  const todayDay = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())
+  return Math.round((deadlineDay - todayDay) / 86_400_000)
+}
+
+export function isDisputeSlaBreached(dispute: DisputeRecord, today: Date): boolean {
+  return !isTerminalDispute(dispute.status)
+    && dispute.resolutionDeadline !== null
+    && disputeDaysRemaining(dispute.resolutionDeadline, today) < 0
+}

--- a/openbank-admin-ui/src/test/dispute-portfolio.test.ts
+++ b/openbank-admin-ui/src/test/dispute-portfolio.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  disputeDaysRemaining,
+  isDisputeSlaBreached,
+  isTerminalDispute,
+  parseDisputeList,
+  type DisputeRecord,
+} from '@/lib/disputes/disputePortfolio'
+
+const dispute: DisputeRecord = {
+  id: 'd-1', reference: 'DSP-1', disputeType: 'UNAUTHORIZED', status: 'OPEN',
+  accountId: 'account-1', transactionId: 'transaction-1', amount: 42.5, currency: 'EUR',
+  resolutionDeadline: '2026-09-09', createdAt: '2026-08-01T10:00:00Z',
+}
+
+describe('dispute portfolio contract', () => {
+  it('accepts the service-owned field and status vocabulary', () => {
+    expect(parseDisputeList([dispute])).toEqual([dispute])
+    expect(isTerminalDispute('RESOLVED_CUSTOMER')).toBe(true)
+    expect(isTerminalDispute('RESOLVED_MERCHANT')).toBe(true)
+    expect(isTerminalDispute('WITHDRAWN')).toBe(true)
+    expect(isTerminalDispute('ESCALATED')).toBe(false)
+  })
+
+  it.each([
+    [{ ...dispute, reference: undefined }],
+    [{ ...dispute, status: 'CLOSED' }],
+    [{ ...dispute, resolutionDeadline: '2026-02-30' }],
+    [{ ...dispute, amount: Number.NaN }],
+    [{ ...dispute, currency: 'euro' }],
+  ])('rejects a payload that cannot support truthful rendering', invalid => {
+    expect(() => parseDisputeList(invalid)).toThrow('invalid dispute portfolio payload')
+  })
+
+  it('treats the LocalDate deadline as inclusive and never breaches terminal cases', () => {
+    const today = new Date(2026, 8, 9, 18, 30)
+    expect(disputeDaysRemaining('2026-09-09', today)).toBe(0)
+    expect(isDisputeSlaBreached(dispute, today)).toBe(false)
+    expect(isDisputeSlaBreached({ ...dispute, resolutionDeadline: '2026-09-08' }, today)).toBe(true)
+    expect(isDisputeSlaBreached({ ...dispute, status: 'WITHDRAWN', resolutionDeadline: '2026-09-08' }, today)).toBe(false)
+  })
+})

--- a/openbank-admin-ui/src/test/disputes-route.test.ts
+++ b/openbank-admin-ui/src/test/disputes-route.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { auth } from '@/auth'
+import { DISPUTE_STATUSES } from '@/lib/disputes/disputePortfolio'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+const row = (status: string, id = `id-${status}`) => ({
+  id, reference: `DSP-${status}`, disputeType: 'UNAUTHORIZED', status,
+  accountId: 'account-1', transactionId: 'transaction-1', amount: 10, currency: 'EUR',
+  resolutionDeadline: '2026-10-01', createdAt: '2026-09-01T10:00:00Z',
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env.KUBERNETES_SERVICE_HOST = 'true'
+  vi.mocked(auth).mockResolvedValue({
+    user: { accessToken: 'test-token', roles: ['ROLE_COMPLIANCE'] },
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  delete process.env.KUBERNETES_SERVICE_HOST
+})
+
+describe('GET /api/disputes', () => {
+  it('refuses an unauthenticated request before contacting the service', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/disputes/route')
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('loads every real status in parallel and de-duplicates a transitioning case', async () => {
+    const sharedId = 'transitioning-case'
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const status = new URL(String(url)).searchParams.get('status')!
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer test-token' })
+      const id = status === 'OPEN' || status === 'UNDER_REVIEW' ? sharedId : `id-${status}`
+      return new Response(JSON.stringify([row(status, id)]), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/disputes/route')
+
+    const response = await GET()
+    const body = await response.json() as Array<{ id: string; status: string }>
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(DISPUTE_STATUSES.length)
+    expect(String(fetchMock.mock.calls[0][0])).toContain('dispute-service.dispute.svc:8135')
+    expect(body).toHaveLength(DISPUTE_STATUSES.length - 1)
+    expect(body.find(item => item.id === sharedId)?.status).toBe('UNDER_REVIEW')
+  })
+
+  it('fails the portfolio closed when any status page is invalid', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const status = new URL(String(url)).searchParams.get('status')!
+      return new Response(JSON.stringify(status === 'ESCALATED' ? [row('CLOSED')] : [row(status)]), { status: 200 })
+    }))
+    const { GET } = await import('@/app/api/disputes/route')
+
+    const response = await GET()
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_upstream_response' })
+  })
+
+  it.each([401, 403])('preserves upstream access loss as HTTP %s', async statusCode => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: statusCode })))
+    const { GET } = await import('@/app/api/disputes/route')
+
+    const response = await GET()
+
+    expect(response.status).toBe(statusCode)
+    await expect(response.json()).resolves.toEqual({
+      error: statusCode === 401 ? 'unauthorized' : 'forbidden',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Make the Disputes screen represent the complete dispute-service portfolio instead of an OPEN-only response interpreted through nonexistent fields and statuses. A session/RBAC-gated BFF loads all real lifecycle states in parallel, validates them, and gives the screen one consistent model for totals, search, deadlines, and status badges.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #9363
Refs #3965

## Changes

- aggregate all eight dispute-service statuses through a bounded server route
- relay only the authenticated operator bearer and require `compliance:view`
- validate the service-owned DTO and reject a mismatched status page
- de-duplicate a case observed during a concurrent status transition
- replace nonexistent UI fields/statuses with the real contract vocabulary
- use one terminal-state definition and inclusive LocalDate SLA calculation everywhere

## Definition of Done

- [x] Unit and route tests added.
- [x] No dispute-service public API, database, event, or dependency change.
- [x] TypeScript and scoped ESLint pass.
- [x] Production Next build passes, including `/api/disputes` and `/disputes` (97/97 pages).

## Security checklist

- [x] No secrets, real PII, suppressions, or new dependency.
- [x] New BFF is fail-closed and session/RBAC gated.
- [x] Auth-visible route: `security-review-required`.
- [x] Account/dispute metadata path: `gdpr-review-required`.

## Compliance impact

- [x] PSD2 / SCA / RTS

The change makes operator dispute status and resolution-deadline reporting match the owning service. It does not change dispute decisions or money movement.

## Rollout / Rollback

- Deployment: existing rolling Admin UI GitOps rollout
- Rollback: revert this single commit and redeploy the prior Admin UI image
- Data migration: N/A

## Verification

- focused Vitest: 5 files, 31 tests passed
- `npx tsc --noEmit` — passed
- scoped ESLint — passed
- `npm run build` — passed, 97/97 pages

## Reviewer notes

Please compare the status and field vocabulary against the owning dispute-service contract and verify that all portfolio states are represented exactly once.