### PR TITLE
fix(admin-ui): paginate merchant catalogue

### DIFF
--- a/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
@@ -32,7 +32,7 @@ test('keeps the current merchant page visible when its refresh is malformed', as
 
   await page.goto('/merchants')
   await expect(page.getByText('First merchant')).toBeVisible()
-  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
   await expect(page.getByText('Second merchant')).toBeVisible()
   await expect(page.getByText('Showing 51–51 of 51')).toBeVisible()
 

--- a/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const merchant = (descriptorKey: string, cleanName: string) => ({
+  descriptorKey,
+  cleanName,
+  logoUrl: null,
+  logoContentHash: null,
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+})
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the current merchant page visible when its refresh is malformed', async ({ page }) => {
+  let malformed = false
+  await page.route('**/api/svc/transaction-service/api/v1/merchants/unmatched**', route => route.fulfill({ json: [] }))
+  await page.route('**/api/svc/transaction-service/api/v1/merchants?**', route => {
+    const requestedPage = new URL(route.request().url()).searchParams.get('page')
+    const row = requestedPage === '1' ? merchant('SECOND', 'Second merchant') : merchant('FIRST', 'First merchant')
+    if (malformed && requestedPage === '1') row.updatedAt = 'not-a-date'
+    return route.fulfill({ json: { data: [row], total: 51 } })
+  })
+
+  await page.goto('/merchants')
+  await expect(page.getByText('First merchant')).toBeVisible()
+  await page.getByRole('button', { name: 'Next' }).click()
+  await expect(page.getByText('Second merchant')).toBeVisible()
+  await expect(page.getByText('Showing 51–51 of 51')).toBeVisible()
+
+  malformed = true
+  await page.getByRole('button', { name: 'Refresh the merchant catalogue' }).click()
+  await expect(page.getByText('Second merchant')).toBeVisible()
+  await expect(page.getByText(/Načtení selhalo|Failed to load/)).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -22,26 +22,13 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui'
+import { parseMerchantCataloguePage, parseUnmatchedMerchantDescriptors, type MerchantCatalogueRow, type UnmatchedMerchantDescriptor } from '@/lib/merchants/merchantCatalogueContract'
 
 const SERVICE = 'transaction-service'
 const CATALOGUE = '/api/v1/merchants'
 
-type Merchant = {
-  descriptorKey: string
-  cleanName: string
-  /** Provenance — where the stored bitmap came from. NOT the URL a customer app is given. */
-  logoUrl?: string | null
-  /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
-  logoContentHash?: string | null
-  category?: string | null
-  lat?: number | null
-  lon?: number | null
-  city?: string | null
-  country?: string | null
-  updatedAt?: string
-}
-
-type Unmatched = { descriptorKey: string; occurrences: number }
+type Merchant = MerchantCatalogueRow
+type Unmatched = UnmatchedMerchantDescriptor
 
 type Draft = {
   descriptorKey: string
@@ -56,12 +43,15 @@ type Draft = {
 type PendingRemoval = { kind: 'entry' | 'logo'; merchant: Merchant }
 
 const EMPTY_DRAFT: Draft = { descriptorKey: '', cleanName: '', category: '', city: '', country: '', lat: '', lon: '' }
+const PAGE_SIZE = 50
 
 export default function MerchantsPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [rows, setRows] = useState<Merchant[]>([])
   const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(0)
+  const loadedPage = useRef<number | null>(null)
   const [unmatched, setUnmatched] = useState<Unmatched[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
@@ -72,23 +62,29 @@ export default function MerchantsPage() {
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null)
   const [removing, setRemoving] = useState(false)
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (requestedPage: number) => {
+    const canRetainSnapshot = loadedPage.current === requestedPage
     setLoading(true)
+    if (!canRetainSnapshot) { setRows([]); setTotal(0); loadedPage.current = null }
     try {
       const [listRes, unmatchedRes] = await Promise.all([
-        fetch(svcUrl(SERVICE, CATALOGUE, { size: '100' }), { cache: 'no-store' }),
+        fetch(svcUrl(SERVICE, CATALOGUE, { page: String(requestedPage), size: String(PAGE_SIZE) }), { cache: 'no-store' }),
         fetch(svcUrl(SERVICE, `${CATALOGUE}/unmatched`, { limit: '25' }), { cache: 'no-store' }),
       ])
       if (!listRes.ok) {
         setUnavailable({ kind: await classifyBffFailure(listRes) })
         return
       }
-      const page = await listRes.json() as { data?: Merchant[]; total?: number }
-      setRows(Array.isArray(page.data) ? page.data : [])
-      setTotal(typeof page.total === 'number' ? page.total : 0)
+      let nextPage
+      try { nextPage = parseMerchantCataloguePage(await listRes.json() as unknown, PAGE_SIZE) } catch { setUnavailable({ kind: 'error' }); return }
+      const lastPage = nextPage.total === 0 ? 0 : Math.floor((nextPage.total - 1) / PAGE_SIZE)
+      if (requestedPage > lastPage) { setPage(lastPage); return }
+      setRows(nextPage.data); setTotal(nextPage.total); loadedPage.current = requestedPage
       // The worklist failing must not blank the catalogue: they are separate reads, and a stale
       // or empty worklist is a smaller loss than losing the rows an operator is editing.
-      setUnmatched(unmatchedRes.ok ? (await unmatchedRes.json() as Unmatched[]) : [])
+      if (unmatchedRes.ok) {
+        try { setUnmatched(parseUnmatchedMerchantDescriptors(await unmatchedRes.json() as unknown)) } catch { /* independent worklist drift must not blank catalogue */ }
+      }
       setUnavailable(null)
     } catch {
       setUnavailable({ kind: 'unreachable' })
@@ -97,7 +93,7 @@ export default function MerchantsPage() {
     }
   }, [])
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => { void load(page) }, [load, page])
 
   const save = async () => {
     if (!draft) return
@@ -124,7 +120,7 @@ export default function MerchantsPage() {
         return
       }
       setDraft(null)
-      await load()
+      await load(page)
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
     } finally {
@@ -142,7 +138,7 @@ export default function MerchantsPage() {
         setActionError(t('Smazání selhalo', 'Delete failed'))
         return false
       }
-      await load()
+      await load(page)
       return true
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
@@ -180,7 +176,7 @@ export default function MerchantsPage() {
         setActionError(body?.message ?? t('Nahrání loga selhalo', 'The logo upload failed'))
         return
       }
-      await load()
+      await load(page)
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
     } finally {
@@ -199,7 +195,7 @@ export default function MerchantsPage() {
         setActionError(t('Smazání loga selhalo', 'Deleting the logo failed'))
         return false
       }
-      await load()
+      await load(page)
       return true
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
@@ -230,7 +226,7 @@ export default function MerchantsPage() {
         )}
         icon={<Store size={20} style={{ color: 'var(--accent)' }} />}
         actions={<button
-          onClick={load}
+          onClick={() => void load(page)}
           disabled={loading}
           type="button"
           aria-busy={loading}
@@ -253,7 +249,7 @@ export default function MerchantsPage() {
         dense={rows.length > 0}
       />}
 
-      {!unavailable && <>
+      {(!unavailable || rows.length > 0) && <>
         <section className="card" style={{ marginBottom: 18 }}>
           <h2 style={{ fontSize: 14, margin: '0 0 4px' }}>{t('Nespárované descriptory', 'Unmatched descriptors')}</h2>
           <p style={{ fontSize: 12, color: 'var(--text-tertiary)', margin: '0 0 10px' }}>
@@ -394,6 +390,15 @@ export default function MerchantsPage() {
               )}
             </tbody>
           </table>
+          <nav aria-label={t('Stránkování katalogu obchodníků', 'Merchant catalogue pagination')} style={{ padding: '12px 14px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+            <span aria-live="polite" style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>
+              {total === 0 ? t('Žádné záznamy', 'No entries') : t(`Zobrazeno ${page * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE + rows.length, total)} z ${total}`, `Showing ${page * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE + rows.length, total)} of ${total}`)}
+            </span>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" className="btn btn-secondary btn-sm" disabled={loading || unavailable !== null || page === 0} onClick={() => setPage(current => Math.max(0, current - 1))}>{t('Předchozí', 'Previous')}</button>
+              <button type="button" className="btn btn-secondary btn-sm" disabled={loading || unavailable !== null || (page + 1) * PAGE_SIZE >= total} onClick={() => setPage(current => current + 1)}>{t('Další', 'Next')}</button>
+            </div>
+          </nav>
         </div>
       </>}
       {pendingRemoval && <MerchantRemovalDialog

--- a/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
+++ b/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface MerchantCatalogueRow {
+  descriptorKey: string
+  cleanName: string
+  logoUrl: string | null
+  logoContentHash: string | null
+  category: string | null
+  lat: number | null
+  lon: number | null
+  city: string | null
+  country: string | null
+  updatedAt: string
+}
+
+export interface MerchantCataloguePage { data: MerchantCatalogueRow[]; total: number }
+export interface UnmatchedMerchantDescriptor { descriptorKey: string; occurrences: number }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid merchant ${field}`)
+  return value
+}
+
+function nullableString(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  return requiredString(record, field)
+}
+
+function nullableNumber(record: Record<string, unknown>, field: string): number | null {
+  const value = record[field]
+  if (value === null) return null
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid merchant ${field}`)
+  return value
+}
+
+function parseMerchant(value: unknown): MerchantCatalogueRow {
+  if (!isRecord(value)) throw new Error('Invalid merchant row')
+  const lat = nullableNumber(value, 'lat')
+  const lon = nullableNumber(value, 'lon')
+  const updatedAt = requiredString(value, 'updatedAt')
+  if ((lat === null) !== (lon === null) || (lat !== null && (lat < -90 || lat > 90)) || (lon !== null && (lon < -180 || lon > 180))) throw new Error('Invalid merchant location')
+  if (Number.isNaN(Date.parse(updatedAt))) throw new Error('Invalid merchant updatedAt')
+  return {
+    descriptorKey: requiredString(value, 'descriptorKey'), cleanName: requiredString(value, 'cleanName'),
+    logoUrl: nullableString(value, 'logoUrl'), logoContentHash: nullableString(value, 'logoContentHash'),
+    category: nullableString(value, 'category'), lat, lon, city: nullableString(value, 'city'),
+    country: nullableString(value, 'country'), updatedAt,
+  }
+}
+
+export function parseMerchantCataloguePage(raw: unknown, pageSize: number): MerchantCataloguePage {
+  if (!isRecord(raw) || !Array.isArray(raw.data) || typeof raw.total !== 'number' || !Number.isInteger(raw.total) || raw.total < 0) throw new Error('Invalid merchant page')
+  if (raw.data.length > pageSize || raw.data.length > raw.total) throw new Error('Invalid merchant page window')
+  return { data: raw.data.map(parseMerchant), total: raw.total }
+}
+
+export function parseUnmatchedMerchantDescriptors(raw: unknown): UnmatchedMerchantDescriptor[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid unmatched merchant list')
+  return raw.map(value => {
+    if (!isRecord(value)) throw new Error('Invalid unmatched merchant')
+    const occurrences = value.occurrences
+    if (typeof occurrences !== 'number' || !Number.isInteger(occurrences) || occurrences <= 0) throw new Error('Invalid merchant occurrences')
+    return { descriptorKey: requiredString(value, 'descriptorKey'), occurrences }
+  })
+}

--- a/openbank-admin-ui/src/test/merchant-catalogue-contract.test.ts
+++ b/openbank-admin-ui/src/test/merchant-catalogue-contract.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseMerchantCataloguePage, parseUnmatchedMerchantDescriptors } from '@/lib/merchants/merchantCatalogueContract'
+
+const row = { descriptorKey: 'BILLA', cleanName: 'Billa', logoUrl: null, logoContentHash: null, category: 'GROCERIES', lat: 50.0755, lon: 14.4378, city: 'Praha', country: 'CZ', updatedAt: '2026-09-09T08:00:00Z' }
+
+describe('merchant catalogue response contract', () => {
+  it('preserves the complete catalogue page and worklist evidence', () => {
+    expect(parseMerchantCataloguePage({ data: [row], total: 51 }, 50)).toMatchObject({ total: 51, data: [{ descriptorKey: 'BILLA' }] })
+    expect(parseUnmatchedMerchantDescriptors([{ descriptorKey: 'ALZACZ', occurrences: 42 }])).toEqual([{ descriptorKey: 'ALZACZ', occurrences: 42 }])
+  })
+  it.each([[{ ...row, cleanName: '' }, 'cleanName'], [{ ...row, lon: null }, 'location'], [{ ...row, lat: 91 }, 'location'], [{ ...row, updatedAt: 'not-a-date' }, 'updatedAt']])('rejects malformed catalogue rows', (candidate, message) => {
+    expect(() => parseMerchantCataloguePage({ data: [candidate], total: 1 }, 50)).toThrow(message)
+  })
+  it('rejects impossible page windows and unmatched counts', () => {
+    expect(() => parseMerchantCataloguePage({ data: [row], total: 0 }, 50)).toThrow('window')
+    expect(() => parseUnmatchedMerchantDescriptors([{ descriptorKey: 'ALZACZ', occurrences: 0 }])).toThrow('occurrences')
+  })
+})

--- a/openbank-admin-ui/src/test/merchants-logo.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo.test.tsx
@@ -11,8 +11,20 @@ vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: 
 
 const HASH = 'a'.repeat(64)
 
-const withLogo = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: HASH }
-const withoutLogo = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+const merchant = (descriptorKey: string, cleanName: string, logoContentHash: string | null) => ({
+  descriptorKey,
+  cleanName,
+  logoUrl: null,
+  logoContentHash,
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+})
+const withLogo = merchant('BILLA', 'Billa', HASH)
+const withoutLogo = merchant('ALZACZ', 'Alza.cz', null)
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })

--- a/openbank-admin-ui/src/test/merchants-removal-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-removal-dialog.test.tsx
@@ -7,7 +7,18 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import MerchantsPage from '@/app/merchants/page'
 
-const merchant = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: 'a'.repeat(64) }
+const merchant = {
+  descriptorKey: 'BILLA',
+  cleanName: 'Billa',
+  logoUrl: null,
+  logoContentHash: 'a'.repeat(64),
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+}
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
 
 function renderPage(write: () => Response = () => json({}, 204)) {

--- a/openbank-admin-ui/src/test/merchants-worklist.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-worklist.test.tsx
@@ -3,14 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import React from 'react'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import MerchantsPage from '@/app/merchants/page'
 
 vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
 
 const catalogue = {
-  data: [{ descriptorKey: 'BILLA', cleanName: 'Billa', category: 'GROCERIES', city: 'Praha', country: 'CZ' }],
+  data: [{ descriptorKey: 'BILLA', cleanName: 'Billa', logoUrl: null, logoContentHash: null, category: 'GROCERIES', lat: null, lon: null, city: 'Praha', country: 'CZ', updatedAt: '2026-09-09T08:00:00Z' }],
   total: 1,
 }
 const worklist = [
@@ -63,5 +63,24 @@ describe('merchant catalogue worklist', () => {
     render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
 
     await waitFor(() => expect(screen.queryByText('Billa')).not.toBeInTheDocument())
+  })
+
+  it('makes every backend page reachable and reports the visible range', async () => {
+    const first = { ...catalogue.data[0], descriptorKey: 'FIRST', cleanName: 'First merchant' }
+    const second = { ...catalogue.data[0], descriptorKey: 'SECOND', cleanName: 'Second merchant' }
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+      const isSecondPage = String(url).includes('page=1')
+      return Promise.resolve(json({ data: [isSecondPage ? second : first], total: 51 }))
+    }))
+
+    render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+    await screen.findByText('First merchant')
+    expect(screen.getByText('Showing 1–1 of 51')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await screen.findByText('Second merchant')
+    expect(screen.getByText('Showing 51–51 of 51')).toBeInTheDocument()
+    expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).includes('page=1&size=50'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- make every backend merchant catalogue page reachable with accessible previous/next controls and an exact visible range
- validate catalogue and unmatched-worklist payloads before rendering them
- preserve the current verified page when a refresh fails and walk back safely after deleting the final page

## Verification
- 19 targeted Vitest tests
- npm run type-check
- npm run lint (0 errors; existing warnings only)
- Playwright merchant pagination recovery E2E
- production build (97/97 routes)

Closes #9416