### PR TITLE
fix(admin-ui): keep onboarding evidence current

### DIFF
--- a/openbank-admin-ui/e2e/onboarding-evidence.spec.ts
+++ b/openbank-admin-ui/e2e/onboarding-evidence.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test, type Route } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('shows every onboarding stage and purges customer evidence after authorization loss', async ({ page }) => {
+  let unauthorized = false
+  const funnel = {
+    REGISTERED: 1, KYC_OPEN: 2, KYC_DOCUMENTS_REQUIRED: 3, KYC_UNDER_REVIEW: 4,
+    SCA_PENDING: 5, ACTIVE: 6, BLOCKED: 7,
+  }
+  const customer = {
+    partyId: '11111111-1111-4111-8111-111111111111', legalName: 'Sensitive Customer', email: 'customer@example.test',
+    partyStatus: 'PENDING_KYC', kycCaseId: null, kycStatus: 'DOCUMENTS_REQUIRED', scaEnrolled: false,
+    deviceCount: 0, funnelStage: 'KYC_DOCUMENTS_REQUIRED', blockedReason: null,
+    createdAt: '2026-09-09T10:00:00Z', updatedAt: '2026-09-09T10:01:00Z',
+  }
+  const fulfill = (route: Route, body: unknown) => route.fulfill({
+    status: unauthorized ? 401 : 200,
+    contentType: 'application/json',
+    body: JSON.stringify(unauthorized ? { error: 'unauthorized' } : body),
+  })
+  await page.route('**/api/svc/onboarding-service/api/v1/onboarding/funnel', route => fulfill(route, funnel))
+  await page.route('**/api/svc/onboarding-service/api/v1/onboarding/records?*', route => fulfill(route, {
+    items: [customer], total: 1, page: 0, size: 20,
+  }))
+
+  await page.goto('/onboarding')
+  const filters = page.getByRole('group', { name: 'Onboarding stage filters' })
+  await expect(filters.getByRole('button')).toHaveCount(7)
+  await expect(filters.getByRole('button', { name: /KYC Documents/ })).toContainText('3')
+  const row = page.getByRole('row', { name: /Sensitive Customer/ })
+  await row.click()
+  await expect(page.getByRole('dialog')).toContainText('customer@example.test')
+
+  unauthorized = true
+  await page.locator('[aria-label="Refresh onboarding"]').evaluate((button: HTMLButtonElement) => button.click())
+  await expect(page.getByText('Sensitive Customer')).toBeHidden()
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await expect(page.getByText(/session has expired/).first()).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -12,52 +12,26 @@ import { ClipboardList, RefreshCw, ChevronRight, X, TrendingUp } from 'lucide-re
 import Link from 'next/link'
 import { Drawer, PageHeader } from '@/components/ui'
 import { Can } from '@/components/auth/AuthGuard'
+import {
+  ONBOARDING_STAGES as STAGES,
+  parseFunnelCounts,
+  parseOnboardingRecordPage,
+  type OnboardingRecord,
+  type OnboardingStage as Stage,
+} from '@/lib/onboarding/evidence'
 
 const SVC = 'onboarding-service'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-interface OnboardingRecord {
-  partyId: string
-  legalName: string | null
-  email: string | null
-  partyStatus: string
-  kycCaseId: string | null
-  kycStatus: string | null
-  scaEnrolled: boolean
-  deviceCount: number
-  funnelStage: string
-  blockedReason: string | null
-  createdAt: string
-  updatedAt: string
-}
-
-interface RecordPage {
-  items: OnboardingRecord[]
-  total: number
-  page: number
-  size: number
-  stageFilter?: string
-}
-
-type FunnelCounts = Record<string, number>
+type FunnelCounts = Record<Stage, number>
 
 // ── Stage display config ──────────────────────────────────────────────────────
-
-const STAGES = [
-  'REGISTERED',
-  'KYC_OPEN',
-  'KYC_UNDER_REVIEW',
-  'SCA_PENDING',
-  'ACTIVE',
-  'BLOCKED',
-] as const
-
-type Stage = typeof STAGES[number]
 
 const STAGE_LABEL_CS: Record<Stage, string> = {
   REGISTERED:               'Registrován',
   KYC_OPEN:                 'KYC otevřeno',
+  KYC_DOCUMENTS_REQUIRED:  'KYC — dokumenty',
   KYC_UNDER_REVIEW:         'KYC — přezkoumání',
   SCA_PENDING:              'SCA čeká',
   ACTIVE:                   'Aktivní',
@@ -67,6 +41,7 @@ const STAGE_LABEL_CS: Record<Stage, string> = {
 const STAGE_LABEL_EN: Record<Stage, string> = {
   REGISTERED:               'Registered',
   KYC_OPEN:                 'KYC Open',
+  KYC_DOCUMENTS_REQUIRED:  'KYC Documents',
   KYC_UNDER_REVIEW:         'KYC Under Review',
   SCA_PENDING:              'SCA Pending',
   ACTIVE:                   'Active',
@@ -76,6 +51,7 @@ const STAGE_LABEL_EN: Record<Stage, string> = {
 const STAGE_COLOR: Record<Stage, string> = {
   REGISTERED:               'var(--text-muted)',
   KYC_OPEN:                 'var(--yellow)',
+  KYC_DOCUMENTS_REQUIRED:  '#f59e0b',
   KYC_UNDER_REVIEW:         'var(--accent)',
   SCA_PENDING:              '#a855f7',
   ACTIVE:                   'var(--green)',
@@ -101,9 +77,24 @@ export default function OnboardingPage() {
   const [stage, setStage] = useState<Stage | ''>('')
   const [loading, setLoading] = useState(true)
   const [listUnavail, setListUnavail] = useState<{ kind: UnavailableKind } | null>(null)
+  const countsRequest = useRef(0)
+  const recordsRequest = useRef(0)
 
   // drawer
   const [selected, setSelected] = useState<OnboardingRecord | null>(null)
+
+  const purgeAuthorizedEvidence = useCallback(() => {
+    countsRequest.current += 1
+    recordsRequest.current += 1
+    setCounts(null)
+    setRecords([])
+    setTotal(0)
+    setSelected(null)
+    setCountsLoading(false)
+    setLoading(false)
+    setCountsUnavail({ kind: 'unauthorized' })
+    setListUnavail({ kind: 'unauthorized' })
+  }, [])
 
   const stageLabel = useCallback((s: string) =>
     language === 'cs'
@@ -115,41 +106,63 @@ export default function OnboardingPage() {
   // ── Load funnel counts ──────────────────────────────────────────────────────
 
   const loadCounts = useCallback(async () => {
+    const request = ++countsRequest.current
     setCountsLoading(true); setCountsUnavail(null)
     try {
       const res = await fetch(svcUrl(SVC, '/api/v1/onboarding/funnel'), { signal: AbortSignal.timeout(5000) })
-      if (!res.ok) { setCountsUnavail({ kind: await classifyBffFailure(res) }); return }
-      setCounts(await res.json())
+      if (!res.ok) {
+        const kind = await classifyBffFailure(res)
+        if (request !== countsRequest.current) return
+        if (kind === 'unauthorized') purgeAuthorizedEvidence()
+        else setCountsUnavail({ kind })
+        return
+      }
+      const parsed = parseFunnelCounts(await res.json())
+      if (request !== countsRequest.current) return
+      if (!parsed) { setCountsUnavail({ kind: 'error' }); return }
+      setCounts(parsed)
     } catch {
-      setCountsUnavail({ kind: 'unreachable' })
-    } finally { setCountsLoading(false) }
-  }, [])
+      if (request === countsRequest.current) setCountsUnavail({ kind: 'unreachable' })
+    } finally {
+      if (request === countsRequest.current) setCountsLoading(false)
+    }
+  }, [purgeAuthorizedEvidence])
 
   // ── Load records list ───────────────────────────────────────────────────────
 
   const loadRecords = useCallback(async (pg: number, stg: Stage | '') => {
-    setLoading(true); setListUnavail(null)
+    const request = ++recordsRequest.current
+    setLoading(true); setListUnavail(null); setSelected(null)
     try {
       const query: Record<string, string> = { page: String(pg), size: '20' }
       if (stg) query.stage = stg
       const res = await fetch(svcUrl(SVC, '/api/v1/onboarding/records', query), { signal: AbortSignal.timeout(5000) })
-      if (!res.ok) { setListUnavail({ kind: await classifyBffFailure(res) }); setRecords([]); return }
-      const data: RecordPage = await res.json()
-      setRecords(data.items ?? [])
+      if (!res.ok) {
+        const kind = await classifyBffFailure(res)
+        if (request !== recordsRequest.current) return
+        if (kind === 'unauthorized') purgeAuthorizedEvidence()
+        else { setListUnavail({ kind }); setRecords([]) }
+        return
+      }
+      const data = parseOnboardingRecordPage(await res.json(), pg, stg)
+      if (request !== recordsRequest.current) return
+      if (!data) { setListUnavail({ kind: 'error' }); setRecords([]); return }
+      setRecords(data.items)
       setTotal(data.total ?? 0)
     } catch {
-      setListUnavail({ kind: 'unreachable' })
-      setRecords([])
-    } finally { setLoading(false) }
-  }, [])
+      if (request === recordsRequest.current) { setListUnavail({ kind: 'unreachable' }); setRecords([]) }
+    } finally {
+      if (request === recordsRequest.current) setLoading(false)
+    }
+  }, [purgeAuthorizedEvidence])
 
   const refresh = useCallback(() => {
     loadCounts()
     loadRecords(page, stage)
   }, [loadCounts, loadRecords, page, stage])
 
-  useEffect(() => { loadCounts() }, [loadCounts])
-  useEffect(() => { loadRecords(page, stage) }, [loadRecords, page, stage])
+  useEffect(() => { void Promise.resolve().then(loadCounts) }, [loadCounts])
+  useEffect(() => { void Promise.resolve().then(() => loadRecords(page, stage)) }, [loadRecords, page, stage])
 
   const handleStageFilter = (s: Stage | '') => {
     setStage(s)
@@ -185,7 +198,7 @@ export default function OnboardingPage() {
           aria-live="polite"
           aria-busy="true"
           aria-label={t('Načítání počtů funnelu…', 'Loading funnel counts…')}
-          style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(112px, 1fr))', gap: '10px', marginBottom: '20px' }}
         >
           {STAGES.map(s => (
             <div key={s} style={{ border: '1px solid var(--border)', borderRadius: '8px', padding: '12px 8px', textAlign: 'center' }}>
@@ -202,7 +215,7 @@ export default function OnboardingPage() {
           <DataUnavailable kind={countsUnavail.kind} service={t('Onboarding-service', 'Onboarding-service')} feature={t('Funnel počty', 'Funnel counts')} lang={language} dense />
         </div>
       ) : (
-        <div role="group" aria-label={t('Filtr fází onboardingu', 'Onboarding stage filters')} style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}>
+        <div role="group" aria-label={t('Filtr fází onboardingu', 'Onboarding stage filters')} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(112px, 1fr))', gap: '10px', marginBottom: '20px' }}>
           {STAGES.map(s => {
             const count = counts?.[s] ?? 0
             const isActive = stage === s

--- a/openbank-admin-ui/src/lib/onboarding/evidence.ts
+++ b/openbank-admin-ui/src/lib/onboarding/evidence.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const ONBOARDING_STAGES = [
+  'REGISTERED',
+  'KYC_OPEN',
+  'KYC_DOCUMENTS_REQUIRED',
+  'KYC_UNDER_REVIEW',
+  'SCA_PENDING',
+  'ACTIVE',
+  'BLOCKED',
+] as const
+
+export type OnboardingStage = typeof ONBOARDING_STAGES[number]
+
+export interface OnboardingRecord {
+  partyId: string
+  legalName: string | null
+  email: string | null
+  partyStatus: 'PENDING_KYC' | 'ACTIVE' | 'SUSPENDED' | 'CLOSED'
+  kycCaseId: string | null
+  kycStatus: 'OPEN' | 'DOCUMENTS_REQUIRED' | 'UNDER_REVIEW' | 'APPROVED' | 'REJECTED' | 'EXPIRED' | null
+  scaEnrolled: boolean
+  deviceCount: number
+  funnelStage: OnboardingStage
+  blockedReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OnboardingRecordPage {
+  items: OnboardingRecord[]
+  total: number
+  page: number
+  size: number
+  stageFilter?: OnboardingStage
+}
+
+const object = (value: unknown): Record<string, unknown> | null =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null
+const integer = (value: unknown): value is number => Number.isSafeInteger(value) && (value as number) >= 0
+const nullableText = (value: unknown): value is string | null => value === null || typeof value === 'string'
+// Match java.util.UUID.fromString semantics used by the service: UUID syntax is
+// authoritative here; version and variant bits are not constrained by the API.
+const uuid = (value: unknown): value is string => typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+const instant = (value: unknown): value is string => typeof value === 'string' && Number.isFinite(Date.parse(value))
+const member = <T extends readonly string[]>(value: unknown, values: T): value is T[number] =>
+  typeof value === 'string' && values.includes(value)
+
+export function parseFunnelCounts(value: unknown): Record<OnboardingStage, number> | null {
+  const raw = object(value)
+  if (!raw || Object.keys(raw).length !== ONBOARDING_STAGES.length) return null
+  for (const stage of ONBOARDING_STAGES) if (!integer(raw[stage])) return null
+  return raw as Record<OnboardingStage, number>
+}
+
+export function parseOnboardingRecordPage(
+  value: unknown,
+  expectedPage: number,
+  expectedStage: OnboardingStage | '',
+): OnboardingRecordPage | null {
+  const raw = object(value)
+  if (!raw || !Array.isArray(raw.items) || raw.items.length > 20 || !integer(raw.total) ||
+    raw.page !== expectedPage || raw.size !== 20 || raw.items.length > raw.total) return null
+  if (expectedStage ? raw.stageFilter !== expectedStage : raw.stageFilter !== undefined && raw.stageFilter !== null) return null
+
+  const items: OnboardingRecord[] = []
+  for (const candidate of raw.items) {
+    const item = object(candidate)
+    if (!item || !uuid(item.partyId) || !nullableText(item.legalName) || !nullableText(item.email) ||
+      !member(item.partyStatus, ['PENDING_KYC', 'ACTIVE', 'SUSPENDED', 'CLOSED'] as const) ||
+      !(item.kycCaseId === null || uuid(item.kycCaseId)) ||
+      !(item.kycStatus === null || member(item.kycStatus, ['OPEN', 'DOCUMENTS_REQUIRED', 'UNDER_REVIEW', 'APPROVED', 'REJECTED', 'EXPIRED'] as const)) ||
+      typeof item.scaEnrolled !== 'boolean' || !integer(item.deviceCount) ||
+      !member(item.funnelStage, ONBOARDING_STAGES) || !nullableText(item.blockedReason) ||
+      !instant(item.createdAt) || !instant(item.updatedAt)) return null
+    if (expectedStage && item.funnelStage !== expectedStage) return null
+    items.push(item as unknown as OnboardingRecord)
+  }
+  return { items, total: raw.total, page: expectedPage, size: 20, ...(expectedStage && { stageFilter: expectedStage }) }
+}

--- a/openbank-admin-ui/src/test/onboarding-evidence.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-evidence.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { ONBOARDING_STAGES, parseFunnelCounts, parseOnboardingRecordPage } from '@/lib/onboarding/evidence'
+
+const record = {
+  partyId: '11111111-1111-4111-8111-111111111111', legalName: 'Ada Bank', email: 'ada@example.test',
+  partyStatus: 'PENDING_KYC', kycCaseId: null, kycStatus: 'OPEN', scaEnrolled: false, deviceCount: 0,
+  funnelStage: 'KYC_OPEN', blockedReason: null, createdAt: '2026-09-09T10:00:00Z', updatedAt: '2026-09-09T10:01:00Z',
+}
+
+describe('onboarding operational evidence', () => {
+  it('accepts only a complete non-negative funnel', () => {
+    const valid = Object.fromEntries(ONBOARDING_STAGES.map(stage => [stage, 0]))
+    expect(parseFunnelCounts(valid)).toEqual(valid)
+    expect(parseFunnelCounts({ ...valid, ACTIVE: -1 })).toBeNull()
+    expect(parseFunnelCounts(Object.fromEntries(Object.entries(valid).filter(([stage]) => stage !== 'BLOCKED')))).toBeNull()
+  })
+
+  it('verifies the requested page and stage', () => {
+    expect(parseOnboardingRecordPage({ items: [record], total: 1, page: 0, size: 20, stageFilter: 'KYC_OPEN' }, 0, 'KYC_OPEN')?.items).toHaveLength(1)
+    expect(parseOnboardingRecordPage({ items: [record], total: 1, page: 1, size: 20, stageFilter: 'KYC_OPEN' }, 0, 'KYC_OPEN')).toBeNull()
+    expect(parseOnboardingRecordPage({ items: [{ ...record, funnelStage: 'ACTIVE' }], total: 1, page: 0, size: 20, stageFilter: 'KYC_OPEN' }, 0, 'KYC_OPEN')).toBeNull()
+  })
+
+  it('rejects malformed records instead of rendering partial customer evidence', () => {
+    expect(parseOnboardingRecordPage({ items: [{ ...record, partyId: 'not-a-uuid' }], total: 1, page: 0, size: 20 }, 0, '')).toBeNull()
+    expect(parseOnboardingRecordPage({ items: [record], total: 0, page: 0, size: 20 }, 0, '')).toBeNull()
+  })
+
+  it('accepts UUID syntax without inventing version-bit constraints absent from the API', () => {
+    const versionless = { ...record, partyId: '00000000-1111-0000-0000-000000000001' }
+    expect(parseOnboardingRecordPage({ items: [versionless], total: 1, page: 0, size: 20 }, 0, '')?.items[0].partyId)
+      .toBe(versionless.partyId)
+  })
+})

--- a/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
@@ -6,8 +6,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import OnboardingPage from '@/app/onboarding/page'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 
-const FUNNEL = { REGISTERED: 12, KYC_OPEN: 4, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { roles: ['ROLE_OPERATOR'] } }, status: 'authenticated' }),
+  signIn: vi.fn(),
+}))
+
+const FUNNEL = { REGISTERED: 12, KYC_OPEN: 4, KYC_DOCUMENTS_REQUIRED: 2, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
 const RECORDS = { items: [], total: 0, page: 0, size: 20 }
+const record = (partyId: string, legalName: string, funnelStage: string) => ({
+  partyId, legalName, email: null, partyStatus: 'PENDING_KYC', kycCaseId: null, kycStatus: 'OPEN',
+  scaEnrolled: false, deviceCount: 0, funnelStage, blockedReason: null,
+  createdAt: '2026-09-09T10:00:00Z', updatedAt: '2026-09-09T10:01:00Z',
+})
 
 function response(status: number, body: unknown) {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
@@ -122,5 +132,62 @@ describe('onboarding funnel loading (issue #8233)', () => {
     expect(await screen.findByText(/onboarding-service/i)).toBeVisible()
     expect(screen.queryByRole('group', { name: 'Onboarding stage filters' })).not.toBeInTheDocument()
     expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('never lets an older list response replace the active stage result', async () => {
+    const oldRequest = deferred<Response>()
+    const activeRequest = deferred<Response>()
+    let recordsCalls = 0
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/onboarding/funnel')) return Promise.resolve(response(200, FUNNEL))
+      if (url.includes('/onboarding/records')) return ++recordsCalls === 1 ? oldRequest.promise : activeRequest.promise
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    renderPage()
+    const filters = await screen.findByRole('group', { name: 'Onboarding stage filters' })
+    fireEvent.click(within(filters).getByRole('button', { name: /KYC Open/ }))
+
+    await act(async () => {
+      activeRequest.resolve(response(200, {
+        items: [record('11111111-1111-4111-8111-111111111111', 'Current customer', 'KYC_OPEN')],
+        total: 1, page: 0, size: 20, stageFilter: 'KYC_OPEN',
+      }))
+      await activeRequest.promise
+    })
+    expect(await screen.findByText('Current customer')).toBeVisible()
+
+    await act(async () => {
+      oldRequest.resolve(response(200, {
+        items: [record('22222222-2222-4222-8222-222222222222', 'Stale customer', 'ACTIVE')],
+        total: 1, page: 0, size: 20,
+      }))
+      await oldRequest.promise
+    })
+    expect(screen.getByText('Current customer')).toBeVisible()
+    expect(screen.queryByText('Stale customer')).not.toBeInTheDocument()
+  })
+
+  it('purges records, funnel counts and the open drawer after authorization loss', async () => {
+    const current = record('11111111-1111-4111-8111-111111111111', 'Sensitive Customer', 'KYC_OPEN')
+    let unauthorized = false
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => Promise.resolve(response(unauthorized ? 401 : 200, unauthorized ? { error: 'unauthorized' } : FUNNEL)),
+      records: () => Promise.resolve(response(unauthorized ? 401 : 200, unauthorized
+        ? { error: 'unauthorized' }
+        : { items: [current], total: 1, page: 0, size: 20 })),
+    }))
+
+    renderPage()
+    const row = await screen.findByRole('row', { name: /Sensitive Customer/ })
+    fireEvent.click(row)
+    expect(screen.getByRole('dialog')).toHaveTextContent('Sensitive Customer')
+    unauthorized = true
+    fireEvent.click(document.querySelector<HTMLButtonElement>('[aria-label="Refresh onboarding"]')!)
+
+    await waitFor(() => expect(screen.queryByText('Sensitive Customer')).not.toBeInTheDocument())
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getAllByText(/session has expired|relace vypršela/)).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Summary
- prevent older funnel and record responses from overwriting the newest onboarding request state
- validate complete funnel counts, requested pagination, stage ownership, customer identity, enums, and timestamps before rendering
- restore the missing KYC documents stage and make the seven-stage filter responsive

## Verification
- 11 focused Vitest tests passed, including an out-of-order response regression
- TypeScript type-check passed
- targeted ESLint passed with 0 errors (two pre-existing mount-fetch warnings)
- production Next.js build passed
- git diff --check passed

Closes #9444