### PR TITLE
fix(admin-ui): bound audit trail evidence

### DIFF
--- a/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
@@ -14,7 +14,7 @@ const ENTRY = {
   actorId: 'operator-42',
   actorType: 'USER',
   occurredAt: '2026-08-31T08:00:00Z',
-  payload: { status: 'ACTIVE' },
+  payload: '{"status":"ACTIVE"}',
 }
 
 test.beforeEach(async ({ context, baseURL }) => {
@@ -23,13 +23,17 @@ test.beforeEach(async ({ context, baseURL }) => {
 
 test('keeps a failed audit retry bound to the same aggregate and recovers', async ({ page }) => {
   let available = true
+  let malformed = false
   let requests = 0
-  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=100`, route => {
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=500`, route => {
     requests += 1
     if (!available) {
       return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
     }
-    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([ENTRY]) })
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([{ ...ENTRY, occurredAt: malformed ? 'not-a-date' : ENTRY.occurredAt }]),
+    })
   })
 
   await page.goto('/audit')
@@ -48,15 +52,20 @@ test('keeps a failed audit retry bound to the same aggregate and recovers', asyn
   await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
   await expect(page.getByText(/novější události mohou chybět|newer events may be missing/)).toBeHidden()
   await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
+
+  malformed = true
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText(/novější události mohou chybět|newer events may be missing/)).toBeVisible()
+  await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
   expect(requests).toBeGreaterThanOrEqual(3)
 })
 
 test('never attributes an older audit snapshot to a different aggregate', async ({ page }) => {
   const differentAggregateId = '86d667cb-52d7-4985-8624-e8130dc28cab'
-  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=100`, route =>
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=500`, route =>
     route.fulfill({ contentType: 'application/json', body: JSON.stringify([ENTRY]) }),
   )
-  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${differentAggregateId}?limit=100`, route =>
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${differentAggregateId}?limit=500`, route =>
     route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' }),
   )
 

--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -10,14 +10,10 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { formatAuditPayload, parseAuditTrail, type AuditTrailEntry } from '@/lib/audit/auditTrailContract'
 
 const AUDIT_SERVICE = '/api/svc/audit-service'
-
-interface AuditEntry {
-  id: string; aggregateId: string; aggregateType: string
-  eventType: string; actorId?: string; actorType?: string
-  payload?: Record<string, unknown>; occurredAt: string
-}
+const EVIDENCE_LIMIT = 500
 
 const EVENT_COLOR: Record<string, string> = {
   CREATED: 'var(--green)', UPDATED: 'var(--accent)', DELETED: 'var(--red)',
@@ -28,7 +24,7 @@ const EVENT_COLOR: Record<string, string> = {
 export default function AuditPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const [entries, setEntries]   = useState<AuditEntry[]>([])
+  const [entries, setEntries]   = useState<AuditTrailEntry[]>([])
   const [loading, setLoading]   = useState(false)
   // Instead of a raw "HTTP 404" string, hold a typed reason that renders as a
   // calm <DataUnavailable> panel. audit-service isn't deployed in every
@@ -43,7 +39,7 @@ export default function AuditPage() {
     if (!query) return
     setLoading(true); setUnavailable(null)
     try {
-      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${query}?limit=100`, { signal: AbortSignal.timeout(5000) })
+      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${query}?limit=${EVIDENCE_LIMIT}`, { signal: AbortSignal.timeout(5000) })
       if (!res.ok) {
         if (loadedAggregateId !== query) {
           setEntries([])
@@ -52,8 +48,18 @@ export default function AuditPage() {
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
-      const data = await res.json()
-      setEntries(Array.isArray(data) ? data : data.entries ?? [])
+      let data: AuditTrailEntry[]
+      try {
+        data = parseAuditTrail(await res.json() as unknown, EVIDENCE_LIMIT)
+      } catch {
+        if (loadedAggregateId !== query) {
+          setEntries([])
+          setLoadedAggregateId(null)
+        }
+        setUnavailable({ kind: 'error' })
+        return
+      }
+      setEntries(data)
       setLoadedAggregateId(query)
     } catch {
       // fetch threw (timeout/abort/network) — the BFF or audit-service didn't
@@ -117,7 +123,9 @@ export default function AuditPage() {
       {entries.length > 0 && (
         <div className="card" style={{ overflow: 'hidden' }}>
           <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', fontSize: '13px', color: 'var(--text-muted)' }}>
-            {entries.length} {t('událostí pro', 'events for')} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{loadedAggregateId}</span>
+            {entries.length === EVIDENCE_LIMIT
+              ? t(`Nejnovějších ${EVIDENCE_LIMIT} událostí; starší mohou existovat`, `Newest ${EVIDENCE_LIMIT} events; older evidence may exist`)
+              : t(`${entries.length} událostí`, `${entries.length} events`)} {t('pro', 'for')} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{loadedAggregateId}</span>
           </div>
           <table className="data-table">
             <thead>
@@ -152,7 +160,7 @@ export default function AuditPage() {
                     <tr key={`${e.id}-payload`}>
                       <td colSpan={5} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
                         <pre style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-secondary)', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                          {JSON.stringify(e.payload, null, 2)}
+                          {formatAuditPayload(e.payload)}
                         </pre>
                       </td>
                     </tr>

--- a/openbank-admin-ui/src/lib/audit/auditTrailContract.ts
+++ b/openbank-admin-ui/src/lib/audit/auditTrailContract.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface AuditTrailEntry {
+  id: string
+  aggregateId: string
+  aggregateType: string
+  eventType: string
+  actorId: string | null
+  actorType: string | null
+  payload: string
+  occurredAt: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid audit ${field}`)
+  return value
+}
+
+function nullableString(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  return requiredString(record, field)
+}
+
+export function parseAuditTrail(raw: unknown, limit: number): AuditTrailEntry[] {
+  if (!Array.isArray(raw) || raw.length > limit) throw new Error('Invalid audit trail')
+  return raw.map(value => {
+    if (!isRecord(value)) throw new Error('Invalid audit entry')
+    const occurredAt = requiredString(value, 'occurredAt')
+    if (Number.isNaN(Date.parse(occurredAt))) throw new Error('Invalid audit occurredAt')
+    return {
+      id: requiredString(value, 'id'),
+      aggregateId: requiredString(value, 'aggregateId'),
+      aggregateType: requiredString(value, 'aggregateType'),
+      eventType: requiredString(value, 'eventType'),
+      actorId: nullableString(value, 'actorId'),
+      actorType: nullableString(value, 'actorType'),
+      payload: requiredString(value, 'payload'),
+      occurredAt,
+    }
+  })
+}
+
+export function formatAuditPayload(payload: string): string {
+  try {
+    return JSON.stringify(JSON.parse(payload), null, 2)
+  } catch {
+    return payload
+  }
+}

--- a/openbank-admin-ui/src/test/audit-trail-contract.test.ts
+++ b/openbank-admin-ui/src/test/audit-trail-contract.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { formatAuditPayload, parseAuditTrail } from '@/lib/audit/auditTrailContract'
+
+const entry = {
+  id: 'audit-42',
+  aggregateId: 'account-42',
+  aggregateType: 'ACCOUNT',
+  eventType: 'UPDATED',
+  actorId: null,
+  actorType: null,
+  payload: '{"status":"ACTIVE"}',
+  occurredAt: '2026-09-09T08:00:00Z',
+}
+
+describe('audit trail response contract', () => {
+  it('preserves valid regulated evidence and formats its encoded payload', () => {
+    expect(parseAuditTrail([entry], 500)).toEqual([entry])
+    expect(formatAuditPayload(entry.payload)).toContain('\n  "status": "ACTIVE"\n')
+  })
+
+  it.each([
+    [[{ ...entry, payload: { status: 'ACTIVE' } }], 'payload'],
+    [[{ ...entry, occurredAt: 'not-a-date' }], 'occurredAt'],
+    [[{ ...entry, actorId: 42 }], 'actorId'],
+    [{ entries: [entry] }, 'trail'],
+  ])('rejects malformed evidence instead of rendering it', (candidate, message) => {
+    expect(() => parseAuditTrail(candidate, 500)).toThrow(message)
+  })
+
+  it('rejects a response beyond the requested evidence window', () => {
+    expect(() => parseAuditTrail([entry, entry], 1)).toThrow('trail')
+  })
+
+  it('keeps a legacy non-JSON payload readable without changing its evidence', () => {
+    expect(formatAuditPayload('legacy payload')).toBe('legacy payload')
+  })
+})


### PR DESCRIPTION
## Summary
- request the audit service's supported 500-entry evidence window instead of silently truncating at 100
- disclose when the newest 500 records are shown and older evidence may exist
- validate the real audit response contract, render encoded JSON payloads readably, and preserve only a verified same-query snapshot on failures

## Verification
- 8 targeted Vitest tests
- npm run type-check
- targeted ESLint
- 2/2 audit-trail recovery Playwright E2E tests, including malformed-response retention
- production build (97/97 routes)

Closes #9428