### PR TITLE
fix(admin-ui): align SWIFT lifecycle evidence

### DIFF
--- a/openbank-admin-ui/e2e/swift-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/swift-recovery.spec.ts
@@ -3,12 +3,12 @@ import { signInAsOperator } from './helpers/auth'
 
 const message = {
   id: 'swift-2026-0042',
-  messageType: 'pacs.008',
+  messageType: 'MT103',
   senderBic: 'KOMBCZPPXXX',
   receiverBic: 'DEUTDEFFXXX',
   amount: 85000.25,
   currency: 'EUR',
-  status: 'PROCESSING',
+  status: 'VALIDATED',
   createdAt: '2026-08-31T12:00:00Z',
   reference: 'SWIFT-REF-0042',
 }
@@ -30,7 +30,7 @@ test.beforeEach(async ({ context, baseURL, page }) => {
   }))
 })
 
-test('keeps SWIFT processing evidence visible after a failed refresh', async ({ page }) => {
+test('keeps valid SWIFT lifecycle evidence visible after a failed refresh', async ({ page }) => {
   let unavailable = false
   await page.route('**/api/svc/swift-service/api/v1/swift/messages**', route => unavailable
     ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
@@ -40,7 +40,7 @@ test('keeps SWIFT processing evidence visible after a failed refresh', async ({ 
 
   await expect(page.getByText('SWIFT-REF-0042')).toBeVisible({ timeout: 20_000 })
   await expect(page.getByText('85,000.25')).toBeVisible()
-  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByText('VALIDATED', { exact: true })).toBeVisible()
 
   unavailable = true
   await page.getByRole('button', { name: /Obnovit SWIFT zprávy|Refresh SWIFT messages/ }).click()
@@ -48,6 +48,6 @@ test('keeps SWIFT processing evidence visible after a failed refresh', async ({ 
   await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
   await expect(page.getByText('SWIFT-REF-0042')).toBeVisible()
   await expect(page.getByText('85,000.25')).toBeVisible()
-  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByText('VALIDATED', { exact: true })).toBeVisible()
   await expect(page.getByText(/zatím žádné SWIFT zprávy|no SWIFT messages yet/)).toHaveCount(0)
 })

--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -14,23 +14,8 @@ import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { readStashedRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
-
-interface SwiftMessage {
-  id: string
-  messageType?: string
-  senderBic?: string
-  receiverBic?: string
-  amount?: number
-  currency?: string
-  status?: string
-  reference?: string
-  createdAt?: string
-  [k: string]: unknown
-}
-
-const STATUS_COLOR: Record<string, string> = {
-  SENT: 'var(--success)', PROCESSING: 'var(--info-text)', PENDING: 'var(--warning)', FAILED: 'var(--danger)',
-}
+import { StatusBadge } from '@/components/ui'
+import { parseSwiftMessages, swiftStatusTone, type SwiftMessage } from '@/lib/swift/swiftMessageContract'
 
 export default function SwiftDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -46,7 +31,8 @@ export default function SwiftDetailPage() {
     const stashed = readStashedRow<SwiftMessage>('swift', id)
     if (stashed) { setMessage(stashed); setUnavailable(null) }
     try {
-      // No by-id backend endpoint — re-fetch the list and pick this id out.
+      // The by-id endpoint exposes the domain model rather than this list response contract, so
+      // re-fetch the validated queue shape and select the requested message.
       const res = await fetch(svcUrl('swift-service', '/api/v1/swift/messages'), { signal: AbortSignal.timeout(10_000), cache: 'no-store' })
       if (!res.ok) {
         if (!stashed) setUnavailable({ kind: await classifyBffFailure(res) })
@@ -54,7 +40,7 @@ export default function SwiftDetailPage() {
         return
       }
       const body = (await res.json()) as unknown
-      const items = (Array.isArray(body) ? body : ((body as { messages?: unknown[] }).messages ?? [])) as SwiftMessage[]
+      const items = parseSwiftMessages(body)
       const found = items.find(m => m.id === id)
       if (found) { setMessage(found); setUnavailable(null) }
       else if (!stashed) setUnavailable({ kind: 'not_found' })
@@ -75,7 +61,7 @@ export default function SwiftDetailPage() {
         subtitle={t('Detail SWIFT zprávy — ISO 20022', 'SWIFT message detail — ISO 20022')}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/swift" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('SWIFT zprávy', 'SWIFT')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span></div>}
         actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-          {message?.status && <span className="pill" style={{ background: `${STATUS_COLOR[message.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[message.status] ?? 'var(--text-muted)' }}>{message.status}</span>}
+          {message?.status && <StatusBadge status={message.status} tone={swiftStatusTone(message.status)} />}
           <Link href="/swift" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>
           <button
             className="btn btn-secondary"

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -15,11 +15,7 @@ import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { StatusBadge } from '@/components/ui'
 import { PageHeader } from '@/components/ui/PageHeader'
-
-interface SwiftMessage {
-  id: string; messageType: string; senderBic: string; receiverBic: string
-  amount: number; currency: string; status: string; createdAt: string; reference: string
-}
+import { parseSwiftMessages, swiftLifecycleGroup, swiftStatusTone, type SwiftMessage } from '@/lib/swift/swiftMessageContract'
 
 export default function SwiftPage() {
   const { t, language } = useLanguage()
@@ -31,8 +27,9 @@ export default function SwiftPage() {
   const { data, loading, unavailable, waking, reload } = useServiceResource<SwiftMessage[]>(
     svcUrl('swift-service', '/api/v1/swift/messages'),
     { select: (raw) => {
+      const parsed = parseSwiftMessages(raw)
       setLastSuccessfulAt(new Date())
-      return Array.isArray(raw) ? (raw as SwiftMessage[]) : ((raw as { messages?: SwiftMessage[] }).messages ?? [])
+      return parsed
     } },
   )
   const messages = data ?? []
@@ -92,9 +89,9 @@ export default function SwiftPage() {
         {hasSnapshot && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Zpráv celkem', 'Total messages'), value: messages.length, icon: <Globe size={16} />, color: 'var(--accent)' },
-            { label: t('Odesláno', 'Sent'), value: messages.filter(m => m.status === 'SENT').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Čeká', 'Pending'), value: messages.filter(m => m.status === 'PENDING' || m.status === 'PROCESSING').length, icon: <Clock size={16} />, color: 'var(--warning)' },
-            { label: t('Chyby', 'Errors'), value: messages.filter(m => m.status === 'FAILED').length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
+            { label: t('V procesu', 'In flight'), value: messages.filter(m => swiftLifecycleGroup(m.status) === 'in_flight').length, icon: <Clock size={16} />, color: 'var(--warning)' },
+            { label: t('Potvrzeno', 'Confirmed'), value: messages.filter(m => swiftLifecycleGroup(m.status) === 'confirmed').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
+            { label: t('K řešení', 'Exceptions'), value: messages.filter(m => swiftLifecycleGroup(m.status) === 'exception').length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
               <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
@@ -150,7 +147,7 @@ export default function SwiftPage() {
                       {m.amount?.toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {m.currency}
                     </td>
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{m.reference}</td>
-                    <td style={{ padding: '12px 16px' }}><StatusBadge status={m.status} tone={m.status === 'PROCESSING' ? 'info' : undefined} /></td>
+                    <td style={{ padding: '12px 16px' }}><StatusBadge status={m.status} tone={swiftStatusTone(m.status)} /></td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{m.createdAt ? new Date(m.createdAt).toLocaleDateString(dateLocale) : '—'}</td>
                     <td style={{ padding: '12px 8px', textAlign: 'right' }}><ChevronRight size={14} style={{ color: 'var(--text-tertiary)' }} /></td>
                   </tr>

--- a/openbank-admin-ui/src/lib/swift/swiftMessageContract.test.ts
+++ b/openbank-admin-ui/src/lib/swift/swiftMessageContract.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseSwiftMessages, swiftLifecycleGroup, swiftStatusTone } from './swiftMessageContract'
+
+const valid = {
+  id: '8ab7a9bb-cffc-4fd9-8792-ce84eb0bd379',
+  messageType: 'MT103',
+  senderBic: 'KOMBCZPPXXX',
+  receiverBic: 'DEUTDEFFXXX',
+  amount: 85000.25,
+  currency: 'EUR',
+  status: 'VALIDATED',
+  createdAt: '2026-09-09T12:00:00Z',
+  reference: 'SWIFT-REF-0042',
+}
+
+describe('SWIFT message response contract', () => {
+  it('accepts the service response and its compatibility envelope', () => {
+    expect(parseSwiftMessages([valid])).toEqual([valid])
+    expect(parseSwiftMessages({ messages: [valid] })).toEqual([valid])
+  })
+
+  it('rejects invented lifecycle states and malformed evidence', () => {
+    expect(() => parseSwiftMessages([{ ...valid, status: 'PROCESSING' }])).toThrow('Invalid SWIFT status')
+    expect(() => parseSwiftMessages([{ ...valid, amount: Number.NaN }])).toThrow('Invalid SWIFT amount')
+    expect(() => parseSwiftMessages({ items: [valid] })).toThrow('Invalid SWIFT message list')
+  })
+
+  it('classifies every service lifecycle state without a success fall-through', () => {
+    expect((['PENDING', 'VALIDATED', 'SENT'] as const).map(swiftLifecycleGroup)).toEqual(['in_flight', 'in_flight', 'in_flight'])
+    expect((['ACKNOWLEDGED', 'COMPLETED'] as const).map(swiftLifecycleGroup)).toEqual(['confirmed', 'confirmed'])
+    expect((['REJECTED', 'FAILED'] as const).map(swiftLifecycleGroup)).toEqual(['exception', 'exception'])
+    expect((['PENDING', 'VALIDATED', 'SENT', 'ACKNOWLEDGED', 'COMPLETED', 'REJECTED', 'FAILED'] as const).map(swiftStatusTone))
+      .toEqual(['warning', 'info', 'info', 'success', 'success', 'danger', 'danger'])
+  })
+})

--- a/openbank-admin-ui/src/lib/swift/swiftMessageContract.ts
+++ b/openbank-admin-ui/src/lib/swift/swiftMessageContract.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tone } from '@/components/ui/tone'
+
+export const SWIFT_MESSAGE_TYPES = ['MT103', 'MT202', 'MT900', 'MT910', 'MT940', 'MT950', 'MT199'] as const
+export const SWIFT_STATUSES = ['PENDING', 'VALIDATED', 'SENT', 'ACKNOWLEDGED', 'REJECTED', 'FAILED', 'COMPLETED'] as const
+
+export type SwiftMessageType = (typeof SWIFT_MESSAGE_TYPES)[number]
+export type SwiftStatus = (typeof SWIFT_STATUSES)[number]
+
+export interface SwiftMessage {
+  id: string
+  messageType: SwiftMessageType
+  senderBic: string
+  receiverBic: string
+  amount: number
+  currency: string
+  status: SwiftStatus
+  createdAt: string
+  reference: string
+}
+
+export type SwiftLifecycleGroup = 'in_flight' | 'confirmed' | 'exception'
+
+const MESSAGE_TYPES = new Set<string>(SWIFT_MESSAGE_TYPES)
+const STATUSES = new Set<string>(SWIFT_STATUSES)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid SWIFT ${field}`)
+  return value
+}
+
+function parseMessage(value: unknown): SwiftMessage {
+  if (!isRecord(value)) throw new Error('Invalid SWIFT message')
+
+  const messageType = requiredString(value, 'messageType')
+  const status = requiredString(value, 'status')
+  const amount = value.amount
+  const currency = requiredString(value, 'currency')
+  const createdAt = requiredString(value, 'createdAt')
+
+  if (!MESSAGE_TYPES.has(messageType)) throw new Error('Invalid SWIFT messageType')
+  if (!STATUSES.has(status)) throw new Error('Invalid SWIFT status')
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) throw new Error('Invalid SWIFT amount')
+  if (!/^[A-Z]{3}$/.test(currency)) throw new Error('Invalid SWIFT currency')
+  if (Number.isNaN(Date.parse(createdAt))) throw new Error('Invalid SWIFT createdAt')
+
+  return {
+    id: requiredString(value, 'id'),
+    messageType: messageType as SwiftMessageType,
+    senderBic: requiredString(value, 'senderBic'),
+    receiverBic: requiredString(value, 'receiverBic'),
+    amount,
+    currency,
+    status: status as SwiftStatus,
+    createdAt,
+    reference: requiredString(value, 'reference'),
+  }
+}
+
+export function parseSwiftMessages(raw: unknown): SwiftMessage[] {
+  const rows = Array.isArray(raw)
+    ? raw
+    : isRecord(raw) && Array.isArray(raw.messages)
+      ? raw.messages
+      : null
+  if (!rows) throw new Error('Invalid SWIFT message list')
+  return rows.map(parseMessage)
+}
+
+export function swiftLifecycleGroup(status: SwiftStatus): SwiftLifecycleGroup {
+  if (status === 'ACKNOWLEDGED' || status === 'COMPLETED') return 'confirmed'
+  if (status === 'REJECTED' || status === 'FAILED') return 'exception'
+  return 'in_flight'
+}
+
+export function swiftStatusTone(status: SwiftStatus): Tone {
+  if (status === 'ACKNOWLEDGED' || status === 'COMPLETED') return 'success'
+  if (status === 'REJECTED' || status === 'FAILED') return 'danger'
+  if (status === 'PENDING') return 'warning'
+  return 'info'
+}

--- a/openbank-admin-ui/src/test/swift-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/swift-status-badge.guard.test.ts
@@ -5,11 +5,13 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 describe('SWIFT status presentation contract', () => {
-  it('uses the shared badge and retains the informational processing state', () => {
+  it('uses the shared badge and the service lifecycle contract', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/swift/page.tsx'), 'utf8')
 
     expect(source).toContain("import { StatusBadge } from '@/components/ui'")
-    expect(source).toContain("<StatusBadge status={m.status} tone={m.status === 'PROCESSING' ? 'info' : undefined} />")
+    expect(source).toContain('<StatusBadge status={m.status} tone={swiftStatusTone(m.status)} />')
+    expect(source).toContain('swiftLifecycleGroup(m.status)')
+    expect(source).not.toContain('PROCESSING')
     expect(source).not.toContain('STATUS_COLORS')
   })
 })


### PR DESCRIPTION
## Summary

- validates SWIFT queue records against the service response contract before they become operator evidence
- replaces the invented `PROCESSING` state with all seven real backend lifecycle states
- uses consistent lifecycle grouping and semantic tones across the queue and detail
- keeps the last known-good snapshot when refresh fails or returns malformed data

## Verification

- `npm test -- --run src/lib/swift/swiftMessageContract.test.ts src/test/swift-status-badge.guard.test.ts src/test/swift-detail-loading.guard.test.ts src/test/swift-refresh.guard.test.ts src/test/swift-raw-disclosure.guard.test.ts src/test/payment-rails-rbac.guard.test.ts src/test/swift-route-rbac.guard.test.ts src/test/table-keyboard-a11y.guard.test.ts` (7 files, 8 tests)
- `npm run type-check`
- `npm run lint -- --quiet`
- `npm run build` (97/97 routes)
- `npx playwright test e2e/swift-recovery.spec.ts --reporter=line` (1/1 Chromium)

Closes #9384

Stacked on #9367 for the admin-ui `sharp` security baseline; merge only after that dependency lands, exact-head CI is green, and an eligible independent review approves this PR.