### PR TITLE
fix(admin-ui): keep onboarding results current

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -12,46 +12,23 @@ import { ClipboardList, RefreshCw, ChevronRight, X, TrendingUp } from 'lucide-re
 import Link from 'next/link'
 import { Drawer, PageHeader } from '@/components/ui'
 import { Can } from '@/components/auth/AuthGuard'
+import {
+  ONBOARDING_STAGES, parseFunnelCounts, parseOnboardingPage,
+  type OnboardingRecordEvidence, type OnboardingRecordPageEvidence,
+} from '@/lib/onboarding/evidenceContract'
 
 const SVC = 'onboarding-service'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-interface OnboardingRecord {
-  partyId: string
-  legalName: string | null
-  email: string | null
-  partyStatus: string
-  kycCaseId: string | null
-  kycStatus: string | null
-  scaEnrolled: boolean
-  deviceCount: number
-  funnelStage: string
-  blockedReason: string | null
-  createdAt: string
-  updatedAt: string
-}
-
-interface RecordPage {
-  items: OnboardingRecord[]
-  total: number
-  page: number
-  size: number
-  stageFilter?: string
-}
+type OnboardingRecord = OnboardingRecordEvidence
+type RecordPage = OnboardingRecordPageEvidence
 
 type FunnelCounts = Record<string, number>
 
 // ── Stage display config ──────────────────────────────────────────────────────
 
-const STAGES = [
-  'REGISTERED',
-  'KYC_OPEN',
-  'KYC_UNDER_REVIEW',
-  'SCA_PENDING',
-  'ACTIVE',
-  'BLOCKED',
-] as const
+const STAGES = ONBOARDING_STAGES
 
 type Stage = typeof STAGES[number]
 
@@ -104,6 +81,8 @@ export default function OnboardingPage() {
 
   // drawer
   const [selected, setSelected] = useState<OnboardingRecord | null>(null)
+  const countsGeneration = useRef(0)
+  const recordsGeneration = useRef(0)
 
   const stageLabel = useCallback((s: string) =>
     language === 'cs'
@@ -115,32 +94,43 @@ export default function OnboardingPage() {
   // ── Load funnel counts ──────────────────────────────────────────────────────
 
   const loadCounts = useCallback(async () => {
+    const generation = ++countsGeneration.current
     setCountsLoading(true); setCountsUnavail(null)
     try {
       const res = await fetch(svcUrl(SVC, '/api/v1/onboarding/funnel'), { signal: AbortSignal.timeout(5000) })
+      if (generation !== countsGeneration.current) return
       if (!res.ok) { setCountsUnavail({ kind: await classifyBffFailure(res) }); return }
-      setCounts(await res.json())
+      const next = parseFunnelCounts(await res.json() as unknown)
+      if (generation === countsGeneration.current) setCounts(next)
     } catch {
-      setCountsUnavail({ kind: 'unreachable' })
-    } finally { setCountsLoading(false) }
+      if (generation === countsGeneration.current) setCountsUnavail({ kind: 'unreachable' })
+    } finally {
+      if (generation === countsGeneration.current) setCountsLoading(false)
+    }
   }, [])
 
   // ── Load records list ───────────────────────────────────────────────────────
 
   const loadRecords = useCallback(async (pg: number, stg: Stage | '') => {
+    const generation = ++recordsGeneration.current
     setLoading(true); setListUnavail(null)
     try {
       const query: Record<string, string> = { page: String(pg), size: '20' }
       if (stg) query.stage = stg
       const res = await fetch(svcUrl(SVC, '/api/v1/onboarding/records', query), { signal: AbortSignal.timeout(5000) })
+      if (generation !== recordsGeneration.current) return
       if (!res.ok) { setListUnavail({ kind: await classifyBffFailure(res) }); setRecords([]); return }
-      const data: RecordPage = await res.json()
-      setRecords(data.items ?? [])
-      setTotal(data.total ?? 0)
+      const data = parseOnboardingPage(await res.json() as unknown, pg)
+      if (generation !== recordsGeneration.current) return
+      setRecords(data.items)
+      setTotal(data.total)
     } catch {
+      if (generation !== recordsGeneration.current) return
       setListUnavail({ kind: 'unreachable' })
       setRecords([])
-    } finally { setLoading(false) }
+    } finally {
+      if (generation === recordsGeneration.current) setLoading(false)
+    }
   }, [])
 
   const refresh = useCallback(() => {

--- a/openbank-admin-ui/src/lib/onboarding/evidenceContract.ts
+++ b/openbank-admin-ui/src/lib/onboarding/evidenceContract.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const ONBOARDING_STAGES = [
+  'REGISTERED', 'KYC_OPEN', 'KYC_UNDER_REVIEW', 'SCA_PENDING', 'ACTIVE', 'BLOCKED',
+] as const
+
+export type OnboardingStage = typeof ONBOARDING_STAGES[number]
+
+export interface OnboardingRecordEvidence {
+  partyId: string
+  legalName: string | null
+  email: string | null
+  partyStatus: string
+  kycCaseId: string | null
+  kycStatus: string | null
+  scaEnrolled: boolean
+  deviceCount: number
+  funnelStage: OnboardingStage
+  blockedReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OnboardingRecordPageEvidence {
+  items: OnboardingRecordEvidence[]
+  total: number
+  page: number
+  size: number
+  stageFilter?: string
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('Invalid onboarding evidence')
+  return value as Record<string, unknown>
+}
+
+function text(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid ${field}`)
+  return value
+}
+
+function nullableText(value: unknown, field: string): string | null {
+  return value === null ? null : text(value, field)
+}
+
+function count(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid ${field}`)
+  return value
+}
+
+function instant(value: unknown, field: string): string {
+  const parsed = text(value, field)
+  if (Number.isNaN(Date.parse(parsed))) throw new Error(`Invalid ${field}`)
+  return parsed
+}
+
+function stage(value: unknown): OnboardingStage {
+  if (typeof value !== 'string' || !ONBOARDING_STAGES.includes(value as OnboardingStage)) {
+    throw new Error('Invalid onboarding stage')
+  }
+  return value as OnboardingStage
+}
+
+export function parseFunnelCounts(raw: unknown): Record<OnboardingStage, number> {
+  const body = record(raw)
+  return Object.fromEntries(ONBOARDING_STAGES.map(item => [item, count(body[item], `${item} count`)])) as Record<OnboardingStage, number>
+}
+
+export function parseOnboardingPage(raw: unknown, expectedPage: number): OnboardingRecordPageEvidence {
+  const body = record(raw)
+  if (!Array.isArray(body.items) || body.page !== expectedPage) throw new Error('Mismatched onboarding page')
+  const items = body.items.map(value => {
+    const item = record(value)
+    if (typeof item.scaEnrolled !== 'boolean') throw new Error('Invalid SCA state')
+    return {
+      partyId: text(item.partyId, 'party id'),
+      legalName: nullableText(item.legalName, 'legal name'),
+      email: nullableText(item.email, 'email'),
+      partyStatus: text(item.partyStatus, 'party status'),
+      kycCaseId: nullableText(item.kycCaseId, 'KYC case id'),
+      kycStatus: nullableText(item.kycStatus, 'KYC status'),
+      scaEnrolled: item.scaEnrolled,
+      deviceCount: count(item.deviceCount, 'device count'),
+      funnelStage: stage(item.funnelStage),
+      blockedReason: nullableText(item.blockedReason, 'blocked reason'),
+      createdAt: instant(item.createdAt, 'created timestamp'),
+      updatedAt: instant(item.updatedAt, 'updated timestamp'),
+    }
+  })
+  const stageFilter = body.stageFilter === undefined ? undefined : text(body.stageFilter, 'stage filter')
+  return {
+    items,
+    total: count(body.total, 'record total'),
+    page: count(body.page, 'page'),
+    size: count(body.size, 'page size'),
+    ...(stageFilter === undefined ? {} : { stageFilter }),
+  }
+}

--- a/openbank-admin-ui/src/test/onboarding-evidence-contract.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-evidence-contract.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseFunnelCounts, parseOnboardingPage } from '@/lib/onboarding/evidenceContract'
+
+const funnel = { REGISTERED: 12, KYC_OPEN: 4, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
+const item = {
+  partyId: 'party-1', legalName: 'Ada Banking', email: 'ada@example.test', partyStatus: 'ACTIVE',
+  kycCaseId: null, kycStatus: null, scaEnrolled: true, deviceCount: 1, funnelStage: 'ACTIVE',
+  blockedReason: null, createdAt: '2026-09-01T08:00:00Z', updatedAt: '2026-09-09T08:00:00Z',
+}
+
+describe('onboarding evidence contract', () => {
+  it('accepts complete funnel and page evidence', () => {
+    expect(parseFunnelCounts(funnel)).toEqual(funnel)
+    expect(parseOnboardingPage({ items: [item], total: 1, page: 0, size: 20 }, 0).items).toEqual([item])
+  })
+
+  it.each([
+    { ...funnel, ACTIVE: -1 },
+    { ...funnel, BLOCKED: 1.5 },
+    { ...funnel, KYC_OPEN: Number.NaN },
+    { REGISTERED: 1 },
+  ])('rejects malformed funnel evidence', raw => {
+    expect(() => parseFunnelCounts(raw)).toThrow()
+  })
+
+  it.each([
+    { items: [item], total: 1, page: 1, size: 20 },
+    { items: [{ ...item, funnelStage: 'UNKNOWN' }], total: 1, page: 0, size: 20 },
+    { items: [{ ...item, createdAt: 'never' }], total: 1, page: 0, size: 20 },
+    { items: [{ ...item, deviceCount: -1 }], total: 1, page: 0, size: 20 },
+    { items: [item], total: -1, page: 0, size: 20 },
+  ])('rejects malformed or mismatched page evidence', raw => {
+    expect(() => parseOnboardingPage(raw, 0)).toThrow()
+  })
+})

--- a/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
@@ -123,4 +123,36 @@ describe('onboarding funnel loading (issue #8233)', () => {
     expect(screen.queryByRole('group', { name: 'Onboarding stage filters' })).not.toBeInTheDocument()
     expect(screen.queryByText('0')).not.toBeInTheDocument()
   })
+
+  it('does not let an older unfiltered response replace the active stage filter', async () => {
+    const firstRecords = deferred<Response>()
+    const activeRecord = {
+      partyId: 'party-active', legalName: 'Current Result', email: null, partyStatus: 'ACTIVE',
+      kycCaseId: null, kycStatus: null, scaEnrolled: true, deviceCount: 1, funnelStage: 'ACTIVE',
+      blockedReason: null, createdAt: '2026-09-01T08:00:00Z', updatedAt: '2026-09-09T08:00:00Z',
+    }
+    let recordsCalls = 0
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => Promise.resolve(response(200, FUNNEL)),
+      records: () => {
+        recordsCalls += 1
+        return recordsCalls === 1
+          ? firstRecords.promise
+          : Promise.resolve(response(200, { items: [activeRecord], total: 1, page: 0, size: 20, stageFilter: 'ACTIVE' }))
+      },
+    }))
+
+    renderPage()
+    const filters = await screen.findByRole('group', { name: 'Onboarding stage filters' })
+    fireEvent.click(within(filters).getByRole('button', { name: /Active/ }))
+    expect(await screen.findByText('Current Result')).toBeVisible()
+
+    await act(async () => {
+      firstRecords.resolve(response(200, RECORDS))
+      await firstRecords.promise
+    })
+
+    expect(screen.getByText('Current Result')).toBeVisible()
+    expect(within(filters).getByRole('button', { name: /Active/ })).toHaveAttribute('aria-pressed', 'true')
+  })
 })


### PR DESCRIPTION
## Summary
- give funnel and customer-list requests independent generation ownership so stale responses cannot replace current state
- validate funnel counts, page identity, record stages, timestamps and non-negative operational counts before rendering
- preserve error-vs-empty semantics, refresh behavior and existing RBAC
- add a regression that resolves the obsolete unfiltered request after the active-filter response

## Verification
- 15 focused Vitest tests pass
- TypeScript type-check passes
- targeted ESLint: 0 errors (2 pre-existing effect warnings)
- production Next.js build passes, 97/97 routes generated

Closes #9444