### PR TITLE
fix(admin-ui): qualify portfolio counts

### DIFF
--- a/openbank-admin-ui/src/components/party/CustomerPortfolioPanel.tsx
+++ b/openbank-admin-ui/src/components/party/CustomerPortfolioPanel.tsx
@@ -7,18 +7,14 @@ import Link from 'next/link'
 import { Landmark, ShieldAlert, WalletCards } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
+import { parseAccountPortfolio, parseAmlPortfolio, parseLendingPortfolio, type PortfolioSummary } from '@/lib/party/portfolioContract'
 
 type Source = 'accounts' | 'lending' | 'aml'
-type SourceState = { kind: 'loading' } | { kind: 'ok'; count: number; statuses: string[] } | { kind: 'unknown'; why: BffFailure }
+type SourceState = { kind: 'loading' } | ({ kind: 'ok' } & PortfolioSummary) | { kind: 'unknown'; why: BffFailure }
 type State = Record<Source, SourceState>
+const AML_LIMIT = 100
 
 const initial = (): State => ({ accounts: { kind: 'loading' }, lending: { kind: 'loading' }, aml: { kind: 'loading' } })
-
-function rows(body: unknown): Record<string, unknown>[] {
-  if (Array.isArray(body)) return body as Record<string, unknown>[]
-  const obj = body as { data?: unknown[]; items?: unknown[]; content?: unknown[] }
-  return (obj?.data ?? obj?.items ?? obj?.content ?? []) as Record<string, unknown>[]
-}
 
 export function CustomerPortfolioPanel({ partyId }: { partyId: string }) {
   const { t } = useLanguage()
@@ -29,7 +25,7 @@ export function CustomerPortfolioPanel({ partyId }: { partyId: string }) {
     const sources: { source: Source; url: string }[] = [
       { source: 'accounts', url: svcUrl('account-service', '/api/v1/accounts', { partyId, limit: '100' }) },
       { source: 'lending', url: svcUrl('lending-service', '/api/v1/lending/applications', { partyId }) },
-      { source: 'aml', url: svcUrl('aml-service', '/api/v1/aml/cases', { partyId, limit: '100', offset: '0' }) },
+      { source: 'aml', url: svcUrl('aml-service', '/api/v1/aml/cases', { partyId, limit: String(AML_LIMIT), offset: '0' }) },
     ]
     void Promise.all(sources.map(async ({ source, url }) => {
       try {
@@ -39,9 +35,11 @@ export function CustomerPortfolioPanel({ partyId }: { partyId: string }) {
           if (live) setState(s => ({ ...s, [source]: { kind: 'unknown', why } }))
           return
         }
-        const list = rows(await res.json())
-        const statuses = [...new Set(list.map(r => String(r.status ?? r.state ?? '')).filter(Boolean))]
-        if (live) setState(s => ({ ...s, [source]: { kind: 'ok', count: list.length, statuses } }))
+        const body = await res.json() as unknown
+        const summary = source === 'accounts'
+          ? parseAccountPortfolio(body)
+          : source === 'aml' ? parseAmlPortfolio(body, AML_LIMIT) : parseLendingPortfolio(body)
+        if (live) setState(s => ({ ...s, [source]: { kind: 'ok', ...summary } }))
       } catch {
         if (live) setState(s => ({ ...s, [source]: { kind: 'unknown', why: 'unreachable' } }))
       }
@@ -64,7 +62,11 @@ export function CustomerPortfolioPanel({ partyId }: { partyId: string }) {
         return <Link href={href} key={source} className="card" style={{ padding: 14, textDecoration: 'none', color: 'inherit' }}>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 12, color: 'var(--text-secondary)' }}><Icon size={15} /> {title}</div>
           {value.kind === 'loading' && <div style={{ marginTop: 8, color: 'var(--text-tertiary)' }}>{t('Načítám…', 'Loading…')}</div>}
-          {value.kind === 'ok' && <><div style={{ fontSize: 24, fontWeight: 800, marginTop: 6 }}>{value.count}</div><div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>{value.statuses.join(' · ') || t('bez stavů', 'no statuses')}</div></>}
+          {value.kind === 'ok' && <>
+            <div aria-label={value.lowerBound ? t(`Nejméně ${value.count}`, `At least ${value.count}`) : undefined} style={{ fontSize: 24, fontWeight: 800, marginTop: 6 }}>{value.count}{value.lowerBound ? '+' : ''}</div>
+            <div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>{value.statuses.join(' · ') || t('bez stavů', 'no statuses')}</div>
+            {value.lowerBound && <div style={{ marginTop: 4, fontSize: 10, color: 'var(--text-tertiary)' }}>{t('Nejméně tento počet; služba vrátila plné stránkované okno.', 'At least this many; the service returned a full paginated window.')}</div>}
+          </>}
           {value.kind === 'unknown' && <div style={{ marginTop: 8, fontSize: 11, color: '#b45309' }}>{t('Nelze zjistit', 'Unavailable')} · {value.why}</div>}
         </Link>
       })}

--- a/openbank-admin-ui/src/lib/party/portfolioContract.ts
+++ b/openbank-admin-ui/src/lib/party/portfolioContract.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface PortfolioSummary {
+  count: number
+  lowerBound: boolean
+  statuses: string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseRows(raw: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(raw) || raw.some(row => !isRecord(row))) throw new Error('Invalid portfolio rows')
+  return raw as Record<string, unknown>[]
+}
+
+function summarize(rows: Record<string, unknown>[], lowerBound: boolean): PortfolioSummary {
+  const statuses = [...new Set(rows.map(row => {
+    const value = row.status ?? row.state
+    if (value === undefined || value === null || value === '') return null
+    if (typeof value !== 'string') throw new Error('Invalid portfolio status')
+    return value
+  }).filter((value): value is string => value !== null))]
+  return { count: rows.length, lowerBound, statuses }
+}
+
+export function parseAccountPortfolio(raw: unknown): PortfolioSummary {
+  if (!isRecord(raw) || !isRecord(raw.pagination) || typeof raw.pagination.hasMore !== 'boolean') {
+    throw new Error('Invalid account portfolio')
+  }
+  const cursor = raw.pagination.nextCursor
+  if (cursor !== null && typeof cursor !== 'string') throw new Error('Invalid account cursor')
+  return summarize(parseRows(raw.data), raw.pagination.hasMore)
+}
+
+export function parseLendingPortfolio(raw: unknown): PortfolioSummary {
+  return summarize(parseRows(raw), false)
+}
+
+export function parseAmlPortfolio(raw: unknown, limit: number): PortfolioSummary {
+  const rows = parseRows(raw)
+  if (rows.length > limit) throw new Error('Invalid AML portfolio window')
+  return summarize(rows, rows.length === limit)
+}

--- a/openbank-admin-ui/src/test/customer-360-portfolio.test.tsx
+++ b/openbank-admin-ui/src/test/customer-360-portfolio.test.tsx
@@ -15,9 +15,9 @@ describe('Customer 360 authoritative portfolio', () => {
   it('queries each owning service by literal party-filtered route', async () => {
     const f = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
-      if (url.includes('account-service')) return json([{ status: 'ACTIVE' }, { status: 'BLOCKED' }])
-      if (url.includes('lending-service')) return json({ items: [{ state: 'ASSESSMENT' }] })
-      return json({ data: [{ status: 'OPEN' }] })
+      if (url.includes('account-service')) return json({ data: [{ status: 'ACTIVE' }, { status: 'BLOCKED' }], pagination: { nextCursor: null, hasMore: false } })
+      if (url.includes('lending-service')) return json([{ state: 'ASSESSMENT' }])
+      return json([{ status: 'OPEN' }])
     })
     vi.stubGlobal('fetch', f)
     render(<LanguageProvider><CustomerPortfolioPanel partyId={PARTY} /></LanguageProvider>)
@@ -34,11 +34,29 @@ describe('Customer 360 authoritative portfolio', () => {
   it('degrades one source without hiding successful sources', async () => {
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       if (String(input).includes('lending-service')) return json({ error: 'unreachable' }, 502)
+      if (String(input).includes('account-service')) return json({ data: [], pagination: { nextCursor: null, hasMore: false } })
       return json([])
     }))
     render(<LanguageProvider><CustomerPortfolioPanel partyId={PARTY} /></LanguageProvider>)
 
     await waitFor(() => expect(screen.getByText(/Unavailable · error/i)).toBeInTheDocument())
     expect(screen.getAllByText('0')).toHaveLength(2)
+  })
+
+  it('marks capped owning-service windows as lower bounds', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('account-service')) return json({ data: [{ status: 'ACTIVE' }, { status: 'ACTIVE' }], pagination: { nextCursor: 'more', hasMore: true } })
+      if (url.includes('lending-service')) return json([{ state: 'ASSESSMENT' }])
+      return json(Array.from({ length: 100 }, () => ({ status: 'OPEN' })))
+    }))
+    render(<LanguageProvider><CustomerPortfolioPanel partyId={PARTY} /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText('2+')).toBeInTheDocument())
+    expect(screen.getByText('100+')).toBeInTheDocument()
+    expect(screen.getByLabelText('At least 2')).toBeInTheDocument()
+    expect(screen.getByLabelText('At least 100')).toBeInTheDocument()
+    expect(screen.getAllByText('At least this many; the service returned a full paginated window.')).toHaveLength(2)
+    expect(screen.getByText('1')).toBeInTheDocument()
   })
 })

--- a/openbank-admin-ui/src/test/customer-portfolio-contract.test.ts
+++ b/openbank-admin-ui/src/test/customer-portfolio-contract.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseAccountPortfolio, parseAmlPortfolio, parseLendingPortfolio } from '@/lib/party/portfolioContract'
+
+describe('Customer 360 portfolio contracts', () => {
+  it('uses account cursor evidence instead of presenting a page length as a total', () => {
+    expect(parseAccountPortfolio({
+      data: [{ status: 'ACTIVE' }, { status: 'BLOCKED' }],
+      pagination: { nextCursor: 'next', hasMore: true },
+    })).toEqual({ count: 2, lowerBound: true, statuses: ['ACTIVE', 'BLOCKED'] })
+  })
+
+  it('treats a full AML window as a lower bound and a shorter one as exact', () => {
+    expect(parseAmlPortfolio([{ status: 'OPEN' }, { status: 'OPEN' }], 2)).toEqual({ count: 2, lowerBound: true, statuses: ['OPEN'] })
+    expect(parseAmlPortfolio([{ status: 'OPEN' }], 2).lowerBound).toBe(false)
+  })
+
+  it('keeps the uncapped party lending list exact', () => {
+    expect(parseLendingPortfolio([{ state: 'ASSESSMENT' }])).toEqual({ count: 1, lowerBound: false, statuses: ['ASSESSMENT'] })
+  })
+
+  it.each([
+    [{ data: [], pagination: { hasMore: 'yes', nextCursor: null } }, parseAccountPortfolio],
+    [[{ status: 42 }], parseLendingPortfolio],
+    [{ data: [] }, (raw: unknown) => parseAmlPortfolio(raw, 100)],
+  ])('rejects malformed owning-service evidence', (raw, parser) => {
+    expect(() => parser(raw)).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- stop presenting capped account and AML response windows as authoritative exact totals
- use account cursor evidence and AML window saturation to render honest lower bounds such as 100+
- validate each owning-service response independently and explain the lower-bound semantics in the UI

## Verification
- 9 targeted Vitest tests
- npm run type-check
- targeted ESLint
- production build (97/97 routes)

Closes #9433