### PR TITLE
fix(admin-ui): distinguish ledger evidence

### DIFF
--- a/openbank-admin-ui/e2e/ledger-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/ledger-recovery.spec.ts
@@ -11,9 +11,10 @@ const journalPage = {
     description: 'Customer transfer settlement',
     status: 'POSTED',
     createdAt: '2026-08-31T12:00:00Z',
+    synthetic: false,
     lines: [
-      { id: 'line-debit', glAccountId: 'gl-debit-12345678', side: 'DEBIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 1 },
-      { id: 'line-credit', glAccountId: 'gl-credit-1234567', side: 'CREDIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 2 },
+      { id: 'line-debit', glAccountId: 'gl-debit-12345678', side: 'DEBIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 1, subAccountId: 'sub-account-12345678' },
+      { id: 'line-credit', glAccountId: 'gl-credit-1234567', side: 'CREDIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 2, subAccountId: null },
     ],
   }],
   pagination: { limit: 20, hasNextPage: false, nextCursor: null },
@@ -33,6 +34,7 @@ test('keeps balanced journal evidence visible after a repeated search fails', as
   await page.getByRole('button', { name: /Načíst záznamy|Load Entries/ }).click()
 
   await expect(page.getByText('Customer transfer settlement')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText(/Obchodní|Business/)).toBeVisible()
   await page.getByRole('button', { name: /Zobrazit řádky deníku|Show journal lines/ }).click()
   await expect(page.getByText('DEBIT', { exact: true })).toBeVisible()
   await expect(page.getByText('CREDIT', { exact: true })).toBeVisible()

--- a/openbank-admin-ui/src/app/ledger/page.tsx
+++ b/openbank-admin-ui/src/app/ledger/page.tsx
@@ -10,22 +10,16 @@ import { Search, ChevronDown, ChevronRight } from 'lucide-react'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import type { JournalEntry, CursorPage } from '@/types'
 import { PageHeader } from '@/components/ui/PageHeader'
-
-const STATUS_PILL: Record<string, string> = {
-  POSTED:   'pill pill-success',
-  PENDING:  'pill pill-warning',
-  REVERSED: 'pill pill-neutral',
-  DRAFT:    'pill pill-info',
-}
+import { StatusBadge } from '@/components/ui'
+import { parseLedgerJournalPage, type LedgerJournalPage } from '@/lib/ledger/ledgerJournalContract'
 
 export default function LedgerPage() {
   const [fromDate, setFromDate] = useState(() => { const d = new Date(); d.setMonth(d.getMonth() - 1); return d.toISOString().slice(0, 10) })
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [toDate, setToDate]     = useState(() => new Date().toISOString().slice(0, 10))
-  const [result, setResult]     = useState<CursorPage<JournalEntry> | null>(null)
+  const [result, setResult]     = useState<LedgerJournalPage | null>(null)
   const [loading, setLoading]   = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
@@ -42,7 +36,12 @@ export default function LedgerPage() {
       if (!res.ok) {
         throw new Error(await classifyBffFailure(res))
       }
-      return await res.json() as CursorPage<JournalEntry>
+      const raw = await res.json() as unknown
+      try {
+        return parseLedgerJournalPage(raw)
+      } catch {
+        throw new Error('unreachable')
+      }
     } catch (error) {
       throw error instanceof Error ? error : new Error('unreachable')
     }
@@ -146,19 +145,20 @@ export default function LedgerPage() {
                 <th>{t('Datum záznamu', 'Entry Date')}</th>
                 <th>{t('Datum valuty', 'Value Date')}</th>
                 <th>{t('Stav', 'Status')}</th>
+                <th>{t('Původ', 'Origin')}</th>
                 <th>{t('Řádky', 'Lines')}</th>
                 <th>{t('Popis', 'Description')}</th>
               </tr>
             </thead>
             <tbody>
               {!result && !loading && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Vyberte období a klikněte na "Načíst záznamy".', 'Select a date range and click "Load Entries".')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Vyberte období a klikněte na "Načíst záznamy".', 'Select a date range and click "Load Entries".')}</div></td></tr>
               )}
               {loading && !result && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Načítání záznamů hlavní knihy…', 'Loading journal entries…')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Načítání záznamů hlavní knihy…', 'Loading journal entries…')}</div></td></tr>
               )}
               {!loading && result && result.data.length === 0 && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Pro toto období nebyly nalezeny žádné záznamy.', 'No journal entries found for this period.')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Pro toto období nebyly nalezeny žádné záznamy.', 'No journal entries found for this period.')}</div></td></tr>
               )}
               {result?.data.map(entry => {
                 const isOpen = expanded === entry.id
@@ -174,7 +174,8 @@ export default function LedgerPage() {
                       <td><span className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{entry.transactionId.slice(0, 8)}…</span></td>
                       <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{entry.entryDate}</span></td>
                       <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{entry.valueDate}</span></td>
-                      <td><span className={STATUS_PILL[entry.status] ?? 'pill pill-neutral'}>{entry.status}</span></td>
+                      <td><StatusBadge status={entry.status} /></td>
+                      <td><StatusBadge status={entry.synthetic ? 'SYNTHETIC' : 'BUSINESS'} tone={entry.synthetic ? 'info' : 'neutral'} label={entry.synthetic ? t('Canary', 'Canary') : t('Obchodní', 'Business')} /></td>
                       <td>
                         <span style={{
                           display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
@@ -193,7 +194,7 @@ export default function LedgerPage() {
                     </tr>
                     {isOpen && (
                       <tr>
-                        <td colSpan={8} style={{ padding: 0, background: 'var(--surface-2)' }}>
+                        <td colSpan={9} style={{ padding: 0, background: 'var(--surface-2)' }}>
                           <div id={`ledger-entry-${entry.id}`} style={{ padding: '12px 20px 12px 50px', borderBottom: '2px solid var(--accent-border)' }}>
                             <div style={{ fontSize: '11px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
                               {t('Řádky deníku', 'Journal Lines')}
@@ -202,6 +203,7 @@ export default function LedgerPage() {
                               <thead>
                                 <tr style={{ color: 'var(--text-tertiary)' }}>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Účet HK', 'GL Account')}</th>
+                                  <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Podúčet', 'Sub-account')}</th>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Strana', 'Side')}</th>
                                   <th style={{ textAlign: 'right', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Částka', 'Amount')}</th>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>CCY</th>
@@ -214,6 +216,9 @@ export default function LedgerPage() {
                                   <tr key={line.id} style={{ borderTop: '1px solid var(--border)' }}>
                                     <td style={{ padding: '6px 12px 6px 0' }}>
                                       <span className="mono" style={{ fontSize: '11px' }}>{line.glAccountId.slice(0, 8)}…</span>
+                                    </td>
+                                    <td style={{ padding: '6px 12px 6px 0' }}>
+                                      <span className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{line.subAccountId ? `${line.subAccountId.slice(0, 8)}…` : '—'}</span>
                                     </td>
                                     <td style={{ padding: '6px 12px 6px 0' }}>
                                       <span style={{

--- a/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.test.ts
+++ b/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseLedgerJournalPage } from './ledgerJournalContract'
+
+const entry = {
+  id: 'journal-1', entryNumber: 42, transactionId: 'transaction-1', entryDate: '2026-09-09', valueDate: '2026-09-09',
+  description: 'Customer transfer', status: 'POSTED', createdAt: '2026-09-09T12:00:00Z', synthetic: false,
+  lines: [{
+    id: 'line-1', glAccountId: 'gl-1', side: 'DEBIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250,
+    baseCurrencyCode: 'EUR', sequence: 1, subAccountId: 'sub-account-1',
+  }],
+}
+
+describe('ledger journal response contract', () => {
+  it('preserves provenance and cursor evidence', () => {
+    expect(parseLedgerJournalPage({ data: [entry], pagination: { limit: 20, hasNextPage: true, nextCursor: 'next', totalCount: 21 } }))
+      .toMatchObject({ data: [{ synthetic: false, lines: [{ subAccountId: 'sub-account-1' }] }], pagination: { nextCursor: 'next', totalCount: 21 } })
+  })
+
+  it('rejects invented states, missing provenance and unusable cursors', () => {
+    expect(() => parseLedgerJournalPage({ data: [{ ...entry, status: 'DRAFT' }], pagination: { limit: 20, hasNextPage: false } })).toThrow('Invalid ledger status')
+    expect(() => parseLedgerJournalPage({ data: [{ ...entry, synthetic: undefined }], pagination: { limit: 20, hasNextPage: false } })).toThrow('Invalid ledger synthetic')
+    expect(() => parseLedgerJournalPage({ data: [entry], pagination: { limit: 20, hasNextPage: true } })).toThrow('Invalid ledger nextCursor')
+  })
+})

--- a/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.ts
+++ b/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const JOURNAL_STATUSES = ['PENDING', 'POSTED', 'REVERSED'] as const
+export type JournalStatus = (typeof JOURNAL_STATUSES)[number]
+
+export interface LedgerJournalLine {
+  id: string
+  glAccountId: string
+  side: 'DEBIT' | 'CREDIT'
+  amount: number
+  currencyCode: string
+  baseAmount: number
+  baseCurrencyCode: string
+  sequence: number
+  subAccountId: string | null
+}
+
+export interface LedgerJournalEntry {
+  id: string
+  entryNumber: number | null
+  transactionId: string
+  entryDate: string
+  valueDate: string
+  description: string | null
+  status: JournalStatus
+  lines: LedgerJournalLine[]
+  createdAt: string
+  synthetic: boolean
+}
+
+export interface LedgerJournalPage {
+  data: LedgerJournalEntry[]
+  pagination: {
+    limit: number
+    hasNextPage: boolean
+    nextCursor?: string
+    previousCursor?: string
+    totalCount?: number
+  }
+}
+
+const STATUSES = new Set<string>(JOURNAL_STATUSES)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, field: string, allowEmpty = false): string {
+  const value = record[field]
+  if (typeof value !== 'string' || (!allowEmpty && value.trim() === '')) throw new Error(`Invalid ledger ${field}`)
+  return value
+}
+
+function nullableString(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  return stringField(record, field, true)
+}
+
+function finiteNumber(record: Record<string, unknown>, field: string): number {
+  const value = record[field]
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid ledger ${field}`)
+  return value
+}
+
+function dateOnly(record: Record<string, unknown>, field: string): string {
+  const value = stringField(record, field)
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00Z`) : null
+  if (!parsed || Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Invalid ledger ${field}`)
+  }
+  return value
+}
+
+function parseLine(value: unknown): LedgerJournalLine {
+  if (!isRecord(value)) throw new Error('Invalid ledger line')
+  const side = stringField(value, 'side')
+  const amount = finiteNumber(value, 'amount')
+  const baseAmount = finiteNumber(value, 'baseAmount')
+  const sequence = finiteNumber(value, 'sequence')
+  const currencyCode = stringField(value, 'currencyCode')
+  const baseCurrencyCode = stringField(value, 'baseCurrencyCode')
+  if (side !== 'DEBIT' && side !== 'CREDIT') throw new Error('Invalid ledger side')
+  if (amount < 0 || baseAmount < 0) throw new Error('Invalid ledger amount')
+  if (!Number.isInteger(sequence) || sequence < 0) throw new Error('Invalid ledger sequence')
+  if (!/^[A-Z]{3}$/.test(currencyCode) || !/^[A-Z]{3}$/.test(baseCurrencyCode)) throw new Error('Invalid ledger currency')
+  if (value.subAccountId !== null && typeof value.subAccountId !== 'string') throw new Error('Invalid ledger subAccountId')
+
+  return {
+    id: stringField(value, 'id'),
+    glAccountId: stringField(value, 'glAccountId'),
+    side,
+    amount,
+    currencyCode,
+    baseAmount,
+    baseCurrencyCode,
+    sequence,
+    subAccountId: value.subAccountId,
+  }
+}
+
+function parseEntry(value: unknown): LedgerJournalEntry {
+  if (!isRecord(value)) throw new Error('Invalid ledger entry')
+  const status = stringField(value, 'status')
+  const entryNumber = value.entryNumber
+  const createdAt = stringField(value, 'createdAt')
+  if (!STATUSES.has(status)) throw new Error('Invalid ledger status')
+  if (entryNumber !== null && (typeof entryNumber !== 'number' || !Number.isInteger(entryNumber))) throw new Error('Invalid ledger entryNumber')
+  if (value.description !== null && typeof value.description !== 'string') throw new Error('Invalid ledger description')
+  if (!Array.isArray(value.lines)) throw new Error('Invalid ledger lines')
+  if (typeof value.synthetic !== 'boolean') throw new Error('Invalid ledger synthetic')
+  if (Number.isNaN(Date.parse(createdAt))) throw new Error('Invalid ledger createdAt')
+
+  return {
+    id: stringField(value, 'id'),
+    entryNumber,
+    transactionId: stringField(value, 'transactionId'),
+    entryDate: dateOnly(value, 'entryDate'),
+    valueDate: dateOnly(value, 'valueDate'),
+    description: nullableString(value, 'description'),
+    status: status as JournalStatus,
+    lines: value.lines.map(parseLine),
+    createdAt,
+    synthetic: value.synthetic,
+  }
+}
+
+function optionalCursor(record: Record<string, unknown>, field: string): string | undefined {
+  const value = record[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string' || value === '') throw new Error(`Invalid ledger ${field}`)
+  return value
+}
+
+export function parseLedgerJournalPage(raw: unknown): LedgerJournalPage {
+  if (!isRecord(raw) || !Array.isArray(raw.data) || !isRecord(raw.pagination)) throw new Error('Invalid ledger page')
+  const limit = finiteNumber(raw.pagination, 'limit')
+  const hasNextPage = raw.pagination.hasNextPage
+  const nextCursor = optionalCursor(raw.pagination, 'nextCursor')
+  const previousCursor = optionalCursor(raw.pagination, 'previousCursor')
+  const totalCount = raw.pagination.totalCount
+  if (!Number.isInteger(limit) || limit <= 0) throw new Error('Invalid ledger limit')
+  if (typeof hasNextPage !== 'boolean') throw new Error('Invalid ledger hasNextPage')
+  if (hasNextPage && !nextCursor) throw new Error('Invalid ledger nextCursor')
+  if (totalCount !== undefined && totalCount !== null && (typeof totalCount !== 'number' || !Number.isInteger(totalCount) || totalCount < 0)) {
+    throw new Error('Invalid ledger totalCount')
+  }
+
+  return {
+    data: raw.data.map(parseEntry),
+    pagination: {
+      limit,
+      hasNextPage,
+      ...(nextCursor ? { nextCursor } : {}),
+      ...(previousCursor ? { previousCursor } : {}),
+      ...(typeof totalCount === 'number' ? { totalCount } : {}),
+    },
+  }
+}

--- a/openbank-admin-ui/src/test/ledger-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/ledger-pagination.test.tsx
@@ -12,11 +12,11 @@ vi.mock('@/components/auth/AuthGuard', () => ({
 }))
 
 const firstPage = {
-  data: [{ id: 'entry-1', transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page' }],
+  data: [{ id: 'entry-1', entryNumber: 1, transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page', createdAt: '2026-08-01T12:00:00Z', synthetic: false }],
   pagination: { limit: 20, hasNextPage: true, nextCursor: 'cursor-1' },
 }
 const secondPage = {
-  data: [{ id: 'entry-2', transactionId: 'transaction-2', entryDate: '2026-08-02', valueDate: '2026-08-02', status: 'POSTED', lines: [], description: 'Second page' }],
+  data: [{ id: 'entry-2', entryNumber: 2, transactionId: 'transaction-2', entryDate: '2026-08-02', valueDate: '2026-08-02', status: 'POSTED', lines: [], description: 'Second page', createdAt: '2026-08-02T12:00:00Z', synthetic: true }],
   pagination: { limit: 20, hasNextPage: false },
 }
 
@@ -78,5 +78,20 @@ describe('General Ledger pagination', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('next page could not be loaded'))
     expect(screen.getByText('First page')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Load more' })).toBeTruthy()
+  })
+
+  it('keeps the first page when a successful next-page response is malformed', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(firstPage))
+      .mockResolvedValueOnce(response({ data: 'not-a-journal-page', pagination: { limit: 20, hasNextPage: false } }))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    await screen.findByText('First page')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('next page could not be loaded'))
+    expect(screen.getByText('First page')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Closes #9400

## What
- validate ledger journal responses at the BFF boundary
- align lifecycle states with the backend contract and remove invented DRAFT state
- expose synthetic/canary origin and sub-account provenance
- retain the last valid page when a later response is malformed

## Verification
- focused Vitest contract, pagination, and locale coverage
- TypeScript type-check
- ESLint
- production build (97/97 routes)
- Playwright ledger recovery scenario (1/1)

## Dependency
Stacked on `security/admin-ui-sharp-0.35.4`. Merge only after that base lands, exact-head CI is green, and an eligible independent review is present.
