### PR TITLE
fix(kyc): unparseable status filter is a 400, never the unfiltered list

### DIFF
--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/rest/KycResource.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/rest/KycResource.kt
@@ -71,7 +71,17 @@ class KycResource {
         @QueryParam("size") @DefaultValue("20") size: Int,
         @QueryParam("status") statusParam: String?,
     ): Response {
-        val status = statusParam?.uppercase()?.let { runCatching { KycCaseStatus.valueOf(it) }.getOrNull() }
+        // #9038: absent status means unfiltered; an UNPARSEABLE one must not silently drop the
+        // condition and answer the full list with a 200 (the #8699 shape). libs-runtime maps
+        // IllegalArgumentException to 400; never a service-local mapper (#526).
+        val status = statusParam?.uppercase()?.let {
+            runCatching { KycCaseStatus.valueOf(it) }
+                .getOrElse { _ ->
+                    throw IllegalArgumentException(
+                        "unknown status '$it'; expected one of ${KycCaseStatus.entries.joinToString()}",
+                    )
+                }
+        }
         // Echo the EFFECTIVE window, never the raw query values. `size` was already clamped for the
         // query and echoed un-clamped, so `?size=500` answered `"size": 500` over at most 100 rows —
         // a caller computing ceil(total / size) off that pages past the end and renders a short list

--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -3,7 +3,9 @@
 openapi: 3.1.0
 info:
   title: KYC Service API
-  version: 1.9.0
+  # 1.9.0 -> 1.10.0 (#9038): additive — the list operation declares the 400 it already answers
+  # for an unparseable ?status= filter.
+  version: 1.10.0
   description: Know Your Customer case management — open cases, run checks, approve/reject.
   license:
     name: Apache-2.0
@@ -46,6 +48,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KycCasePage'
+        '400':
+          description: >-
+            The status filter is present but not one of the declared enum values — answered 400
+            since #9038; an unparseable filter never silently degrades to the unfiltered list.
     post:
       tags: [KYC]
       summary: Open a KYC case

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycCasePageApiContractTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycCasePageApiContractTest.kt
@@ -277,6 +277,28 @@ class KycCasePageApiContractTest {
         spec.at("/paths/${pointer(CASES_PATH)}/get/responses/200/content/application~1json/schema"),
     )
 
+    // --------------------------------------------------------------- unparseable filter is loud
+
+    @Test
+    fun `the spec declares the 400 an unparseable status filter answers`() {
+        val declared = spec.at("/paths/${pointer(CASES_PATH)}/get/responses")
+        assertThat(declared.has("400"))
+            .describedAs("%s must declare the 400 for GET %s — it is the contract since #9038", SPEC_PATH, CASES_PATH)
+            .isTrue()
+    }
+
+    @Test
+    @TestSecurity(user = "contract-test", roles = ["ROLE_ADMIN"])
+    fun `an unparseable status filter is a 400, never the unfiltered list`() {
+        // #9038: runCatching{}.getOrNull() used to drop the condition, answering every case with a
+        // 200 to a typo — the #8699 shape. Absent stays unfiltered, unparseable is loud.
+        given()
+            .get("$CASES_PATH?status=APPRVED")
+            .then().statusCode(400)
+        listCases("?status=APPROVED")
+        listCases()
+    }
+
     /** `(minimum, maximum)` the spec declares for the `size` query parameter. */
     private fun sizeParameterBounds(): Pair<Int, Int> {
         val schema = spec.at("/paths/${pointer(CASES_PATH)}/get/parameters")


### PR DESCRIPTION
Refs #9038

- `?status=` filter na `GET /api/v1/kyc/cases`: strict parse — absent = null, neparsovatelné = 400 (libs-runtime). Dříve typo tiše dropnulo filtr (tvar #8699).
- openapi 1.9.0 → 1.10.0: operace nově deklaruje 400, který reálně odpovídá.
- Testy: KycCasePageApiContractTest — typo → 400, valid/absent → 200, plus spec deklaruje 400.