### PR TITLE
fix(admin-ui): align standing order contract

### DIFF
--- a/openbank-admin-ui/e2e/standing-orders-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/standing-orders-recovery.spec.ts
@@ -21,15 +21,20 @@ test.describe('Standing Orders recovery', () => {
           contentType: 'application/json',
           body: JSON.stringify([{
             id: '11111111-1111-1111-1111-111111111111',
+            partyId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
             debtorAccountId: '22222222-2222-2222-2222-222222222222',
-            creditorAccountId: '33333333-3333-3333-3333-333333333333',
+            creditorIban: 'CZ6508000000192000145399',
             creditorName: 'Verified Supplier SE',
-            amount: 7250,
+            amountMinorUnits: 725000,
             currency: 'CZK',
             frequency: 'MONTHLY',
-            status: 'ACTIVE',
+            paymentType: 'DOMESTIC',
+            status: 'PAUSED',
             nextExecutionDate: '2026-09-15',
-            description: 'Monthly evidence payment',
+            remittanceInfo: 'Monthly evidence payment',
+            executionCount: 3,
+            createdAt: '2026-01-01T08:00:00Z',
+            updatedAt: '2026-09-01T08:00:00Z',
           }]),
         })
         return
@@ -41,6 +46,8 @@ test.describe('Standing Orders recovery', () => {
     await page.goto('/standing-orders')
     await expect(page.getByText('Verified Supplier SE')).toBeVisible()
     await expect(page.getByText('Monthly evidence payment')).toBeVisible()
+    await expect(page.getByText('PAUSED', { exact: true })).toBeVisible()
+    await expect(page.getByText(/Domestic payment|Domácí platba/)).toBeVisible()
 
     const initialRequests = requests
     failRefresh = true

--- a/openbank-admin-ui/src/app/standing-orders/page.tsx
+++ b/openbank-admin-ui/src/app/standing-orders/page.tsx
@@ -12,15 +12,17 @@ import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { formatLocalDate, formatMinorUnits, parseStandingOrders, type StandingOrder } from '@/lib/standing-orders/standingOrderContract'
 
-interface StandingOrder {
-  id: string; debtorAccountId: string; creditorAccountId: string; creditorName: string
-  amount: number; currency: string; frequency: string; status: string
-  nextExecutionDate: string; description: string
+const FREQ_LABELS: Record<StandingOrder['frequency'], [string, string]> = {
+  ONCE: ['Jednorázově', 'Once'], DAILY: ['Denně', 'Daily'], WEEKLY: ['Týdně', 'Weekly'],
+  BIWEEKLY: ['Každé dva týdny', 'Every two weeks'], MONTHLY: ['Měsíčně', 'Monthly'],
+  QUARTERLY: ['Čtvrtletně', 'Quarterly'], ANNUALLY: ['Ročně', 'Annually'],
 }
-
-const FREQ_LABELS: Record<string, string> = {
-  DAILY: 'Denně', WEEKLY: 'Týdně', MONTHLY: 'Měsíčně', QUARTERLY: 'Čtvrtletně', YEARLY: 'Ročně'
+const PAYMENT_TYPE_LABELS: Record<StandingOrder['paymentType'], [string, string]> = {
+  SEPA_CREDIT: ['SEPA převod', 'SEPA credit transfer'],
+  DOMESTIC: ['Domácí platba', 'Domestic payment'],
+  INTERNAL: ['Vnitrobankovní převod', 'Internal transfer'],
 }
 
 export default function StandingOrdersPage() {
@@ -35,22 +37,24 @@ export default function StandingOrdersPage() {
   // a scaled-down service as "down" and always claimed "running on port 8121".)
   const { data, loading, unavailable, waking, reload } = useServiceResource<StandingOrder[]>(
     svcUrl('standing-order-service', '/api/v1/standing-orders'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as StandingOrder[]) : ((raw as { standingOrders?: StandingOrder[] }).standingOrders ?? [])) },
+    { select: parseStandingOrders },
   )
   const orders = data ?? []
 
   const filtered = orders.filter(o =>
     o.creditorName?.toLowerCase().includes(search.toLowerCase()) ||
-    o.description?.toLowerCase().includes(search.toLowerCase()) ||
+    o.remittanceInfo?.toLowerCase().includes(search.toLowerCase()) ||
+    o.creditorIban?.toLowerCase().includes(search.toLowerCase()) ||
+    o.paymentType?.toLowerCase().includes(search.toLowerCase()) ||
     o.currency?.includes(search.toUpperCase())
   )
 
   return (
     <AuthGuard>
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <PageHeader icon={<Repeat size={20} aria-hidden="true" />} title={t('Trvalé příkazy', 'Standing Orders')} subtitle={t('Trvalé příkazy a opakované platby — SEPA SCT', 'Standing orders and recurring payments — SEPA SCT')} actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <PageHeader icon={<Repeat size={20} aria-hidden="true" />} title={t('Trvalé příkazy', 'Standing Orders')} subtitle={t('Jednorázové i opakované platby napříč podporovanými platebními typy', 'One-off and recurring payments across supported payment types')} actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             <ServiceStatusBadge
-              label="standing-order :8121"
+              label="standing-order-service"
               loading={loading}
               waking={waking}
               unavailable={unavailable}
@@ -77,11 +81,13 @@ export default function StandingOrdersPage() {
             </span>
           </div>} />
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '24px' }}>
           {[
             { label: t('Celkem příkazů', 'Total orders'), value: orders.length, icon: <Repeat size={16} aria-hidden="true" />, color: 'var(--accent)' },
             { label: t('Aktivní', 'Active'), value: orders.filter(o => o.status === 'ACTIVE').length, icon: <CheckCircle2 size={16} aria-hidden="true" />, color: 'var(--success)' },
-            { label: t('Pozastavené', 'Suspended'), value: orders.filter(o => o.status === 'SUSPENDED').length, icon: <Clock size={16} aria-hidden="true" />, color: 'var(--warning)' },
+            { label: t('Pozastavené', 'Paused'), value: orders.filter(o => o.status === 'PAUSED').length, icon: <Clock size={16} aria-hidden="true" />, color: 'var(--warning)' },
+            { label: t('Vyžadují pozornost', 'Needs attention'), value: orders.filter(o => o.status === 'FAILED').length, icon: <XCircle size={16} aria-hidden="true" />, color: 'var(--danger)' },
+            { label: t('Dokončené', 'Completed'), value: orders.filter(o => o.status === 'COMPLETED').length, icon: <CheckCircle2 size={16} aria-hidden="true" />, color: 'var(--success)' },
             { label: t('Zrušené', 'Cancelled'), value: orders.filter(o => o.status === 'CANCELLED').length, icon: <XCircle size={16} aria-hidden="true" />, color: 'var(--danger)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
@@ -116,7 +122,7 @@ export default function StandingOrdersPage() {
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>
-                {[t('Příjemce', 'Recipient'), t('Částka', 'Amount'), t('Frekvence', 'Frequency'), t('Příští platba', 'Next run'), t('Status', 'Status'), t('Popis', 'Description')].map(h => (
+                {[t('Příjemce', 'Recipient'), t('Částka', 'Amount'), t('Typ platby', 'Payment type'), t('Frekvence', 'Frequency'), t('Příští platba', 'Next run'), t('Status', 'Status'), t('Popis', 'Description')].map(h => (
                   <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
                 ))}
               </tr></thead>
@@ -126,20 +132,21 @@ export default function StandingOrdersPage() {
                   onMouseLeave={e => (e.currentTarget.style.background = '')}>
                   <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 500, color: 'var(--text-primary)' }}>{o.creditorName}</td>
                   <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>
-                    {o.amount?.toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {o.currency}
+                    {formatMinorUnits(o.amountMinorUnits, numberLocale)} {o.currency}
                   </td>
-                  <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{t(FREQ_LABELS[o.frequency] ?? o.frequency, o.frequency)}</td>
+                  <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{t(...PAYMENT_TYPE_LABELS[o.paymentType])}</td>
+                  <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{t(...FREQ_LABELS[o.frequency])}</td>
                   <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
                     <Calendar size={11} aria-hidden="true" style={{ color: 'var(--text-tertiary)' }} />
-                    {o.nextExecutionDate ? new Date(o.nextExecutionDate).toLocaleDateString(numberLocale) : '—'}
+                    {formatLocalDate(o.nextExecutionDate, numberLocale)}
                   </td>
                   <td style={{ padding: '12px 16px' }}>
                     <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
-                      background: o.status === 'ACTIVE' ? 'var(--success-bg)' : o.status === 'SUSPENDED' ? 'var(--warning-bg)' : 'var(--surface-3)',
-                      color: o.status === 'ACTIVE' ? 'var(--success-text)' : o.status === 'SUSPENDED' ? 'var(--warning-text)' : 'var(--text-tertiary)',
-                      border: `1px solid ${o.status === 'ACTIVE' ? 'var(--success-border)' : o.status === 'SUSPENDED' ? 'var(--warning-border)' : 'var(--border)'}` }}>{o.status}</span>
+                      background: o.status === 'ACTIVE' || o.status === 'COMPLETED' ? 'var(--success-bg)' : o.status === 'PAUSED' ? 'var(--warning-bg)' : o.status === 'FAILED' ? 'var(--danger-bg)' : 'var(--surface-3)',
+                      color: o.status === 'ACTIVE' || o.status === 'COMPLETED' ? 'var(--success-text)' : o.status === 'PAUSED' ? 'var(--warning-text)' : o.status === 'FAILED' ? 'var(--danger-text)' : 'var(--text-tertiary)',
+                      border: `1px solid ${o.status === 'ACTIVE' || o.status === 'COMPLETED' ? 'var(--success-border)' : o.status === 'PAUSED' ? 'var(--warning-border)' : o.status === 'FAILED' ? 'var(--danger-border)' : 'var(--border)'}` }}>{o.status}</span>
                   </td>
-                  <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{o.description}</td>
+                  <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{o.remittanceInfo ?? '—'}</td>
                 </tr>
               ))}</tbody>
             </table>

--- a/openbank-admin-ui/src/lib/standing-orders/standingOrderContract.ts
+++ b/openbank-admin-ui/src/lib/standing-orders/standingOrderContract.ts
@@ -1,0 +1,93 @@
+export const STANDING_ORDER_STATUSES = ['ACTIVE', 'PAUSED', 'CANCELLED', 'COMPLETED', 'FAILED'] as const
+export const STANDING_ORDER_FREQUENCIES = ['ONCE', 'DAILY', 'WEEKLY', 'BIWEEKLY', 'MONTHLY', 'QUARTERLY', 'ANNUALLY'] as const
+export const STANDING_ORDER_PAYMENT_TYPES = ['SEPA_CREDIT', 'DOMESTIC', 'INTERNAL'] as const
+
+export type StandingOrderStatus = typeof STANDING_ORDER_STATUSES[number]
+export type StandingOrderFrequency = typeof STANDING_ORDER_FREQUENCIES[number]
+export type StandingOrderPaymentType = typeof STANDING_ORDER_PAYMENT_TYPES[number]
+
+export type StandingOrder = {
+  id: string
+  partyId: string
+  debtorAccountId: string
+  creditorIban: string
+  creditorName: string
+  status: StandingOrderStatus
+  frequency: StandingOrderFrequency
+  paymentType: StandingOrderPaymentType
+  amountMinorUnits: number
+  currency: string
+  nextExecutionDate: string
+  remittanceInfo?: string
+  executionCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: JsonRecord, key: string): string {
+  const value = record[key]
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`invalid ${key}`)
+  return value
+}
+
+function isLocalDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const [year, month, day] = value.split('-').map(Number)
+  const parsed = new Date(Date.UTC(year, month - 1, day))
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day
+}
+
+export function parseStandingOrders(value: unknown): StandingOrder[] {
+  if (!Array.isArray(value)) throw new Error('standing-order response is not a list')
+  return value.map(item => {
+    if (!isRecord(item)) throw new Error('invalid standing order')
+    const status = requiredString(item, 'status')
+    const frequency = requiredString(item, 'frequency')
+    const paymentType = requiredString(item, 'paymentType')
+    const currency = requiredString(item, 'currency')
+    const nextExecutionDate = requiredString(item, 'nextExecutionDate')
+    if (!STANDING_ORDER_STATUSES.includes(status as StandingOrderStatus)) throw new Error('invalid status')
+    if (!STANDING_ORDER_FREQUENCIES.includes(frequency as StandingOrderFrequency)) throw new Error('invalid frequency')
+    if (!STANDING_ORDER_PAYMENT_TYPES.includes(paymentType as StandingOrderPaymentType)) throw new Error('invalid payment type')
+    if (!/^[A-Z]{3}$/.test(currency)) throw new Error('invalid currency')
+    if (!isLocalDate(nextExecutionDate)) throw new Error('invalid next execution date')
+    if (!Number.isSafeInteger(item.amountMinorUnits) || (item.amountMinorUnits as number) <= 0) throw new Error('invalid amount')
+    if (!Number.isInteger(item.executionCount) || (item.executionCount as number) < 0) throw new Error('invalid execution count')
+    const createdAt = requiredString(item, 'createdAt')
+    const updatedAt = requiredString(item, 'updatedAt')
+    if (!Number.isFinite(Date.parse(createdAt)) || !Number.isFinite(Date.parse(updatedAt))) throw new Error('invalid timestamp')
+    return {
+      id: requiredString(item, 'id'),
+      partyId: requiredString(item, 'partyId'),
+      debtorAccountId: requiredString(item, 'debtorAccountId'),
+      creditorIban: requiredString(item, 'creditorIban'),
+      creditorName: requiredString(item, 'creditorName'),
+      status: status as StandingOrderStatus,
+      frequency: frequency as StandingOrderFrequency,
+      paymentType: paymentType as StandingOrderPaymentType,
+      amountMinorUnits: item.amountMinorUnits as number,
+      currency,
+      nextExecutionDate,
+      remittanceInfo: typeof item.remittanceInfo === 'string' && item.remittanceInfo.length > 0 ? item.remittanceInfo : undefined,
+      executionCount: item.executionCount as number,
+      createdAt,
+      updatedAt,
+    }
+  })
+}
+
+export function formatMinorUnits(minorUnits: number, locale: string): string {
+  return (minorUnits / 100).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+export function formatLocalDate(value: string, locale: string): string {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeZone: 'UTC' })
+    .format(new Date(Date.UTC(year, month - 1, day)))
+}

--- a/openbank-admin-ui/src/test/operations-table-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/operations-table-accessibility.guard.test.ts
@@ -11,7 +11,10 @@ describe('read-only operations tables', () => {
       const page = readFileSync(path.join(app, route, 'page.tsx'), 'utf8')
       expect(page, route).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
       expect(page, route).toContain('aria-label={t(')
-      expect(page, route).toContain('toLocaleString(numberLocale')
+      expect(
+        page.includes('toLocaleString(numberLocale') || page.includes(', numberLocale)'),
+        `${route} must pass the active locale to its value formatter`,
+      ).toBe(true)
     }
   })
 

--- a/openbank-admin-ui/src/test/standing-order-contract.test.ts
+++ b/openbank-admin-ui/src/test/standing-order-contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { formatLocalDate, formatMinorUnits, parseStandingOrders } from '@/lib/standing-orders/standingOrderContract'
+
+const order = {
+  id: '11111111-1111-1111-1111-111111111111',
+  partyId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  debtorAccountId: '22222222-2222-2222-2222-222222222222',
+  creditorIban: 'CZ6508000000192000145399',
+  creditorName: 'Supplier SE',
+  status: 'PAUSED',
+  frequency: 'BIWEEKLY',
+  paymentType: 'DOMESTIC',
+  amountMinorUnits: 725001,
+  amount: 7250.01,
+  currency: 'CZK',
+  nextExecutionDate: '2026-09-15',
+  remittanceInfo: 'Invoice 42',
+  executionCount: 3,
+  createdAt: '2026-01-01T08:00:00Z',
+  updatedAt: '2026-09-01T08:00:00Z',
+}
+
+describe('standing-order read contract', () => {
+  it('uses backend lifecycle, schedule, payment type and authoritative minor units', () => {
+    expect(parseStandingOrders([order])).toEqual([expect.objectContaining({
+      status: 'PAUSED',
+      frequency: 'BIWEEKLY',
+      paymentType: 'DOMESTIC',
+      amountMinorUnits: 725001,
+      remittanceInfo: 'Invoice 42',
+    })])
+  })
+
+  it('rejects invented legacy states and malformed money or dates', () => {
+    expect(() => parseStandingOrders([{ ...order, status: 'SUSPENDED' }])).toThrow(/status/)
+    expect(() => parseStandingOrders([{ ...order, amountMinorUnits: 72.5 }])).toThrow(/amount/)
+    expect(() => parseStandingOrders([{ ...order, nextExecutionDate: '2026-02-30' }])).toThrow(/date/)
+  })
+
+  it('formats minor units exactly and keeps LocalDate stable across time zones', () => {
+    expect(formatMinorUnits(725001, 'en-GB')).toBe('7,250.01')
+    expect(formatLocalDate('2026-09-15', 'en-GB')).toBe('15 Sept 2026')
+  })
+})


### PR DESCRIPTION
## Summary
- validate the standing-order read contract instead of accepting arbitrary arrays
- replace the invented SUSPENDED state with PAUSED and surface FAILED/COMPLETED portfolio outcomes
- explain every backend frequency and payment type
- format authoritative minor units exactly and keep LocalDate rendering timezone-stable
- expand filtering to remittance, creditor IBAN and payment type while preserving snapshot recovery

## Verification
- focused Vitest: 2 files, 4 tests
- standing-order recovery Playwright: 1/1
- `npx tsc --noEmit`
- scoped ESLint
- `npm run build` (97/97 pages)

Closes #9372