### PR TITLE
fix(admin-ui): report PID list availability

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import { Map, Plus, Search, RefreshCw, Fingerprint, Clock, CheckCircle2, AlertTriangle, ShieldCheck } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -12,20 +12,11 @@ import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'
+import { parsePidRecords, type PidRecordEvidence } from '@/lib/pid/pidRecordContract'
 
 const PID_SERVICE = '/api/svc/pid-service'
 
-interface PidRecord {
-  id: string
-  personId: string
-  identifierType: string
-  identifierValue: string
-  issuingCountry: string
-  status: string
-  verified: boolean
-  createdAt: string
-  validUntil?: string
-}
+type PidRecord = PidRecordEvidence
 
 interface BankIdSyncPayload {
   readonly bankIdSub: string
@@ -94,32 +85,41 @@ export default function PidPage() {
   // values edited after the non-idempotent POST /parties began.
   const [pendingBankIdSync, setPendingBankIdSync] = useState<PendingBankIdSync | null>(null)
   const [successMsg, setSuccessMsg] = useState<string | null>(null)
+  const loadGeneration = useRef(0)
 
   const load = useCallback(async () => {
+    const generation = ++loadGeneration.current
     setLoading(true); setError(null); setUnavailable(null)
     try {
       const res = await fetch(`${PID_SERVICE}/api/v1/pids`, { signal: AbortSignal.timeout(5000) })
+      if (generation !== loadGeneration.current) return
       if (!res.ok) {
-        // 404/405 usually mean the list endpoint isn't implemented yet, so treat
-        // those as an empty list; everything else is classified for the panel.
-        if (res.status === 404 || res.status === 405) {
-          setRecords([])
-        } else {
-          setRecords([])
-          setUnavailable({ kind: await classifyBffFailure(res) })
-        }
+        // The service publishes no PID-list route today. A 404 is therefore an unavailable
+        // capability, not a missing record; 405 proves the path cannot serve this read either.
+        const kind: UnavailableKind = res.status === 404
+          ? 'not_deployed'
+          : res.status === 405 ? 'error' : await classifyBffFailure(res)
+        if (generation !== loadGeneration.current) return
+        setRecords([])
+        setUnavailable({ kind })
         return
       }
-      const data = await res.json()
-      setRecords(Array.isArray(data) ? data : data.items ?? data.content ?? [])
+      const data = parsePidRecords(await res.json() as unknown)
+      if (generation === loadGeneration.current) setRecords(data)
     } catch {
       // Timeout / abort / network — the BFF or pid-service didn't answer.
+      if (generation !== loadGeneration.current) return
       setRecords([])
       setUnavailable({ kind: 'unreachable' })
-    } finally { setLoading(false) }
+    } finally {
+      if (generation === loadGeneration.current) setLoading(false)
+    }
   }, [])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    const initialLoadId = window.setTimeout(load, 0)
+    return () => clearTimeout(initialLoadId)
+  }, [load])
 
   const filtered = records.filter(r =>
     !search || r.identifierValue?.toLowerCase().includes(search.toLowerCase()) ||
@@ -268,7 +268,7 @@ export default function PidPage() {
           </div>}
         />
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        {!loading && !unavailable && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Záznamů celkem', 'Total Records'), value: records.length, icon: <Fingerprint size={16} />, color: 'var(--accent)' },
             { label: t('Aktivní', 'Active'), value: records.filter(r => r.status === 'ACTIVE').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
@@ -282,7 +282,7 @@ export default function PidPage() {
               <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
             </div>
           ))}
-        </div>
+        </div>}
 
         <div className="card" style={{ marginBottom: '24px', padding: '20px' }}>
           <h2 style={{ fontSize: '16px', marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/openbank-admin-ui/src/lib/pid/pidRecordContract.ts
+++ b/openbank-admin-ui/src/lib/pid/pidRecordContract.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface PidRecordEvidence {
+  id: string
+  personId: string
+  identifierType: string
+  identifierValue: string
+  issuingCountry: string
+  status: string
+  verified: boolean
+  createdAt: string
+  validUntil?: string
+}
+
+function text(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid ${field}`)
+  return value
+}
+
+function date(value: unknown, field: string): string {
+  const candidate = text(value, field)
+  if (Number.isNaN(Date.parse(candidate))) throw new Error(`Invalid ${field}`)
+  return candidate
+}
+
+export function parsePidRecords(raw: unknown): PidRecordEvidence[] {
+  // No list envelope is published today. If one is added, its contract must land with the route;
+  // guessing at items/content here would turn any unrelated JSON object into a valid empty list.
+  if (!Array.isArray(raw)) throw new Error('Invalid PID list response')
+  return raw.map(value => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('Invalid PID record')
+    const item = value as Record<string, unknown>
+    if (typeof item.verified !== 'boolean') throw new Error('Invalid PID verification state')
+    return {
+      id: text(item.id, 'PID id'),
+      personId: text(item.personId, 'person id'),
+      identifierType: text(item.identifierType, 'identifier type'),
+      identifierValue: text(item.identifierValue, 'identifier value'),
+      issuingCountry: text(item.issuingCountry, 'issuing country'),
+      status: text(item.status, 'PID status'),
+      verified: item.verified,
+      createdAt: date(item.createdAt, 'created timestamp'),
+      ...(item.validUntil === undefined ? {} : { validUntil: date(item.validUntil, 'valid-until timestamp') }),
+    }
+  })
+}

--- a/openbank-admin-ui/src/test/pid-list-truth.test.tsx
+++ b/openbank-admin-ui/src/test/pid-list-truth.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import PidPage from '@/app/pid/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { parsePidRecords } from '@/lib/pid/pidRecordContract'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { roles: ['ROLE_ADMIN'] } }, status: 'authenticated' }),
+  signIn: vi.fn(),
+}))
+
+function response(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('PID list truthfulness', () => {
+  it.each([
+    [404, 'PID-service is not deployed in this environment'],
+    [405, 'Failed to load: PID records'],
+  ])('renders an unserved list route as unavailable, never as empty (%s)', async (status, title) => {
+    vi.stubGlobal('fetch', vi.fn(async () => response(status, { error: 'not served' })))
+    render(<LanguageProvider initialLanguage="en"><PidPage /></LanguageProvider>)
+
+    expect(await screen.findByText(title)).toBeVisible()
+    expect(screen.queryByText('No PID records found')).not.toBeInTheDocument()
+    expect(screen.queryByText('Total Records')).not.toBeInTheDocument()
+  })
+
+  it('keeps a genuine successful empty list distinct from route absence', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => response(200, [])))
+    render(<LanguageProvider initialLanguage="en"><PidPage /></LanguageProvider>)
+
+    expect(await screen.findByText('No PID records found')).toBeVisible()
+    expect(screen.getByText('Total Records')).toBeVisible()
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0)
+  })
+
+  it.each([{ items: [] }, { content: [] }, {}, null])('rejects an unpublished response envelope', raw => {
+    expect(() => parsePidRecords(raw)).toThrow('Invalid PID list response')
+  })
+
+  it('rejects malformed record evidence', () => {
+    expect(() => parsePidRecords([{
+      id: 'pid-1', personId: 'party-1', identifierType: 'BANK_ID', identifierValue: 'x',
+      issuingCountry: 'CZ', status: 'ACTIVE', verified: true, createdAt: 'not-a-date',
+    }])).toThrow('created timestamp')
+  })
+})


### PR DESCRIPTION
## Summary
- stop translating an unpublished PID list route's 404/405 into a legitimate empty catalogue
- accept only the array response shape the UI actually understands and validate each record before rendering
- hide zero-valued PID KPI cards while the list is loading or unavailable
- prevent an older load from overwriting a newer refresh while preserving quick-create and BankID retry recovery

## Verification
- 10 focused Vitest interaction and recovery tests pass
- production Next.js build passes TypeScript and generates 97/97 routes
- targeted ESLint: 0 errors (1 pre-existing effect warning)

Closes #9446