### PR TITLE
fix(admin-ui): align clearing batch evidence

### DIFF
--- a/openbank-admin-ui/e2e/clearing-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/clearing-recovery.spec.ts
@@ -4,12 +4,19 @@ import { signInAsOperator } from './helpers/auth'
 const batch = {
   id: 'batch-2026-0042',
   batchReference: 'CLR-2026-0042',
-  paymentRail: 'SEPA',
-  status: 'PROCESSING',
+  rail: 'SEPA_SCT',
+  settlementType: 'NET',
+  status: 'IN_CLEARING',
   itemCount: 18,
-  totalAmount: 125000.50,
+  totalDebit: 125000.50,
+  totalCredit: 100000,
+  netPosition: -25000.50,
   currency: 'EUR',
+  cycleId: 'cycle-42',
+  settlementDate: '2026-08-31',
+  settledAt: null,
   createdAt: '2026-08-31T12:00:00Z',
+  updatedAt: '2026-08-31T12:05:00Z',
 }
 
 test.beforeEach(async ({ context, baseURL, page }) => {
@@ -38,15 +45,15 @@ test('keeps clearing and settlement evidence visible after a failed refresh', as
   await page.goto('/clearing')
 
   await expect(page.getByText('CLR-2026-0042')).toBeVisible({ timeout: 20_000 })
-  await expect(page.getByText('125,000.50', { exact: true })).toBeVisible()
-  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByRole('table').getByText(/EUR\s*125,000\.50/)).toBeVisible()
+  await expect(page.getByText('IN_CLEARING', { exact: true })).toBeVisible()
 
   unavailable = true
   await page.getByRole('button', { name: /Obnovit clearing dávky|Refresh clearing batches/ }).click()
 
   await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
   await expect(page.getByText('CLR-2026-0042')).toBeVisible()
-  await expect(page.getByText('125,000.50', { exact: true })).toBeVisible()
-  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByRole('table').getByText(/EUR\s*125,000\.50/)).toBeVisible()
+  await expect(page.getByText('IN_CLEARING', { exact: true })).toBeVisible()
   await expect(page.getByText(/zatím žádné clearing dávky|no clearing batches yet/)).toHaveCount(0)
 })

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -14,11 +14,7 @@ import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { StatCard } from '@/components/ui/StatCard'
 import { StatusBadge } from '@/components/ui/StatusBadge'
-
-interface ClearingBatch {
-  id: string; batchReference: string; paymentRail: string; status: string
-  itemCount: number; totalAmount: number; currency: string; createdAt: string; settledAt?: string
-}
+import { formatClearingMoney, parseClearingBatches, type ClearingBatch } from '@/lib/clearing/clearingBatchContract'
 
 export default function ClearingPage() {
   const { t, language } = useLanguage()
@@ -29,7 +25,7 @@ export default function ClearingPage() {
     svcUrl('clearing-service', '/api/v1/clearing/batches'),
     { select: (raw) => {
       setLastSuccessfulAt(new Date())
-      return Array.isArray(raw) ? (raw as ClearingBatch[]) : ((raw as { batches?: ClearingBatch[] }).batches ?? [])
+      return parseClearingBatches(raw)
     } },
   )
   const batches = data ?? []
@@ -38,13 +34,14 @@ export default function ClearingPage() {
 
   const filtered = batches.filter(b =>
     b.batchReference?.toLowerCase().includes(search.toLowerCase()) ||
-    b.paymentRail?.toLowerCase().includes(search.toLowerCase()) ||
+    b.rail.toLowerCase().includes(search.toLowerCase()) ||
     b.status?.toLowerCase().includes(search.toLowerCase())
   )
 
   const settled = batches.filter(b => b.status === 'SETTLED')
-  const pending = batches.filter(b => b.status === 'PENDING' || b.status === 'PROCESSING')
-  const totalVolume = batches.reduce((s, b) => s + (b.totalAmount ?? 0), 0)
+  const pending = batches.filter(b => b.status === 'PENDING' || b.status === 'IN_CLEARING')
+  const currencies = [...new Set(batches.map(b => b.currency))]
+  const totalDebit = currencies.length === 1 ? batches.reduce((sum, batch) => sum + batch.totalDebit, 0) : null
 
   return (
     <AuthGuard permission="payment-rails:view">
@@ -89,8 +86,8 @@ export default function ClearingPage() {
           {[
             { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} aria-hidden="true" /> },
             { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} aria-hidden="true" />, tone: 'success' as const },
-            { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} aria-hidden="true" />, tone: 'warning' as const },
-            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }), icon: <Banknote size={16} aria-hidden="true" /> },
+            { label: t('Čeká / V clearingu', 'Pending / In clearing'), value: pending.length, icon: <Clock size={16} aria-hidden="true" />, tone: 'warning' as const },
+            { label: t('Hrubé debety', 'Gross debits'), value: totalDebit === null ? t('Více měn', 'Multiple currencies') : formatClearingMoney(totalDebit, currencies[0] ?? 'EUR', numberLocale), icon: <Banknote size={16} aria-hidden="true" /> },
           ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone} />)}
         </div>}
 
@@ -118,7 +115,7 @@ export default function ClearingPage() {
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>
-                {[t('Reference', 'Reference'), t('Rail', 'Rail'), t('Položky', 'Items'), t('Objem', 'Volume'), t('Měna', 'Currency'), t('Status', 'Status'), t('Vytvořeno', 'Created')].map(h => (
+                {[t('Reference', 'Reference'), t('Rail', 'Rail'), t('Položky', 'Items'), t('Debet / Kredit', 'Debit / Credit'), t('Čistá pozice', 'Net position'), t('Status', 'Status'), t('Vytvořeno', 'Created')].map(h => (
                   <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
                 ))}
               </tr></thead>
@@ -128,10 +125,13 @@ export default function ClearingPage() {
                     onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
                     onMouseLeave={e => (e.currentTarget.style.background = '')}>
                     <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{b.batchReference}</td>
-                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.paymentRail}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.rail.replaceAll('_', ' ')}</td>
                     <td style={{ padding: '12px 16px', fontSize: '13px', color: 'var(--text-primary)' }}>{b.itemCount}</td>
-                    <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>{(b.totalAmount ?? 0).toLocaleString(numberLocale, { minimumFractionDigits: 2 })}</td>
-                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.currency}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-primary)' }}>
+                      <div>{formatClearingMoney(b.totalDebit, b.currency, numberLocale)}</div>
+                      <div style={{ color: 'var(--text-tertiary)', marginTop: 2 }}>{formatClearingMoney(b.totalCredit, b.currency, numberLocale)}</div>
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: b.netPosition < 0 ? 'var(--danger)' : 'var(--text-primary)' }}>{formatClearingMoney(b.netPosition, b.currency, numberLocale)}</td>
                     <td style={{ padding: '12px 16px' }}><StatusBadge status={b.status} tone={b.status === 'FAILED' ? 'danger' : b.status === 'SETTLED' ? 'success' : 'warning'} /></td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{b.createdAt ? new Date(b.createdAt).toLocaleString(numberLocale) : '—'}</td>
                   </tr>

--- a/openbank-admin-ui/src/lib/clearing/clearingBatchContract.ts
+++ b/openbank-admin-ui/src/lib/clearing/clearingBatchContract.ts
@@ -1,0 +1,67 @@
+export const CLEARING_STATUSES = ['PENDING', 'IN_CLEARING', 'SETTLED', 'FAILED', 'REVERSED'] as const
+export const PAYMENT_RAILS = ['SEPA_SCT', 'SEPA_SCT_INST', 'SWIFT', 'DOMESTIC', 'INTERNAL'] as const
+export const SETTLEMENT_TYPES = ['GROSS', 'NET', 'DEFERRED_NET'] as const
+
+export type ClearingStatus = (typeof CLEARING_STATUSES)[number]
+export type PaymentRail = (typeof PAYMENT_RAILS)[number]
+
+export interface ClearingBatch {
+  id: string; batchReference: string; rail: PaymentRail
+  settlementType: (typeof SETTLEMENT_TYPES)[number]; status: ClearingStatus
+  totalDebit: number; totalCredit: number; netPosition: number; currency: string; itemCount: number
+  cycleId: string | null; settlementDate: string | null; settledAt: string | null
+  createdAt: string; updatedAt: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const requiredString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid clearing batch ${field}`)
+  return value
+}
+
+const optionalString = (value: unknown, field: string): string | null => {
+  if (value === null || value === undefined) return null
+  return requiredString(value, field)
+}
+
+const finiteNumber = (value: unknown, field: string): number => {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN
+  if (!Number.isFinite(parsed)) throw new Error(`Invalid clearing batch ${field}`)
+  return parsed
+}
+
+const enumValue = <T extends readonly string[]>(value: unknown, allowed: T, field: string): T[number] => {
+  if (typeof value !== 'string' || !allowed.includes(value)) throw new Error(`Invalid clearing batch ${field}`)
+  return value as T[number]
+}
+
+export function parseClearingBatches(raw: unknown): ClearingBatch[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid clearing batches response')
+  return raw.map((value) => {
+    if (!isRecord(value)) throw new Error('Invalid clearing batch')
+    const itemCount = finiteNumber(value.itemCount, 'itemCount')
+    if (!Number.isInteger(itemCount) || itemCount < 0) throw new Error('Invalid clearing batch itemCount')
+    return {
+      id: requiredString(value.id, 'id'), batchReference: requiredString(value.batchReference, 'batchReference'),
+      rail: enumValue(value.rail, PAYMENT_RAILS, 'rail'),
+      settlementType: enumValue(value.settlementType, SETTLEMENT_TYPES, 'settlementType'),
+      status: enumValue(value.status, CLEARING_STATUSES, 'status'),
+      totalDebit: finiteNumber(value.totalDebit, 'totalDebit'), totalCredit: finiteNumber(value.totalCredit, 'totalCredit'),
+      netPosition: finiteNumber(value.netPosition, 'netPosition'),
+      currency: requiredString(value.currency, 'currency').toUpperCase(), itemCount,
+      cycleId: optionalString(value.cycleId, 'cycleId'), settlementDate: optionalString(value.settlementDate, 'settlementDate'),
+      settledAt: optionalString(value.settledAt, 'settledAt'), createdAt: requiredString(value.createdAt, 'createdAt'),
+      updatedAt: requiredString(value.updatedAt, 'updatedAt'),
+    }
+  })
+}
+
+export function formatClearingMoney(value: number, currency: string, locale: string): string {
+  try {
+    return new Intl.NumberFormat(locale, { style: 'currency', currency, currencyDisplay: 'code' }).format(value)
+  } catch {
+    return `${value.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`
+  }
+}

--- a/openbank-admin-ui/src/test/clearing-batch-contract.test.ts
+++ b/openbank-admin-ui/src/test/clearing-batch-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatClearingMoney, parseClearingBatches } from '@/lib/clearing/clearingBatchContract'
+
+const batch = {
+  id: 'b-1', batchReference: 'CLR-1', rail: 'SEPA_SCT', settlementType: 'NET', status: 'IN_CLEARING',
+  totalDebit: '125.40', totalCredit: 100, netPosition: '-25.40', currency: 'eur', itemCount: 3,
+  cycleId: 'cycle-1', settlementDate: '2026-09-09', settledAt: null,
+  createdAt: '2026-09-09T10:00:00Z', updatedAt: '2026-09-09T10:01:00Z',
+}
+
+describe('clearing batch contract', () => {
+  it('maps backend fields and preserves decimal values', () => {
+    expect(parseClearingBatches([batch])[0]).toMatchObject({
+      rail: 'SEPA_SCT', status: 'IN_CLEARING', totalDebit: 125.4, totalCredit: 100,
+      netPosition: -25.4, currency: 'EUR', itemCount: 3,
+    })
+  })
+
+  it('rejects invented statuses and legacy UI field names', () => {
+    expect(() => parseClearingBatches([{ ...batch, status: 'PROCESSING' }])).toThrow(/status/)
+    const { rail: _rail, totalDebit: _totalDebit, ...legacy } = batch
+    expect(() => parseClearingBatches([{ ...legacy, paymentRail: 'SEPA', totalAmount: 125.4 }])).toThrow()
+  })
+
+  it('formats each batch in its declared currency', () => {
+    expect(formatClearingMoney(125.4, 'EUR', 'en-GB')).toMatch(/EUR.*125\.40|125\.40.*EUR/)
+  })
+})


### PR DESCRIPTION
## Summary
- validate the clearing-service batch response instead of trusting legacy UI fields
- render the actual rail and lifecycle status, plus debit, credit, and net position in the declared currency
- avoid combining mixed currencies under an EUR label
- update retained-snapshot browser coverage to use the production contract

## Verification
- 4 focused Vitest checks passed
- TypeScript and ESLint passed
- production build generated 97/97 pages
- clearing recovery Playwright E2E passed

Closes #9375