### PR TITLE
fix(admin-ui): clarify security scanner risk states

### DIFF
--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -43,16 +43,23 @@ interface Finding {
 }
 
 const SEVERITY_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  CRITICAL: { bg: '#fef2f2', text: '#991b1b', border: '#fecaca' },
+  CRITICAL: { bg: 'var(--danger-bg)', text: 'var(--danger-text)', border: 'var(--danger-border)' },
   HIGH:     { bg: 'var(--danger-bg)',   text: 'var(--danger-text)',   border: 'var(--danger-border)' },
   MEDIUM:   { bg: 'var(--warning-bg)',  text: 'var(--warning-text)',  border: 'var(--warning-border)' },
   LOW:      { bg: 'var(--info-bg)',     text: 'var(--info-text)',     border: 'var(--info-border)' },
   INFO:     { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
 }
 
-const GRADE_COLORS: Record<string, string> = {
-  'A+': '#059669', A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#ef4444', F: '#991b1b'
+const GRADE_TONES: Record<string, { text: string; bg: string; border: string }> = {
+  'A+': { text: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+  A: { text: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+  B: { text: 'var(--info-text)', bg: 'var(--info-bg)', border: 'var(--info-border)' },
+  C: { text: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)' },
+  D: { text: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
+  F: { text: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
 }
+
+const gradeTone = (grade: string) => GRADE_TONES[grade] ?? { text: 'var(--text-secondary)', bg: 'var(--surface-2)', border: 'var(--border)' }
 
 const OWASP_LABELS: Record<string, [string, string]> = {
   A01_BROKEN_ACCESS_CONTROL:       ['A01 Řízení přístupu',      'A01 Access Control'],
@@ -104,7 +111,10 @@ export default function SecurityPage() {
     }
   }, [applyEnvelope])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    const initialLoad = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(initialLoad)
+  }, [load])
 
   const results = report?.serviceResults ?? []
   // Only services the scanner could actually reach have a meaningful verdict. An
@@ -124,7 +134,7 @@ export default function SecurityPage() {
 
   const formatDate = (d: string) => {
     try {
-      return new Intl.DateTimeFormat('cs-CZ', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d))
+      return new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d))
     } catch {
       return d
     }
@@ -146,9 +156,9 @@ export default function SecurityPage() {
             {report && (
               <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '13px', fontWeight: 800,
                 padding: '4px 12px', borderRadius: '20px',
-                background: ['A+','A'].includes(platformGrade) ? 'var(--success-bg)' : ['B'].includes(platformGrade) ? 'var(--info-bg)' : ['C'].includes(platformGrade) ? 'var(--warning-bg)' : 'var(--danger-bg)',
-                color: ['A+','A'].includes(platformGrade) ? 'var(--success-text)' : ['B'].includes(platformGrade) ? 'var(--info-text)' : ['C'].includes(platformGrade) ? 'var(--warning-text)' : 'var(--danger-text)',
-                border: `1px solid ${['A+','A'].includes(platformGrade) ? 'var(--success-border)' : ['B'].includes(platformGrade) ? 'var(--info-border)' : ['C'].includes(platformGrade) ? 'var(--warning-border)' : 'var(--danger-border)'}` }}>
+                background: gradeTone(platformGrade).bg,
+                color: gradeTone(platformGrade).text,
+                border: `1px solid ${gradeTone(platformGrade).border}` }}>
                 <Shield size={12} /> {platformGrade} · {avgScore}/100
               </span>
             )}
@@ -171,11 +181,11 @@ export default function SecurityPage() {
         </p>
 
         {criticalCount > 0 && (
-          <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
-            background: '#fef2f2', border: '1px solid #fecaca',
+          <div role="alert" style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
+            background: 'var(--danger-bg)', border: '1px solid var(--danger-border)',
             display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <AlertTriangle size={16} style={{ color: '#dc2626', flexShrink: 0 }} />
-            <span style={{ fontSize: '13px', fontWeight: 600, color: '#991b1b' }}>
+            <AlertTriangle size={16} aria-hidden="true" style={{ color: 'var(--danger-text)', flexShrink: 0 }} />
+            <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--danger-text)' }}>
               {criticalCount} {criticalCount > 1 ? t('kritické zranitelnosti', 'critical vulnerabilities') : t('kritická zranitelnost', 'critical vulnerability')} — {t('okamžitá akce nutná', 'immediate action required')}
             </span>
           </div>
@@ -183,14 +193,14 @@ export default function SecurityPage() {
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Průměrné skóre', 'Platform Score'), value: `${avgScore}/100`, icon: <Shield size={16} />, color: avgScore >= 80 ? 'var(--success)' : avgScore >= 60 ? 'var(--warning)' : 'var(--danger)' },
-            { label: t('Kritické', 'Critical'), value: criticalCount, icon: <AlertTriangle size={16} />, color: '#dc2626' },
-            { label: t('Vysoké', 'High'), value: highCount, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
-            { label: t('Skenované služby', 'Scanned Services'), value: `${report?.reachableServices ?? 0}/${report?.totalServices ?? 0}`, icon: <CheckCircle2 size={16} />, color: 'var(--accent)' },
+            { label: t('Průměrné skóre', 'Platform Score'), value: `${avgScore}/100`, icon: <Shield size={16} />, text: avgScore >= 80 ? 'var(--success-text)' : avgScore >= 60 ? 'var(--warning-text)' : 'var(--danger-text)', bg: avgScore >= 80 ? 'var(--success-bg)' : avgScore >= 60 ? 'var(--warning-bg)' : 'var(--danger-bg)' },
+            { label: t('Kritické', 'Critical'), value: criticalCount, icon: <AlertTriangle size={16} />, text: 'var(--danger-text)', bg: 'var(--danger-bg)' },
+            { label: t('Vysoké', 'High'), value: highCount, icon: <AlertTriangle size={16} />, text: 'var(--danger-text)', bg: 'var(--danger-bg)' },
+            { label: t('Skenované služby', 'Scanned Services'), value: `${report?.reachableServices ?? 0}/${report?.totalServices ?? 0}`, icon: <CheckCircle2 size={16} />, text: 'var(--accent-text)', bg: 'var(--accent-bg)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
-              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
+              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: k.bg,
+                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.text, marginBottom: '10px' }}>{k.icon}</div>
               <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
               <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
             </div>
@@ -286,7 +296,7 @@ export default function SecurityPage() {
                       style={{ padding: '4px 10px', borderRadius: '4px', fontSize: '11px', fontWeight: 600, border: 'none', cursor: 'pointer',
                         background: filter === f ? 'var(--surface-1)' : 'transparent',
                         color: filter === f ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                        boxShadow: filter === f ? '0 1px 2px rgba(0,0,0,0.05)' : 'none', transition: 'all 0.2s' }}>
+                        boxShadow: filter === f ? 'var(--shadow-xs)' : 'none', transition: 'all 0.2s' }}>
                       {f === 'ALL' ? t('Vše', 'All') : f === 'CRITICAL' ? t('Kritické', 'Critical') : t('Vysoké', 'High')}
                     </button>
                   ))}
@@ -322,7 +332,7 @@ export default function SecurityPage() {
                           <td style={{ padding: '12px 16px' }}>
                             {r.reachable ? (
                               <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                                <span style={{ fontSize: '14px', fontWeight: 800, color: GRADE_COLORS[r.grade] ?? 'var(--text-secondary)' }}>{r.grade}</span>
+                                <span style={{ fontSize: '14px', fontWeight: 800, color: gradeTone(r.grade).text }}>{r.grade}</span>
                                 <span style={{ fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)' }}>{r.score}</span>
                               </div>
                             ) : (
@@ -371,7 +381,7 @@ export default function SecurityPage() {
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                     {selected.reachable ? (
                       <>
-                        <span style={{ fontSize: '20px', fontWeight: 900, color: GRADE_COLORS[selected.grade] ?? 'var(--text-secondary)' }}>{selected.grade}</span>
+                        <span style={{ fontSize: '20px', fontWeight: 900, color: gradeTone(selected.grade).text }}>{selected.grade}</span>
                         <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{selected.score}/100</span>
                       </>
                     ) : (
@@ -396,7 +406,7 @@ export default function SecurityPage() {
                     </div>
                   ) : (selected.findings ?? []).length === 0 ? (
                     <div style={{ padding: '48px 32px', textAlign: 'center' }}>
-                      <CheckCircle2 size={32} style={{ color: 'var(--success)', marginBottom: '12px', marginInline: 'auto' }} />
+                      <CheckCircle2 size={32} style={{ color: 'var(--success-text)', marginBottom: '12px', marginInline: 'auto' }} />
                       <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--text-primary)' }}>{t('Žádné nálezy', 'No findings')}</div>
                       <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>{t('Tato služba prošla všemi kontrolami.', 'This service passed all checks.')}</div>
                     </div>
@@ -414,7 +424,7 @@ export default function SecurityPage() {
                             {f.cweId && <div style={{ fontSize: '10px', fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)', marginBottom: '6px' }}>{f.cweId}{f.cvssScore ? ` · CVSS ${f.cvssScore}` : ''}</div>}
                             <div style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '12px', lineHeight: 1.5 }}>{f.description}</div>
                             {f.remediation && (
-                              <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', background: 'rgba(0,0,0,0.02)', padding: '8px 12px', borderRadius: '4px', borderLeft: '3px solid var(--accent)' }}>
+                              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', background: 'var(--surface-2)', padding: '8px 12px', borderRadius: '4px', borderLeft: '3px solid var(--accent-border)' }}>
                                 {f.remediation}
                               </div>
                             )}

--- a/openbank-admin-ui/src/test/security-theme-semantics.guard.test.ts
+++ b/openbank-admin-ui/src/test/security-theme-semantics.guard.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(path.resolve(__dirname, '../app/security/page.tsx'), 'utf8')
+const rawColour = /#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}(?![0-9a-fA-F])|rgba?\(/
+const tokenAlphaSuffix = /var\(--[^)]+\)[0-9a-f]{2}/i
+
+describe('security scanner theme contract', () => {
+  it('uses valid shared semantics for every risk and grade state', () => {
+    expect(source).not.toMatch(rawColour)
+    expect(source).not.toMatch(tokenAlphaSuffix)
+    for (const tone of ['accent', 'success', 'warning', 'danger', 'info']) {
+      expect(source).toContain(`var(--${tone}-text)`)
+      expect(source).toContain(`var(--${tone}-bg)`)
+      expect(source).toContain(`var(--${tone}-border)`)
+    }
+    expect(source).toContain("language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain('role="alert"')
+  })
+})


### PR DESCRIPTION
## Summary
- centralize severity and A–F grade presentation as complete shared semantic token triplets
- remove light-only literals and invalid CSS-variable alpha concatenation from risk headline cards
- make the critical summary a programmatic alert and render remediation on a theme-aware surface
- format scan timestamps using the selected UI language
- defer the initial scan request to satisfy the React effect performance gate
- preserve system:view RBAC, read-only behavior, reachable-only scoring and the “not scanned” unknown verdict
- add a focused security scanner theme regression guard

## Verification
- security-focused Vitest matrix: 4 existing files, 25 tests
- `npm run type-check`
- targeted ESLint: zero findings
- `npm run build` (97 routes)
- `git diff --check`

Closes #9504
Refs #7654