### PR TITLE
security(admin-ui): contain dynamic API path segments

### DIFF
--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -9,6 +9,11 @@ const ACCOUNT_SERVICE = '/api/svc/account-service'
 const TRANSACTION_SERVICE = '/api/svc/transaction-service'
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
+// Values supplied by routes, deep links, and operator input must remain one path segment.
+// Encoding at this boundary prevents a value such as "../../other-endpoint" from changing
+// which same-origin API operation the browser calls.
+const pathSegment = (value: string): string => encodeURIComponent(value)
+
 export const SERVICES: { name: string; port: number }[] = [
   { name: 'account-service',        port: 8100 },
   { name: 'ledger-service',         port: 8101 },
@@ -78,13 +83,14 @@ export async function fetchAllGovernanceManifests(): Promise<{ byService: Record
 }
 
 export const accountApi = {
-  list: (partyId: string, cursor?: string) =>
-    apiFetchSimple<CursorPage<Account>>(
-      `${ACCOUNT_SERVICE}/api/v1/accounts?partyId=${partyId}${cursor ? `&cursor=${cursor}` : ''}`
-    ),
-  get: (id: string) => apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}`),
-  getBalance: (id: string) => apiFetchSimple<AccountBalance>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/balance`),
-  getByIban: (iban: string) => apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/iban/${iban}`),
+  list: (partyId: string, cursor?: string) => {
+    const params = new URLSearchParams({ partyId })
+    if (cursor) params.set('cursor', cursor)
+    return apiFetchSimple<CursorPage<Account>>(`${ACCOUNT_SERVICE}/api/v1/accounts?${params}`)
+  },
+  get: (id: string) => apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${pathSegment(id)}`),
+  getBalance: (id: string) => apiFetchSimple<AccountBalance>(`${ACCOUNT_SERVICE}/api/v1/accounts/${pathSegment(id)}/balance`),
+  getByIban: (iban: string) => apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/iban/${pathSegment(iban)}`),
   open: (data: { partyId: string; productId: string; accountType: string; currencyCode: string; legalName: string }, idempotencyKey: string) =>
     apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts`, {
       method: 'POST',
@@ -92,11 +98,11 @@ export const accountApi = {
       body: JSON.stringify(data),
     }),
   close: (id: string, reason?: string) =>
-    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/close`, { method: 'POST', body: JSON.stringify({ reason }) }),
+    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${pathSegment(id)}/close`, { method: 'POST', body: JSON.stringify({ reason }) }),
   freeze: (id: string, reason: string) =>
-    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/freeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
+    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${pathSegment(id)}/freeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
   unfreeze: (id: string, reason: string) =>
-    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/unfreeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
+    apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${pathSegment(id)}/unfreeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
 }
 
 // Operator-initiated customer messaging (ADR-0176 D2/D5). Mirrors the SHIPPED
@@ -161,7 +167,7 @@ export const opsMessageApi = {
   // Checker decision (ApprovalResource.decide): one PATCH with an approve boolean. Self-approval
   // is refused server-side (403); an unknown/already-decided id is 404/409 — all thrown here.
   decide: (id: string, approve: boolean) =>
-    apiFetchSimple<ApprovalDecision>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${id}`, {
+    apiFetchSimple<ApprovalDecision>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${pathSegment(id)}`, {
       method: 'PATCH',
       body: JSON.stringify({ approve }),
     }),
@@ -177,17 +183,18 @@ export const ledgerApi = {
     if (cursor) params.set('cursor', cursor)
     return apiFetchSimple<CursorPage<JournalEntry>>(`${LEDGER_SERVICE}/api/v1/journals?${params}`)
   },
-  get: (id: string) => apiFetchSimple<JournalEntry>(`${LEDGER_SERVICE}/api/v1/journals/${id}`),
+  get: (id: string) => apiFetchSimple<JournalEntry>(`${LEDGER_SERVICE}/api/v1/journals/${pathSegment(id)}`),
   getByTransaction: (transactionId: string) =>
-    apiFetchSimple<JournalEntry[]>(`${LEDGER_SERVICE}/api/v1/journals/transaction/${transactionId}`),
+    apiFetchSimple<JournalEntry[]>(`${LEDGER_SERVICE}/api/v1/journals/transaction/${pathSegment(transactionId)}`),
 }
 
 export const transactionApi = {
-  list: (accountId: string, cursor?: string) =>
-    apiFetchSimple<CursorPage<Transaction>>(
-      `${TRANSACTION_SERVICE}/api/v1/transactions?accountId=${accountId}${cursor ? `&cursor=${cursor}` : ''}`
-    ),
-  get: (id: string) => apiFetchSimple<Transaction>(`${TRANSACTION_SERVICE}/api/v1/transactions/${id}`),
+  list: (accountId: string, cursor?: string) => {
+    const params = new URLSearchParams({ accountId })
+    if (cursor) params.set('cursor', cursor)
+    return apiFetchSimple<CursorPage<Transaction>>(`${TRANSACTION_SERVICE}/api/v1/transactions?${params}`)
+  },
+  get: (id: string) => apiFetchSimple<Transaction>(`${TRANSACTION_SERVICE}/api/v1/transactions/${pathSegment(id)}`),
 }
 
 import type { ServiceHealthEntry } from '@/app/api/services/health/route'
@@ -268,4 +275,3 @@ export async function fetchAllServiceSnapshots(): Promise<ServiceSnapshot[]> {
     return SERVICES.map(s => ({ name: s.name, port: s.port, info: null, health: null, rateLimitMax: null, rateLimitRemaining: null, apiVersion: null, latencyMs: null, reachable: false }))
   }
 }
-

--- a/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
+++ b/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
@@ -101,6 +101,16 @@ describe('opsMessageApi — shipped notification-service contract', () => {
     expect(lastCall().body).toEqual({ approve: false })
   })
 
+  it('keeps a deep-linked approval id inside one URL path segment', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(404, { message: 'not found' })))
+
+    await expect(opsMessageApi.decide('../../messages?recipient=attacker', true)).rejects.toThrow('not found')
+
+    expect(lastCall().url).toBe(
+      '/api/svc/notification-service/api/v1/notifications/approvals/..%2F..%2Fmessages%3Frecipient%3Dattacker'
+    )
+  })
+
   it('exposes exactly the shipped OperatorMessageTemplate variable sets — no OPERATOR_ACCOUNT_NOTICE', () => {
     expect(OPERATOR_MESSAGE_TEMPLATE_VARS).toEqual({
       GENERIC_NOTICE: ['subject', 'note'],


### PR DESCRIPTION
CodeQL alert #504 traces a deep-linked approval id into the shared browser fetch helper. A value containing path traversal or a query delimiter could change which same-origin API operation the browser called.

This change encodes every dynamic path segment in the shared account, ledger, transaction, and notification clients and builds query strings with URLSearchParams. The regression test proves that a hostile approval id remains a single path segment.

Validation:
- npm test -- --run src/test/opsmessage-api.contract.test.ts (8 passed)
- npm run type-check
- npx eslint src/lib/api.ts src/test/opsmessage-api.contract.test.ts

Security evidence: Code scanning alert #504.
