### PR TITLE
ci(governance): require PRs to target main

### DIFF
--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,10 +1,10 @@
 # -----------------------------------------------------------------------------
 # Issue hygiene — the link-in-PR lint (ADR-0052, rules.yaml: issues).
 #
-# Every PR's "Linked issues" section must be consciously addressed: either a
-# real reference (Closes/Fixes/Resolves/Refs #<n>) or an explicit N/A. Leaving
-# the template placeholder untouched is the failure this gate prevents — it is
-# the producer that lets rules.yaml flip `issues.enforced` advisory -> block.
+# Every PR must target `main`, and its "Linked issues" section must be
+# consciously addressed: either a real reference (Closes/Fixes/Resolves/Refs
+# #<n>) or an explicit N/A. A non-main base can make GitHub close the PR and its
+# issue while shipping nothing; #9385/#9392 demonstrated that failure mode.
 #
 # Lives in its own workflow (not ci.yml) so it can subscribe to the `edited`
 # event: fixing the PR body must re-evaluate THIS check without re-running the
@@ -42,6 +42,17 @@ jobs:
             const author = pr.user?.login ?? ''
             const labels = (pr.labels ?? []).map(l => l.name)
             const headRef = pr.head?.ref ?? ''
+            const baseRef = pr.base?.ref ?? ''
+
+            // A PR merged into an intermediate branch can look complete, close its issue, and
+            // disappear from the backlog without ever reaching production. This repository has
+            // one integration branch; dependent work waits for its prerequisite on `main`.
+            if (baseRef !== 'main') {
+              core.setFailed(
+                `issue-hygiene: PR targets '${baseRef || '(unknown)'}', but every PR must target `
+                + '`main`. Change the base branch before review or merge.')
+              return
+            }
 
             // --- Exemptions -------------------------------------------------
             const botAuthor = author.endsWith('[bot]')


### PR DESCRIPTION
## Summary

Prevents a pull request from being merged into an intermediate branch and appearing complete without ever reaching `main`. Issue hygiene now fails every non-`main` target before its existing bot or release exemptions are considered.

## Type of change

- [x] ci

## Linked issues

N/A — immediate governance follow-up to the observed #9385/#9392 wrong-base incident.

## Changes

- Require `pull_request.base.ref == main` in the existing required `issue-hygiene` check.
- Explain the lost-change failure mode and the supported dependency workflow.

## Definition of Done

- [x] Existing workflow supply-chain validation passes across all 80 workflows.
- [x] The check remains read-only and uses the already available pull-request payload.
- [x] The required check name remains unchanged.

## Security checklist

- [x] No secrets, permissions, dependencies, or executable checkout surface added.

## Compliance impact

- [x] DORA

The gate preserves traceability between a merged PR, its closed issue, and code actually integrated into the release branch.

## Rollout / Rollback

- Deployment strategy: active for new PR events as soon as this workflow reaches `main`
- Rollback plan: revert this commit
- Data migration reversible: N/A
