### PR TITLE
fix(card-issuance): corrupted persisted closedReason is LOUD, never a silent null

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
@@ -16,7 +16,18 @@ fun CardEntity.toDomain() = Card(
     currency = currency, deliveryAddress = deliveryAddress,
     activatedAt = activatedAt, blockedAt = blockedAt, blockedReason = blockedReason,
     expiresAt = expiresAt,
-    closedReason = closedReason?.let { r -> runCatching { CardClosedReason.valueOf(r) }.getOrNull() },
+    // #9038: a persisted value that does not parse is data corruption — be LOUD, never silently
+    // null the field back into the domain (#9037's strictPersisted shape). Every other enum on
+    // this row already throws via valueOf; closedReason was the silent exception.
+    closedReason = closedReason?.let { r ->
+        runCatching { CardClosedReason.valueOf(r) }
+            .getOrElse { _ ->
+                throw IllegalStateException(
+                    "persisted card $id has unparseable closedReason '$r'; " +
+                        "expected one of ${CardClosedReason.entries.joinToString()}",
+                )
+            }
+    },
     createdAt = createdAt, updatedAt = updatedAt,
     contactlessEnabled = contactlessEnabled, onlineEnabled = onlineEnabled,
     atmEnabled = atmEnabled, abroadEnabled = abroadEnabled,

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/persistence/CardMapperUpdateParityTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/persistence/CardMapperUpdateParityTest.kt
@@ -11,8 +11,10 @@ import com.openbank.cardissuance.domain.model.CardStatus
 import com.openbank.cardissuance.domain.model.CardType
 import com.openbank.cardissuance.infrastructure.persistence.entity.CardEntity
 import com.openbank.cardissuance.infrastructure.persistence.mapper.applyFrom
+import com.openbank.cardissuance.infrastructure.persistence.mapper.toDomain
 import com.openbank.cardissuance.infrastructure.persistence.mapper.toEntity
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.LocalDate
@@ -112,5 +114,19 @@ class CardMapperUpdateParityTest {
                 drifted,
             )
             .isEmpty()
+    }
+
+    @Test
+    fun `read-back of an unparseable persisted closedReason is LOUD, never a silent null`() {
+        // #9038: a corrupted persisted value must raise — getOrNull used to null the field back
+        // into the domain and the corruption stayed invisible.
+        val corrupted = card().toEntity().also { it.closedReason = "SINGLE_USE_CONSUMD" }
+        assertThatThrownBy { corrupted.toDomain() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SINGLE_USE_CONSUMD")
+
+        val valid = card().toEntity().also { it.closedReason = "SINGLE_USE_CONSUMED" }
+        assertThat(valid.toDomain().closedReason).isEqualTo(CardClosedReason.SINGLE_USE_CONSUMED)
+        assertThat(card(closedReason = null).toEntity().toDomain().closedReason).isNull()
     }
 }


### PR DESCRIPTION
Refs #9038

- `CardMapper.toDomain` read-back: `runCatching{}.getOrNull()` tiše znullingoval neparsovatelnou persistovanou hodnotu — data corruption prošla jako legitimní null. Teď `IllegalStateException` (id karty, špatná hodnota, povolená množina), stejný tvar jako #9037 strictPersisted.
- Test: garbage → raise, valid → parse, null → null.

## Security checklist

- [x] No secrets, keys, or credentials added
- [x] Input validation preserved or strengthened (unknown enum on read-back now fails fast instead of being silently coerced)
- [x] No new external network calls
- [x] Threat model reviewed — no change to trust boundaries (`docs/threat-models/card-issuance.md` unchanged)
- [x] Audit/logging unaffected
