### PR TITLE
fix(admin-ui): clarify payment verification states

### DIFF
--- a/openbank-admin-ui/e2e/sct-inst-vop.spec.ts
+++ b/openbank-admin-ui/e2e/sct-inst-vop.spec.ts
@@ -40,7 +40,10 @@ test.describe('SCT Inst payee verification', () => {
       expect(body.creditorIban).toBe('DE89370400440532013000')
       await route.fulfill({
         contentType: 'application/json',
-        body: JSON.stringify({ status: body.creditorName.startsWith('Wrong') ? 'no_match' : 'match' }),
+        body: JSON.stringify({
+          status: body.creditorName.startsWith('Wrong') ? 'no_match' : 'match',
+          verifiedAt: '2026-09-10T08:15:30Z',
+        }),
       })
     })
 

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -162,9 +162,13 @@ function TabNav({ active, onChange }: { active: Tab; onChange: (t: Tab) => void 
 
 function VopSection({ formData, setFormData }: { formData: SepaFormData; setFormData: React.Dispatch<React.SetStateAction<SepaFormData>> }) {
   const { t } = useLanguage()
-  const vopColor: Record<string, string> = {
-    idle: 'var(--text-tertiary)', match: '#16a34a', close_match: '#d97706',
-    no_match: '#dc2626', no_data: '#6366f1', loading: 'var(--text-tertiary)',
+  const vopTone: Record<VopStatus, { text: string; bg: string; border: string }> = {
+    idle: { text: 'var(--text-tertiary)', bg: 'var(--surface-2)', border: 'var(--border)' },
+    loading: { text: 'var(--text-secondary)', bg: 'var(--surface-2)', border: 'var(--border)' },
+    match: { text: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+    close_match: { text: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)' },
+    no_match: { text: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
+    no_data: { text: 'var(--info-text)', bg: 'var(--info-bg)', border: 'var(--info-border)' },
   }
   const vopIcon = (s: VopStatus) => {
     if (s === 'loading') return <Clock size={16} />
@@ -178,14 +182,15 @@ function VopSection({ formData, setFormData }: { formData: SepaFormData; setForm
     close_match: 'CLOSE_MATCH — jméno se mírně liší', no_match: 'NO_MATCH — jméno nesouhlasí',
     no_data: 'NO_DATA — ověření nedostupné',
   }
+  const tone = vopTone[formData.vopStatus]
   return (
-    <div style={{ padding: '14px', borderRadius: '8px', border: `1px solid ${vopColor[formData.vopStatus]}44`, background: `${vopColor[formData.vopStatus]}08` }}>
+    <div style={{ padding: '14px', borderRadius: '8px', border: `1px solid ${tone.border}`, background: tone.bg }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
-        <ShieldCheck size={14} style={{ color: formData.instant ? '#d97706' : 'var(--text-secondary)' }} />
+        <ShieldCheck size={14} style={{ color: formData.instant ? 'var(--warning-text)' : 'var(--text-secondary)' }} />
         <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Ověření příjemce (VoP)', 'Verification of Payee (VoP)')}</span>
         {formData.instant && (
           <span style={{ fontSize: '10px', fontWeight: 700, padding: '2px 6px', borderRadius: '4px',
-            background: '#d9770622', color: '#d97706' }}>{t('Povinné', 'Mandatory')}</span>
+            background: 'var(--warning-bg)', color: 'var(--warning-text)', border: '1px solid var(--warning-border)' }}>{t('Povinné', 'Mandatory')}</span>
         )}
       </div>
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '6px' }}>
@@ -223,7 +228,7 @@ function VopSection({ formData, setFormData }: { formData: SepaFormData; setForm
         </button>
       </div>
       {formData.vopStatus !== 'idle' && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', fontWeight: 600, color: vopColor[formData.vopStatus] }}>
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', fontWeight: 600, color: tone.text }}>
           {vopIcon(formData.vopStatus)}
           {vopLabel[formData.vopStatus]}
           {/* Only close_match carries a name — the backend never echoes one on no_match. */}
@@ -320,7 +325,7 @@ function PaymentsContent() {
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : t('Nepodařilo se načíst platby', 'Failed to load payments'))
     } finally { setLoading(false) }
-  }, [])
+  }, [t])
 
   const loadSct = useCallback(async () => {
     setSctLoading(true)
@@ -346,8 +351,15 @@ function PaymentsContent() {
     setSctLoading(false)
   }, [t])
 
-  useEffect(() => { load() }, [load])
-  useEffect(() => { if (activeTab === 'sct-inst') loadSct() }, [activeTab, loadSct])
+  useEffect(() => {
+    const initialLoad = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(initialLoad)
+  }, [load])
+  useEffect(() => {
+    if (activeTab !== 'sct-inst') return
+    const initialSctLoad = window.setTimeout(() => { void loadSct() }, 0)
+    return () => window.clearTimeout(initialSctLoad)
+  }, [activeTab, loadSct])
 
   const selectPaymentType = (t: CreateType) => {
     if (!canCreate) return
@@ -511,14 +523,14 @@ function PaymentsContent() {
     if (s === 'SETTLED') return { bg: 'var(--success-bg)', text: 'var(--success-text)', border: 'var(--success-border)' }
     if (s === 'TIMEOUT' || s === 'REJECTED') return { bg: 'var(--danger-bg)', text: 'var(--danger-text)', border: 'var(--danger-border)' }
     if (s === 'RECALLED') return { bg: 'var(--warning-bg)', text: 'var(--warning-text)', border: 'var(--warning-border)' }
-    return { bg: 'rgba(99,102,241,0.1)', text: '#6366f1', border: 'rgba(99,102,241,0.2)' }
+    return { bg: 'var(--accent-bg)', text: 'var(--accent-text)', border: 'var(--accent-border)' }
   }
   const timeoutCountdown = (timeoutAt?: string, status?: string) => {
     if (status !== 'PROCESSING' || !timeoutAt) return null
     // eslint-disable-next-line react-hooks/purity -- time-relative display; timestamps are stable server data.
     const ms = new Date(timeoutAt).getTime() - Date.now()
-    if (ms <= 0) return <span style={{ fontSize: '11px', color: 'var(--danger)', fontWeight: 700 }}>TIMEOUT</span>
-    return <span style={{ fontSize: '11px', color: ms < 3000 ? 'var(--danger)' : 'var(--warning)', fontWeight: 600 }}>{(ms / 1000).toFixed(1)}s</span>
+    if (ms <= 0) return <span style={{ fontSize: '11px', color: 'var(--danger-text)', fontWeight: 700 }}>TIMEOUT</span>
+    return <span style={{ fontSize: '11px', color: ms < 3000 ? 'var(--danger-text)' : 'var(--warning-text)', fontWeight: 600 }}>{(ms / 1000).toFixed(1)}s</span>
   }
 
   return (
@@ -592,14 +604,14 @@ function PaymentsContent() {
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px', marginBottom: '20px' }}>
             {[
-              { label: t('Platby celkem', 'Total payments'), value: sctPayments.length, icon: <Zap size={16} />, color: 'var(--accent)' },
-              { label: t('Vypořádáno', 'Settled'), value: sctSettled, icon: <CheckCircle2 size={16} />, color: '#16a34a' },
-              { label: t('Zpracovává se', 'Processing'), value: sctProcessing, icon: <Timer size={16} />, color: '#d97706' },
-              { label: t('Objem (EUR)', 'Volume (EUR)'), value: sctVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }), icon: <Zap size={16} />, color: 'var(--accent)' },
+              { label: t('Platby celkem', 'Total payments'), value: sctPayments.length, icon: <Zap size={16} />, text: 'var(--accent-text)', bg: 'var(--accent-bg)' },
+              { label: t('Vypořádáno', 'Settled'), value: sctSettled, icon: <CheckCircle2 size={16} />, text: 'var(--success-text)', bg: 'var(--success-bg)' },
+              { label: t('Zpracovává se', 'Processing'), value: sctProcessing, icon: <Timer size={16} />, text: 'var(--warning-text)', bg: 'var(--warning-bg)' },
+              { label: t('Objem (EUR)', 'Volume (EUR)'), value: sctVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }), icon: <Zap size={16} />, text: 'var(--accent-text)', bg: 'var(--accent-bg)' },
             ].map(k => (
               <div key={k.label} className="stat-card">
-                <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
+                <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: k.bg,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.text, marginBottom: '10px' }}>{k.icon}</div>
                 <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
                 <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
               </div>
@@ -677,8 +689,8 @@ function PaymentsContent() {
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>
               {[
                 { label: t('SEPA Platby', 'SEPA Payments'), value: sepaCount, color: 'var(--accent)' },
-                { label: t('Tuzemské Platby', 'Domestic Payments'), value: domesticCount, color: 'var(--green)' },
-                { label: t('Čekající / Zpracovává se', 'Pending / Processing'), value: pendingCount, color: 'var(--yellow)' },
+                { label: t('Tuzemské Platby', 'Domestic Payments'), value: domesticCount, color: 'var(--info-text)' },
+                { label: t('Čekající / Zpracovává se', 'Pending / Processing'), value: pendingCount, color: 'var(--warning-text)' },
               ].map(s => (
                 <div key={s.label} className="stat-card">
                   <div className="stat-value" style={{ color: s.color }}>{loading ? '—' : s.value}</div>
@@ -710,7 +722,7 @@ function PaymentsContent() {
                         border: `1px solid var(--border)`, background: 'var(--surface-1)', cursor: 'pointer',
                         textAlign: 'left', transition: 'all 0.15s ease' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                        <div style={{ width: '36px', height: '36px', borderRadius: '8px', background: 'var(--accent)18',
+                        <div style={{ width: '36px', height: '36px', borderRadius: '8px', background: 'var(--accent-bg)',
                           display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                           <Icon size={18} style={{ color: 'var(--accent)' }} />
                         </div>
@@ -719,7 +731,7 @@ function PaymentsContent() {
                           <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginTop: '2px' }}>{t(opt.descCs, opt.descEn)}</div>
                         </div>
                       </div>
-                      <div style={{ fontSize: '11px', fontWeight: 600, color: opt.type === 'domestic-instant' || opt.type === 'sct-inst' ? '#d97706' : 'var(--text-tertiary)' }}>
+                      <div style={{ fontSize: '11px', fontWeight: 600, color: opt.type === 'domestic-instant' || opt.type === 'sct-inst' ? 'var(--warning-text)' : 'var(--text-tertiary)' }}>
                         {t('Vypořádání:', 'Settlement:')} {opt.speed}
                       </div>
                     </button>
@@ -740,7 +752,7 @@ function PaymentsContent() {
                 </h2>
                 {domesticForm.instant && (
                   <span style={{ fontSize: '10px', fontWeight: 700, padding: '3px 8px', borderRadius: '4px',
-                    background: '#d9770622', color: '#d97706' }}>
+                    background: 'var(--warning-bg)', color: 'var(--warning-text)', border: '1px solid var(--warning-border)' }}>
                     {t('OKAMŽITÁ PLATBA — settlement <10 sec, 24/7/365', 'INSTANT — settlement <10 sec, 24/7/365')}
                   </span>
                 )}
@@ -855,7 +867,7 @@ function PaymentsContent() {
                       onChange={e => setDomesticForm({ ...domesticForm, statementLabel: e.target.value })} />
                   </div>
                 </div>
-                {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
+                {createError && <div role="alert" style={{ color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', borderRadius: '6px', padding: '8px 10px', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
                   <button ref={domesticSubmitRef} type="submit" className="btn btn-primary" disabled={creating}>
@@ -877,7 +889,7 @@ function PaymentsContent() {
                 </h2>
                 {sepaForm.instant && (
                   <span style={{ fontSize: '10px', fontWeight: 700, padding: '3px 8px', borderRadius: '4px',
-                    background: '#0ea5e922', color: '#0ea5e9' }}>
+                    background: 'var(--info-bg)', color: 'var(--info-text)', border: '1px solid var(--info-border)' }}>
                     {t('SCT INST — settlement <10 sec, 24/7/365', 'SCT INST — settlement <10 sec, 24/7/365')}
                   </span>
                 )}
@@ -937,7 +949,7 @@ function PaymentsContent() {
                   </div>
                 </div>
                 <VopSection formData={sepaForm} setFormData={setSepaForm} />
-                {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
+                {createError && <div role="alert" style={{ color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', borderRadius: '6px', padding: '8px 10px', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
                   <button ref={sepaSubmitRef} type="submit" className="btn btn-primary" disabled={creating}>
@@ -1013,7 +1025,7 @@ function PaymentsContent() {
           )}
 
           {createSuccess && (
-            <div className="card" style={{ padding: '16px', color: 'var(--green)', marginBottom: '16px', fontSize: '14px', fontWeight: 600 }}>
+            <div role="status" className="card" style={{ padding: '16px', color: 'var(--success-text)', background: 'var(--success-bg)', border: '1px solid var(--success-border)', marginBottom: '16px', fontSize: '14px', fontWeight: 600 }}>
               {createSuccess}
             </div>
           )}
@@ -1041,7 +1053,7 @@ function PaymentsContent() {
             </div>
           </div>
 
-          {error && <div className="card" style={{ padding: '16px', color: 'var(--red)', marginBottom: '16px' }}>{error}</div>}
+          {error && <div role="alert" className="card" style={{ padding: '16px', color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', marginBottom: '16px' }}>{error}</div>}
 
           {/* Payments table */}
           <div className="card" style={{ overflow: 'hidden' }}>
@@ -1075,7 +1087,7 @@ function PaymentsContent() {
                     onClick={() => { stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) }}
                     onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) } }}>
                     <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{p.id.slice(0, 8)}…</td>
-                    <td><span className="tag" style={{ color: p.type === 'SEPA' ? 'var(--accent)' : 'var(--green)' }}>{p.type}</span></td>
+                    <td><span className="tag" style={{ color: p.type === 'SEPA' ? 'var(--accent-text)' : 'var(--info-text)' }}>{p.type}</span></td>
                     <td>
                       <StatusBadge status={p.status} />
                     </td>

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -18,6 +18,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard'
 import { hasPermission } from '@/lib/auth/roles'
 import { PageHeader, StatusBadge } from '@/components/ui'
 import { useSingleFlight, useIdempotencyKey, wasSkipped } from '@/lib/mutations/singleFlight'
+import { parseVopEvidence } from '@/lib/payments/vopEvidence'
 
 // ADR-0080 P1 (pentest FIND-S3-03/04): all backend access goes through same-origin BFF
 // routes — never NEXT_PUBLIC_ localhost URLs, which leaked the internal port map into the
@@ -162,6 +163,7 @@ function TabNav({ active, onChange }: { active: Tab; onChange: (t: Tab) => void 
 
 function VopSection({ formData, setFormData }: { formData: SepaFormData; setFormData: React.Dispatch<React.SetStateAction<SepaFormData>> }) {
   const { t } = useLanguage()
+  const requestRef = useRef(0)
   const vopTone: Record<VopStatus, { text: string; bg: string; border: string }> = {
     idle: { text: 'var(--text-tertiary)', bg: 'var(--surface-2)', border: 'var(--border)' },
     loading: { text: 'var(--text-secondary)', bg: 'var(--surface-2)', border: 'var(--border)' },
@@ -199,29 +201,38 @@ function VopSection({ formData, setFormData }: { formData: SepaFormData; setForm
           value={formData.creditorName} onChange={e => setFormData({ ...formData, vopStatus: 'idle', vopResult: null, creditorName: e.target.value })} />
         <button type="button" className="btn btn-secondary btn-sm" disabled={!formData.creditorIban || !formData.creditorName || formData.vopStatus === 'loading'}
           onClick={async () => {
+            const request = ++requestRef.current
+            const verifiedIban = formData.creditorIban
+            const verifiedName = formData.creditorName
             setFormData(prev => ({ ...prev, vopStatus: 'loading', vopResult: null }))
             try {
               const res = await fetch(`${VOP_API}/api/v1/vop/verify`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ creditorIban: formData.creditorIban, creditorName: formData.creditorName }),
+                body: JSON.stringify({ creditorIban: verifiedIban, creditorName: verifiedName }),
+                signal: AbortSignal.timeout(8000),
               })
               if (!res.ok) {
                 // The service answered, but not with a verdict. That is not a payee mismatch —
                 // never render it as no_match, which would tell the operator the payee is wrong
                 // when we never actually checked.
-                setFormData(prev => ({ ...prev, vopStatus: 'no_data', vopResult: null }))
+                setFormData(prev => request === requestRef.current && prev.creditorIban === verifiedIban && prev.creditorName === verifiedName
+                  ? { ...prev, vopStatus: 'no_data', vopResult: null }
+                  : prev)
                 return
               }
-              const body = await res.json() as { status: VopStatus; matchedName?: string | null }
-              // matchedName is only ever populated for close_match (ADR-0171 §6) — the backend
-              // will not echo a name on no_match, so there is nothing to guard here beyond
-              // rendering what we are given.
-              setFormData(prev => ({ ...prev, vopStatus: body.status, vopResult: body.matchedName ?? body.status }))
+              const evidence = parseVopEvidence(await res.json())
+              setFormData(prev => {
+                if (request !== requestRef.current || prev.creditorIban !== verifiedIban || prev.creditorName !== verifiedName) return prev
+                if (!evidence) return { ...prev, vopStatus: 'no_data', vopResult: null }
+                return { ...prev, vopStatus: evidence.status, vopResult: evidence.matchedName ?? evidence.status }
+              })
             } catch {
               // VoP is fail-open (ADR-0171 §3): an unreachable service must not block the payment,
               // but it must never look like a successful verification either.
-              setFormData(prev => ({ ...prev, vopStatus: 'no_data', vopResult: null }))
+              setFormData(prev => request === requestRef.current && prev.creditorIban === verifiedIban && prev.creditorName === verifiedName
+                ? { ...prev, vopStatus: 'no_data', vopResult: null }
+                : prev)
             }
           }}>
           <ShieldCheck size={12} />{t('Ověřit', 'Verify')}
@@ -906,14 +917,14 @@ function PaymentsContent() {
                     <label htmlFor="sepa-creditor-iban" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('IBAN příjemce', 'Creditor IBAN')}</label>
                     <input id="sepa-creditor-iban" className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }}
                       placeholder="CZ65 0800 0000 1920 0014 5399" value={sepaForm.creditorIban}
-                      onChange={e => setSepaForm({ ...sepaForm, creditorIban: e.target.value })} required />
+                      onChange={e => setSepaForm({ ...sepaForm, creditorIban: e.target.value, vopStatus: 'idle', vopResult: null })} required />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
                     <label htmlFor="sepa-creditor-name" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno příjemce', 'Creditor Name')}</label>
                     <input id="sepa-creditor-name" className="input" style={{ width: '100%' }} placeholder="John Doe" value={sepaForm.creditorName}
-                      onChange={e => setSepaForm({ ...sepaForm, creditorName: e.target.value })} required />
+                      onChange={e => setSepaForm({ ...sepaForm, creditorName: e.target.value, vopStatus: 'idle', vopResult: null })} required />
                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '3px' }}>
                       {t('Max 70 znaků. SWIFT charset: A-Z, 0-9, / - ? : ( ) . , \' + (bez diakritiky)', 'Max 70 chars. SWIFT charset: A-Z, 0-9, / - ? : ( ) . , \' + (no diacritics)')}
                     </div>

--- a/openbank-admin-ui/src/lib/payments/vopEvidence.ts
+++ b/openbank-admin-ui/src/lib/payments/vopEvidence.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export type VopVerdict = 'match' | 'close_match' | 'no_match' | 'no_data'
+
+export interface VopEvidence {
+  status: VopVerdict
+  matchedName: string | null
+  verifiedAt: string
+}
+
+const VERDICTS = new Set<VopVerdict>(['match', 'close_match', 'no_match', 'no_data'])
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/
+
+export function parseVopEvidence(value: unknown): VopEvidence | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.status !== 'string' || !VERDICTS.has(candidate.status as VopVerdict)) return null
+  if (typeof candidate.verifiedAt !== 'string' || !RFC3339.test(candidate.verifiedAt) || !Number.isFinite(Date.parse(candidate.verifiedAt))) return null
+
+  const status = candidate.status as VopVerdict
+  const matchedName = candidate.matchedName
+  if (status === 'close_match') {
+    if (typeof matchedName !== 'string' || matchedName.trim().length === 0 || matchedName.length > 140) return null
+  } else if (matchedName !== undefined && matchedName !== null) {
+    // Never let an anomalous response turn MATCH/NO_MATCH into an account-name disclosure.
+    return null
+  }
+
+  return { status, matchedName: status === 'close_match' ? matchedName as string : null, verifiedAt: candidate.verifiedAt }
+}

--- a/openbank-admin-ui/src/test/payments-theme-semantics.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-theme-semantics.guard.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+const rawSemanticLiteral = /#(?:16a34a|d97706|dc2626|6366f1|0ea5e9)\b/i
+const undefinedLegacyToken = /var\(--(?:red|green|yellow)\)/
+const tokenAlphaSuffix = /var\(--[^)]+\)[0-9a-f]{2}/i
+
+describe('payment workflow theme contract', () => {
+  it('uses complete semantic triplets for money-path states', () => {
+    expect(source).not.toMatch(rawSemanticLiteral)
+    expect(source).not.toMatch(undefinedLegacyToken)
+    expect(source).not.toMatch(tokenAlphaSuffix)
+    for (const tone of ['accent', 'success', 'warning', 'danger', 'info']) {
+      expect(source).toContain(`var(--${tone}-text)`)
+      expect(source).toContain(`var(--${tone}-bg)`)
+      expect(source).toContain(`var(--${tone}-border)`)
+    }
+    expect(source).toContain('aria-live="polite"')
+  })
+})

--- a/openbank-admin-ui/src/test/vop-evidence.test.ts
+++ b/openbank-admin-ui/src/test/vop-evidence.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { parseVopEvidence } from '@/lib/payments/vopEvidence'
+
+const verifiedAt = '2026-09-10T08:15:30Z'
+
+describe('VoP evidence boundary', () => {
+  it.each(['match', 'no_match', 'no_data'] as const)('accepts %s without disclosing a name', status => {
+    expect(parseVopEvidence({ status, matchedName: null, verifiedAt })).toEqual({ status, matchedName: null, verifiedAt })
+  })
+
+  it('accepts the bounded account name only for close_match', () => {
+    expect(parseVopEvidence({ status: 'close_match', matchedName: 'Verified Supplier GmbH', verifiedAt }))
+      .toEqual({ status: 'close_match', matchedName: 'Verified Supplier GmbH', verifiedAt })
+  })
+
+  it.each([
+    null,
+    [],
+    { status: 'MATCH', verifiedAt },
+    { status: 'match' },
+    { status: 'match', verifiedAt: 'not-a-date' },
+    { status: 'match', matchedName: 'must-not-leak', verifiedAt },
+    { status: 'no_match', matchedName: 'must-not-leak', verifiedAt },
+    { status: 'close_match', matchedName: '', verifiedAt },
+    { status: 'close_match', matchedName: 'x'.repeat(141), verifiedAt },
+  ])('rejects malformed or disclosure-unsafe evidence %#', value => {
+    expect(parseVopEvidence(value)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- give every Verification of Payee verdict an explicit shared text/background/border semantic triplet and announce verdict changes politely
- bind each verdict to the exact IBAN and payee name that were verified, so a late response cannot bless edited payment details
- validate the VoP evidence envelope, RFC 3339 timestamp, verdict vocabulary, and bounded `close_match` disclosure before rendering it
- reject account-holder name disclosure on `match`, `no_match`, or `no_data`; malformed evidence fails open as visibly unavailable, never as match
- add an 8-second request bound while preserving the documented VoP fail-open policy
- modernize instant-payment, settlement, processing, success and error states for coherent light/dark rendering
- preserve payment creation RBAC, stable idempotency keys, single-flight submission, review confirmation and API payloads

## Verification
- focused Vitest: 2 files, 14 tests
- `npm run type-check`
- targeted ESLint: zero findings
- `npm run build` (97/97 routes)
- production Chromium E2E: `sct-inst-vop.spec.ts` 1/1
- `git diff --check`

Closes #9502
Refs #7654