### PR TITLE
fix(admin-ui): validate fraud review evidence

### DIFF
--- a/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from '@playwright/test'
 import { signInAsOperator } from './helpers/auth'
 
 const reviewRecord = {
-  scoreId: 'score-001',
+  scoreId: '11111111-1111-4111-8111-111111111111',
   amount: 125000,
   currency: 'CZK',
   rail: 'SCT_INST',
-  accountId: 'account-12345678',
-  counterpartyId: 'party-87654321',
+  accountId: '22222222-2222-4222-8222-222222222222',
+  counterpartyId: '33333333-3333-4333-8333-333333333333',
   verdict: 'REVIEW',
   score: 91,
   ruleVersion: 'fraud-rules-2026.08',
@@ -29,6 +29,25 @@ test.beforeEach(async ({ context, baseURL, page }) => {
       expires: '2099-01-01T00:00:00.000Z',
     }),
   }))
+})
+
+test('retains verified evidence when a refresh returns a non-review row', async ({ page }) => {
+  let wrongVerdict = false
+  await page.route('**/api/svc/fraud-service/api/v1/fraud/review-queue**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([{ ...reviewRecord, verdict: wrongVerdict ? 'ALLOW' : 'REVIEW' }]),
+  }))
+
+  await page.goto('/fraud')
+  await expect(page.getByText('fraud-rules-2026.08')).toBeVisible({ timeout: 20_000 })
+
+  wrongVerdict = true
+  await page.getByRole('button', { name: /Obnovit frontu podvodů|Refresh fraud queue/ }).click()
+
+  await expect(page.getByText('fraud-rules-2026.08')).toBeVisible()
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible()
+  await expect(page.getByText('ALLOW')).toBeHidden()
 })
 
 test('retains the bounded fraud evidence snapshot when refresh fails', async ({ page }) => {

--- a/openbank-admin-ui/src/app/fraud/page.tsx
+++ b/openbank-admin-ui/src/app/fraud/page.tsx
@@ -14,19 +14,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
-
-type ScoredRecord = {
-  scoreId: string
-  amount: number
-  currency: string
-  rail: string
-  accountId: string | null
-  counterpartyId: string | null
-  verdict: string
-  score: number
-  ruleVersion: string
-  createdAt: string
-}
+import { parseFraudReviewQueue, type FraudReviewEvidence } from '@/lib/fraud/fraudReviewContract'
 
 function scoreTone(score: number): Tone {
   if (score >= 80) return 'danger'
@@ -37,7 +25,7 @@ function scoreTone(score: number): Tone {
 export default function FraudPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const [rows, setRows] = useState<ScoredRecord[]>([])
+  const [rows, setRows] = useState<FraudReviewEvidence[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [hasSnapshot, setHasSnapshot] = useState(false)
@@ -51,8 +39,15 @@ export default function FraudPage() {
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
-      const data = await res.json() as unknown
-      setRows(Array.isArray(data) ? data as ScoredRecord[] : [])
+      const raw = await res.json() as unknown
+      let nextRows: FraudReviewEvidence[]
+      try {
+        nextRows = parseFraudReviewQueue(raw)
+      } catch {
+        setUnavailable({ kind: 'error' })
+        return
+      }
+      setRows(nextRows)
       setHasSnapshot(true)
       setLastUpdatedAt(new Date())
       setUnavailable(null)

--- a/openbank-admin-ui/src/lib/fraud/fraudReviewContract.ts
+++ b/openbank-admin-ui/src/lib/fraud/fraudReviewContract.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface FraudReviewEvidence {
+  scoreId: string
+  amount: number
+  currency: string
+  rail: string
+  accountId: string | null
+  counterpartyId: string | null
+  verdict: 'REVIEW'
+  score: number
+  ruleVersion: string
+  createdAt: string
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid fraud ${field}`)
+  return value
+}
+
+function nullableUuid(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  const parsed = stringField(record, field)
+  if (!UUID.test(parsed)) throw new Error(`Invalid fraud ${field}`)
+  return parsed
+}
+
+function parseFraudReview(value: unknown): FraudReviewEvidence {
+  if (!isRecord(value)) throw new Error('Invalid fraud review evidence')
+  const scoreId = stringField(value, 'scoreId')
+  const amount = value.amount
+  const score = value.score
+  const currency = stringField(value, 'currency')
+  const verdict = stringField(value, 'verdict')
+  const createdAt = stringField(value, 'createdAt')
+  if (!UUID.test(scoreId)) throw new Error('Invalid fraud scoreId')
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) throw new Error('Invalid fraud amount')
+  if (typeof score !== 'number' || !Number.isInteger(score) || score < 0) throw new Error('Invalid fraud score')
+  if (!/^[A-Z]{3}$/.test(currency)) throw new Error('Invalid fraud currency')
+  if (verdict !== 'REVIEW') throw new Error('Invalid fraud verdict')
+  if (Number.isNaN(Date.parse(createdAt))) throw new Error('Invalid fraud createdAt')
+
+  return {
+    scoreId,
+    amount,
+    currency,
+    rail: stringField(value, 'rail'),
+    accountId: nullableUuid(value, 'accountId'),
+    counterpartyId: nullableUuid(value, 'counterpartyId'),
+    verdict: 'REVIEW',
+    score,
+    ruleVersion: stringField(value, 'ruleVersion'),
+    createdAt,
+  }
+}
+
+export function parseFraudReviewQueue(raw: unknown): FraudReviewEvidence[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid fraud review queue')
+  return raw.map(parseFraudReview)
+}

--- a/openbank-admin-ui/src/test/fraud-review-contract.test.ts
+++ b/openbank-admin-ui/src/test/fraud-review-contract.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseFraudReviewQueue } from '@/lib/fraud/fraudReviewContract'
+
+const row = {
+  scoreId: '11111111-1111-4111-8111-111111111111', amount: 125000, currency: 'CZK', rail: 'SCT_INST',
+  accountId: '22222222-2222-4222-8222-222222222222', counterpartyId: null, verdict: 'REVIEW', score: 91,
+  ruleVersion: 'v4', createdAt: '2026-09-09T08:15:00Z',
+}
+
+describe('fraud review response contract', () => {
+  it('preserves review and rule-version evidence', () => {
+    expect(parseFraudReviewQueue([row])).toMatchObject([{ verdict: 'REVIEW', score: 91, ruleVersion: 'v4' }])
+  })
+
+  it.each([
+    [{ ...row, verdict: 'ALLOW' }, 'verdict'],
+    [{ ...row, score: -1 }, 'score'],
+    [{ ...row, amount: Number.NaN }, 'amount'],
+    [{ ...row, currency: 'CZ' }, 'currency'],
+    [{ ...row, createdAt: 'not-a-date' }, 'createdAt'],
+  ])('rejects malformed analyst evidence', (candidate, message) => {
+    expect(() => parseFraudReviewQueue([candidate])).toThrow(message)
+  })
+})


### PR DESCRIPTION
Closes #9412

## What
- validate fraud review rows against the persisted evidence contract
- enforce the endpoint invariant that every row is a `REVIEW` verdict
- reject invalid scores, amounts, currencies, identifiers, rule versions, rails, and timestamps
- preserve the last verified bounded snapshot when a later successful refresh is malformed

## Verification
- focused Vitest contract coverage: 6 tests
- TypeScript type-check
- ESLint
- production build: 97/97 routes
- Playwright fraud recovery coverage: 2/2

## Dependency
Stacked on `security/admin-ui-sharp-0.35.4`. Merge only after that base lands, exact-head CI is green, and an eligible independent review is present.
