### PR TITLE
fix(admin-ui): validate loyalty evidence

### DIFF
--- a/openbank-admin-ui/e2e/loyalty-evidence-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/loyalty-evidence-recovery.spec.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PARTY_ID = '11111111-1111-4111-8111-111111111111'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('rejects malformed loyalty evidence and recovers with verified customer data', async ({ page }) => {
+  await page.route('**/api/loyalty', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      state: 'ok',
+      benefits: [],
+      earnSources: [],
+      provisioning: {
+        at: '2026-09-09T08:00:00Z',
+        outstandingLeaves: 1200,
+        annualCapPerParty: 1000,
+        ruleVersion: 'v1',
+      },
+    }),
+  }))
+
+  let lookup = 0
+  await page.route('**/api/loyalty/party/*', route => {
+    lookup += 1
+    const body = lookup === 1
+      ? { state: 'ok', partyId: '22222222-2222-4222-8222-222222222222', balance: 0, earnedThisYear: 0, earnedTotal: 0, nextExpiry: null, history: [] }
+      : { state: 'ok', partyId: PARTY_ID, balance: 80, earnedThisYear: 120, earnedTotal: 300, nextExpiry: null, history: [] }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
+  })
+
+  await page.goto('/loyalty')
+  await page.getByRole('button', { name: /Customer|Klient/ }).click()
+  await page.getByLabel(/Customer UUID|UUID klienta/).fill(PARTY_ID)
+  const submit = page.getByRole('button', { name: /Look up|Vyhledat/ })
+
+  await submit.click()
+  await expect(page.getByText(/Loyalty-service is not responding|Loyalty-service neodpovídá/)).toBeVisible()
+  await expect(page.getByText('80', { exact: true })).toHaveCount(0)
+
+  await submit.click()
+  await expect(page.getByText('80', { exact: true })).toBeVisible()
+  await expect(page.getByRole('link', { name: /Open Customer 360|Otevřít Customer 360/ })).toHaveAttribute('href', `/customer-360?partyId=${PARTY_ID}`)
+})

--- a/openbank-admin-ui/src/app/loyalty/page.tsx
+++ b/openbank-admin-ui/src/app/loyalty/page.tsx
@@ -14,7 +14,7 @@
 // produces a reviewable draft. The editable surface is deliberately empty, and that is the lesson,
 // not a gap.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import {
   ArrowRight, Bot, CircleAlert, Coins, FileText, Gift, Landmark, Leaf, Scale, Search, ShieldCheck, Sparkles,
@@ -29,11 +29,13 @@ import {
 } from '@/lib/loyalty/lipaContent'
 import type { LoyaltyCatalogueResponse, LoyaltyState } from '@/app/api/loyalty/route'
 import type { LoyaltyPartyResponse } from '@/app/api/loyalty/party/[partyId]/route'
+import { parseLoyaltyCatalogue, parseLoyaltyParty } from '@/lib/loyalty/evidenceContract'
 
 const TABS = ['principles', 'catalogues', 'party', 'finance', 'ai'] as const
 type Tab = (typeof TABS)[number]
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const REQUEST_TIMEOUT_MS = 10_000
 
 /** A service state that is not `ok` becomes the shared unavailable panel, never a blank table. */
 function unavailableKind(state: LoyaltyState): UnavailableKind | null {
@@ -52,6 +54,7 @@ export default function LoyaltyPage() {
   const [party, setParty] = useState<LoyaltyPartyResponse | null>(null)
   const [partyLoading, setPartyLoading] = useState(false)
   const [partyError, setPartyError] = useState<string | null>(null)
+  const partyRequestId = useRef(0)
 
   const say = useCallback((text: Bilingual) => t(text.cs, text.en), [t])
   const locale = language === 'cs' ? 'cs-CZ' : 'en-GB'
@@ -59,8 +62,11 @@ export default function LoyaltyPage() {
 
   useEffect(() => {
     let cancelled = false
-    fetch('/api/loyalty', { cache: 'no-store' })
-      .then(r => r.json() as Promise<LoyaltyCatalogueResponse>)
+    fetch('/api/loyalty', { cache: 'no-store', signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+      .then(async r => {
+        if (!r.ok) throw new Error('Loyalty catalogue request failed')
+        return parseLoyaltyCatalogue(await r.json() as unknown)
+      })
       .then(body => { if (!cancelled) setCatalogue(body) })
       .catch(() => { if (!cancelled) setCatalogue({ state: 'unreachable', benefits: [], earnSources: [], provisioning: null }) })
       .finally(() => { if (!cancelled) setLoading(false) })
@@ -68,21 +74,31 @@ export default function LoyaltyPage() {
   }, [])
 
   const lookUpParty = useCallback(async () => {
+    const requestId = ++partyRequestId.current
     const id = partyId.trim()
     if (!UUID_RE.test(id)) {
       setPartyError(t('Zadejte platné UUID klienta.', 'Enter a valid customer UUID.'))
       setParty(null)
+      setPartyLoading(false)
       return
     }
     setPartyError(null)
+    setParty(null)
     setPartyLoading(true)
     try {
-      const response = await fetch(`/api/loyalty/party/${id}`, { cache: 'no-store' })
-      setParty(await response.json() as LoyaltyPartyResponse)
+      const response = await fetch(`/api/loyalty/party/${id}`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      })
+      if (!response.ok) throw new Error('Loyalty customer request failed')
+      const evidence = parseLoyaltyParty(await response.json() as unknown, id)
+      if (partyRequestId.current === requestId) setParty(evidence)
     } catch {
-      setParty({ state: 'unreachable', partyId: id, balance: 0, earnedThisYear: 0, earnedTotal: 0, nextExpiry: null, history: [] })
+      if (partyRequestId.current === requestId) {
+        setParty({ state: 'unreachable', partyId: id, balance: 0, earnedThisYear: 0, earnedTotal: 0, nextExpiry: null, history: [] })
+      }
     } finally {
-      setPartyLoading(false)
+      if (partyRequestId.current === requestId) setPartyLoading(false)
     }
   }, [partyId, t])
 
@@ -315,13 +331,15 @@ export default function LoyaltyPage() {
                   id="lipa-party"
                   value={partyId}
                   onChange={e => setPartyId(e.target.value)}
-                  onKeyDown={e => { if (e.key === 'Enter') void lookUpParty() }}
+                  onKeyDown={e => { if (e.key === 'Enter' && !partyLoading) void lookUpParty() }}
                   placeholder={t('UUID klienta', 'Customer UUID')}
                   className="w-96 max-w-full rounded-xl border border-slate-300 px-3 py-2 font-mono text-sm"
                 />
                 <button
                   type="button"
                   onClick={() => void lookUpParty()}
+                  disabled={partyLoading}
+                  aria-busy={partyLoading}
                   className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-violet-700"
                 >
                   <Search className="h-4 w-4" />

--- a/openbank-admin-ui/src/lib/loyalty/evidenceContract.ts
+++ b/openbank-admin-ui/src/lib/loyalty/evidenceContract.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LoyaltyCatalogueResponse, LoyaltyState } from '@/app/api/loyalty/route'
+import type { LeafLedgerRow, LoyaltyPartyResponse } from '@/app/api/loyalty/party/[partyId]/route'
+
+const STATES = new Set<LoyaltyState>(['ok', 'not_deployed', 'unreachable', 'unauthorized'])
+const ENTRY_TYPES = new Set<LeafLedgerRow['type']>(['EARN', 'BURN', 'EXPIRE', 'REVERSE'])
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('Invalid loyalty evidence')
+  return value as Record<string, unknown>
+}
+
+function state(value: unknown): LoyaltyState {
+  if (typeof value !== 'string' || !STATES.has(value as LoyaltyState)) throw new Error('Invalid loyalty state')
+  return value as LoyaltyState
+}
+
+function text(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid ${field}`)
+  return value
+}
+
+function count(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid ${field}`)
+  return value
+}
+
+function instant(value: unknown, field: string, nullable = false): string | null {
+  if (nullable && value === null) return null
+  if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) throw new Error(`Invalid ${field}`)
+  return value
+}
+
+export function parseLoyaltyCatalogue(raw: unknown): LoyaltyCatalogueResponse {
+  const body = record(raw)
+  const parsedState = state(body.state)
+  if (parsedState !== 'ok') return { state: parsedState, benefits: [], earnSources: [], provisioning: null }
+  if (!Array.isArray(body.benefits) || !Array.isArray(body.earnSources) || body.provisioning === null) {
+    throw new Error('Incomplete loyalty catalogue')
+  }
+  const benefits = body.benefits.map(item => {
+    const row = record(item)
+    return {
+      id: text(row.id, 'benefit id'),
+      engine: text(row.engine, 'benefit engine'),
+      priceLeaves: count(row.priceLeaves, 'benefit price'),
+      validityDays: count(row.validityDays, 'benefit validity'),
+      description: text(row.description, 'benefit description'),
+    }
+  })
+  const earnSources = body.earnSources.map(item => {
+    const row = record(item)
+    return {
+      id: text(row.id, 'earn source id'),
+      leaves: count(row.leaves, 'earn amount'),
+      validityDays: count(row.validityDays, 'earn validity'),
+    }
+  })
+  const provisioning = record(body.provisioning)
+  return {
+    state: 'ok',
+    benefits,
+    earnSources,
+    provisioning: {
+      at: instant(provisioning.at, 'provisioning timestamp') as string,
+      outstandingLeaves: count(provisioning.outstandingLeaves, 'outstanding balance'),
+      annualCapPerParty: count(provisioning.annualCapPerParty, 'annual cap'),
+      ruleVersion: text(provisioning.ruleVersion, 'rule version'),
+    },
+  }
+}
+
+export function parseLoyaltyParty(raw: unknown, expectedPartyId: string): LoyaltyPartyResponse {
+  const body = record(raw)
+  const parsedState = state(body.state)
+  if (parsedState !== 'ok') {
+    return { state: parsedState, partyId: expectedPartyId, balance: 0, earnedThisYear: 0, earnedTotal: 0, nextExpiry: null, history: [] }
+  }
+  if (body.partyId !== expectedPartyId || !Array.isArray(body.history)) throw new Error('Mismatched loyalty customer')
+  const history = body.history.map(item => {
+    const row = record(item)
+    if (typeof row.type !== 'string' || !ENTRY_TYPES.has(row.type as LeafLedgerRow['type'])) throw new Error('Invalid ledger type')
+    return {
+      id: text(row.id, 'ledger id'),
+      type: row.type as LeafLedgerRow['type'],
+      leaves: count(row.leaves, 'ledger amount'),
+      remainingLeaves: count(row.remainingLeaves, 'remaining balance'),
+      earnSourceId: row.earnSourceId === null ? null : text(row.earnSourceId, 'earn source id'),
+      benefitId: row.benefitId === null ? null : text(row.benefitId, 'benefit id'),
+      ruleVersion: text(row.ruleVersion, 'rule version'),
+      occurredAt: instant(row.occurredAt, 'ledger timestamp') as string,
+      expiresAt: instant(row.expiresAt, 'expiry timestamp', true),
+    }
+  })
+  return {
+    state: 'ok',
+    partyId: expectedPartyId,
+    balance: count(body.balance, 'balance'),
+    earnedThisYear: count(body.earnedThisYear, 'year earnings'),
+    earnedTotal: count(body.earnedTotal, 'total earnings'),
+    nextExpiry: instant(body.nextExpiry, 'next expiry', true),
+    history,
+  }
+}

--- a/openbank-admin-ui/src/test/loyalty-evidence-contract.test.ts
+++ b/openbank-admin-ui/src/test/loyalty-evidence-contract.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseLoyaltyCatalogue, parseLoyaltyParty } from '@/lib/loyalty/evidenceContract'
+
+const PARTY = '11111111-1111-4111-8111-111111111111'
+const catalogue = {
+  state: 'ok',
+  benefits: [{ id: 'fee-waiver', engine: 'pricing', priceLeaves: 100, validityDays: 30, description: 'Fee waiver' }],
+  earnSources: [{ id: 'savings-goal', leaves: 20, validityDays: 730 }],
+  provisioning: { at: '2026-09-09T08:00:00Z', outstandingLeaves: 1200, annualCapPerParty: 1000, ruleVersion: 'v1' },
+}
+const party = {
+  state: 'ok',
+  partyId: PARTY,
+  balance: 80,
+  earnedThisYear: 120,
+  earnedTotal: 300,
+  nextExpiry: '2026-12-01T00:00:00Z',
+  history: [{
+    id: 'entry-1', type: 'EARN', leaves: 100, remainingLeaves: 80, earnSourceId: 'savings-goal',
+    benefitId: null, ruleVersion: 'v1', occurredAt: '2026-08-01T10:00:00Z', expiresAt: '2028-08-01T10:00:00Z',
+  }],
+}
+
+describe('Lípa evidence contract', () => {
+  it('accepts complete catalogue and customer evidence', () => {
+    expect(parseLoyaltyCatalogue(catalogue)).toEqual(catalogue)
+    expect(parseLoyaltyParty(party, PARTY)).toEqual(party)
+  })
+
+  it.each([
+    { ...catalogue, benefits: [{ ...catalogue.benefits[0], priceLeaves: -1 }] },
+    { ...catalogue, provisioning: { ...catalogue.provisioning, outstandingLeaves: Number.NaN } },
+    { ...catalogue, provisioning: { ...catalogue.provisioning, at: 'not-a-date' } },
+    { ...catalogue, earnSources: null },
+  ])('rejects malformed catalogue evidence', raw => {
+    expect(() => parseLoyaltyCatalogue(raw)).toThrow()
+  })
+
+  it.each([
+    { ...party, partyId: '22222222-2222-4222-8222-222222222222' },
+    { ...party, balance: -1 },
+    { ...party, earnedTotal: 1.5 },
+    { ...party, history: [{ ...party.history[0], occurredAt: 'never' }] },
+    { ...party, history: [{ ...party.history[0], type: 'CREDIT' }] },
+  ])('rejects malformed or mismatched customer evidence', raw => {
+    expect(() => parseLoyaltyParty(raw, PARTY)).toThrow()
+  })
+
+  it('keeps an unavailable service distinct from a real zero balance', () => {
+    expect(parseLoyaltyParty({ state: 'unreachable' }, PARTY)).toMatchObject({ state: 'unreachable', balance: 0 })
+    expect(parseLoyaltyParty({ ...party, balance: 0 }, PARTY)).toMatchObject({ state: 'ok', balance: 0 })
+  })
+})


### PR DESCRIPTION
## Summary
- validate Lípa catalogue, provisioning and customer ledger payloads before rendering them as bank evidence
- require exact customer identity, safe non-negative counts, known ledger types and valid timestamps
- normalize unavailable states so error payloads cannot masquerade as a real zero balance
- preserve existing read-only catalogue governance and loyalty RBAC

## Verification
- 43 focused Vitest tests pass
- TypeScript type-check passes
- targeted ESLint passes with zero findings
- production Next.js build passes, 97/97 routes generated

Closes #9441