### PR TITLE
feat(admin-ui): add contextual operational insights

### DIFF
--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -23,6 +23,8 @@ import { AgentMeshExplainer } from '@/components/agent/AgentMeshExplainer'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { StatusBadge, type Tone } from '@/components/ui'
 import styles from './IAOps.module.css'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { AI_INSIGHTS } from '@/components/insights/catalog'
 
 // ── Types (mirror /api/iaops/governance) ───────────────────────────────────
 type DStatus = 'built' | 'partial' | 'planned'
@@ -267,6 +269,11 @@ function IAOpsContent() {
           </button>
         </div>}
       />
+
+      <ContextualInsights dashboardUid="openbank-ai" panels={AI_INSIGHTS}
+        titleCs="Cena a spolehlivost AI" titleEn="AI cost and reliability"
+        descriptionCs="Kolik agentní provoz stojí, jak rychle odpovídá a kdy se požadavky neprovedly."
+        descriptionEn="What agent operations cost, how quickly they respond and when requests were not executed." />
 
       {loading && !data ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>

--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -15,6 +15,8 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { LifecycleStrip, type CompLifecycle } from '@/components/infra/LifecycleStrip'
 import { PageHeader, StatusBadge, TONE_BORDER_LEFT_CLASS, statusTone } from '@/components/ui'
 import { cn } from '@/lib/utils'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { EVENT_INSIGHTS } from '@/components/insights/catalog'
 
 type InfraStatus = 'UP' | 'DOWN' | 'UNKNOWN'
 
@@ -190,6 +192,11 @@ export default function InfrastructurePage() {
           </button>
         </div>}
       />
+
+      <ContextualInsights dashboardUid="openbank-evb" panels={EVENT_INSIGHTS}
+        titleCs="Tok událostí" titleEn="Event processing"
+        descriptionCs="Spolehlivost předávání, dead letters a služby, ve kterých se práce hromadí."
+        descriptionEn="Delivery reliability, dead letters and services where work accumulates." />
 
       {unavailable && (
         <div style={{

--- a/openbank-admin-ui/src/app/ledger/page.tsx
+++ b/openbank-admin-ui/src/app/ledger/page.tsx
@@ -9,9 +9,11 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Search, ChevronDown, ChevronRight } from 'lucide-react'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { AuthGuard } from '@/components/auth/AuthGuard'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import type { JournalEntry, CursorPage } from '@/types'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { LEDGER_INSIGHTS } from '@/components/insights/catalog'
 
 const STATUS_PILL: Record<string, string> = {
   POSTED:   'pill pill-success',
@@ -80,6 +82,14 @@ export default function LedgerPage() {
     <AuthGuard permission="accounts:view">
     <div>
       <PageHeader breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Hlavní kniha', 'General Ledger')}</span></div>} title={t('Hlavní kniha', 'General Ledger')} subtitle={t('Zápisy v podvojném účetnictví', 'Double-entry journal entries')} />
+
+      <Can permission="system:view">
+        <ContextualInsights dashboardUid="openbank-ledger-int" panels={LEDGER_INSIGHTS}
+          titleCs="Integrita účetního toku" titleEn="Ledger flow integrity"
+          descriptionCs="Čekající předání, chybovost a rychlost zaúčtování bez zavádějících účetních závěrů."
+          descriptionEn="Pending delivery, failures and posting speed without misleading accounting conclusions."
+          from={fromDate} to={toDate} />
+      </Can>
 
       <div className="card">
         <div style={{

--- a/openbank-admin-ui/src/app/system/health/page.tsx
+++ b/openbank-admin-ui/src/app/system/health/page.tsx
@@ -13,6 +13,8 @@ import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { cn } from '@/lib/utils'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { HEALTH_INSIGHTS } from '@/components/insights/catalog'
 
 const POLL = 15_000
 
@@ -98,6 +100,12 @@ export default function SystemHealthPage() {
           </button>
         </div>}
       />
+
+      <ContextualInsights dashboardUid="openbank-slo" panels={HEALTH_INSIGHTS}
+        titleCs="Dopad na zákazníky" titleEn="Customer impact"
+        descriptionCs="Dostupnost klíčových platebních cest a tempo čerpání jejich chybového rozpočtu."
+        descriptionEn="Availability of critical payment journeys and the rate at which they consume error budget."
+        />
 
       {/* Summary */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>

--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -10,6 +10,9 @@ import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader, StatusBadge } from '@/components/ui'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { PAYMENT_INSIGHTS } from '@/components/insights/catalog'
+import { Can } from '@/components/auth/AuthGuard'
 
 const TYPE_COLOR: Record<string, string> = {
   DEBIT:      'var(--danger)',
@@ -162,6 +165,14 @@ export default function TransactionsPage() {
         icon={<ArrowLeftRight size={18} aria-hidden="true" />}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Transakce', 'Transactions')}</span></div>}
       />
+
+      <Can permission="system:view">
+        <ContextualInsights dashboardUid="openbank-sla" panels={PAYMENT_INSIGHTS}
+          titleCs="Zdraví plateb" titleEn="Payment health"
+          descriptionCs="Úspěšnost, rychlost a SLA napříč platebními cestami."
+          descriptionEn="Success, speed and SLA across payment rails."
+          from={dateFrom || undefined} to={dateTo || undefined} />
+      </Can>
 
       <div className="card" style={{ marginBottom: '16px' }}>
         {/* Primary search bar */}

--- a/openbank-admin-ui/src/components/insights/ContextualInsights.module.css
+++ b/openbank-admin-ui/src/components/insights/ContextualInsights.module.css
@@ -1,0 +1,30 @@
+.section { margin: 0 0 18px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); box-shadow: var(--shadow-xs); overflow: hidden; }
+.header { display: flex; align-items: stretch; min-height: 92px; background: linear-gradient(120deg, color-mix(in srgb, var(--accent) 7%, var(--surface)), var(--surface) 62%); }
+.toggle { appearance: none; border: 0; background: transparent; color: inherit; display: flex; align-items: center; gap: 13px; min-width: 0; flex: 1; padding: 16px 18px; text-align: left; cursor: pointer; }
+.toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: -3px; }
+.icon { width: 36px; height: 36px; flex: 0 0 36px; display: grid; place-items: center; border-radius: 10px; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, var(--surface)); border: 1px solid color-mix(in srgb, var(--accent) 23%, var(--border)); }
+.copy { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.eyebrow { color: var(--accent); font-size: 9px; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.title { color: var(--text-primary); font-size: 14px; font-weight: 750; }
+.description { color: var(--text-secondary); font-size: 11px; line-height: 1.45; }
+.chevron, .chevronOpen { flex: 0 0 auto; margin-left: auto; color: var(--text-tertiary); transition: transform .18s ease; }
+.chevronOpen { transform: rotate(180deg); }
+.actions { flex: 0 0 auto; padding: 16px 18px 16px 8px; display: flex; align-items: center; gap: 8px; }
+.body { border-top: 1px solid var(--border); padding: 14px; background: var(--surface-2); }
+.freshness { margin: 0 2px 10px; color: var(--text-tertiary); font-size: 10px; }
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.panel { min-width: 0; padding: 13px; border: 1px solid var(--border); border-radius: 11px; background: var(--surface); overflow: hidden; }
+.panel:last-child:nth-child(odd) { grid-column: 1 / -1; }
+.panelCopy { min-height: 49px; margin-bottom: 8px; }
+.panelCopy h3 { color: var(--text-primary); font-size: 12px; font-weight: 700; margin: 0 0 3px; }
+.panelCopy p { color: var(--text-secondary); font-size: 10px; line-height: 1.4; margin: 0; }
+.frameWrap { position: relative; height: 176px; overflow: hidden; border-radius: 8px; background: var(--surface-2); }
+.frameTrend { height: 224px; }
+.frameReady, .frameHidden { width: 100%; height: 100%; border: 0; color-scheme: light dark; }
+.frameHidden { position: absolute; inset: 0; visibility: hidden; }
+.skeleton, .unavailable { position: absolute; inset: 0; z-index: 1; display: grid; place-items: center; color: var(--text-tertiary); font-size: 11px; }
+.skeleton { background: linear-gradient(100deg, var(--surface-2) 30%, var(--surface-3) 50%, var(--surface-2) 70%); background-size: 220% 100%; animation: shimmer 1.4s ease-in-out infinite; }
+.unavailable { align-content: center; gap: 7px; background: var(--surface-2); }
+@keyframes shimmer { to { background-position-x: -220%; } }
+@media (max-width: 840px) { .grid { grid-template-columns: 1fr; } .panel:last-child:nth-child(odd) { grid-column: auto; } .header { flex-wrap: wrap; } .actions { width: 100%; padding: 0 18px 14px 67px; } }
+@media (prefers-reduced-motion: reduce) { .chevron, .chevronOpen, .skeleton { transition: none; animation: none; } }

--- a/openbank-admin-ui/src/components/insights/ContextualInsights.tsx
+++ b/openbank-admin-ui/src/components/insights/ContextualInsights.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+'use client'
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { Activity, ChevronDown, ExternalLink, RefreshCw } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import styles from './ContextualInsights.module.css'
+
+export interface InsightPanel {
+  id: number
+  titleCs: string
+  titleEn: string
+  descriptionCs: string
+  descriptionEn: string
+  height?: 'stat' | 'trend'
+}
+
+interface Props {
+  dashboardUid: string
+  titleCs: string
+  titleEn: string
+  descriptionCs: string
+  descriptionEn: string
+  panels: InsightPanel[]
+  from?: string
+  to?: string
+  defaultOpen?: boolean
+}
+
+const DEFAULT_FROM = 'now-24h'
+const DEFAULT_TO = 'now'
+
+function utcBoundary(value: string | undefined, end: boolean) {
+  if (!value) return end ? DEFAULT_TO : DEFAULT_FROM
+  const parsed = Date.parse(`${value}T${end ? '23:59:59.999' : '00:00:00'}Z`)
+  return Number.isFinite(parsed) ? String(parsed) : (end ? DEFAULT_TO : DEFAULT_FROM)
+}
+
+export function ContextualInsights({
+  dashboardUid, titleCs, titleEn, descriptionCs, descriptionEn, panels,
+  from, to, defaultOpen = false,
+}: Props) {
+  const { t } = useLanguage()
+  const [open, setOpen] = useState(defaultOpen)
+  const [theme, setTheme] = useState('light')
+  const [refresh, setRefresh] = useState(0)
+  const contentId = useId()
+
+  useEffect(() => {
+    const sync = () => setTheme(document.documentElement.classList.contains('dark') ? 'dark' : 'light')
+    sync()
+    const observer = new MutationObserver(sync)
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  const commonParams = useMemo(() => new URLSearchParams({
+    kiosk: '1', theme, timezone: 'utc', from: utcBoundary(from, false), to: utcBoundary(to, true),
+  }), [from, theme, to])
+  const detailUrl = `/tools/grafana/d/${dashboardUid}?${new URLSearchParams({ theme, timezone: 'utc', from: utcBoundary(from, false), to: utcBoundary(to, true) })}`
+
+  return <section className={styles.section}>
+    <div className={styles.header}>
+      <button type="button" className={styles.toggle} onClick={() => setOpen(value => !value)} aria-expanded={open} aria-controls={contentId}>
+        <span className={styles.icon}><Activity size={17} aria-hidden="true" /></span>
+        <span className={styles.copy}>
+          <span className={styles.eyebrow}>{t('Živý provozní přehled', 'Live operational insight')}</span>
+          <span className={styles.title}>{t(titleCs, titleEn)}</span>
+          <span className={styles.description}>{t(descriptionCs, descriptionEn)}</span>
+        </span>
+        <ChevronDown size={18} aria-hidden="true" className={open ? styles.chevronOpen : styles.chevron} />
+      </button>
+      <div className={styles.actions}>
+        {open && <button type="button" className="btn btn-secondary btn-sm" onClick={() => setRefresh(value => value + 1)}>
+          <RefreshCw size={13} aria-hidden="true" />{t('Obnovit', 'Refresh')}
+        </button>}
+        <a className="btn btn-secondary btn-sm" href={detailUrl} target="_blank" rel="noreferrer">
+          <ExternalLink size={13} aria-hidden="true" />{t('Detailní analýza', 'Detailed analysis')}
+        </a>
+      </div>
+    </div>
+    {open && <div id={contentId} className={styles.body} role="region" aria-label={t(titleCs, titleEn)}>
+      <p className={styles.freshness}>{from && to
+        ? t('Živá data · UTC · období je převzaté z této stránky', 'Live data · UTC · period follows this page')
+        : t('Živá data · UTC · posledních 24 hodin', 'Live data · UTC · last 24 hours')}</p>
+      <div className={styles.grid}>
+        {panels.map(panel => {
+          const params = new URLSearchParams(commonParams)
+          params.set('panelId', String(panel.id))
+          params.set('refresh', '1m')
+          return <article key={panel.id} className={styles.panel}>
+            <div className={styles.panelCopy}>
+              <h3>{t(panel.titleCs, panel.titleEn)}</h3>
+              <p>{t(panel.descriptionCs, panel.descriptionEn)}</p>
+            </div>
+            <GrafanaPanel key={`${panel.id}-${theme}-${refresh}`} src={`/tools/grafana/d-solo/${dashboardUid}?${params}`} title={t(panel.titleCs, panel.titleEn)} tall={panel.height === 'trend'} />
+          </article>
+        })}
+      </div>
+    </div>}
+  </section>
+}
+
+function GrafanaPanel({ src, title, tall }: { src: string; title: string; tall: boolean }) {
+  const { t } = useLanguage()
+  const [state, setState] = useState<'loading' | 'ready' | 'slow' | 'unavailable'>('loading')
+  const frame = useRef<HTMLIFrameElement>(null)
+
+  useEffect(() => {
+    setState('loading')
+    const started = Date.now()
+    let slowShown = false
+    const poll = window.setInterval(() => {
+      try {
+        const doc = frame.current?.contentDocument
+        if (doc?.querySelector('[data-testid="data-testid Panel header"], [data-testid^="data-testid Panel header "], .panel-content, .react-grid-layout')) {
+          setState('ready')
+          window.clearInterval(poll)
+          return
+        }
+      } catch { /* Keycloak is cross-origin while the authenticated session is established. */ }
+      const elapsed = Date.now() - started
+      if (elapsed >= 20_000 && !slowShown) {
+        slowShown = true
+        setState('slow')
+      }
+      if (elapsed >= 120_000) {
+        setState('unavailable')
+        window.clearInterval(poll)
+      }
+    }, 500)
+    return () => window.clearInterval(poll)
+  }, [src])
+
+  return <div className={`${styles.frameWrap} ${tall ? styles.frameTrend : ''}`}>
+    {state === 'loading' && <div className={styles.skeleton} role="status"><span>{t('Načítám data…', 'Loading data…')}</span></div>}
+    {state === 'slow' && <div className={styles.unavailable} role="status">
+      <RefreshCw size={18} aria-hidden="true" />
+      <span>{t('Připojení trvá déle, stále to zkouším…', 'Connection is taking longer; still trying…')}</span>
+    </div>}
+    {state === 'unavailable' && <div className={styles.unavailable} role="status">
+      <Activity size={18} aria-hidden="true" />
+      <span>{t('Panel teď není dostupný', 'Panel is unavailable right now')}</span>
+    </div>}
+    <iframe ref={frame} src={src} title={title} loading="lazy" scrolling="no"
+      className={state === 'ready' ? styles.frameReady : styles.frameHidden} />
+  </div>
+}

--- a/openbank-admin-ui/src/components/insights/catalog.ts
+++ b/openbank-admin-ui/src/components/insights/catalog.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { InsightPanel } from './ContextualInsights'
+
+export const PAYMENT_INSIGHTS: InsightPanel[] = [
+  { id: 6, titleCs: 'Úspěšnost plateb', titleEn: 'Payment success rate', descriptionCs: 'Vývoj úspěšnosti v pětiminutových oknech napříč obdobím.', descriptionEn: 'Success-rate trend in five-minute windows across the period.', height: 'trend' },
+  { id: 2, titleCs: 'SEPA Instant do 10 sekund', titleEn: 'SEPA Instant under 10 seconds', descriptionCs: 'Plnění zákaznického času pro okamžité platby.', descriptionEn: 'Customer-time target for instant payments.' },
+  { id: 1, titleCs: 'Doba zpracování', titleEn: 'Processing duration', descriptionCs: 'Medián a pomalý konec zpracování plateb.', descriptionEn: 'Median and slow tail of payment processing.', height: 'trend' },
+  { id: 4, titleCs: 'Dokončení podle typu', titleEn: 'Completion by payment type', descriptionCs: 'Pomáhá odlišit plošný problém od jedné platební koleje.', descriptionEn: 'Separates a broad incident from a single payment rail.', height: 'trend' },
+]
+
+export const LEDGER_INSIGHTS: InsightPanel[] = [
+  { id: 2, titleCs: 'Nevyřízený outbox', titleEn: 'Pending outbox', descriptionCs: 'Zápisy, které ještě čekají na bezpečné předání.', descriptionEn: 'Entries still waiting for safe delivery.' },
+  { id: 4, titleCs: 'Chybovost hlavní knihy', titleEn: 'Ledger error rate', descriptionCs: 'Technické chyby při práci s účetními zápisy.', descriptionEn: 'Technical failures while processing ledger entries.' },
+  { id: 9, titleCs: 'Latence zaúčtování p95', titleEn: 'Posting latency p95', descriptionCs: 'Jak dlouho čeká pomalejší část zaúčtování.', descriptionEn: 'How long the slower share of postings takes.', height: 'trend' },
+  { id: 11, titleCs: 'Odeslané a dokončené platby', titleEn: 'Submitted and completed payments', descriptionCs: 'Tok rozpracovaných plateb bez tvrzení o účetním nesouladu.', descriptionEn: 'Flow of in-flight payments without claiming an accounting mismatch.', height: 'trend' },
+]
+
+export const HEALTH_INSIGHTS: InsightPanel[] = [
+  { id: 1, titleCs: 'Dostupnost platebních cest', titleEn: 'Payment-rail availability', descriptionCs: 'Třicetidenní dostupnost podle platební koleje.', descriptionEn: 'Thirty-day availability by payment rail.' },
+  { id: 2, titleCs: 'Zbývající chybový rozpočet', titleEn: 'Error budget remaining', descriptionCs: 'Kolik prostoru zbývá před porušením SLO.', descriptionEn: 'Room remaining before the SLO is breached.' },
+  { id: 3, titleCs: 'Rychlost čerpání rozpočtu', titleEn: 'Error-budget burn rate', descriptionCs: 'Krátké i delší okno odhalí rychle rostoucí dopad.', descriptionEn: 'Short and long windows expose a fast-growing impact.', height: 'trend' },
+]
+
+export const EVENT_INSIGHTS: InsightPanel[] = [
+  { id: 3, titleCs: 'Mrtvé zprávy dnes', titleEn: 'Dead letters today', descriptionCs: 'Události, které nebylo možné bezpečně zpracovat.', descriptionEn: 'Events that could not be processed safely.' },
+  { id: 4, titleCs: 'Úspěšnost předávání', titleEn: 'Dispatch success rate', descriptionCs: 'Spolehlivost doručení událostí mezi službami.', descriptionEn: 'Reliability of event delivery between services.' },
+  { id: 5, titleCs: 'Backlog podle služby', titleEn: 'Backlog by service', descriptionCs: 'Kde se čekající nebo chybné události hromadí.', descriptionEn: 'Where pending or failed events accumulate.', height: 'trend' },
+  { id: 2, titleCs: 'Vývoj dead-letter toku', titleEn: 'Dead-letter trend', descriptionCs: 'Ukazuje, zda jde o jednorázovou nebo pokračující závadu.', descriptionEn: 'Shows whether a failure is isolated or ongoing.', height: 'trend' },
+]
+
+export const AI_INSIGHTS: InsightPanel[] = [
+  { id: 2, titleCs: 'Náklady LLM za 24 hodin', titleEn: 'LLM spend over 24 hours', descriptionCs: 'Odvozené provozní náklady všech modelových volání.', descriptionEn: 'Derived operational cost of all model calls.' },
+  { id: 4, titleCs: 'Chybovost za 15 minut', titleEn: '15-minute error rate', descriptionCs: 'Aktuální spolehlivost agentních volání.', descriptionEn: 'Current reliability of agent calls.' },
+  { id: 5, titleCs: 'Přeskočeno bez API klíče', titleEn: 'Skipped without API key', descriptionCs: 'Požadavky, které nebyly skutečně provedeny.', descriptionEn: 'Requests that were not actually executed.' },
+  { id: 10, titleCs: 'Odezva modelů', titleEn: 'Model latency', descriptionCs: 'Medián a pomalý konec úspěšných volání.', descriptionEn: 'Median and slow tail of successful calls.', height: 'trend' },
+]

--- a/openbank-admin-ui/src/test/contextual-insights.test.tsx
+++ b/openbank-admin-ui/src/test/contextual-insights.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ContextualInsights } from '@/components/insights/ContextualInsights'
+import { PAYMENT_INSIGHTS } from '@/components/insights/catalog'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+afterEach(() => { cleanup(); vi.useRealTimers() })
+
+it('presents selected Grafana panels as native, period-aware insight cards', () => {
+  vi.useFakeTimers()
+  render(<LanguageProvider initialLanguage="en">
+    <ContextualInsights dashboardUid="openbank-sla" panels={PAYMENT_INSIGHTS}
+      titleCs="Zdraví plateb" titleEn="Payment health"
+      descriptionCs="Stav" descriptionEn="Health"
+      from="2026-09-01" to="2026-09-08" defaultOpen />
+  </LanguageProvider>)
+
+  expect(screen.getByRole('button', { name: /Payment health/ })).toHaveAttribute('aria-expanded', 'true')
+  const toggle = screen.getByRole('button', { name: /Payment health/ })
+  const controlled = document.getElementById(toggle.getAttribute('aria-controls') ?? '')
+  expect(controlled).toHaveAttribute('role', 'region')
+  expect(controlled).toHaveAccessibleName('Payment health')
+  const panel = screen.getByTitle('Payment success rate')
+  expect(panel).toHaveAttribute('src', expect.stringContaining('/tools/grafana/d-solo/openbank-sla?'))
+  expect(panel).toHaveAttribute('src', expect.stringContaining('panelId=6'))
+  expect(panel).toHaveAttribute('src', expect.stringContaining('kiosk=1'))
+  expect(panel).toHaveAttribute('src', expect.stringContaining('from=1788220800000'))
+  expect(screen.getByRole('link', { name: 'Detailed analysis' }).getAttribute('href')).not.toContain('kiosk=')
+
+  const doc = document.implementation.createHTMLDocument()
+  doc.body.innerHTML = '<div class="panel-content"></div>'
+  Object.defineProperty(panel, 'contentDocument', { value: doc })
+  act(() => vi.advanceTimersByTime(500))
+  expect(panel).toBeVisible()
+  expect(screen.queryAllByText('Loading data…')).toHaveLength(PAYMENT_INSIGHTS.length - 1)
+})
+
+it('recovers when Grafana becomes ready after the slow-connection warning', () => {
+  vi.useFakeTimers()
+  render(<LanguageProvider initialLanguage="en">
+    <ContextualInsights dashboardUid="openbank-slo" panels={PAYMENT_INSIGHTS.slice(0, 1)}
+      titleCs="Dopad" titleEn="Impact" descriptionCs="Stav" descriptionEn="Health" defaultOpen />
+  </LanguageProvider>)
+  const panel = screen.getByTitle('Payment success rate')
+  act(() => vi.advanceTimersByTime(20_500))
+  expect(screen.getByText('Connection is taking longer; still trying…')).toBeInTheDocument()
+  const doc = document.implementation.createHTMLDocument()
+  doc.body.innerHTML = '<div class="panel-content"></div>'
+  Object.defineProperty(panel, 'contentDocument', { value: doc })
+  act(() => vi.advanceTimersByTime(500))
+  expect(panel).toBeVisible()
+  expect(screen.queryByText('Connection is taking longer; still trying…')).not.toBeInTheDocument()
+})
+
+it('keeps optional operational context collapsed until requested', () => {
+  render(<LanguageProvider initialLanguage="en">
+    <ContextualInsights dashboardUid="openbank-evb" panels={PAYMENT_INSIGHTS.slice(0, 1)}
+      titleCs="Tok událostí" titleEn="Event processing" descriptionCs="Stav" descriptionEn="Health" />
+  </LanguageProvider>)
+  const toggle = screen.getByRole('button', { name: /Event processing/ })
+  expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  expect(screen.queryByTitle('Payment success rate')).not.toBeInTheDocument()
+  fireEvent.click(toggle)
+  expect(screen.getByTitle('Payment success rate')).toBeInTheDocument()
+})

--- a/openbank-admin-ui/src/test/ledger-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/ledger-pagination.test.tsx
@@ -9,6 +9,7 @@ import LedgerPage from '@/app/ledger/page'
 
 vi.mock('@/components/auth/AuthGuard', () => ({
   AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 const firstPage = {

--- a/openbank-admin-ui/src/test/transactions-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/transactions-pagination.test.tsx
@@ -7,6 +7,10 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import TransactionsPage from '@/app/transactions/page'
 
+vi.mock('@/components/auth/AuthGuard', () => ({
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 function transaction(index: number) {
   return {
     id: `transaction-${index}`,

--- a/openbank-admin-ui/src/test/transactions-search-ux.test.tsx
+++ b/openbank-admin-ui/src/test/transactions-search-ux.test.tsx
@@ -7,6 +7,10 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import TransactionsPage from '@/app/transactions/page'
 
+vi.mock('@/components/auth/AuthGuard', () => ({
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 afterEach(() => {
   cleanup()
   localStorage.clear()

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-ledger-integrity.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-ledger-integrity.yaml
@@ -72,8 +72,9 @@ data:
           "panels": []
         },
         {
+          "id": 2,
           "type": "stat",
-          "title": "Outbox backlog (total)",
+          "title": "Ledger outbox backlog",
           "description": "LIVE metric",
           "datasource": {
             "type": "prometheus",
@@ -91,7 +92,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(openbank_outbox_backlog)",
+              "expr": "sum(openbank_outbox_backlog{service=\"ledger\"})",
               "legendFormat": "",
               "refId": "A",
               "instant": true,
@@ -200,6 +201,7 @@ data:
           }
         },
         {
+          "id": 4,
           "type": "stat",
           "title": "Ledger error %",
           "description": "",
@@ -529,6 +531,7 @@ data:
           }
         },
         {
+          "id": 9,
           "type": "timeseries",
           "title": "Ledger posting p95 latency",
           "description": "",
@@ -654,6 +657,7 @@ data:
           }
         },
         {
+          "id": 11,
           "type": "timeseries",
           "title": "Payments submitted vs completed",
           "description": "openbank_* contract",


### PR DESCRIPTION
Operators can now inspect the operational context of the workflow they are already using instead of leaving Admin UI for a broad Grafana dashboard. Transactions, Ledger, System Health, Infrastructure, and Agent Control Room gain a compact collapsed insight section with selected same-origin Grafana panels, page-aware periods, bilingual explanations, responsive layout, and graceful SSO/loading states.

The Ledger dashboard also gains stable IDs for the four embedded panels and its backlog card now measures only `service="ledger"`; the misleading fleet-wide value is no longer presented as ledger health. Users without `system:view` do not see Grafana-backed sections.

Closes #9497

Validation:

- `npm run type-check`
- focused ESLint over all changed Admin UI files
- `npx vitest run src/test/contextual-insights.test.tsx src/test/reporting-presentation.test.tsx` (10 tests)
- `npm run build`
- ledger dashboard ConfigMap parses as YAML and embedded dashboard JSON
- raw-colour ratchet passes
- independent agent review: clean after RBAC, metric semantics, layout, SSO readiness, and accessibility fixes
