### PR TITLE
fix(admin-ui): make transaction evidence truthful

### DIFF
--- a/openbank-admin-ui/e2e/transactions-search-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/transactions-search-recovery.spec.ts
@@ -22,7 +22,7 @@ test.describe('Transaction ledger search recovery', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             data: [{
-              id: 'transaction-42',
+              id: '33333333-3333-4333-8333-333333333333',
               referenceNumber: 'TXN-EVIDENCE-42',
               type: 'CREDIT',
               sourceAccountId: '11111111-1111-1111-1111-111111111111',
@@ -34,9 +34,10 @@ test.describe('Transaction ledger search recovery', () => {
               valueDate: '2026-08-31',
               bookingDate: '2026-08-31',
               initiatedAt: '2026-08-31T08:00:00Z',
+              completedAt: '2026-08-31T08:00:01Z',
             }],
             count: 1,
-            limit: 50,
+            limit: 51,
             offset: 0,
           }),
         })
@@ -52,6 +53,9 @@ test.describe('Transaction ledger search recovery', () => {
 
     await expect(page.getByText('TXN-EVIDENCE-42')).toBeVisible()
     await expect(page.getByText('Verified settlement')).toBeVisible()
+    const amount = page.getByText(/1.*250.*CZK/).first()
+    await expect(amount).toBeVisible()
+    expect(await amount.textContent()).not.toMatch(/[+-]/)
 
     await page.getByRole('button', { name: /Search transactions|Vyhledat transakce/ }).click()
 
@@ -59,5 +63,62 @@ test.describe('Transaction ledger search recovery', () => {
     await expect(page.getByText('Verified settlement')).toBeVisible()
     await expect(page.getByText(/Failed to load: Transaction search|Načtení selhalo: Vyhledávání transakcí/)).toBeVisible()
     expect(requests).toBe(2)
+  })
+
+  test('rejects a malformed successful response without replacing verified money-path evidence', async ({ page }) => {
+    let malformed = false
+    await page.route('**/api/svc/transaction-service/api/v1/transactions/search**', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [{
+          id: '33333333-3333-4333-8333-333333333333', referenceNumber: 'TXN-EVIDENCE-42',
+          type: 'CREDIT', sourceAccountId: null, targetAccountId: '22222222-2222-4222-8222-222222222222',
+          amount: 1250, currencyCode: 'CZK', status: malformed ? 'SETTLED' : 'COMPLETED', description: 'Verified settlement',
+          valueDate: '2026-08-31', bookingDate: '2026-08-31', initiatedAt: '2026-08-31T08:00:00Z', completedAt: '2026-08-31T08:00:01Z',
+        }],
+        count: 1, limit: 51, offset: 0,
+      }),
+    }))
+
+    await page.goto('/transactions')
+    await page.getByLabel(/Filter by IBAN|Filtrovat podle IBAN/).fill('CZ6508000000192000145399')
+    const search = page.getByRole('button', { name: /Search transactions|Vyhledat transakce/ })
+    await search.click()
+    await expect(page.getByText('TXN-EVIDENCE-42')).toBeVisible()
+
+    malformed = true
+    await search.click()
+    await expect(page.getByText('TXN-EVIDENCE-42')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Transaction search|Načtení selhalo: Vyhledávání transakcí/)).toBeVisible()
+    await expect(page.getByText('SETTLED')).toBeHidden()
+  })
+
+  test('purges retained transaction evidence when authorization is lost', async ({ page }) => {
+    let unauthorized = false
+    await page.route('**/api/svc/transaction-service/api/v1/transactions/search**', route => {
+      if (unauthorized) return route.fulfill({ status: 401, contentType: 'application/json', body: '{"error":"unauthorized"}' })
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [{
+            id: '33333333-3333-4333-8333-333333333333', referenceNumber: 'TXN-PRIVATE-42',
+            type: 'CREDIT', sourceAccountId: null, targetAccountId: null, amount: 1250,
+            currencyCode: 'CZK', status: 'COMPLETED', description: 'Restricted evidence',
+            valueDate: '2026-08-31', bookingDate: '2026-08-31', initiatedAt: '2026-08-31T08:00:00Z', completedAt: '2026-08-31T08:00:01Z',
+          }],
+          count: 1, limit: 51, offset: 0,
+        }),
+      })
+    })
+
+    await page.goto('/transactions')
+    const search = page.getByRole('button', { name: /Search transactions|Vyhledat transakce/ })
+    await search.click()
+    await expect(page.getByText('TXN-PRIVATE-42')).toBeVisible()
+
+    unauthorized = true
+    await search.click()
+    await expect(page.getByText(/Session expired|Vypršela relace/i)).toBeVisible()
+    await expect(page.getByText('TXN-PRIVATE-42')).toHaveCount(0)
   })
 })

--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -13,6 +13,12 @@ import { PageHeader, StatusBadge } from '@/components/ui'
 import { ContextualInsights } from '@/components/insights/ContextualInsights'
 import { PAYMENT_INSIGHTS } from '@/components/insights/catalog'
 import { Can } from '@/components/auth/AuthGuard'
+import {
+  parseTransactionSearchResult,
+  TRANSACTION_STATUSES,
+  TRANSACTION_TYPES,
+  type TransactionSearchResult,
+} from '@/lib/transactions/transactionSearchContract'
 
 const TYPE_COLOR: Record<string, string> = {
   DEBIT:      'var(--danger)',
@@ -24,40 +30,19 @@ const TYPE_COLOR: Record<string, string> = {
   ADJUSTMENT: 'var(--text-tertiary)',
 }
 
-interface TxResult {
-  id: string
-  referenceNumber: string
-  type: string
-  sourceAccountId?: string
-  targetAccountId?: string
-  amount: number
-  currencyCode: string
-  status: string
-  description?: string
-  valueDate: string
-  bookingDate: string
-  initiatedAt: string
-  completedAt?: string
-}
-
-interface SearchResult {
-  data: TxResult[]
-  count: number
-  limit: number
-  offset: number
-}
-
-const CHANNELS = ['API', 'BRANCH', 'ATM', 'MOBILE', 'INTERNET', 'BATCH']
-const STATUSES = ['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED', 'REVERSED']
-const TYPES    = ['DEBIT', 'CREDIT', 'TRANSFER', 'FEE', 'INTEREST', 'REVERSAL', 'ADJUSTMENT']
 const PAGE_SIZE = 50
+const REQUEST_SIZE = PAGE_SIZE + 1
+
+interface TransactionResultPage extends TransactionSearchResult {
+  hasNextPage: boolean
+}
 
 export default function TransactionsPage() {
   const { t, language } = useLanguage()
   const [showFilters, setShowFilters] = useState(false)
   const [loading, setLoading] = useState(false)
   const [failure, setFailure] = useState<BffFailure | null>(null)
-  const [result, setResult] = useState<SearchResult | null>(null)
+  const [result, setResult] = useState<TransactionResultPage | null>(null)
   const [resultQueryKey, setResultQueryKey] = useState<string | null>(null)
   const searchGeneration = useRef(0)
   const activeRequest = useRef<AbortController | null>(null)
@@ -75,10 +60,9 @@ export default function TransactionsPage() {
   const [dateTo, setDateTo]               = useState('')
   const [amountMin, setAmountMin]         = useState('')
   const [amountMax, setAmountMax]         = useState('')
-  const [channel, setChannel]             = useState('')
 
-  const hasFilters = [iban, bban, referenceNumber, endToEndId, counterparty, status, type, dateFrom, dateTo, amountMin, amountMax, channel].some(Boolean)
-  const queryKey = [accountId, iban, bban, referenceNumber, endToEndId, counterparty, status, type, dateFrom, dateTo, amountMin, amountMax, channel].join('\u0000')
+  const hasFilters = [iban, bban, referenceNumber, endToEndId, counterparty, status, type, dateFrom, dateTo, amountMin, amountMax].some(Boolean)
+  const queryKey = [accountId, iban, bban, referenceNumber, endToEndId, counterparty, status, type, dateFrom, dateTo, amountMin, amountMax].join('\u0000')
   const queryChanged = result !== null && resultQueryKey !== queryKey
 
   useEffect(() => () => {
@@ -104,7 +88,12 @@ export default function TransactionsPage() {
     const controller = new AbortController()
     activeRequest.current = controller
     const requestedQueryKey = queryKey
+    const canRetainSnapshot = result !== null && resultQueryKey === requestedQueryKey
     setLoading(true); setFailure(null)
+    if (!canRetainSnapshot) {
+      setResult(null)
+      setResultQueryKey(null)
+    }
     try {
       const params = new URLSearchParams()
       if (accountId)     params.set('accountId', accountId)
@@ -119,13 +108,13 @@ export default function TransactionsPage() {
       if (dateTo)        params.set('dateTo', dateTo)
       if (amountMin)     params.set('amountMin', amountMin)
       if (amountMax)     params.set('amountMax', amountMax)
-      if (channel)       params.set('channel', channel)
-      params.set('limit', String(PAGE_SIZE))
+      // One-row lookahead removes the false "Next" affordance when a page has exactly 50 rows.
+      params.set('limit', String(REQUEST_SIZE))
       params.set('offset', String(offset))
 
       const res = await fetch(
         svcUrl('transaction-service', '/api/v1/transactions/search', Object.fromEntries(params)),
-        { cache: 'no-store', signal: controller.signal },
+        { cache: 'no-store', signal: AbortSignal.any([controller.signal, AbortSignal.timeout(8_000)]) },
       )
       if (generation !== searchGeneration.current) return
       if (!res.ok) {
@@ -134,12 +123,35 @@ export default function TransactionsPage() {
         // sandbox), not that the search itself failed. Distinguish the cases so
         // the operator sees a meaningful state instead of a raw "HTTP 404".
         const nextFailure = await classifyBffFailure(res)
-        if (generation === searchGeneration.current) setFailure(nextFailure)
+        if (generation === searchGeneration.current) {
+          if (res.status === 401 || res.status === 403) {
+            setResult(null)
+            setResultQueryKey(null)
+          }
+          setFailure(res.status === 401 || res.status === 403 ? 'unauthorized' : nextFailure)
+        }
         return
       }
-      const nextResult = await res.json() as SearchResult
+      const raw = await res.json() as unknown
       if (generation !== searchGeneration.current) return
-      setResult(nextResult)
+      let nextResult: TransactionSearchResult
+      try {
+        nextResult = parseTransactionSearchResult(raw)
+      } catch {
+        setFailure('error')
+        return
+      }
+      if (nextResult.limit !== REQUEST_SIZE || nextResult.offset !== offset) {
+        setFailure('error')
+        return
+      }
+      setResult({
+        ...nextResult,
+        data: nextResult.data.slice(0, PAGE_SIZE),
+        count: Math.min(nextResult.count, PAGE_SIZE),
+        limit: PAGE_SIZE,
+        hasNextPage: nextResult.data.length > PAGE_SIZE,
+      })
       setResultQueryKey(requestedQueryKey)
     } catch {
       // Network-level failure (BFF unreachable from the browser).
@@ -154,7 +166,7 @@ export default function TransactionsPage() {
     invalidatePendingSearch()
     setIban(''); setBban(''); setReferenceNumber(''); setEndToEndId('')
     setCounterparty(''); setStatus(''); setType(''); setDateFrom('')
-    setDateTo(''); setAmountMin(''); setAmountMax(''); setChannel('')
+    setDateTo(''); setAmountMin(''); setAmountMax('')
   }
 
   return (
@@ -201,7 +213,7 @@ export default function TransactionsPage() {
           </div>
           <button type="button" className="btn btn-secondary" onClick={() => setShowFilters(f => !f)} aria-expanded={showFilters} aria-controls="transaction-search-filters">
             <Filter size={13} />
-            {hasFilters ? <span style={{ color: 'var(--accent)' }}>{t('Filtry', 'Filters')} ({[iban,bban,referenceNumber,endToEndId,counterparty,status,type,dateFrom,dateTo,amountMin,amountMax,channel].filter(Boolean).length})</span> : t('Filtry', 'Filters')}
+            {hasFilters ? <span style={{ color: 'var(--accent)' }}>{t('Filtry', 'Filters')} ({[iban,bban,referenceNumber,endToEndId,counterparty,status,type,dateFrom,dateTo,amountMin,amountMax].filter(Boolean).length})</span> : t('Filtry', 'Filters')}
           </button>
           <button type="button" className="btn btn-primary" onClick={() => search()} disabled={loading} aria-busy={loading} aria-label={loading ? t('Vyhledávání transakcí', 'Searching transactions') : t('Vyhledat transakce', 'Search transactions')}>
             {loading ? <RefreshCw size={13} aria-hidden="true" className="animate-spin" /> : <Search size={13} aria-hidden="true" />}
@@ -229,21 +241,14 @@ export default function TransactionsPage() {
                 <label htmlFor="transaction-status" style={{ fontSize: '11px', color: 'var(--text-tertiary)', display: 'block', marginBottom: '4px' }}>{t('Status', 'Status')}</label>
                 <select id="transaction-status" className="input" style={{ width: '100%' }} value={status} onChange={e => updateSearchField(setStatus, e.target.value)}>
                   <option value="">{t('Vše', 'All')}</option>
-                  {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                  {TRANSACTION_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
                 </select>
               </div>
               <div>
                 <label htmlFor="transaction-type" style={{ fontSize: '11px', color: 'var(--text-tertiary)', display: 'block', marginBottom: '4px' }}>{t('Typ transakce', 'Transaction type')}</label>
                 <select id="transaction-type" className="input" style={{ width: '100%' }} value={type} onChange={e => updateSearchField(setType, e.target.value)}>
                   <option value="">{t('Vše', 'All')}</option>
-                  {TYPES.map(ty => <option key={ty} value={ty}>{ty}</option>)}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="transaction-channel" style={{ fontSize: '11px', color: 'var(--text-tertiary)', display: 'block', marginBottom: '4px' }}>{t('Kanál', 'Channel')}</label>
-                <select id="transaction-channel" className="input" style={{ width: '100%' }} value={channel} onChange={e => updateSearchField(setChannel, e.target.value)}>
-                  <option value="">{t('Vše', 'All')}</option>
-                  {CHANNELS.map(c => <option key={c} value={c}>{c}</option>)}
+                  {TRANSACTION_TYPES.map(ty => <option key={ty} value={ty}>{ty}</option>)}
                 </select>
               </div>
               <div>
@@ -308,12 +313,12 @@ export default function TransactionsPage() {
                     <tr key={tx.id}>
                       <td style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '11px' }}>{tx.referenceNumber}</td>
                       <td><span style={{ fontSize: '11px', fontWeight: 600, color: TYPE_COLOR[tx.type] || 'var(--text-secondary)' }}>{tx.type}</span></td>
-                      <td style={{ fontWeight: 600, color: tx.type === 'DEBIT' ? 'var(--danger)' : 'var(--success)' }}>
-                        {tx.type === 'DEBIT' ? '-' : '+'}{Number(tx.amount).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB', { minimumFractionDigits: 2 })} {tx.currencyCode}
+                      <td style={{ fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
+                        {tx.amount.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB', { minimumFractionDigits: 2 })} {tx.currencyCode}
                       </td>
                       <td><StatusBadge status={tx.status} /></td>
-                      <td style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-tertiary)' }}>{tx.sourceAccountId?.slice(0, 8)}…</td>
-                      <td style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-tertiary)' }}>{tx.targetAccountId?.slice(0, 8)}…</td>
+                      <td style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-tertiary)' }}>{tx.sourceAccountId ? `${tx.sourceAccountId.slice(0, 8)}…` : '—'}</td>
+                      <td style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-tertiary)' }}>{tx.targetAccountId ? `${tx.targetAccountId.slice(0, 8)}…` : '—'}</td>
                       <td style={{ maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '12px' }}>{tx.description || '—'}</td>
                       <td style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{tx.bookingDate}</td>
                     </tr>
@@ -335,7 +340,7 @@ export default function TransactionsPage() {
                 type="button"
                 className="btn btn-secondary btn-sm"
                 aria-label={t('Další stránka transakcí', 'Next transaction page')}
-                disabled={loading || queryChanged || result.data.length !== PAGE_SIZE}
+                disabled={loading || queryChanged || !result.hasNextPage}
                 onClick={() => search(result.offset + PAGE_SIZE)}
               >
                 {t('Další', 'Next')}

--- a/openbank-admin-ui/src/lib/transactions/transactionSearchContract.ts
+++ b/openbank-admin-ui/src/lib/transactions/transactionSearchContract.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const TRANSACTION_TYPES = ['DEBIT', 'CREDIT', 'TRANSFER', 'FEE', 'INTEREST', 'REVERSAL', 'ADJUSTMENT'] as const
+export type TransactionType = (typeof TRANSACTION_TYPES)[number]
+export const TRANSACTION_STATUSES = ['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED', 'REVERSED'] as const
+export type TransactionStatus = (typeof TRANSACTION_STATUSES)[number]
+
+export interface TransactionSearchRow {
+  id: string
+  referenceNumber: string
+  type: TransactionType
+  sourceAccountId: string | null
+  targetAccountId: string | null
+  amount: number
+  currencyCode: string
+  status: TransactionStatus
+  description: string | null
+  valueDate: string
+  bookingDate: string
+  initiatedAt: string
+  completedAt: string | null
+}
+
+export interface TransactionSearchResult {
+  data: TransactionSearchRow[]
+  count: number
+  limit: number
+  offset: number
+}
+
+const TYPES = new Set<string>(TRANSACTION_TYPES)
+const STATUSES = new Set<string>(TRANSACTION_STATUSES)
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, field: string, maxLength = 500): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '' || value.length > maxLength) throw new Error(`Invalid transaction ${field}`)
+  return value
+}
+
+function nullableString(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  return stringField(record, field)
+}
+
+function numberField(record: Record<string, unknown>, field: string): number {
+  const value = record[field]
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid transaction ${field}`)
+  return value
+}
+
+function dateField(record: Record<string, unknown>, field: string): string {
+  const value = stringField(record, field)
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00Z`) : null
+  if (!parsed || Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Invalid transaction ${field}`)
+  }
+  return value
+}
+
+function timestampField(record: Record<string, unknown>, field: string): string {
+  const value = stringField(record, field)
+  if (!RFC3339.test(value) || Number.isNaN(Date.parse(value))) throw new Error(`Invalid transaction ${field}`)
+  return value
+}
+
+function nullableUuid(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  const parsed = stringField(record, field)
+  if (!UUID.test(parsed)) throw new Error(`Invalid transaction ${field}`)
+  return parsed
+}
+
+function parseRow(value: unknown): TransactionSearchRow {
+  if (!isRecord(value)) throw new Error('Invalid transaction row')
+  const id = stringField(value, 'id')
+  const type = stringField(value, 'type')
+  const status = stringField(value, 'status')
+  const amount = numberField(value, 'amount')
+  const currencyCode = stringField(value, 'currencyCode')
+  const initiatedAt = timestampField(value, 'initiatedAt')
+  const completedAt = value.completedAt === null ? null : timestampField(value, 'completedAt')
+  if (!UUID.test(id)) throw new Error('Invalid transaction id')
+  if (!TYPES.has(type)) throw new Error('Invalid transaction type')
+  if (!STATUSES.has(status)) throw new Error('Invalid transaction status')
+  if (amount <= 0) throw new Error('Invalid transaction amount')
+  if (!/^[A-Z]{3}$/.test(currencyCode)) throw new Error('Invalid transaction currencyCode')
+
+  return {
+    id,
+    referenceNumber: stringField(value, 'referenceNumber', 200),
+    type: type as TransactionType,
+    sourceAccountId: nullableUuid(value, 'sourceAccountId'),
+    targetAccountId: nullableUuid(value, 'targetAccountId'),
+    amount,
+    currencyCode,
+    status: status as TransactionStatus,
+    description: nullableString(value, 'description'),
+    valueDate: dateField(value, 'valueDate'),
+    bookingDate: dateField(value, 'bookingDate'),
+    initiatedAt,
+    completedAt,
+  }
+}
+
+export function parseTransactionSearchResult(raw: unknown): TransactionSearchResult {
+  if (!isRecord(raw) || !Array.isArray(raw.data)) throw new Error('Invalid transaction search result')
+  const count = numberField(raw, 'count')
+  const limit = numberField(raw, 'limit')
+  const offset = numberField(raw, 'offset')
+  if (![count, limit, offset].every(Number.isInteger) || count < 0 || limit <= 0 || limit > 200 || offset < 0) {
+    throw new Error('Invalid transaction pagination')
+  }
+  if (count !== raw.data.length || count > limit) throw new Error('Invalid transaction count')
+  const data = raw.data.map(parseRow)
+  if (new Set(data.map(row => row.id)).size !== data.length) throw new Error('Duplicate transaction id')
+  for (const row of data) {
+    const completed = row.status === 'COMPLETED' || row.status === 'REVERSED'
+    if (completed !== (row.completedAt !== null)) throw new Error('Invalid transaction lifecycle')
+    if (row.completedAt && Date.parse(row.completedAt) < Date.parse(row.initiatedAt)) throw new Error('Invalid transaction lifecycle')
+  }
+  return { data, count, limit, offset }
+}

--- a/openbank-admin-ui/src/test/transaction-search-contract.test.ts
+++ b/openbank-admin-ui/src/test/transaction-search-contract.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseTransactionSearchResult } from '@/lib/transactions/transactionSearchContract'
+
+const row = {
+  id: '11111111-1111-4111-8111-111111111111', referenceNumber: 'TXN-42', type: 'CREDIT',
+  sourceAccountId: null, targetAccountId: '22222222-2222-4222-8222-222222222222', amount: 1250,
+  currencyCode: 'CZK', status: 'COMPLETED', description: 'Settlement', valueDate: '2026-09-09',
+  bookingDate: '2026-09-09', initiatedAt: '2026-09-09T08:00:00Z', completedAt: '2026-09-09T08:00:01Z',
+}
+
+describe('transaction search response contract', () => {
+  it('preserves money-path and paging evidence', () => {
+    expect(parseTransactionSearchResult({ data: [row], count: 1, limit: 50, offset: 0 }))
+      .toMatchObject({ data: [{ amount: 1250, currencyCode: 'CZK', status: 'COMPLETED' }], count: 1, limit: 50, offset: 0 })
+  })
+
+  it.each([
+    [{ ...row, status: 'SETTLED' }, 'status'],
+    [{ ...row, type: 'PAYMENT' }, 'type'],
+    [{ ...row, amount: Number.NaN }, 'amount'],
+    [{ ...row, currencyCode: 'CZ' }, 'currencyCode'],
+    [{ ...row, bookingDate: '2026-02-30' }, 'bookingDate'],
+  ])('rejects malformed transaction evidence', (candidate, message) => {
+    expect(() => parseTransactionSearchResult({ data: [candidate], count: 1, limit: 50, offset: 0 })).toThrow(message)
+  })
+
+  it('rejects paging metadata that does not describe the returned window', () => {
+    expect(() => parseTransactionSearchResult({ data: [row], count: 0, limit: 50, offset: 0 })).toThrow('count')
+  })
+
+  it.each([
+    [{ ...row, initiatedAt: '2026-09-09 08:00:00' }, 'initiatedAt'],
+    [{ ...row, status: 'PENDING', completedAt: row.completedAt }, 'lifecycle'],
+    [{ ...row, status: 'COMPLETED', completedAt: null }, 'lifecycle'],
+    [{ ...row, completedAt: '2026-09-09T07:59:59Z' }, 'lifecycle'],
+    [{ ...row, referenceNumber: 'x'.repeat(201) }, 'referenceNumber'],
+  ])('rejects ambiguous transaction evidence', (candidate, message) => {
+    expect(() => parseTransactionSearchResult({ data: [candidate], count: 1, limit: 50, offset: 0 })).toThrow(message)
+  })
+
+  it('rejects duplicate transaction identities', () => {
+    expect(() => parseTransactionSearchResult({ data: [row, row], count: 2, limit: 50, offset: 0 })).toThrow('Duplicate')
+  })
+})

--- a/openbank-admin-ui/src/test/transactions-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/transactions-pagination.test.tsx
@@ -13,20 +13,24 @@ vi.mock('@/components/auth/AuthGuard', () => ({
 
 function transaction(index: number) {
   return {
-    id: `transaction-${index}`,
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
     referenceNumber: `TXN-${String(index).padStart(3, '0')}`,
     type: 'CREDIT',
+    sourceAccountId: null,
+    targetAccountId: null,
     amount: 100 + index,
     currencyCode: 'CZK',
     status: 'COMPLETED',
+    description: null,
     valueDate: '2026-09-01',
     bookingDate: '2026-09-01',
     initiatedAt: '2026-09-01T08:00:00Z',
+    completedAt: '2026-09-01T08:00:01Z',
   }
 }
 
 function resultResponse(data: ReturnType<typeof transaction>[], offset: number) {
-  return new Response(JSON.stringify({ data, count: data.length, limit: 50, offset }), {
+  return new Response(JSON.stringify({ data, count: data.length, limit: 51, offset }), {
     status: 200,
     headers: { 'content-type': 'application/json' },
   })
@@ -40,7 +44,7 @@ afterEach(() => {
 
 describe('Transaction search pagination', () => {
   it('requests the next 50-row page with offset 50', async () => {
-    const firstPage = Array.from({ length: 50 }, (_, index) => transaction(index))
+    const firstPage = Array.from({ length: 51 }, (_, index) => transaction(index))
     const secondPage = [transaction(50)]
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(String(input), 'https://admin.openbank.example')
@@ -64,12 +68,12 @@ describe('Transaction search pagination', () => {
     expect(screen.getByRole('button', { name: 'Next transaction page' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Previous transaction page' })).toBeEnabled()
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(String(fetchMock.mock.calls[0][0])).toContain('limit=50&offset=0')
-    expect(String(fetchMock.mock.calls[1][0])).toContain('limit=50&offset=50')
+    expect(String(fetchMock.mock.calls[0][0])).toContain('limit=51&offset=0')
+    expect(String(fetchMock.mock.calls[1][0])).toContain('limit=51&offset=50')
   })
 
   it('resets to offset 0 when a changed filter is searched', async () => {
-    const firstPage = Array.from({ length: 50 }, (_, index) => transaction(index))
+    const firstPage = Array.from({ length: 51 }, (_, index) => transaction(index))
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(String(input), 'https://admin.openbank.example')
       const offset = Number(url.searchParams.get('offset'))
@@ -92,11 +96,11 @@ describe('Transaction search pagination', () => {
     await screen.findByText('TXN-099')
     const latestUrl = String(fetchMock.mock.calls.at(-1)?.[0])
     expect(latestUrl).toContain('iban=CZ6508000000192000145399')
-    expect(latestUrl).toContain('limit=50&offset=0')
+    expect(latestUrl).toContain('limit=51&offset=0')
   })
 
   it('does not let a superseded page response replace a newer search', async () => {
-    const firstPage = Array.from({ length: 50 }, (_, index) => transaction(index))
+    const firstPage = Array.from({ length: 51 }, (_, index) => transaction(index))
     let resolveNextPage: ((response: Response) => void) | undefined
     const nextPage = new Promise<Response>(resolve => { resolveNextPage = resolve })
     const fetchMock = vi.fn(async (input: string | URL | Request) => {

--- a/openbank-admin-ui/src/test/transactions-search.guard.test.ts
+++ b/openbank-admin-ui/src/test/transactions-search.guard.test.ts
@@ -12,4 +12,16 @@ describe('transactions search contract', () => {
     expect(source).toContain("t('Vyhledat transakce', 'Search transactions')")
     expect(source).toContain('onClick={() => search()}')
   })
+
+  it('does not offer or send the unsupported channel filter', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/transactions/page.tsx'), 'utf8')
+    expect(source).not.toContain('transaction-channel')
+    expect(source).not.toContain("params.set('channel'")
+  })
+
+  it('does not invent an account-relative sign in the global ledger', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/transactions/page.tsx'), 'utf8')
+    expect(source).not.toContain("tx.type === 'DEBIT' ? '-' : '+'")
+    expect(source).toContain("fontVariantNumeric: 'tabular-nums'")
+  })
 })


### PR DESCRIPTION
Closes #9407

## What
- remove the unsupported channel filter that transaction-service silently ignored
- validate and sanitize search pages and money-path rows against the real lifecycle, type, amount, currency, calendar date, strict RFC 3339 timestamp, identifier and paging contracts
- reject duplicate transaction identities, oversized rendered fields and impossible completion lifecycles
- retain the last verified result only for the exact same query after technical or malformed refresh failures
- purge retained evidence atomically after 401/403 and bound every search request to 8 seconds
- use a 51-row lookahead so exactly-full pages do not advertise a false Next page
- stop inventing account-relative `+`/`-` signs in the global ledger and render absent source/target accounts explicitly

## Verification
- transaction-focused Vitest: 5 files, 21 tests
- `npm run type-check`
- targeted ESLint: zero findings
- production build: 97/97 routes
- production Chromium transaction recovery/value/auth coverage: 3/3
- `git diff --check`