### PR TITLE
fix(admin-ui): expose Service Map evidence health

### DIFF
--- a/openbank-admin-ui/e2e/service-map-evidence.spec.ts
+++ b/openbank-admin-ui/e2e/service-map-evidence.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const graph = {
+  available: true,
+  nodes: [{ name: 'openbank-account-service', dependsOn: 0, dependedOnBy: 0 }],
+  edges: [],
+  infraNodes: [{ id: 'infra:postgres', kind: 'infra', tech: 'postgres', label: 'PostgreSQL' }],
+  externalNodes: [],
+  infraEdges: [{ from: 'openbank-account-service', to: 'infra:postgres', type: 'db' }],
+  externalEdges: [],
+}
+
+test('Service Map verifies independent evidence then purges it at the authorization boundary', async ({ page, context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+  let unauthorized = false
+  await page.route('**/api/services/health', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify({ services: [{ port: 8100, status: 'UP' }] }),
+  }))
+  await page.route('**/api/services/governance', route => {
+    return route.fulfill(unauthorized
+      ? { status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'unauthorized' }) }
+      : { status: 200, contentType: 'application/json', body: JSON.stringify({ available: true, byService: {} }) })
+  })
+  await page.route('**/api/catalog/graph', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify(graph),
+  }))
+
+  await page.goto('/docs/service-map')
+  await expect(page.getByTestId('map-evidence-topology').first()).toContainText('Verified')
+  await expect(page.getByText('PostgreSQL').first()).toBeVisible()
+  await page.getByText('PostgreSQL').first().click()
+  await expect(page.getByText(/CONNECTED SERVICES/i).first()).toBeVisible()
+
+  unauthorized = true
+  await page.getByRole('button', { name: /Refresh Status|Obnovit stav/ }).click()
+  await expect(page.getByTestId('map-evidence-health').first()).toContainText('Session expired')
+  await expect(page.getByTestId('map-evidence-governance').first()).toContainText('Session expired')
+  await expect(page.getByTestId('map-evidence-topology').first()).toContainText('Session expired')
+  await expect(page.getByText('PostgreSQL')).toHaveCount(0)
+  await expect(page.getByText(/CONNECTED SERVICES/i)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/api/services/governance/route.ts
+++ b/openbank-admin-ui/src/app/api/services/governance/route.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NextResponse } from 'next/server'
-import { promises as fs } from 'fs'
+import { readFile } from 'fs/promises'
 import path from 'path'
 
 export const dynamic = 'force-dynamic'
@@ -45,12 +45,15 @@ function governanceFile(): string {
 
 export async function GET() {
   let services: GovernanceService[] = []
+  let available = true
   try {
-    const raw = await fs.readFile(governanceFile(), 'utf-8')
+    const raw = await readFile(governanceFile(), 'utf-8')
     const parsed = JSON.parse(raw) as { services?: GovernanceService[] }
     if (Array.isArray(parsed?.services)) services = parsed.services
+    else available = false
   } catch {
-    services = [] // honest empty — pages degrade through the graceful-state rule
+    services = []
+    available = false
   }
 
   const items: ManifestItem[] = services.map(s => ({
@@ -63,7 +66,7 @@ export async function GET() {
   for (const m of items) byService[m.serviceName] = m
 
   return NextResponse.json(
-    { items, byService, timestamp: new Date().toISOString(), source: 'governance.json (ADR-0071)' },
+    { items, byService, available, timestamp: new Date().toISOString(), source: 'governance.json (ADR-0071)' },
     { headers: { 'Cache-Control': 'no-store' } }
   )
 }

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -3,10 +3,10 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Network, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, ArrowRight, ArrowLeft, Layers, BookOpen, Play, Pause, KeyRound, ShieldCheck, Boxes, Cloud, Send, Server } from 'lucide-react'
 import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
-import { svcUrl } from '@/lib/services/bff'
+import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
@@ -15,6 +15,11 @@ import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
 import { layoutBand } from '@/components/topology/layout'
+import {
+  parseMapGovernance, parseMapHealth, parseServiceMapGraph,
+  type MapExternalEdge as ExternalEdgeT, type MapExternalNode as ExternalNodeT,
+  type MapInfraEdge as InfraEdgeT, type MapInfraNode as InfraNodeT,
+} from '@/lib/governance/service-map-evidence'
 
 // Service definitions with positions for the map
 const SERVICES = [
@@ -114,6 +119,24 @@ const GROUP_LABELS: Record<string, { label: string; color: string }> = {
   cards:      { label: 'Cards',           color: '#db2777' },
 }
 type HealthStatus = 'UP' | 'DOWN' | 'UNKNOWN'
+type EvidenceState = 'loading' | 'ok' | 'unreachable' | 'not_deployed' | 'scaled_to_zero' | 'unauthorized' | 'error'
+type EvidenceResult<T> = { ok: true; value: T } | { ok: false; state: EvidenceState }
+
+const evidenceFailure = (failure: BffFailure): EvidenceState => {
+  if (failure === 'not_deployed' || failure === 'scaled_to_zero' || failure === 'unauthorized' || failure === 'unreachable') return failure
+  return 'error'
+}
+
+async function fetchEvidence<T>(url: string, parse: (value: unknown) => T | null): Promise<EvidenceResult<T>> {
+  try {
+    const response = await fetch(url, { cache: 'no-store', signal: AbortSignal.timeout(10_000) })
+    if (!response.ok) return { ok: false, state: evidenceFailure(await classifyBffFailure(response)) }
+    const parsed = parse(await response.json())
+    return parsed === null ? { ok: false, state: 'error' } : { ok: true, value: parsed }
+  } catch {
+    return { ok: false, state: 'unreachable' }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Auto-layout — a clean, deterministic grid per group so nodes never overlap
@@ -267,10 +290,6 @@ function LegoBrick({ cx, cy, color, degree, selected }: { cx: number; cy: number
 // application.yaml, never hand-authored. Presentation-only metadata (colour,
 // icon, bilingual copy) lives here; the topology itself is code-derived.
 // ---------------------------------------------------------------------------
-type InfraNodeT = { id: string; kind: 'infra'; tech: string; label: string }
-type ExternalNodeT = { id: string; kind: 'external'; vendor: string; label: string }
-type InfraEdgeT = { from: string; to: string; type: 'db' | 'broker' | 'auth' | 'authz' }
-type ExternalEdgeT = { from: string; to: string; type: 'push' | 'webhook' | 'registry' | 'api' | 'llm'; enabled: boolean }
 type TierMeta = { color: string; Icon: typeof Database; labelCs: string; labelEn: string; descCs: string; descEn: string }
 
 const INFRA_META: Record<string, TierMeta> = {
@@ -354,73 +373,98 @@ export default function ServiceMapPage() {
   const [graphEdges, setGraphEdges] = useState<{ from: string; to: string; via: string; type: 'rest' | 'kafka' }[]>([])
   // Per-service degree (upstream + downstream) from the graph → drives brick size.
   const [degrees, setDegrees] = useState<Record<string, number>>({})
-  const [isChecking, setIsChecking] = useState(false)
+  const [isChecking, setIsChecking] = useState(true)
   // Data-flow tiers (infra substrate + external 3rd parties), from the same graph fetch.
   const [infraNodes, setInfraNodes] = useState<InfraNodeT[]>([])
   const [externalNodes, setExternalNodes] = useState<ExternalNodeT[]>([])
   const [infraEdges, setInfraEdges] = useState<InfraEdgeT[]>([])
   const [externalEdges, setExternalEdges] = useState<ExternalEdgeT[]>([])
+  const [evidence, setEvidence] = useState<Record<'health' | 'governance' | 'topology', EvidenceState>>({
+    health: 'loading', governance: 'loading', topology: 'loading',
+  })
+  const [verified, setVerified] = useState<Record<'health' | 'governance' | 'topology', boolean>>({
+    health: false, governance: false, topology: false,
+  })
   // Animation + tier visibility controls. Infra has ~130 edges → hidden by default
   // (revealed per-service on hover, or globally via its toggle); external is sparse → shown.
   const [flow, setFlow] = useFlowAnimation()
   const [showInfra, setShowInfra] = useState(false)
   const [showExternal, setShowExternal] = useState(true)
+  const requestGeneration = useRef(0)
 
-  const checkHealth = async () => {
+  const checkHealth = useCallback(async () => {
+    const generation = ++requestGeneration.current
     setIsChecking(true)
-    try {
-      const [res, govRes, graphRes] = await Promise.all([
-        fetch('/api/services/health'),
-        fetch('/api/services/governance'),
-        fetch('/api/catalog/graph'),
-      ])
+    setEvidence(current => ({
+      health: current.health === 'ok' ? 'ok' : 'loading',
+      governance: current.governance === 'ok' ? 'ok' : 'loading',
+      topology: current.topology === 'ok' ? 'ok' : 'loading',
+    }))
+    const [healthResult, governanceResult, graphResult] = await Promise.all([
+      fetchEvidence('/api/services/health', parseMapHealth),
+      fetchEvidence('/api/services/governance', parseMapGovernance),
+      fetchEvidence('/api/catalog/graph', parseServiceMapGraph),
+    ])
+    if (generation !== requestGeneration.current) return
 
-      if (res.ok) {
-        const data = await res.json() as { services: { port: number; status: string }[] }
-        const newStatuses: Record<string, HealthStatus> = {}
-        for (const svc of SERVICES) {
-          const entry = data.services.find(s => s.port === svc.port)
-          if (!entry) { newStatuses[svc.id] = 'UNKNOWN'; continue }
-          newStatuses[svc.id] = entry.status === 'UP' ? 'UP' : entry.status === 'DOWN' ? 'DOWN' : 'UNKNOWN'
-        }
-        setHealthStatuses(newStatuses)
-      }
-
-      if (govRes.ok) {
-        const govData = await govRes.json() as { byService?: Record<string, GovernanceManifestEntry> }
-        setGovernanceData(govData.byService ?? {})
-      }
-
-      if (graphRes.ok) {
-        const graph = await graphRes.json() as {
-          edges?: { from: string; to: string; via: string; type: 'rest' | 'kafka' }[]
-          nodes?: { name: string; dependsOn?: number; dependedOnBy?: number }[]
-          infraNodes?: InfraNodeT[]
-          externalNodes?: ExternalNodeT[]
-          infraEdges?: InfraEdgeT[]
-          externalEdges?: ExternalEdgeT[]
-        }
-        setGraphEdges(Array.isArray(graph.edges) ? graph.edges : [])
-        const deg: Record<string, number> = {}
-        for (const n of graph.nodes ?? []) {
-          const id = SERVICE_NAME_TO_ID[n.name.replace(/^openbank-/, '')]
-          if (id) deg[id] = (n.dependsOn ?? 0) + (n.dependedOnBy ?? 0)
-        }
-        setDegrees(deg)
-        setInfraNodes(Array.isArray(graph.infraNodes) ? graph.infraNodes : [])
-        setExternalNodes(Array.isArray(graph.externalNodes) ? graph.externalNodes : [])
-        setInfraEdges(Array.isArray(graph.infraEdges) ? graph.infraEdges : [])
-        setExternalEdges(Array.isArray(graph.externalEdges) ? graph.externalEdges : [])
-      }
-    } catch {
-    } finally {
+    if ([healthResult, governanceResult, graphResult].some(result => !result.ok && result.state === 'unauthorized')) {
+      requestGeneration.current += 1
+      setHealthStatuses({})
+      setGovernanceData({})
+      setGraphEdges([])
+      setDegrees({})
+      setInfraNodes([])
+      setExternalNodes([])
+      setInfraEdges([])
+      setExternalEdges([])
+      setSelected(null)
+      setVerified({ health: false, governance: false, topology: false })
+      setEvidence({ health: 'unauthorized', governance: 'unauthorized', topology: 'unauthorized' })
       setIsChecking(false)
+      return
     }
-  }
+
+    const nextEvidence: Record<'health' | 'governance' | 'topology', EvidenceState> = {
+      health: healthResult.ok ? 'ok' : healthResult.state,
+      governance: governanceResult.ok ? (governanceResult.value.available ? 'ok' : 'not_deployed') : governanceResult.state,
+      topology: graphResult.ok ? (graphResult.value.available ? 'ok' : 'not_deployed') : graphResult.state,
+    }
+    if (healthResult.ok) {
+      const newStatuses: Record<string, HealthStatus> = {}
+      for (const svc of SERVICES) {
+        const entry = healthResult.value.find(service => service.port === svc.port)
+        newStatuses[svc.id] = entry?.status ?? 'UNKNOWN'
+      }
+      setHealthStatuses(newStatuses)
+    }
+    if (governanceResult.ok && governanceResult.value.available) setGovernanceData(governanceResult.value.byService)
+    if (graphResult.ok && graphResult.value.available) {
+      const graph = graphResult.value.graph
+      const deg: Record<string, number> = {}
+      for (const node of graph.nodes) {
+        const id = SERVICE_NAME_TO_ID[node.name.replace(/^openbank-/, '')]
+        if (id) deg[id] = (node.dependsOn ?? 0) + (node.dependedOnBy ?? 0)
+      }
+      setGraphEdges(graph.edges)
+      setDegrees(deg)
+      setInfraNodes(graph.infraNodes)
+      setExternalNodes(graph.externalNodes)
+      setInfraEdges(graph.infraEdges)
+      setExternalEdges(graph.externalEdges)
+    }
+    setVerified(current => ({
+      health: current.health || healthResult.ok,
+      governance: current.governance || (governanceResult.ok && governanceResult.value.available),
+      topology: current.topology || (graphResult.ok && graphResult.value.available),
+    }))
+    setEvidence(nextEvidence)
+    setIsChecking(false)
+  }, [])
 
   useEffect(() => {
-    checkHealth()
-  }, [])
+    void Promise.resolve().then(checkHealth)
+    return () => { requestGeneration.current += 1 }
+  }, [checkHealth])
 
   const selectedSvc = SERVICES.find(s => s.id === selected)
   const selectedTier: InfraNodeT | ExternalNodeT | undefined = [...infraNodes, ...externalNodes].find(n => n.id === selected)
@@ -556,6 +600,22 @@ export default function ServiceMapPage() {
     sdd: 'SEPA Direct Debit mandáty a inkasa',
   }
 
+  const evidenceLabels = {
+    health: t('Provozní stav', 'Runtime health'),
+    governance: t('Governance', 'Governance'),
+    topology: t('Vazby a integrace', 'Dependencies & integrations'),
+  }
+  const evidenceCopy = (key: keyof typeof evidence, state: EvidenceState) => {
+    if (state === 'loading') return t('Načítám', 'Loading')
+    if (state === 'ok') return t('Ověřeno', 'Verified')
+    const stale = verified[key] ? t(' · poslední ověřená data', ' · last verified data') : ''
+    if (state === 'unauthorized') return t('Relace vypršela', 'Session expired')
+    if (state === 'scaled_to_zero') return t('Zdroj je uspán', 'Source scaled to zero') + stale
+    if (state === 'not_deployed') return t('Snapshot není nasazen', 'Snapshot not deployed') + stale
+    if (state === 'error') return t('Neplatná evidence', 'Invalid evidence') + stale
+    return t('Zdroj neodpovídá', 'Source unavailable') + stale
+  }
+
   return (
     <div>
       <DocsPageHeader
@@ -570,6 +630,22 @@ export default function ServiceMapPage() {
       />
 
       <CatalogDriftBanner present={CATALOG_PRESENT} />
+
+      <section className="card" aria-label={t('Stav zdrojů mapy', 'Map evidence status')} style={{ padding: '12px 14px', marginBottom: 16, display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10 }}>
+        {(Object.keys(evidence) as (keyof typeof evidence)[]).map(key => {
+          const state = evidence[key]
+          const tone = state === 'ok' ? 'var(--success)' : state === 'loading' ? 'var(--text-tertiary)' : 'var(--warning)'
+          return (
+            <div key={key} data-testid={`map-evidence-${key}`} role={state === 'ok' || state === 'loading' ? undefined : 'status'} aria-live={state === 'ok' || state === 'loading' ? undefined : 'polite'} style={{ minWidth: 0, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--surface-2)', border: '1px solid var(--border)' }}>
+              <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)', marginBottom: 3 }}>{evidenceLabels[key]}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: tone, fontSize: 11 }}>
+                <span aria-hidden="true" style={{ width: 7, height: 7, borderRadius: '50%', background: tone, flexShrink: 0 }} />
+                <span>{evidenceCopy(key, state)}</span>
+              </div>
+            </div>
+          )
+        })}
+      </section>
 
       {/* Filter tabs and Controls */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexWrap: 'wrap', gap: '16px' }}>

--- a/openbank-admin-ui/src/lib/governance/service-map-evidence.ts
+++ b/openbank-admin-ui/src/lib/governance/service-map-evidence.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
+
+export type MapHealthEntry = { port: number; status: 'UP' | 'DOWN' | 'UNKNOWN' }
+export type MapEdge = { from: string; to: string; via: string; type: 'rest' | 'kafka' }
+export type MapNode = { name: string; dependsOn?: number; dependedOnBy?: number }
+export type MapInfraNode = { id: string; kind: 'infra'; tech: string; label: string }
+export type MapExternalNode = { id: string; kind: 'external'; vendor: string; label: string }
+export type MapInfraEdge = { from: string; to: string; type: 'db' | 'broker' | 'auth' | 'authz' }
+export type MapExternalEdge = { from: string; to: string; type: 'push' | 'webhook' | 'registry' | 'api' | 'llm'; enabled: boolean }
+export type ServiceMapGraph = {
+  edges: MapEdge[]; nodes: MapNode[]; infraNodes: MapInfraNode[]; externalNodes: MapExternalNode[]
+  infraEdges: MapInfraEdge[]; externalEdges: MapExternalEdge[]
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+const text = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0
+const count = (value: unknown): value is number => Number.isInteger(value) && (value as number) >= 0
+const port = (value: unknown): value is number => Number.isInteger(value) && (value as number) > 0 && (value as number) <= 65_535
+
+function arrayOf<T>(value: unknown, parser: (item: unknown) => T | null): T[] | null {
+  if (!Array.isArray(value) || value.length > 500) return null
+  const parsed = value.map(parser)
+  return parsed.some(item => item === null) ? null : parsed as T[]
+}
+
+export function parseMapHealth(value: unknown): MapHealthEntry[] | null {
+  const envelope = record(value)
+  const services = envelope && arrayOf(envelope.services, raw => {
+    const item = record(raw)
+    return item && port(item.port) && ['UP', 'DOWN', 'UNKNOWN'].includes(String(item.status))
+      ? { port: item.port, status: item.status as MapHealthEntry['status'] }
+      : null
+  })
+  if (!services || new Set(services.map(item => item.port)).size !== services.length) return null
+  return services
+}
+
+export function parseMapGovernance(value: unknown): { available: boolean; byService: Record<string, GovernanceManifestEntry> } | null {
+  const envelope = record(value)
+  if (!envelope || typeof envelope.available !== 'boolean') return null
+  const byService = record(envelope.byService)
+  if (!byService || Object.keys(byService).length > 200) return null
+  for (const [key, raw] of Object.entries(byService)) {
+    const item = record(raw)
+    if (!item || item.serviceName !== key || !text(item.serviceName) || !text(item.primaryDatastore) ||
+      !(item.databaseName === null || text(item.databaseName)) || !text(item.dataLineageRole) ||
+      !(item.flywayDeclaredVersion === null || text(item.flywayDeclaredVersion)) ||
+      !(item.flywayCurrentVersion === null || text(item.flywayCurrentVersion)) ||
+      ![true, false, 'unknown'].includes(item.flywayDrift as boolean | string)) return null
+  }
+  if (!envelope.available && Object.keys(byService).length > 0) return null
+  return { available: envelope.available, byService: byService as Record<string, GovernanceManifestEntry> }
+}
+
+export function parseServiceMapGraph(value: unknown): { available: boolean; graph: ServiceMapGraph } | null {
+  const envelope = record(value)
+  if (!envelope || typeof envelope.available !== 'boolean') return null
+  const edges = arrayOf(envelope.edges, raw => {
+    const item = record(raw)
+    return item && text(item.from) && text(item.to) && text(item.via) && ['rest', 'kafka'].includes(String(item.type)) ? item as MapEdge : null
+  })
+  const nodes = arrayOf(envelope.nodes, raw => {
+    const item = record(raw)
+    return item && text(item.name) && (item.dependsOn === undefined || count(item.dependsOn)) &&
+      (item.dependedOnBy === undefined || count(item.dependedOnBy)) ? item as MapNode : null
+  })
+  const infraNodes = arrayOf(envelope.infraNodes ?? [], raw => {
+    const item = record(raw); return item && item.kind === 'infra' && text(item.id) && text(item.tech) && text(item.label) ? item as MapInfraNode : null
+  })
+  const externalNodes = arrayOf(envelope.externalNodes ?? [], raw => {
+    const item = record(raw); return item && item.kind === 'external' && text(item.id) && text(item.vendor) && text(item.label) ? item as MapExternalNode : null
+  })
+  const infraEdges = arrayOf(envelope.infraEdges ?? [], raw => {
+    const item = record(raw); return item && text(item.from) && text(item.to) && ['db', 'broker', 'auth', 'authz'].includes(String(item.type)) ? item as MapInfraEdge : null
+  })
+  const externalEdges = arrayOf(envelope.externalEdges ?? [], raw => {
+    const item = record(raw); return item && text(item.from) && text(item.to) && ['push', 'webhook', 'registry', 'api', 'llm'].includes(String(item.type)) && typeof item.enabled === 'boolean' ? item as MapExternalEdge : null
+  })
+  if (!edges || !nodes || !infraNodes || !externalNodes || !infraEdges || !externalEdges) return null
+  if (!envelope.available && [edges, nodes, infraNodes, externalNodes, infraEdges, externalEdges].some(list => list.length)) return null
+  const nodeIds = [...nodes.map(node => node.name), ...infraNodes.map(node => node.id), ...externalNodes.map(node => node.id)]
+  if (new Set(nodeIds).size !== nodeIds.length) return null
+  return { available: envelope.available, graph: { edges, nodes, infraNodes, externalNodes, infraEdges, externalEdges } }
+}

--- a/openbank-admin-ui/src/test/service-map-evidence.test.ts
+++ b/openbank-admin-ui/src/test/service-map-evidence.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseMapGovernance, parseMapHealth, parseServiceMapGraph } from '@/lib/governance/service-map-evidence'
+
+describe('Service Map evidence parsers', () => {
+  it('validates health entries and rejects duplicate ports', () => {
+    expect(parseMapHealth({ services: [{ port: 8100, status: 'UP' }] })).toEqual([{ port: 8100, status: 'UP' }])
+    expect(parseMapHealth({ services: [{ port: 8100, status: 'BROKEN' }] })).toBeNull()
+    expect(parseMapHealth({ services: [{ port: 0, status: 'UP' }] })).toBeNull()
+    expect(parseMapHealth({ services: [{ port: 8100, status: 'UP' }, { port: 8100, status: 'DOWN' }] })).toBeNull()
+  })
+
+  it('keeps unavailable governance distinct and rejects contradictory evidence', () => {
+    expect(parseMapGovernance({ available: false, byService: {} })).toEqual({ available: false, byService: {} })
+    expect(parseMapGovernance({ available: false, byService: { account: {} } })).toBeNull()
+    expect(parseMapGovernance({ byService: {} })).toBeNull()
+  })
+
+  it('validates graph envelopes and rejects malformed or contradictory snapshots', () => {
+    const empty = { available: true, nodes: [], edges: [], infraNodes: [], externalNodes: [], infraEdges: [], externalEdges: [] }
+    expect(parseServiceMapGraph(empty)?.available).toBe(true)
+    expect(parseServiceMapGraph({ ...empty, nodes: 'invalid' })).toBeNull()
+    expect(parseServiceMapGraph({ ...empty, available: false, edges: [{ from: 'a', to: 'b', via: 'b', type: 'rest' }] })).toBeNull()
+    expect(parseServiceMapGraph({ ...empty, nodes: [{ name: 'account' }, { name: 'account' }] })).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/service-map-governance-route.test.ts
+++ b/openbank-admin-ui/src/test/service-map-governance-route.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }))
+vi.mock('fs/promises', async importOriginal => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  const scopedReadFile = (...args: Parameters<typeof actual.readFile>) =>
+    String(args[0]).endsWith('__service-map-governance-test__.json') ? readFile(...args) : actual.readFile(...args)
+  return { ...actual, default: { ...actual, readFile: scopedReadFile }, readFile: scopedReadFile }
+})
+
+import { GET } from '@/app/api/services/governance/route'
+
+describe('Service Map governance BFF evidence', () => {
+  beforeEach(() => {
+    readFile.mockReset()
+    process.env.OPENBANK_GOVERNANCE = '/tmp/__service-map-governance-test__.json'
+  })
+
+  afterEach(() => delete process.env.OPENBANK_GOVERNANCE)
+
+  it('marks a missing snapshot unavailable', async () => {
+    readFile.mockRejectedValue(new Error('missing'))
+    expect(await (await GET()).json()).toMatchObject({ available: false, items: [], byService: {} })
+  })
+
+  it('marks a malformed snapshot unavailable instead of verified empty', async () => {
+    readFile.mockResolvedValue(JSON.stringify({ schema: 'unexpected' }))
+    expect(await (await GET()).json()).toMatchObject({ available: false, items: [], byService: {} })
+  })
+
+  it('keeps a valid empty snapshot distinct', async () => {
+    readFile.mockResolvedValue(JSON.stringify({ services: [] }))
+    expect(await (await GET()).json()).toMatchObject({ available: true, items: [], byService: {} })
+  })
+})

--- a/openbank-admin-ui/src/test/service-map-topology.test.tsx
+++ b/openbank-admin-ui/src/test/service-map-topology.test.tsx
@@ -62,7 +62,7 @@ function mockFetch() {
     if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
     if (url.includes('/api/catalog/graph')) return json(GRAPH)
     if (url.includes('/api/services/health')) return json({ services: [] })
-    if (url.includes('/api/services/governance')) return json({ byService: {} })
+    if (url.includes('/api/services/governance')) return json({ available: true, byService: {} })
     return json({})
   })
 }
@@ -110,5 +110,105 @@ describe('service-map data-flow tiers', () => {
     const apnsParticles = [...container.querySelectorAll('animateMotion')]
       .filter(m => (m.querySelector('mpath')?.getAttribute('href') ?? '').includes('apple-apns'))
     expect(apnsParticles.length).toBe(0)
+  })
+
+  it('keeps successful topology visible when health evidence is malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null')
+      if (url.includes('/api/catalog/graph')) return json(GRAPH)
+      if (url.includes('/api/services/health')) return json({ services: 'invalid' })
+      return json({ available: true, byService: {} })
+    }))
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    expect(await screen.findByText('PostgreSQL')).toBeInTheDocument()
+    expect(screen.getByTestId('map-evidence-health')).toHaveTextContent(/Invalid evidence/i)
+    expect(screen.getByTestId('map-evidence-topology')).toHaveTextContent(/Verified/i)
+  })
+
+  it('shows an unavailable graph snapshot instead of claiming verified empty topology', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null')
+      if (url.includes('/api/catalog/graph')) return json({ available: false, nodes: [], edges: [], infraNodes: [], externalNodes: [], infraEdges: [], externalEdges: [] })
+      if (url.includes('/api/services/health')) return json({ services: [] })
+      return json({ available: true, byService: {} })
+    }))
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    expect(await screen.findByText(/Snapshot not deployed/i)).toBeInTheDocument()
+    expect(screen.getByTestId('map-evidence-topology')).not.toHaveTextContent(/Verified/)
+  })
+
+  it('retains the last verified graph when its refresh response is malformed', async () => {
+    let graphReads = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null')
+      if (url.includes('/api/catalog/graph')) return json(++graphReads === 1 ? GRAPH : { available: true, nodes: 'invalid', edges: [] })
+      if (url.includes('/api/services/health')) return json({ services: [] })
+      return json({ available: true, byService: {} })
+    }))
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    expect(await screen.findByText('PostgreSQL')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Refresh Status|Obnovit stav/ }))
+    await waitFor(() => expect(screen.getByTestId('map-evidence-topology')).toHaveTextContent(/Invalid evidence.*last verified data/i))
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+  })
+
+  it('purges every previously verified source when any refresh returns unauthorized', async () => {
+    let governanceReads = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null')
+      if (url.includes('/api/catalog/graph')) return json(GRAPH)
+      if (url.includes('/api/services/health')) return json({ services: [] })
+      if (url.includes('/api/services/governance')) {
+        governanceReads += 1
+        return governanceReads === 1
+          ? json({ available: true, byService: {} })
+          : json({ error: 'unauthorized' }, 401)
+      }
+      return json({})
+    }))
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    expect(await screen.findByText('PostgreSQL')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('PostgreSQL'))
+    expect(screen.getByText(/CONNECTED SERVICES/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh Status|Obnovit stav/ }))
+    await waitFor(() => expect(screen.getByTestId('map-evidence-health')).toHaveTextContent(/Session expired/i))
+    expect(screen.getByTestId('map-evidence-governance')).toHaveTextContent(/Session expired/i)
+    expect(screen.getByTestId('map-evidence-topology')).toHaveTextContent(/Session expired/i)
+    expect(screen.queryByText('PostgreSQL')).not.toBeInTheDocument()
+    expect(screen.queryByText(/CONNECTED SERVICES/i)).not.toBeInTheDocument()
+  })
+
+  it('ignores an older refresh that resolves after a newer verified response', async () => {
+    let graphReads = 0
+    let releaseOlder: (() => void) | undefined
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null')
+      if (url.includes('/api/services/health')) return json({ services: [] })
+      if (url.includes('/api/services/governance')) return json({ available: true, byService: {} })
+      if (url.includes('/api/catalog/graph')) {
+        graphReads += 1
+        const read = graphReads
+        if (read === 1) await new Promise<void>(resolve => { releaseOlder = resolve })
+        return json(read === 1 ? { available: true, nodes: 'invalid', edges: [] } : GRAPH)
+      }
+      return json({})
+    }))
+    render(React.createElement(React.StrictMode, null, React.createElement(Providers, null, React.createElement(ServiceMapPage))))
+    await waitFor(() => expect(graphReads).toBe(2))
+    releaseOlder?.()
+
+    await waitFor(() => expect(screen.getByTestId('map-evidence-topology')).toHaveTextContent(/Verified/i))
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- validate health, governance, and topology payloads independently before rendering them
- preserve the last verified source data after technical or malformed refresh failures
- classify BFF failures accurately, enforce 10-second fetch bounds, and keep only the latest refresh result
- purge all cached map evidence and open detail state when any source crosses the 401 authorization boundary
- distinguish verified, unavailable, scaled-to-zero, and expired-session evidence in the Service Map

## Verification
- 15 focused Vitest tests passed
- TypeScript type-check passed
- targeted ESLint passed with zero findings
- production Next.js build passed (97/97 pages)
- production-mode Playwright E2E passed in Chromium (1/1)
- signed commit rebased onto current main with stable patch-id
- `git diff --check` passed

Closes #9470
