### PR TITLE
feat(admin-ui): explain fee waiver eligibility

### DIFF
--- a/openbank-admin-ui/e2e/fee-schedule-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/fee-schedule-recovery.spec.ts
@@ -15,8 +15,14 @@ const FEE = {
   amount: 1.5,
   currency: 'EUR',
   frequency: 'PER_TRANSACTION',
+  description: null,
   status: 'ACTIVE',
-  waivable: false,
+  waivable: true,
+  waiveCondition: 'Monthly turnover > 1500 EUR',
+  waiverEvaluable: true,
+  waiverRule: { attribute: 'MONTHLY_TURNOVER', operator: '>', threshold: '1500', thresholdCurrency: 'EUR', textValue: null },
+  productId: 'product-1',
+  updatedAt: '2026-09-09T10:00:00Z',
 }
 
 test.beforeEach(async ({ context, baseURL }) => {
@@ -36,6 +42,8 @@ test('keeps the last fee schedule during an outage and recovers', async ({ page 
 
   await page.goto('/fees')
   await expect(page.getByText(FEE.code, { exact: true })).toBeVisible()
+  await expect(page.getByText(/Automatic:|Automaticky:/)).toBeVisible()
+  await expect(page.getByText(/monthly turnover > 1500 EUR/)).toBeVisible()
   await expect(page.getByText('1', { exact: true }).first()).toBeVisible()
 
   available = false

--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -11,27 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
-
-// Shape served by openbank-product-catalog GET /api/v1/fees — the bank-wide fee
-// schedule, flattened from the per-product Fee model. The UI no longer hardcodes
-// any of this; pricing is owned by the catalog service.
-interface FeeScheduleItem {
-  id: string
-  code: string
-  name: string
-  type: string
-  amount: number
-  currency: string
-  frequency: string
-  description: string | null
-  waivable: boolean
-  waiveCondition: string | null
-  productId: string
-  productCode: string
-  productName: string
-  status: string
-  updatedAt: string
-}
+import { describeWaiverRule, FeeScheduleContractError, parseFeeSchedule, type FeeScheduleItem } from '@/lib/fees/feeScheduleContract'
 
 export default function FeesPage() {
   const { t, language } = useLanguage()
@@ -57,21 +37,19 @@ export default function FeesPage() {
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
-      const data = await res.json()
-      if (!Array.isArray(data)) {
-        setUnavailable({ kind: 'error' })
-        return
-      }
-      setFees(data as FeeScheduleItem[])
-    } catch {
+      setFees(parseFeeSchedule(await res.json()))
+    } catch (error) {
       // Timeout / abort / network — product-catalog didn't answer.
-      setUnavailable({ kind: 'unreachable' })
+      setUnavailable({ kind: error instanceof FeeScheduleContractError ? 'error' : 'unreachable' })
     } finally {
       setLoading(false)
     }
   }, [])
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0)
+    return () => window.clearTimeout(timer)
+  }, [load])
 
   const filtered = useMemo(() => {
     return fees.filter(f => {
@@ -92,6 +70,7 @@ export default function FeesPage() {
 
   const uniqueTypes = useMemo(() => Array.from(new Set(fees.map(f => f.type))).sort(), [fees])
   const activeCount = fees.filter(f => f.status === 'ACTIVE').length
+  const automatedWaivers = fees.filter(f => f.waivable && f.waiverEvaluable).length
 
   return (
     <AuthGuard permission="payments:view">
@@ -111,7 +90,7 @@ export default function FeesPage() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>
           <StatCard label={t('Celkem poplatků', 'Total Fees')} value={fees.length} icon={<Receipt size={14} aria-hidden="true" />} />
           <StatCard label={t('Aktivní (na aktivním produktu)', 'Active (on active product)')} value={activeCount} tone="success" />
-          <StatCard label={t('Kategorie poplatků', 'Fee Categories')} value={uniqueTypes.length} />
+          <StatCard label={t('Automatická waiver pravidla', 'Automated waiver rules')} value={automatedWaivers} />
         </div>
 
         <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', flexWrap: 'wrap' }}>
@@ -160,7 +139,7 @@ export default function FeesPage() {
                 <th>{t('Typ', 'Type')}</th>
                 <th>{t('Částka', 'Amount')}</th>
                 <th>{t('Měna', 'Currency')}</th>
-                <th>{t('Frekvence', 'Frequency')}</th>
+                <th>{t('Waiver pravidlo', 'Waiver rule')}</th>
                 <th>{t('Status', 'Status')}</th>
               </tr>
             </thead>
@@ -204,7 +183,11 @@ export default function FeesPage() {
                     {fee.amount.toLocaleString(numberLocale, { minimumFractionDigits: 2 })}
                   </td>
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{fee.currency}</td>
-                  <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{fee.frequency}</td>
+                  <td style={{ fontSize: '12px', color: 'var(--text-muted)', maxWidth: 240 }}>
+                    {!fee.waivable ? t('Nelze prominout', 'Not waivable') : fee.waiverEvaluable && fee.waiverRule
+                      ? <><strong style={{ color: 'var(--success-text)' }}>{t('Automaticky:', 'Automatic:')}</strong> {describeWaiverRule(fee.waiverRule)}</>
+                      : <><strong style={{ color: 'var(--warning-text)' }}>{t('Manuální posouzení:', 'Manual review:')}</strong> {fee.waiveCondition ?? t('podle schválené výjimky', 'under an approved exception')}</>}
+                  </td>
                   <td><StatusBadge status={fee.status} /></td>
                 </tr>
               ))}

--- a/openbank-admin-ui/src/lib/fees/feeScheduleContract.ts
+++ b/openbank-admin-ui/src/lib/fees/feeScheduleContract.ts
@@ -1,0 +1,74 @@
+export const PRODUCT_STATUSES = ['ACTIVE', 'INACTIVE', 'DRAFT', 'DEPRECATED', 'ARCHIVED'] as const
+
+export interface WaiverRule {
+  attribute: string
+  operator: string
+  threshold: string | null
+  thresholdCurrency: string | null
+  textValue: string | null
+}
+
+export interface FeeScheduleItem {
+  id: string; code: string; name: string; type: string; amount: number; currency: string; frequency: string
+  description: string | null; waivable: boolean; waiveCondition: string | null
+  waiverEvaluable: boolean; waiverRule: WaiverRule | null
+  productId: string; productCode: string; productName: string
+  status: (typeof PRODUCT_STATUSES)[number]; updatedAt: string
+}
+
+export class FeeScheduleContractError extends Error {}
+
+const record = (value: unknown, field: string): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new FeeScheduleContractError(`Invalid ${field}`)
+  return value as Record<string, unknown>
+}
+const string = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') throw new FeeScheduleContractError(`Invalid ${field}`)
+  return value
+}
+const optionalString = (value: unknown, field: string): string | null =>
+  value === null || value === undefined ? null : string(value, field)
+const boolean = (value: unknown, field: string): boolean => {
+  if (typeof value !== 'boolean') throw new FeeScheduleContractError(`Invalid ${field}`)
+  return value
+}
+
+function parseRule(value: unknown): WaiverRule | null {
+  if (value === null || value === undefined) return null
+  const rule = record(value, 'waiverRule')
+  return {
+    attribute: string(rule.attribute, 'waiverRule.attribute'), operator: string(rule.operator, 'waiverRule.operator'),
+    threshold: optionalString(rule.threshold, 'waiverRule.threshold'),
+    thresholdCurrency: optionalString(rule.thresholdCurrency, 'waiverRule.thresholdCurrency'),
+    textValue: optionalString(rule.textValue, 'waiverRule.textValue'),
+  }
+}
+
+export function parseFeeSchedule(raw: unknown): FeeScheduleItem[] {
+  if (!Array.isArray(raw)) throw new FeeScheduleContractError('Invalid fee schedule response')
+  return raw.map((value) => {
+    const item = record(value, 'fee schedule item')
+    const amount = typeof item.amount === 'number' ? item.amount : NaN
+    if (!Number.isFinite(amount) || amount < 0) throw new FeeScheduleContractError('Invalid amount')
+    const status = string(item.status, 'status')
+    if (!PRODUCT_STATUSES.includes(status as (typeof PRODUCT_STATUSES)[number])) throw new FeeScheduleContractError('Invalid status')
+    const waivable = boolean(item.waivable, 'waivable')
+    const waiverEvaluable = boolean(item.waiverEvaluable, 'waiverEvaluable')
+    const waiverRule = parseRule(item.waiverRule)
+    if (waiverEvaluable !== (waiverRule !== null)) throw new FeeScheduleContractError('Inconsistent waiver rule')
+    return {
+      id: string(item.id, 'id'), code: string(item.code, 'code'), name: string(item.name, 'name'),
+      type: string(item.type, 'type'), amount, currency: string(item.currency, 'currency').toUpperCase(),
+      frequency: string(item.frequency, 'frequency'), description: optionalString(item.description, 'description'),
+      waivable, waiveCondition: optionalString(item.waiveCondition, 'waiveCondition'), waiverEvaluable, waiverRule,
+      productId: string(item.productId, 'productId'), productCode: string(item.productCode, 'productCode'),
+      productName: string(item.productName, 'productName'), status: status as FeeScheduleItem['status'],
+      updatedAt: string(item.updatedAt, 'updatedAt'),
+    }
+  })
+}
+
+export function describeWaiverRule(rule: WaiverRule): string {
+  const target = rule.threshold === null ? rule.textValue : `${rule.threshold}${rule.thresholdCurrency ? ` ${rule.thresholdCurrency}` : ''}`
+  return `${rule.attribute.replaceAll('_', ' ').toLowerCase()} ${rule.operator} ${target ?? '—'}`
+}

--- a/openbank-admin-ui/src/test/fee-schedule-contract.test.ts
+++ b/openbank-admin-ui/src/test/fee-schedule-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { describeWaiverRule, parseFeeSchedule } from '@/lib/fees/feeScheduleContract'
+
+const fee = {
+  id: 'product:fee', code: 'CURRENT_MONTHLY', name: 'Monthly fee', type: 'ACCOUNT', amount: 4.5,
+  currency: 'eur', frequency: 'MONTHLY', description: null, waivable: true,
+  waiveCondition: 'Balance > 50000 EUR', waiverEvaluable: true,
+  waiverRule: { attribute: 'BALANCE', operator: '>', threshold: '50000', thresholdCurrency: 'EUR', textValue: null },
+  productId: 'product', productCode: 'CURRENT', productName: 'Current account', status: 'ACTIVE',
+  updatedAt: '2026-09-09T10:00:00Z',
+}
+
+describe('fee schedule contract', () => {
+  it('preserves executable waiver evidence', () => {
+    const parsed = parseFeeSchedule([fee])[0]
+    expect(parsed.currency).toBe('EUR')
+    expect(describeWaiverRule(parsed.waiverRule!)).toBe('balance > 50000 EUR')
+  })
+
+  it('rejects contradictory or unknown policy evidence', () => {
+    expect(() => parseFeeSchedule([{ ...fee, waiverRule: null }])).toThrow(/Inconsistent/)
+    expect(() => parseFeeSchedule([{ ...fee, status: 'PUBLISHED' }])).toThrow(/status/)
+  })
+
+  it('accepts a manual-only waiver without inventing an executable rule', () => {
+    expect(parseFeeSchedule([{ ...fee, waiverEvaluable: false, waiverRule: null }])[0]).toMatchObject({ waivable: true, waiverEvaluable: false })
+  })
+})


### PR DESCRIPTION
## Summary
- validate fee schedule payloads before replacing the last trusted snapshot
- expose the product catalog's structured waiver evidence in readable form
- distinguish automatic rules, manual-review exceptions, and non-waivable fees
- preserve outage recovery and cover the operator flow in Playwright

## Verification
- 4 focused Vitest checks passed
- TypeScript and ESLint passed
- production build generated 97/97 pages
- fee schedule recovery Playwright E2E passed

Closes #9377