### PR TITLE
fix(admin-ui): explain audit evidence provenance

### DIFF
--- a/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
@@ -14,7 +14,12 @@ const ENTRY = {
   actorId: 'operator-42',
   actorType: 'USER',
   occurredAt: '2026-08-31T08:00:00Z',
-  payload: { status: 'ACTIVE' },
+  recordedAt: '2026-08-31T08:00:01Z',
+  occurredAtSource: 'EVENT',
+  sourceService: 'account-service',
+  sourceServiceSource: 'EVENT',
+  actChain: [],
+  payload: JSON.stringify({ status: 'ACTIVE' }),
 }
 
 test.beforeEach(async ({ context, baseURL }) => {

--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -4,20 +4,15 @@
 
 'use client'
 
-import { Fragment, useState, useCallback } from 'react'
+import { Fragment, useState, useCallback, useRef } from 'react'
 import { ScrollText, Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { formatAuditPayload, parseAuditEvidenceList, type AuditEvidence } from '@/lib/audit/auditEvidence'
 
 const AUDIT_SERVICE = '/api/svc/audit-service'
-
-interface AuditEntry {
-  id: string; aggregateId: string; aggregateType: string
-  eventType: string; actorId?: string; actorType?: string
-  payload?: Record<string, unknown>; occurredAt: string
-}
 
 const EVENT_COLOR: Record<string, string> = {
   CREATED: 'var(--green)', UPDATED: 'var(--accent)', DELETED: 'var(--red)',
@@ -28,7 +23,7 @@ const EVENT_COLOR: Record<string, string> = {
 export default function AuditPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const [entries, setEntries]   = useState<AuditEntry[]>([])
+  const [entries, setEntries]   = useState<AuditEvidence[]>([])
   const [loading, setLoading]   = useState(false)
   // Instead of a raw "HTTP 404" string, hold a typed reason that renders as a
   // calm <DataUnavailable> panel. audit-service isn't deployed in every
@@ -37,13 +32,19 @@ export default function AuditPage() {
   const [aggregateId, setAggregateId] = useState('')
   const [loadedAggregateId, setLoadedAggregateId] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
+  const activeSearch = useRef<AbortController | null>(null)
 
   const search = useCallback(async () => {
     const query = aggregateId.trim()
     if (!query) return
+    activeSearch.current?.abort()
+    const controller = new AbortController()
+    activeSearch.current = controller
+    const timeout = window.setTimeout(() => controller.abort(), 5000)
     setLoading(true); setUnavailable(null)
     try {
-      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${query}?limit=100`, { signal: AbortSignal.timeout(5000) })
+      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${encodeURIComponent(query)}?limit=100`, { signal: controller.signal })
+      if (activeSearch.current !== controller) return
       if (!res.ok) {
         if (loadedAggregateId !== query) {
           setEntries([])
@@ -52,10 +53,22 @@ export default function AuditPage() {
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
-      const data = await res.json()
-      setEntries(Array.isArray(data) ? data : data.entries ?? [])
+      let data: AuditEvidence[]
+      try {
+        data = parseAuditEvidenceList(await res.json(), query)
+      } catch {
+        if (loadedAggregateId !== query) {
+          setEntries([])
+          setLoadedAggregateId(null)
+        }
+        setUnavailable({ kind: 'error' })
+        return
+      }
+      if (activeSearch.current !== controller) return
+      setEntries(data)
       setLoadedAggregateId(query)
     } catch {
+      if (activeSearch.current !== controller) return
       // fetch threw (timeout/abort/network) — the BFF or audit-service didn't
       // answer at all. Treat as unreachable rather than leaking the raw error.
       if (loadedAggregateId !== query) {
@@ -63,7 +76,13 @@ export default function AuditPage() {
         setLoadedAggregateId(null)
       }
       setUnavailable({ kind: 'unreachable' })
-    } finally { setLoading(false) }
+    } finally {
+      window.clearTimeout(timeout)
+      if (activeSearch.current === controller) {
+        activeSearch.current = null
+        setLoading(false)
+      }
+    }
   }, [aggregateId, loadedAggregateId])
 
   return (
@@ -72,7 +91,7 @@ export default function AuditPage() {
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Auditní log', 'Audit Log')}</span></div>}
         icon={<ScrollText size={18} aria-hidden="true" />}
         title={t('Auditní log', 'Audit Log')}
-        subtitle={t('Neměnný auditní záznam pro všechny entity platformy', 'Immutable audit trail for all platform entities')}
+        subtitle={t('Nejnovější ověřitelné události a jejich původ', 'Latest verifiable events and their provenance')}
       />
 
       {/* Search */}
@@ -87,7 +106,18 @@ export default function AuditPage() {
               placeholder="Aggregate ID (account UUID, party UUID, transaction UUID…)"
               aria-label={t('ID agregátu', 'Aggregate ID')}
               value={aggregateId}
-              onChange={e => setAggregateId(e.target.value)}
+              onChange={e => {
+                activeSearch.current?.abort()
+                activeSearch.current = null
+                setLoading(false)
+                setAggregateId(e.target.value)
+                setUnavailable(null)
+                if (loadedAggregateId !== e.target.value.trim()) {
+                  setEntries([])
+                  setLoadedAggregateId(null)
+                  setExpanded(null)
+                }
+              }}
               onKeyDown={e => e.key === 'Enter' && search()}
             />
           </div>
@@ -117,7 +147,7 @@ export default function AuditPage() {
       {entries.length > 0 && (
         <div className="card" style={{ overflow: 'hidden' }}>
           <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', fontSize: '13px', color: 'var(--text-muted)' }}>
-            {entries.length} {t('událostí pro', 'events for')} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{loadedAggregateId}</span>
+          {t(`Nejnovějších ${entries.length} událostí (limit 100) pro`, `Latest ${entries.length} events (100 maximum) for`)} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{loadedAggregateId}</span>
           </div>
           <table className="data-table">
             <thead>
@@ -125,6 +155,7 @@ export default function AuditPage() {
                 <th>{t('Událost', 'Event')}</th>
                 <th>{t('Typ agregátu', 'Aggregate Type')}</th>
                 <th>{t('Aktér', 'Actor')}</th>
+                <th>{t('Zdroj', 'Source')}</th>
                 <th>{t('Nastalo', 'Occurred At')}</th>
                 <th></th>
               </tr>
@@ -143,16 +174,25 @@ export default function AuditPage() {
                     <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
                       {e.actorId ? `${e.actorType ?? 'USER'}:${e.actorId.slice(0, 8)}…` : 'system'}
                     </td>
+                    <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+                      {e.sourceService}
+                      <span className="tag" style={{ marginLeft: '6px', fontSize: '10px' }}>{e.sourceServiceSource.toLowerCase()}</span>
+                    </td>
                     <td style={{ fontSize: '12px', color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
                       {new Date(e.occurredAt).toLocaleString(dateLocale)}
+                      {e.occurredAtSource === 'INGEST' && (
+                        <span className="tag" title={t('Čas události chyběl; zobrazen je čas přijetí.', 'Producer event time was absent; ingest time is shown.')} style={{ marginLeft: '6px', fontSize: '10px' }}>
+                          {t('čas přijetí', 'ingest time')}
+                        </span>
+                      )}
                     </td>
                     <td style={{ color: 'var(--accent)', fontSize: '12px' }}>{expanded === e.id ? '▲' : '▼'}</td>
                   </tr>
                   {expanded === e.id && e.payload && (
                     <tr key={`${e.id}-payload`}>
-                      <td colSpan={5} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
+                      <td colSpan={6} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
                         <pre style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-secondary)', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                          {JSON.stringify(e.payload, null, 2)}
+                          {formatAuditPayload(e.payload)}
                         </pre>
                       </td>
                     </tr>

--- a/openbank-admin-ui/src/lib/audit/auditEvidence.ts
+++ b/openbank-admin-ui/src/lib/audit/auditEvidence.ts
@@ -1,0 +1,82 @@
+export type AuditEvidence = {
+  id: string
+  aggregateId: string
+  aggregateType: string
+  eventType: string
+  actorId?: string
+  actorType?: string
+  payload: string
+  sourceService: string
+  occurredAt: string
+  recordedAt: string
+  occurredAtSource: 'EVENT' | 'INGEST'
+  sourceServiceSource: 'EVENT' | 'TOPIC' | 'ABSENT'
+  correlationId?: string
+  channel?: string
+  actChain: string[]
+  sessionId?: string
+}
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function requiredString(record: JsonRecord, key: string): string {
+  const value = record[key]
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`invalid ${key}`)
+  return value
+}
+
+function instant(record: JsonRecord, key: string): string {
+  const value = requiredString(record, key)
+  if (!Number.isFinite(Date.parse(value))) throw new Error(`invalid ${key}`)
+  return value
+}
+
+export function parseAuditEvidenceList(value: unknown, requestedAggregateId: string): AuditEvidence[] {
+  if (!Array.isArray(value)) throw new Error('audit response is not a list')
+  return value.map(item => {
+    if (!isRecord(item)) throw new Error('invalid audit entry')
+    const aggregateId = requiredString(item, 'aggregateId')
+    if (aggregateId !== requestedAggregateId) throw new Error('audit entry belongs to another aggregate')
+    const occurredAtSource = requiredString(item, 'occurredAtSource')
+    const sourceServiceSource = requiredString(item, 'sourceServiceSource')
+    if (occurredAtSource !== 'EVENT' && occurredAtSource !== 'INGEST') throw new Error('invalid time provenance')
+    if (!['EVENT', 'TOPIC', 'ABSENT'].includes(sourceServiceSource)) throw new Error('invalid source provenance')
+    if (!Array.isArray(item.actChain) || item.actChain.some(part => typeof part !== 'string')) {
+      throw new Error('invalid delegation chain')
+    }
+    return {
+      id: requiredString(item, 'id'),
+      aggregateId,
+      aggregateType: requiredString(item, 'aggregateType'),
+      eventType: requiredString(item, 'eventType'),
+      actorId: optionalString(item.actorId),
+      actorType: optionalString(item.actorType),
+      payload: requiredString(item, 'payload'),
+      sourceService: requiredString(item, 'sourceService'),
+      occurredAt: instant(item, 'occurredAt'),
+      recordedAt: instant(item, 'recordedAt'),
+      occurredAtSource,
+      sourceServiceSource: sourceServiceSource as AuditEvidence['sourceServiceSource'],
+      correlationId: optionalString(item.correlationId),
+      channel: optionalString(item.channel),
+      actChain: item.actChain as string[],
+      sessionId: optionalString(item.sessionId),
+    }
+  })
+}
+
+export function formatAuditPayload(payload: string): string {
+  try {
+    return JSON.stringify(JSON.parse(payload), null, 2)
+  } catch {
+    return payload
+  }
+}

--- a/openbank-admin-ui/src/test/audit-evidence.test.ts
+++ b/openbank-admin-ui/src/test/audit-evidence.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { formatAuditPayload, parseAuditEvidenceList } from '@/lib/audit/auditEvidence'
+
+const aggregateId = '05a02ef1-381c-40e7-b73f-d6855eead42e'
+const entry = {
+  id: 'e5ec0a88-75e7-4d1c-82ef-cbcd655112d3',
+  aggregateId,
+  aggregateType: 'ACCOUNT',
+  eventType: 'UPDATED',
+  actorId: 'operator-42',
+  actorType: 'USER',
+  payload: '{"status":"ACTIVE"}',
+  sourceService: 'account-service',
+  occurredAt: '2026-08-31T08:00:00Z',
+  recordedAt: '2026-08-31T08:00:01Z',
+  occurredAtSource: 'EVENT',
+  sourceServiceSource: 'TOPIC',
+  actChain: [],
+}
+
+describe('audit evidence contract', () => {
+  it('preserves provenance and pretty-prints the JSON string carried on the wire', () => {
+    const parsed = parseAuditEvidenceList([entry], aggregateId)
+
+    expect(parsed[0]).toMatchObject({
+      aggregateId,
+      occurredAtSource: 'EVENT',
+      sourceServiceSource: 'TOPIC',
+      payload: '{"status":"ACTIVE"}',
+    })
+    expect(formatAuditPayload(parsed[0].payload)).toBe('{\n  "status": "ACTIVE"\n}')
+  })
+
+  it('renders a non-JSON legacy payload as inert text', () => {
+    expect(formatAuditPayload('<script>alert(1)</script>')).toBe('<script>alert(1)</script>')
+  })
+
+  it('rejects evidence attributed to another aggregate or an invalid timestamp', () => {
+    expect(() => parseAuditEvidenceList([{ ...entry, aggregateId: 'other' }], aggregateId)).toThrow(/another aggregate/)
+    expect(() => parseAuditEvidenceList([{ ...entry, occurredAt: 'not-a-date' }], aggregateId)).toThrow(/occurredAt/)
+  })
+})


### PR DESCRIPTION
## Summary
- validate audit entries against the requested aggregate, timestamps, and provenance vocabulary before displaying regulated evidence
- render the service’s JSON-string payload as readable inert text instead of a doubly escaped string
- expose source provenance and clearly qualify ingest-substituted timestamps
- describe the capped response truthfully as the latest 100 entries
- abort superseded searches and clear evidence when the operator changes aggregate identity

## Verification
- focused Vitest: 2 files, 4 tests
- audit recovery Playwright: 2/2
- `npx tsc --noEmit`
- scoped ESLint
- `npm run build` (97/97 pages)

Closes #9370