### PR TITLE
fix(kyb): unparseable declared legal form class throws, never silently OTHER

### DIFF
--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/ManualAttestationRegistryAdapter.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/ManualAttestationRegistryAdapter.kt
@@ -40,9 +40,19 @@ class ManualAttestationRegistryAdapter : RegistryAdapter {
             identifier = identifier,
             legalName = d.legalName.trim(),
             legalFormCode = null,
+            // #9038: an absent declaration maps to OTHER (nothing was claimed), but an
+            // UNPARSEABLE one used to silently become OTHER too — a typo in the applicant's
+            // legal form was persisted as a wrong fact. Strict: IllegalArgumentException,
+            // which libs-runtime maps to 400 at the REST boundary (#526).
             legalFormClass =
             d.legalFormClass?.let {
-                runCatching { LegalFormClass.valueOf(it) }.getOrNull()
+                runCatching { LegalFormClass.valueOf(it) }
+                    .getOrElse { _ ->
+                        throw IllegalArgumentException(
+                            "unknown legal form class '$it'; expected one of " +
+                                LegalFormClass.entries.joinToString(),
+                        )
+                    }
             } ?: LegalFormClass.OTHER,
             status = EntityStatus.UNKNOWN,
             registeredAddress = RegisteredAddress(d.addressLine1, d.city, d.postalCode, d.countryCode.uppercase()),

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/infrastructure/registry/ManualAttestationRegistryAdapterTest.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/infrastructure/registry/ManualAttestationRegistryAdapterTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.infrastructure.registry
+
+import com.openbank.kyb.application.port.`in`.DeclaredEntity
+import com.openbank.kyb.domain.model.IdentifierScheme
+import com.openbank.kyb.domain.model.LegalEntityIdentifier
+import com.openbank.kyb.domain.model.LegalFormClass
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * #9038: a declared legal form class that does not parse must be a 400-boundary error, not a
+ * silently persisted `OTHER` — a typo in the applicant's legal form was written as a wrong fact.
+ */
+class ManualAttestationRegistryAdapterTest {
+
+    private val adapter = ManualAttestationRegistryAdapter().apply {
+        clock = Clock.fixed(Instant.parse("2026-09-05T10:00:00Z"), ZoneOffset.UTC)
+    }
+
+    private val ico = LegalEntityIdentifier.of(IdentifierScheme.CZ_ICO, "45274649")
+
+    private fun declared(legalFormClass: String?) = DeclaredEntity(
+        legalName = "Příklad s.r.o.",
+        countryCode = "cz",
+        legalFormClass = legalFormClass,
+        addressLine1 = "Hlavní 1",
+        city = "Praha",
+        postalCode = "11000",
+    )
+
+    @Test
+    fun `an absent legal form class still maps to OTHER`(): Unit = runBlocking {
+        assertThat(adapter.lookup(ico, declared(null))!!.legalFormClass).isEqualTo(LegalFormClass.OTHER)
+    }
+
+    @Test
+    fun `a valid declared legal form class is honoured`(): Unit = runBlocking {
+        assertThat(adapter.lookup(ico, declared("LIMITED_COMPANY"))!!.legalFormClass)
+            .isEqualTo(LegalFormClass.LIMITED_COMPANY)
+    }
+
+    @Test
+    fun `an unparseable declared legal form class throws, never degrades to OTHER`(): Unit = runBlocking {
+        assertThatThrownBy {
+            runBlocking { adapter.lookup(ico, declared("LIMITED_COMPNAY")) }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("LIMITED_COMPNAY")
+            .hasMessageContaining("LIMITED_COMPANY")
+    }
+}


### PR DESCRIPTION
Refs #9038

- `ManualAttestationRegistryAdapter`: neparsovatelný `legalFormClass` z deklarace žadatele se tiše persistoval jako `OTHER` (write-path silent corruption). Teď `IllegalArgumentException` → 400; absent → OTHER zůstává.
- Test: absent → OTHER, valid → honored, typo → throw.