### PR TITLE
fix(party): unparseable status filter is a 400, never the unfiltered list

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -159,7 +159,17 @@ class PartyResource {
         @QueryParam("size") @DefaultValue("20") size: Int,
         @QueryParam("status") statusParam: String?,
     ): Response {
-        val status = statusParam?.uppercase()?.let { runCatching { PartyStatus.valueOf(it) }.getOrNull() }
+        // #9038: absent status means unfiltered; an UNPARSEABLE one must not silently drop the
+        // condition and answer the full list with a 200 (the #8699 shape). libs-runtime maps
+        // IllegalArgumentException to 400; never a service-local mapper (#526).
+        val status = statusParam?.uppercase()?.let {
+            runCatching { PartyStatus.valueOf(it) }
+                .getOrElse { _ ->
+                    throw IllegalArgumentException(
+                        "unknown status '$it'; expected one of ${PartyStatus.entries.joinToString()}",
+                    )
+                }
+        }
         // ADR-0067 pilot: first live feature-flag evaluation in the fleet. Cosmetic, fail-static —
         // surfaces the resolved variant in a response header so the flip is observable via curl,
         // without changing the response body or any business logic. Flag-as-code: party-list-enriched.

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
@@ -60,6 +60,35 @@ class PartyApiIT {
     }
 
     @Test
+    @Order(3)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_VIEWER"])
+    fun `GET parties with an unparseable status filter is a 400, not the unfiltered list`() {
+        // #9038: runCatching{}.getOrNull() used to drop the condition, answering every party
+        // with a 200 to a typo.
+        Given {
+            queryParam("status", "ACTVE")
+        } When {
+            get("/api/v1/parties")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    @Test
+    @Order(3)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_VIEWER"])
+    fun `GET parties with a valid status filter still answers 200`() {
+        Given {
+            queryParam("status", "ACTIVE")
+        } When {
+            get("/api/v1/parties")
+        } Then {
+            statusCode(200)
+            body("items", notNullValue())
+        }
+    }
+
+    @Test
     @Order(4)
     @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
     fun `POST parties creates individual party and returns 201`() {


### PR DESCRIPTION
Refs #9038

- `?status=` filter na `GET /api/v1/parties`: strict parse — absent = null, neparsovatelné = `IllegalArgumentException` → 400 se seznamem povolených hodnot (libs-runtime, #526). Dříve typo tiše dropnulo filtr a odpovědělo nefiltrovaný seznam s 200 (tvar #8699).
- Testy: PartyApiIT — typo → 400, valid → 200, absent → beze změny.