### PR TITLE
security(ci): trust only default-branch deploy source

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -135,9 +135,14 @@ jobs:
     outputs:
       proceed: ${{ steps.source.outputs.proceed }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
+      # Always checkout the event's trusted default-branch revision. In particular, a
+      # workflow_run must never feed its payload SHA into checkout: that trigger carries
+      # repository secrets and a write-capable downstream job, so coupling it to a payload
+      # ref is a repository-compromise primitive even when today's branch filter says main.
+      # workflow_run.head_sha remains queue metadata above; no file from that payload SHA is
+      # executed. deploy-source proves the checked-out revision against origin/main.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 1
       - id: source
         name: Reject stale or self-generated deploy source


### PR DESCRIPTION
## What

The privileged Admin UI deploy workflow no longer checks out a SHA supplied by a `workflow_run` payload. It always executes the trusted event/default-branch revision; the producer SHA remains metadata for queue isolation only.

This closes the critical OpenSSF/CodeQL Dangerous Workflow alert #499 without weakening deploy freshness checks or branch protection.

## Validation

- `python3 .github/scripts/check-workflow-supply-chain.py` (`SUBJECTS=80`)
- `actionlint .github/workflows/admin-ui-deploy.yml`
- `git diff --check`

## Linked issues

N/A — direct remediation of code-scanning alert #499.
