### PR TITLE
fix(onboarding): recognised event with unparseable status dead-letters, never silently dropped

### DIFF
--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -48,6 +48,16 @@ import java.util.UUID
  * ack that loses an Art. 17 erasure silently, but they are different incidents — read
  * `application.yaml` per channel rather than assuming either. (#5751 wires all three to
  * `dead-letter-queue`, with explicit `openbank.dlq.onboarding.<channel>` topics.)
+ *
+ * **A recognised event type carrying an unparseable status is NOT a poison pill (#9038).** The old
+ * `runCatching { X.valueOf(raw) }.getOrNull() ?: return null` mapped a typo'd or renamed status
+ * onto the same path as an event type we legitimately ignore: the record was acked, the
+ * UNRECOGNISED counter moved, and the funnel silently stopped seeing the party. That conflates two
+ * different situations — "we don't care about this event type" (ack, correct) and "we care, the
+ * producer changed the vocabulary, and every replay will fail the same way until the code or the
+ * data is fixed" (nack; the DLQ keeps it for exactly that investigation). So the parsers throw
+ * [UnparseableStatusException] for the second case, and the consume methods rethrow it after
+ * recording the FAILED metric.
  */
 @ApplicationScoped
 class OnboardingEventConsumer(private val clock: Clock) {
@@ -94,6 +104,10 @@ class OnboardingEventConsumer(private val clock: Clock) {
 
         val event = try {
             parsePartyEvent(node)
+        } catch (e: UnparseableStatusException) {
+            // Recognised event type, unrecognised status vocabulary: nack, do not ack (#9038).
+            metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.FAILED)
+            throw e
         } catch (e: Exception) {
             log.errorf(e, "[party-events-in] Failed to map event: %.200s", payload)
             metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.FAILED)
@@ -136,7 +150,9 @@ class OnboardingEventConsumer(private val clock: Clock) {
             "PARTY_STATUS_CHANGED", "KYC_STATUS_UPDATED", "KYC_STATUS_CHANGED" -> {
                 val rawStatus = node.path("newStatus").asText().takeIf { it.isNotBlank() }
                     ?: node.path("status").asText()
-                val stage = runCatching { PartyStage.valueOf(rawStatus) }.getOrNull() ?: return null
+                val stage = runCatching { PartyStage.valueOf(rawStatus) }.getOrElse {
+                    throw UnparseableStatusException(type, rawStatus, PartyStage::class.simpleName ?: "PartyStage")
+                }
                 OnboardingEvent.PartyStatusChanged(partyId, stage, occurredAt)
             }
             else -> null
@@ -168,7 +184,9 @@ class OnboardingEventConsumer(private val clock: Clock) {
                         "KYC_CASE_REJECTED" -> "REJECTED"
                         else -> return null
                     }
-                val stage = runCatching { KycStage.valueOf(rawStatus) }.getOrNull() ?: return null
+                val stage = runCatching { KycStage.valueOf(rawStatus) }.getOrElse {
+                    throw UnparseableStatusException(type, rawStatus, KycStage::class.simpleName ?: "KycStage")
+                }
                 OnboardingEvent.KycStatusChanged(partyId, caseId, stage, occurredAt)
             }
             else -> null
@@ -206,6 +224,10 @@ class OnboardingEventConsumer(private val clock: Clock) {
         }
         val event = try {
             parse(node)
+        } catch (e: UnparseableStatusException) {
+            // Recognised event type, unrecognised status vocabulary: nack, do not ack (#9038).
+            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
+            throw e
         } catch (e: Exception) {
             log.errorf(e, "[%s] Failed to map event: %.200s", topic, payload)
             metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
@@ -274,3 +296,14 @@ private fun partyIdOf(event: OnboardingEvent): UUID = when (event) {
     is OnboardingEvent.KycStatusChanged -> event.partyId
     is OnboardingEvent.DeviceEnrolled -> event.partyId
 }
+
+/**
+ * A recognised event type carried a status value the enum no longer knows (#9038). Distinct from
+ * "event type we ignore" (parsed to null, acked) and from "malformed JSON" (logged, acked): this
+ * one means the producer's vocabulary drifted from ours, and every replay fails identically until
+ * code or data changes — exactly what the DLQ exists to hold. Thrown by the parsers, recorded as
+ * FAILED, then rethrown so the record is nacked. Extends [IllegalStateException] so any catch site
+ * that already special-cases mapping failures still sees it as one.
+ */
+class UnparseableStatusException(eventType: String, rawStatus: String, enumName: String) :
+    IllegalStateException("Event $eventType carried status '$rawStatus' not present in $enumName")

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/OnboardingRepositoryImpl.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/OnboardingRepositoryImpl.kt
@@ -139,7 +139,15 @@ private fun OnboardingEntity.toDomain() = OnboardingRecord(
     email = email,
     partyStatus = PartyStage.valueOf(partyStatus),
     kycCaseId = kycCaseId,
-    kycStatus = kycStatus?.let { runCatching { KycStage.valueOf(it) }.getOrNull() },
+    // Read-back must fail fast, never coerce to null (#9038): a kycStatus the enum no longer
+    // knows means the stored vocabulary drifted from the code — silently returning null would
+    // report the case as "no KYC status" and the funnel would quietly lose the party. The two
+    // siblings already throw via valueOf; this one now does too.
+    kycStatus = kycStatus?.let {
+        runCatching { KycStage.valueOf(it) }.getOrElse { e ->
+            throw IllegalStateException("onboarding.kycStatus '$it' not present in KycStage", e)
+        }
+    },
     scaEnrolled = scaEnrolled,
     deviceCount = deviceCount,
     funnelStage = FunnelStage.valueOf(funnelStage),

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
@@ -332,6 +332,59 @@ class OnboardingEventConsumerTest {
         coVerify(exactly = 0) { projection.eraseParty(any()) }
         coVerify(exactly = 0) { projection.applyEvent(any()) }
     }
+
+    // ── Unparseable status on a RECOGNISED event type (#9038) ────────────────
+
+    /**
+     * The defect class: `runCatching { X.valueOf(raw) }.getOrNull() ?: return null` made a typo'd
+     * or renamed status indistinguishable from an event type we legitimately ignore — acked,
+     * counted UNRECOGNISED, gone. A recognised type with an unknown status is vocabulary drift
+     * between producer and consumer; it must be nacked so the DLQ keeps the record, and the
+     * projection must never see it.
+     */
+    @Test
+    fun `a recognised party status event with an unparseable status is nacked, never acked`() {
+        val payload = """{"eventType":"PARTY_STATUS_CHANGED","partyId":"${UUID.randomUUID()}","newStatus":"ACTVE"}"""
+
+        assertThatThrownBy {
+            runBlocking { consumer.consumePartyEvent(payload) }
+        }.isInstanceOf(UnparseableStatusException::class.java)
+
+        verify(exactly = 1) { metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
+        verify(exactly = 0) {
+            metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED)
+        }
+        coVerify(exactly = 0) { projection.applyEvent(any()) }
+    }
+
+    @Test
+    fun `a recognised kyc case event with an unparseable status is nacked, never acked`() {
+        val payload = """{"eventType":"KYC_CASE_STATUS_CHANGED","partyId":"${UUID.randomUUID()}",""" +
+            """"kycCaseId":"${UUID.randomUUID()}","status":"UNDER_REVEW"}"""
+
+        assertThatThrownBy {
+            runBlocking { consumer.consumeKycEvent(payload) }
+        }.isInstanceOf(UnparseableStatusException::class.java)
+
+        verify(exactly = 1) { metrics.record("kyc-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
+        coVerify(exactly = 0) { projection.applyEvent(any()) }
+    }
+
+    /**
+     * The other half of the boundary: an event type this consumer does not care about is still a
+     * normal ack — only the status drift on a recognised type is an incident.
+     */
+    @Test
+    fun `an unrecognised event type remains acked and counted UNRECOGNISED`(): Unit = runBlocking {
+        consumer.consumePartyEvent(
+            """{"eventType":"PARTY_PREFERENCE_CHANGED","partyId":"${UUID.randomUUID()}"}""",
+        )
+
+        verify(exactly = 1) {
+            metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED)
+        }
+        coVerify(exactly = 0) { projection.applyEvent(any()) }
+    }
 }
 
 /** A downstream dependency failing — the transient case, named so the tests read as intent. */


### PR DESCRIPTION
## Summary

- `OnboardingEventConsumer`: a recognised event type carrying a status the enum no longer knows now throws `UnparseableStatusException`; the consume methods record the FAILED metric and rethrow, so the record is nacked and the channel's `dead-letter-queue` failure-strategy (#5751) keeps it. Previously `runCatching { valueOf }.getOrNull() ?: return null` acked it as UNRECOGNISED — producer/consumer vocabulary drift was invisible and the funnel silently lost the party.
- `OnboardingRepositoryImpl.toDomain`: read-back of an unknown `kycStatus` coerced to null ("no KYC status"); now fails fast like the two sibling enum fields.
- Tests: unparseable status on `party-events-in` and `kyc-events-in` is nacked and never reaches the projection; unrecognised event types remain acked/UNRECOGNISED.

Refs #9038

## Security checklist

- [x] No secrets, keys, or credentials added
- [x] Input validation preserved or strengthened (unknown enum values now fail loudly instead of being silently dropped or coerced to null)
- [x] No new external network calls
- [x] Threat model reviewed — no change to trust boundaries (`docs/threat-models/onboarding.md` unchanged)
- [x] Audit/logging unaffected (FAILED metric recorded before rethrow, matching the existing projection-failure path)
