### PR TITLE
fix(admin-ui): validate consent evidence

### DIFF
--- a/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
@@ -88,4 +88,27 @@ test.describe('Consent lookup recovery', () => {
     await expect(page.getByText(/Failed to load: Consents|Načtení selhalo: Souhlasy/)).toBeVisible()
     await expect(page.getByText('ALL_ACCESS')).toBeHidden()
   })
+
+  test('keeps valid siblings and discloses partial consent evidence', async ({ page }) => {
+    const valid = {
+      id: '11111111-1111-4111-8111-111111111111', partyId: '22222222-2222-4222-8222-222222222222',
+      granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE', granteeName: 'Verified Marketing Service',
+      scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
+      validFrom: '2026-01-01T00:00:00Z', validTo: '2026-12-31T00:00:00Z', createdAt: '2026-01-01T00:00:00Z',
+    }
+    await page.route('**/api/svc/consent-service/api/v1/consents/grantee/**', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([valid, { ...valid, id: '33333333-3333-4333-8333-333333333333', scopes: ['ALL_ACCESS'] }]),
+    }))
+
+    await page.goto('/consents')
+    await page.getByLabel(/Consent lookup lens|Pohled souhlasů/).selectOption('grantee')
+    await page.getByRole('button', { name: /Look up|Vyhledat/, exact: true }).click()
+
+    await expect(page.getByText('Verified Marketing Service')).toBeVisible()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeVisible()
+    await expect(page.getByText('ALL_ACCESS')).toBeHidden()
+    await expect(page.locator('p[role="alert"]')).toContainText(/Invalid consents excluded: 1|Vyřazené neplatné souhlasy: 1/)
+    await expect(page.getByText(/Nalezeno|Found/, { exact: true }).locator('..')).toContainText('1')
+  })
 })

--- a/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
@@ -20,8 +20,8 @@ test.describe('Consent lookup recovery', () => {
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify([{
-            id: '11111111-1111-1111-1111-111111111111',
-            partyId: '22222222-2222-2222-2222-222222222222',
+            id: '11111111-1111-4111-8111-111111111111',
+            partyId: '22222222-2222-4222-8222-222222222222',
             granteeId: 'party-service:marketing-comms',
             granteeType: 'INTERNAL_SERVICE',
             granteeName: 'Verified Marketing Service',
@@ -62,5 +62,30 @@ test.describe('Consent lookup recovery', () => {
     await expect(page.getByText('Verified Marketing Service')).toBeHidden()
     await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeHidden()
     expect(requests).toBe(successfulRequests + 2)
+  })
+
+  test('keeps verified evidence when a repeated lookup returns malformed authority', async ({ page }) => {
+    let malformed = false
+    await page.route('**/api/svc/consent-service/api/v1/consents/grantee/**', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([{
+        id: '11111111-1111-4111-8111-111111111111', partyId: '22222222-2222-4222-8222-222222222222',
+        granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE', granteeName: 'Verified Marketing Service',
+        scopes: malformed ? ['ALL_ACCESS'] : ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
+        validFrom: '2026-01-01T00:00:00Z', validTo: '2026-12-31T00:00:00Z', createdAt: '2026-01-01T00:00:00Z',
+      }]),
+    }))
+
+    await page.goto('/consents')
+    await page.getByLabel(/Consent lookup lens|Pohled souhlasů/).selectOption('grantee')
+    const lookup = page.getByRole('button', { name: /Look up|Vyhledat/, exact: true })
+    await lookup.click()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeVisible()
+
+    malformed = true
+    await lookup.click()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Consents|Načtení selhalo: Souhlasy/)).toBeVisible()
+    await expect(page.getByText('ALL_ACCESS')).toBeHidden()
   })
 })

--- a/openbank-admin-ui/e2e/party-lookup.spec.ts
+++ b/openbank-admin-ui/e2e/party-lookup.spec.ts
@@ -29,9 +29,9 @@ const A_360 = {
 const B_360 = { available: true, partyId: B.id, asOf: null, partyState: null, domains: [], accountIds: [], consents: [] }
 
 const A_CONSENTS = [{
-  id: 'c-1', partyId: A.id, granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL',
+  id: '11111111-1111-4111-8111-111111111111', partyId: A.id, granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE',
   granteeName: 'Marketing', scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
-  validFrom: '2026-01-01', validTo: '2027-01-01', createdAt: '2026-01-01',
+  validFrom: '2026-01-01T00:00:00Z', validTo: '2026-12-31T00:00:00Z', createdAt: '2026-01-01T00:00:00Z',
 }]
 
 async function stubSearch(page: import('@playwright/test').Page) {

--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -43,14 +43,14 @@ const READINESS = {
 
 const CONSENTS = [
   {
-    id: 'c1', partyId: '11111111-1111-1111-1111-111111111111',
+    id: '11111111-1111-4111-8111-111111111111', partyId: '11111111-1111-4111-8111-111111111111',
     granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE',
     granteeName: 'Party marketing preferences',
     scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
     validFrom: '2026-07-01T00:00:00Z', validTo: '2027-06-30T00:00:00Z', createdAt: '2026-07-01T00:00:00Z',
   },
   {
-    id: 'c2', partyId: '22222222-2222-2222-2222-222222222222',
+    id: '22222222-2222-4222-8222-222222222222', partyId: '22222222-2222-4222-8222-222222222222',
     granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE',
     granteeName: 'Party marketing preferences',
     scopes: ['MARKETING_COMMS_PUSH'], accountIbans: null, status: 'REVOKED',

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -37,6 +37,7 @@ export default function ConsentsPage() {
   const [loadedQuery, setLoadedQuery] = useState<string | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
+  const [excludedCount, setExcludedCount] = useState(0)
 
   // Only the NEWEST lookup may commit its result. Clearing state when the lens changes is not
   // enough: an in-flight request settles afterwards and repopulates it, so a party lookup's rows
@@ -57,6 +58,7 @@ export default function ConsentsPage() {
     if (!canRetainSnapshot) {
       setRows(null)
       setLoadedQuery(null)
+      setExcludedCount(0)
     }
     try {
       // The lens is read ONCE, at request time — never from the closure after the await, where it
@@ -70,12 +72,13 @@ export default function ConsentsPage() {
       }
       const raw = await res.json() as unknown
       if (gen !== generation.current) return
-      try {
-        setRows(parseConsentEvidenceList(raw))
-      } catch {
+      const parsed = parseConsentEvidenceList(raw)
+      if (!parsed.value || (parsed.value.length === 0 && parsed.excludedCount > 0)) {
         setFailure('error')
         return
       }
+      setRows(parsed.value)
+      setExcludedCount(parsed.excludedCount)
       setLoadedQuery(queryKey)
       // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
       // said "the data source contains no records yet", which an operator cannot tell apart from a
@@ -110,6 +113,7 @@ export default function ConsentsPage() {
                 setRows(null)
                 setLoadedQuery(null)
                 setFailure(null)
+                setExcludedCount(0)
                 setParty(null)
                 setLoading(false)
               }}
@@ -215,6 +219,15 @@ export default function ConsentsPage() {
           lang={language === 'cs' ? 'cs' : 'en'}
           dense={rows !== null}
         />
+      )}
+
+      {!loading && rows !== null && excludedCount > 0 && (
+        <p role="alert" style={{ margin: '0 0 20px', padding: '10px 12px', borderRadius: 8, color: 'var(--warning-text)', background: 'var(--warning-bg)', border: '1px solid var(--warning-border)', fontSize: 12 }}>
+          {t(
+            `Vyřazené neplatné souhlasy: ${excludedCount}. Zobrazené souhrny používají pouze ověřené záznamy.`,
+            `Invalid consents excluded: ${excludedCount}. Displayed totals use validated records only.`,
+          )}
+        </p>
       )}
 
       {/* Answered, but empty for this key. Distinct from an unavailable service (above): the earlier

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
+import { parseConsentEvidenceList, type ConsentEvidence } from '@/lib/consents/consentContract'
 
 // consent-service (ADR-0126) exposes NO "list all consents" endpoint — every read is keyed by
 // consentId, partyId or granteeId. So this is deliberately a LOOKUP page, not a table of everything:
@@ -22,20 +23,6 @@ import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
 // marketing consent right now" straight from the owning service, with no projection to drift.
 const MARKETING_GRANTEE = 'party-service:marketing-comms'
 
-interface Consent {
-  id: string
-  partyId: string
-  granteeId: string
-  granteeType: string
-  granteeName: string
-  scopes: string[]
-  accountIbans: string[] | null
-  status: string
-  validFrom: string
-  validTo: string
-  createdAt: string
-}
-
 type Lens = 'party' | 'grantee'
 
 export default function ConsentsPage() {
@@ -46,7 +33,7 @@ export default function ConsentsPage() {
   const [lens, setLens] = useState<Lens>('party')
   const [term, setTerm] = useState('')
   const [party, setParty] = useState<PartyHit | null>(null)
-  const [rows, setRows] = useState<Consent[] | null>(null)
+  const [rows, setRows] = useState<ConsentEvidence[] | null>(null)
   const [loadedQuery, setLoadedQuery] = useState<string | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
@@ -81,9 +68,14 @@ export default function ConsentsPage() {
         setFailure(await classifyBffFailure(res))
         return
       }
-      const data = (await res.json()) as Consent[]
+      const raw = await res.json() as unknown
       if (gen !== generation.current) return
-      setRows(data)
+      try {
+        setRows(parseConsentEvidenceList(raw))
+      } catch {
+        setFailure('error')
+        return
+      }
       setLoadedQuery(queryKey)
       // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
       // said "the data source contains no records yet", which an operator cannot tell apart from a

--- a/openbank-admin-ui/src/lib/consents/consentContract.ts
+++ b/openbank-admin-ui/src/lib/consents/consentContract.ts
@@ -29,6 +29,11 @@ export interface ConsentEvidence {
   createdAt: string
 }
 
+export interface ConsentEvidenceResult {
+  value: ConsentEvidence[] | null
+  excludedCount: number
+}
+
 const STATUSES = new Set<string>(CONSENT_STATUSES)
 const SCOPES = new Set<string>(CONSENT_SCOPES)
 const TYPES = new Set<string>(GRANTEE_TYPES)
@@ -87,7 +92,15 @@ function parseConsent(value: unknown): ConsentEvidence {
   }
 }
 
-export function parseConsentEvidenceList(raw: unknown): ConsentEvidence[] {
-  if (!Array.isArray(raw)) throw new Error('Invalid consent list')
-  return raw.map(parseConsent)
+export function parseConsentEvidenceList(raw: unknown): ConsentEvidenceResult {
+  if (!Array.isArray(raw)) return { value: null, excludedCount: 0 }
+  const value: ConsentEvidence[] = []
+  for (const candidate of raw) {
+    try {
+      value.push(parseConsent(candidate))
+    } catch {
+      // Keep independently valid consent evidence visible; the caller discloses every exclusion.
+    }
+  }
+  return { value, excludedCount: raw.length - value.length }
 }

--- a/openbank-admin-ui/src/lib/consents/consentContract.ts
+++ b/openbank-admin-ui/src/lib/consents/consentContract.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const CONSENT_STATUSES = ['PENDING_SCA', 'ACTIVE', 'EXPIRED', 'REVOKED', 'REJECTED', 'SUPERSEDED'] as const
+export type ConsentStatus = (typeof CONSENT_STATUSES)[number]
+
+export const CONSENT_SCOPES = [
+  'ACCOUNTS_READ', 'BALANCES_READ', 'TRANSACTIONS_READ', 'STATEMENTS_READ', 'PAYMENT_ACCOUNTS_READ',
+  'STANDING_ORDERS_READ', 'DIRECT_DEBITS_READ', 'PAYMENTS_INITIATE', 'PAYMENTS_STATUS_READ',
+  'DOMESTIC_PAYMENT_INITIATE', 'SIPO_PAYMENT_INITIATE', 'FUNDS_CONFIRMATION', 'AGENT_QUERY',
+  'AGENT_INITIATE', 'AGENT_NOTIFY', 'AGENT_ANALYZE', 'TELEMETRY_RUM', 'MARKETING_COMMS_EMAIL',
+  'MARKETING_COMMS_PUSH', 'MARKETING_COMMS_INAPP', 'CREDIT_OFFERS', 'CREDIT_PROFILE_USE', 'CREDIT_AI_AGENT',
+] as const
+export type ConsentScope = (typeof CONSENT_SCOPES)[number]
+
+export const GRANTEE_TYPES = ['TPP', 'BANK_AGENT', 'CUSTOMER_AGENT', 'INTERNAL_SERVICE'] as const
+export type GranteeType = (typeof GRANTEE_TYPES)[number]
+
+export interface ConsentEvidence {
+  id: string
+  partyId: string
+  granteeId: string
+  granteeType: GranteeType
+  granteeName: string
+  scopes: ConsentScope[]
+  accountIbans: string[] | null
+  status: ConsentStatus
+  validFrom: string
+  validTo: string
+  createdAt: string
+}
+
+const STATUSES = new Set<string>(CONSENT_STATUSES)
+const SCOPES = new Set<string>(CONSENT_SCOPES)
+const TYPES = new Set<string>(GRANTEE_TYPES)
+// Match java.util.UUID's wire shape without constraining the version nibble; the service contract
+// accepts UUIDs generally and may legitimately move from v4 to a newer allocation strategy.
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid consent ${field}`)
+  return value
+}
+
+function timestamp(record: Record<string, unknown>, field: string): string {
+  const value = requiredString(record, field)
+  if (Number.isNaN(Date.parse(value))) throw new Error(`Invalid consent ${field}`)
+  return value
+}
+
+function parseConsent(value: unknown): ConsentEvidence {
+  if (!isRecord(value)) throw new Error('Invalid consent evidence')
+  const id = requiredString(value, 'id')
+  const partyId = requiredString(value, 'partyId')
+  const granteeType = requiredString(value, 'granteeType')
+  const status = requiredString(value, 'status')
+  const validFrom = timestamp(value, 'validFrom')
+  const validTo = timestamp(value, 'validTo')
+  const createdAt = timestamp(value, 'createdAt')
+  if (!UUID.test(id) || !UUID.test(partyId)) throw new Error('Invalid consent identifier')
+  if (!TYPES.has(granteeType)) throw new Error('Invalid consent granteeType')
+  if (!STATUSES.has(status)) throw new Error('Invalid consent status')
+  if (!Array.isArray(value.scopes) || value.scopes.length === 0 || !value.scopes.every(scope => typeof scope === 'string' && SCOPES.has(scope))) {
+    throw new Error('Invalid consent scopes')
+  }
+  if (value.accountIbans !== null && (!Array.isArray(value.accountIbans) || !value.accountIbans.every(iban => typeof iban === 'string' && iban.trim() !== ''))) {
+    throw new Error('Invalid consent accountIbans')
+  }
+  if (Date.parse(validTo) <= Date.parse(validFrom)) throw new Error('Invalid consent validity')
+
+  return {
+    id,
+    partyId,
+    granteeId: requiredString(value, 'granteeId'),
+    granteeType: granteeType as GranteeType,
+    granteeName: requiredString(value, 'granteeName'),
+    scopes: value.scopes as ConsentScope[],
+    accountIbans: value.accountIbans as string[] | null,
+    status: status as ConsentStatus,
+    validFrom,
+    validTo,
+    createdAt,
+  }
+}
+
+export function parseConsentEvidenceList(raw: unknown): ConsentEvidence[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid consent list')
+  return raw.map(parseConsent)
+}

--- a/openbank-admin-ui/src/test/consent-contract.test.ts
+++ b/openbank-admin-ui/src/test/consent-contract.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseConsentEvidenceList } from '@/lib/consents/consentContract'
+
+const consent = {
+  id: '11111111-1111-4111-8111-111111111111',
+  partyId: '22222222-2222-4222-8222-222222222222',
+  granteeId: 'party-service:marketing-comms',
+  granteeType: 'INTERNAL_SERVICE',
+  granteeName: 'Marketing service',
+  scopes: ['MARKETING_COMMS_EMAIL'],
+  accountIbans: null,
+  status: 'ACTIVE',
+  validFrom: '2026-01-01T00:00:00Z',
+  validTo: '2026-12-31T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+}
+
+describe('consent response contract', () => {
+  it('preserves the authority and account-coverage evidence', () => {
+    expect(parseConsentEvidenceList([{ ...consent, accountIbans: ['CZ6508000000192000145399'] }]))
+      .toMatchObject([{ status: 'ACTIVE', scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: ['CZ6508000000192000145399'] }])
+  })
+
+  it.each([
+    [{ ...consent, status: 'APPROVED' }, 'status'],
+    [{ ...consent, scopes: ['ALL_ACCESS'] }, 'scopes'],
+    [{ ...consent, validTo: 'not-a-date' }, 'validTo'],
+    [{ ...consent, validTo: consent.validFrom }, 'validity'],
+  ])('rejects malformed consent evidence', (candidate, message) => {
+    expect(() => parseConsentEvidenceList([candidate])).toThrow(message)
+  })
+})

--- a/openbank-admin-ui/src/test/consent-contract.test.ts
+++ b/openbank-admin-ui/src/test/consent-contract.test.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { parseConsentEvidenceList } from '@/lib/consents/consentContract'
+
+const pageSource = readFileSync(path.resolve(__dirname, '../app/consents/page.tsx'), 'utf8')
 
 const consent = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -20,15 +24,27 @@ const consent = {
 describe('consent response contract', () => {
   it('preserves the authority and account-coverage evidence', () => {
     expect(parseConsentEvidenceList([{ ...consent, accountIbans: ['CZ6508000000192000145399'] }]))
-      .toMatchObject([{ status: 'ACTIVE', scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: ['CZ6508000000192000145399'] }])
+      .toMatchObject({ value: [{ status: 'ACTIVE', scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: ['CZ6508000000192000145399'] }], excludedCount: 0 })
   })
 
   it.each([
-    [{ ...consent, status: 'APPROVED' }, 'status'],
-    [{ ...consent, scopes: ['ALL_ACCESS'] }, 'scopes'],
-    [{ ...consent, validTo: 'not-a-date' }, 'validTo'],
-    [{ ...consent, validTo: consent.validFrom }, 'validity'],
-  ])('rejects malformed consent evidence', (candidate, message) => {
-    expect(() => parseConsentEvidenceList([candidate])).toThrow(message)
+    { ...consent, status: 'APPROVED' },
+    { ...consent, scopes: ['ALL_ACCESS'] },
+    { ...consent, validTo: 'not-a-date' },
+    { ...consent, validTo: consent.validFrom },
+  ])('excludes malformed consent evidence', candidate => {
+    expect(parseConsentEvidenceList([consent, candidate])).toEqual({ value: [consent], excludedCount: 1 })
+  })
+
+  it('distinguishes an invalid envelope from a legitimate empty lookup', () => {
+    expect(parseConsentEvidenceList({ consents: [] })).toEqual({ value: null, excludedCount: 0 })
+    expect(parseConsentEvidenceList([])).toEqual({ value: [], excludedCount: 0 })
+  })
+
+  it('discloses partial exclusions and rejects an all-invalid successful response', () => {
+    expect(pageSource).toContain('parsed.value.length === 0 && parsed.excludedCount > 0')
+    expect(pageSource).toContain('excludedCount > 0')
+    expect(pageSource).toContain('Displayed totals use validated records only.')
+    expect(pageSource).toContain('role="alert"')
   })
 })


### PR DESCRIPTION
Closes #9404\nCloses #9516\nRefs #7654\n\n## What\n\n- validate consent-service lookup responses against the real lifecycle, scope, grantee, identifier, account-coverage, and timestamp contract\n- reject invented authority such as unknown scopes or statuses\n- distinguish an invalid response envelope from a legitimate empty lookup\n- retain valid consent evidence from partially malformed responses, exclude invalid siblings, and disclose the exact excluded count\n- retain the last verified snapshot for the exact same lookup when a later response contains no valid evidence\n- preserve newest-request-wins behavior across party/grantee lens changes\n- update browser fixtures to use production-shaped consent evidence\n\n## Preserved behavior\n\n- compliance:view edge RBAC and read-only service endpoint\n- party and grantee lookup lenses, including the fixed marketing grantee\n- same-query snapshot recovery and cross-query state clearing\n- consent lifecycle/status semantics and account coverage\n\n## Verification\n\n- focused Vitest contract, accessibility, and route-permission coverage: 10/10 tests\n- TypeScript type-check\n- ESLint\n- production build: 97/97 routes\n- Playwright consent recovery: 3/3, including partial-evidence disclosure\n- Playwright party lookup and race recovery: 4/4