### PR TITLE
fix(admin-ui): keep interest summaries currency-safe

### DIFF
--- a/openbank-admin-ui/src/app/interest/page.tsx
+++ b/openbank-admin-ui/src/app/interest/page.tsx
@@ -12,11 +12,8 @@ import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { PageHeader } from '@/components/ui/PageHeader'
-
-interface AccrualRecord {
-  id: string; accountId: string; accrualDate: string; accruedAmount: number
-  currency: string; rate: number; dayCount: string; status: string
-}
+import { StatusBadge } from '@/components/ui/StatusBadge'
+import { parseInterestAccruals, statusTone, type AccrualRecord } from '@/lib/interest/interestAccrualContract'
 
 type AccessBlock = 'unauthorized' | 'forbidden'
 
@@ -57,7 +54,7 @@ export default function InterestPage() {
     svcUrl('interest-service', '/api/v1/interest/accruals'),
     { select: (raw) => {
       setLastSuccessfulAt(new Date())
-      return Array.isArray(raw) ? (raw as AccrualRecord[]) : ((raw as { accruals?: AccrualRecord[] }).accruals ?? [])
+      return parseInterestAccruals(raw)
     } },
   )
   const accruals = data ?? []
@@ -87,7 +84,8 @@ export default function InterestPage() {
 
   const accruing = accruals.filter(a => a.status === 'ACCRUING')
   const capitalized = accruals.filter(a => a.status === 'CAPITALIZED')
-  const totalAccrued = accruals.reduce((s, a) => s + (a.accruedAmount ?? 0), 0)
+  const currencies = [...new Set(accruals.map(a => a.currency))]
+  const totalAccrued = currencies.length === 1 ? accruals.reduce((sum, accrual) => sum + accrual.accruedAmount, 0) : null
 
   return (
     <AuthGuard permission="interest:view">
@@ -173,7 +171,7 @@ export default function InterestPage() {
             { label: t('Záznamy celkem', 'Total records'), value: accruals.length, icon: <TrendingUp size={16} aria-hidden="true" />, color: 'var(--accent)' },
             { label: t('Akruuje', 'Accruing'), value: accruing.length, icon: <Percent size={16} aria-hidden="true" />, color: 'var(--warning)' },
             { label: t('Kapitalizováno', 'Capitalised'), value: capitalized.length, icon: <CheckCircle2 size={16} aria-hidden="true" />, color: 'var(--success)' },
-            { label: t('Celkem naakruováno', 'Total accrued'), value: totalAccrued.toLocaleString(numberLocale, { minimumFractionDigits: 2, maximumFractionDigits: 2 }), icon: <Calendar size={16} aria-hidden="true" />, color: 'var(--accent-2)' },
+            { label: t('Celkem naakruováno', 'Total accrued'), value: totalAccrued === null ? t('Více měn', 'Multiple currencies') : `${totalAccrued.toLocaleString(numberLocale, { minimumFractionDigits: 2, maximumFractionDigits: 4 })} ${currencies[0]}`, icon: <Calendar size={16} aria-hidden="true" />, color: 'var(--accent-2)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
               <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
@@ -228,12 +226,7 @@ export default function InterestPage() {
                   <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{a.currency}</td>
                   <td style={{ padding: '12px 16px', fontSize: '12px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}>{((a.rate ?? 0) * 100).toFixed(4)}%</td>
                   <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{a.dayCount}</td>
-                  <td style={{ padding: '12px 16px' }}>
-                    <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
-                      background: a.status === 'CAPITALIZED' ? 'var(--success-bg)' : 'var(--warning-bg)',
-                      color: a.status === 'CAPITALIZED' ? 'var(--success-text)' : 'var(--warning-text)',
-                      border: `1px solid ${a.status === 'CAPITALIZED' ? 'var(--success-border)' : 'var(--warning-border)'}` }}>{a.status}</span>
-                  </td>
+                  <td style={{ padding: '12px 16px' }}><StatusBadge status={a.status} tone={statusTone(a.status)} /></td>
                 </tr>
               ))}</tbody>
             </table>

--- a/openbank-admin-ui/src/lib/interest/interestAccrualContract.ts
+++ b/openbank-admin-ui/src/lib/interest/interestAccrualContract.ts
@@ -1,0 +1,45 @@
+export const ACCRUAL_STATUSES = ['ACCRUING', 'CAPITALIZING', 'CAPITALIZED', 'REVERSED', 'SUSPENDED'] as const
+export const DAY_COUNTS = ['ACT_365', 'ACT_360', 'ACT_ACT', 'THIRTY_360'] as const
+
+export interface AccrualRecord {
+  id: string; accountId: string; accrualDate: string; accruedAmount: number
+  currency: string; rate: number; dayCount: (typeof DAY_COUNTS)[number]
+  status: (typeof ACCRUAL_STATUSES)[number]
+}
+
+const string = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid interest accrual ${field}`)
+  return value
+}
+const number = (value: unknown, field: string): number => {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN
+  if (!Number.isFinite(parsed)) throw new Error(`Invalid interest accrual ${field}`)
+  return parsed
+}
+const enumValue = <T extends readonly string[]>(value: unknown, allowed: T, field: string): T[number] => {
+  if (typeof value !== 'string' || !allowed.includes(value)) throw new Error(`Invalid interest accrual ${field}`)
+  return value as T[number]
+}
+
+export function parseInterestAccruals(raw: unknown): AccrualRecord[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid interest accrual response')
+  return raw.map((value) => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('Invalid interest accrual')
+    const item = value as Record<string, unknown>
+    const accrualDate = string(item.accrualDate, 'accrualDate')
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(accrualDate)) throw new Error('Invalid interest accrual accrualDate')
+    return {
+      id: string(item.id, 'id'), accountId: string(item.accountId, 'accountId'), accrualDate,
+      accruedAmount: number(item.accruedAmount, 'accruedAmount'), currency: string(item.currency, 'currency').toUpperCase(),
+      rate: number(item.rate, 'rate'), dayCount: enumValue(item.dayCount, DAY_COUNTS, 'dayCount'),
+      status: enumValue(item.status, ACCRUAL_STATUSES, 'status'),
+    }
+  })
+}
+
+export function statusTone(status: AccrualRecord['status']): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (status === 'CAPITALIZED') return 'success'
+  if (status === 'REVERSED') return 'danger'
+  if (status === 'ACCRUING' || status === 'CAPITALIZING') return 'warning'
+  return 'neutral'
+}

--- a/openbank-admin-ui/src/test/interest-accrual-contract.test.ts
+++ b/openbank-admin-ui/src/test/interest-accrual-contract.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { parseInterestAccruals, statusTone } from '@/lib/interest/interestAccrualContract'
+
+const accrual = {
+  id: 'accrual-1', accountId: 'account-1', accrualDate: '2026-09-09', accruedAmount: '10.2500',
+  currency: 'czk', rate: '0.0001', dayCount: 'ACT_365', status: 'CAPITALIZING',
+}
+
+describe('interest accrual contract', () => {
+  it('maps decimal payloads and all lifecycle fields', () => {
+    expect(parseInterestAccruals([accrual])[0]).toEqual({
+      id: 'accrual-1', accountId: 'account-1', accrualDate: '2026-09-09', accruedAmount: 10.25,
+      currency: 'CZK', rate: 0.0001, dayCount: 'ACT_365', status: 'CAPITALIZING',
+    })
+  })
+
+  it('rejects unknown statuses and malformed local dates', () => {
+    expect(() => parseInterestAccruals([{ ...accrual, status: 'PENDING' }])).toThrow(/status/)
+    expect(() => parseInterestAccruals([{ ...accrual, accrualDate: '09/09/2026' }])).toThrow(/accrualDate/)
+  })
+
+  it('keeps reversed and suspended states distinct', () => {
+    expect(statusTone('REVERSED')).toBe('danger')
+    expect(statusTone('SUSPENDED')).toBe('neutral')
+  })
+})

--- a/openbank-admin-ui/src/test/interest-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/interest-recovery.test.tsx
@@ -56,6 +56,18 @@ afterEach(() => {
 })
 
 describe('interest snapshot recovery', () => {
+  it('never combines unlike currencies into a monetary total', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(200, [
+      FIRST_ACCRUAL,
+      { ...FIRST_ACCRUAL, id: 'accrual-eur', currency: 'EUR', accruedAmount: 20 },
+    ])))
+
+    await renderPage()
+
+    expect(await screen.findByText('Multiple currencies')).toBeVisible()
+    expect(screen.queryByText('30.25')).not.toBeInTheDocument()
+  })
+
   it('keeps the last successful rows visible after a failed refresh and releases single-flight after success', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse(200, [FIRST_ACCRUAL]))


### PR DESCRIPTION
## Summary
- validate the actual interest accrual response and all supported lifecycle values
- show a monetary total only for a single-currency result; mixed-currency results are labelled explicitly
- render ACCRUING, CAPITALIZING, CAPITALIZED, REVERSED, and SUSPENDED with semantic shared status tones
- preserve privileged retained-snapshot recovery behavior

## Verification
- 11 focused Vitest checks passed
- TypeScript and ESLint passed
- production build generated 97/97 pages

Closes #9382