### PR TITLE
perf(admin-ui): de-duplicate security KPI signals

### DIFF
--- a/openbank-admin-ui/src/app/security/excellence/page.tsx
+++ b/openbank-admin-ui/src/app/security/excellence/page.tsx
@@ -53,9 +53,16 @@ interface Domain {
   unavailableReason?: string
 }
 
-const GRADE_COLORS: Record<string, string> = {
-  'A+': '#059669', A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#ef4444', F: '#991b1b',
+const GRADE_TONES: Record<string, { text: string; bg: string; border: string }> = {
+  'A+': { text: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+  A: { text: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+  B: { text: 'var(--info-text)', bg: 'var(--info-bg)', border: 'var(--info-border)' },
+  C: { text: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)' },
+  D: { text: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
+  F: { text: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
 }
+
+const gradeTone = (grade: string) => GRADE_TONES[grade] ?? { text: 'var(--text-secondary)', bg: 'var(--surface-2)', border: 'var(--border)' }
 
 function gradeFor(score: number): string {
   if (score >= 95) return 'A+'
@@ -66,12 +73,12 @@ function gradeFor(score: number): string {
   return 'F'
 }
 
-const STATUS_TONE: Record<DomainStatus, { color: string; bg: string }> = {
-  ok:          { color: '#059669', bg: '#ecfdf5' },
-  degraded:    { color: '#d97706', bg: '#fffbeb' },
-  critical:    { color: '#b91c1c', bg: '#fef2f2' },
-  unavailable: { color: 'var(--text-tertiary, #6b7280)', bg: 'var(--surface-3, #f3f4f6)' },
-  loading:     { color: 'var(--text-tertiary, #6b7280)', bg: 'var(--surface-3, #f3f4f6)' },
+const STATUS_TONE: Record<DomainStatus, { color: string; bg: string; border: string }> = {
+  ok:          { color: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+  degraded:    { color: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)' },
+  critical:    { color: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)' },
+  unavailable: { color: 'var(--text-tertiary)', bg: 'var(--surface-3)', border: 'var(--border)' },
+  loading:     { color: 'var(--text-tertiary)', bg: 'var(--surface-3)', border: 'var(--border)' },
 }
 
 // ── Fan-out fetchery — každý vrací partial update domény, nikdy nehodí ───────
@@ -243,10 +250,9 @@ async function fetchKpis(): Promise<KpisSnapshot | null> {
   return env.available && env.kpis ? env.kpis : null
 }
 
-async function fetchSegmentation(): Promise<Patch> {
+async function fetchSegmentation(snap: KpisSnapshot | null): Promise<Patch> {
   // NetworkPolicy coverage KPI (gate netpol-coverage-kpi): na CNI bez audit módu
   // je podíl komponent se zvolenou ingress policy = postoj segmentace.
-  const snap = await fetchKpis()
   const n = snap?.netpol
   if (!n?.available || n.coveragePct == null) return unavailable('not_deployed')
   return {
@@ -257,8 +263,7 @@ async function fetchSegmentation(): Promise<Patch> {
   }
 }
 
-async function fetchFreshness(): Promise<Patch> {
-  const snap = await fetchKpis()
+async function fetchFreshness(snap: KpisSnapshot | null): Promise<Patch> {
   const f = snap?.freshness
   if (!f?.available || f.fleetScore == null) return unavailable('not_deployed')
   return {
@@ -269,10 +274,9 @@ async function fetchFreshness(): Promise<Patch> {
   }
 }
 
-async function fetchCredentials(): Promise<Patch> {
+async function fetchCredentials(snap: KpisSnapshot | null): Promise<Patch> {
   // Long-lived credentials: skóre = podíl statických secretů s rotačním deadlinem;
   // overdue deadline je critical, ne degraded — prošlá rotace je aktivní dluh.
-  const snap = await fetchKpis()
   const c = snap?.credentials
   if (!c?.available || c.staticSecrets == null) return unavailable('not_deployed')
   const declared = c.withDeadline ?? 0
@@ -285,10 +289,9 @@ async function fetchCredentials(): Promise<Patch> {
   }
 }
 
-async function fetchFuzz(): Promise<Patch> {
+async function fetchFuzz(snap: KpisSnapshot | null): Promise<Patch> {
   // DAST coverage (ADR-0279 #2): podíl in-scope služeb, které poslední api-fuzz běh
   // skutečně profuzzoval (exercised-surface záznam), ne jen zobrazil v job listu.
-  const snap = await fetchKpis()
   const z = snap?.fuzz
   if (!z?.available || z.coveragePct == null) return unavailable('not_deployed')
   return {
@@ -300,11 +303,10 @@ async function fetchFuzz(): Promise<Patch> {
 }
 
 
-async function fetchThreatModels(): Promise<Patch> {
+async function fetchThreatModels(snap: KpisSnapshot | null): Promise<Patch> {
   // Threat-model stáří (ADR-0279 #23): money-path služba bez modelu je critical
   // (governance pravidlo), model > 90 dní bez změny je stale — prose, které nikdo
   // nepřepočítal proti kódu.
-  const snap = await fetchKpis()
   const m = snap?.threatModels
   if (!m?.available || m.moneyPathTotal == null) return unavailable('not_deployed')
   const pct = Math.round(100 * (m.withModel ?? 0) / m.moneyPathTotal)
@@ -317,11 +319,10 @@ async function fetchThreatModels(): Promise<Patch> {
   }
 }
 
-async function fetchMttr(): Promise<Patch> {
+async function fetchMttr(snap: KpisSnapshot | null): Promise<Patch> {
   // CVE remediation (SLO S1 proxy přes Dependabot alerts, critical+high): otevřená
   // kritická zranitelnost > 14 dní je critical postoj; median fix čas se ukáže,
   // jakmile historie existuje.
-  const snap = await fetchKpis()
   const v = snap?.mttr
   if (!v?.available) return unavailable('not_deployed')
   const open = v.openCount ?? 0
@@ -395,12 +396,19 @@ export default function SecurityExcellencePage() {
   const load = useCallback(async () => {
     setLoading(true)
     setPatches({})
+    // All KPI-derived cards must describe one coherent CI snapshot. Sharing this promise also
+    // collapses six identical BFF requests into one without serialising the wider fan-out.
+    const kpisSnapshot = fetchKpis()
     const fetchers: Record<string, () => Promise<Patch>> = {
       posture: fetchPosture, incidents: fetchIncidents, fraud: fetchFraud, aml: fetchAml,
       sanctions: fetchSanctions, approvals: fetchApprovals, audit: fetchAudit, identity: fetchIdentity,
-      sbom: fetchSbom, segmentation: fetchSegmentation, freshness: fetchFreshness,
-      credentials: fetchCredentials, fuzz: fetchFuzz,
-      threatmodels: fetchThreatModels, mttr: fetchMttr,
+      sbom: fetchSbom,
+      segmentation: async () => fetchSegmentation(await kpisSnapshot),
+      freshness: async () => fetchFreshness(await kpisSnapshot),
+      credentials: async () => fetchCredentials(await kpisSnapshot),
+      fuzz: async () => fetchFuzz(await kpisSnapshot),
+      threatmodels: async () => fetchThreatModels(await kpisSnapshot),
+      mttr: async () => fetchMttr(await kpisSnapshot),
     }
     // Fan-out paralelně; každá doména se doplní jakmile odpoví (progressive render).
     await Promise.all(Object.entries(fetchers).map(async ([id, fn]) => {
@@ -411,7 +419,10 @@ export default function SecurityExcellencePage() {
     setLoading(false)
   }, [])
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => {
+    const initialLoad = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(initialLoad)
+  }, [load])
 
   const domains: Domain[] = DOMAIN_DEFS.map(d => ({ ...d, status: patches[d.id]?.status ?? 'loading', ...patches[d.id] }))
 
@@ -465,18 +476,18 @@ export default function SecurityExcellencePage() {
 
         {/* ── Hero: skóre excelence ─────────────────────────────────────── */}
         <section aria-label={t('Skóre Security Excellence', 'Security Excellence score')}
-          style={{ display: 'flex', gap: 24, alignItems: 'center', margin: '20px 0 28px', padding: '24px 28px', border: '1px solid var(--border, #e5e7eb)', borderRadius: 12, background: 'var(--surface-2, #fafafa)' }}>
+          style={{ display: 'flex', gap: 24, alignItems: 'center', margin: '20px 0 28px', padding: '24px 28px', border: '1px solid var(--border)', borderRadius: 12, background: 'var(--surface-2)' }}>
           <div style={{ textAlign: 'center', minWidth: 120 }}>
-            <div style={{ fontSize: 52, fontWeight: 700, lineHeight: 1, color: grade ? GRADE_COLORS[grade] : 'var(--text-tertiary)' }}
+            <div style={{ fontSize: 52, fontWeight: 700, lineHeight: 1, color: grade ? gradeTone(grade).text : 'var(--text-tertiary)' }}
               aria-live="polite">
               {score != null ? score : '—'}
             </div>
             <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>/ 100</div>
-            {grade && <div style={{ marginTop: 6, display: 'inline-block', padding: '2px 12px', borderRadius: 999, fontWeight: 700, color: '#fff', background: GRADE_COLORS[grade] }}>{grade}</div>}
+            {grade && <div style={{ marginTop: 6, display: 'inline-block', padding: '2px 12px', borderRadius: 999, fontWeight: 700, color: gradeTone(grade).text, background: gradeTone(grade).bg, border: `1px solid ${gradeTone(grade).border}` }}>{grade}</div>}
           </div>
           <div style={{ flex: 1 }}>
             <strong>{t('Skóre excelence platformy', 'Platform excellence score')}</strong>
-            <p style={{ margin: '6px 0 0', color: 'var(--text-secondary, #4b5563)', fontSize: 14 }}>
+            <p style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: 14 }}>
               {t(
                 `Vážený průměr ${answered} z ${total} domén, které odpověděly. Domény označené „Nedostupné" skóre nesnižují — degradace je vidět na kartách, ne skrytá v čísle.`,
                 `Weighted average of ${answered} of ${total} responding domains. Domains marked “Unavailable” do not drag the score down — degradation is visible on the cards, not hidden in the number.`,
@@ -499,11 +510,11 @@ export default function SecurityExcellencePage() {
             return (
               <Link key={d.id} href={d.href} style={{ textDecoration: 'none', color: 'inherit' }}
                 aria-label={`${language === 'cs' ? d.nameCs : d.nameEn} — ${statusLabel(d.status)}`}>
-                <article style={{ border: '1px solid var(--border, #e5e7eb)', borderRadius: 12, padding: '18px 20px', height: '100%', display: 'flex', flexDirection: 'column', gap: 10, background: 'var(--surface-1, #fff)' }}>
+                <article style={{ border: '1px solid var(--border)', borderRadius: 12, padding: '18px 20px', height: '100%', display: 'flex', flexDirection: 'column', gap: 10, background: 'var(--surface-1)' }}>
                   <header style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <Icon size={18} aria-hidden="true" />
                     <strong style={{ flex: 1 }}>{language === 'cs' ? d.nameCs : d.nameEn}</strong>
-                    <span style={{ fontSize: 12, fontWeight: 600, padding: '2px 10px', borderRadius: 999, color: tone.color, background: tone.bg }}>
+                    <span style={{ fontSize: 12, fontWeight: 600, padding: '2px 10px', borderRadius: 999, color: tone.color, background: tone.bg, border: `1px solid ${tone.border}` }}>
                       {statusLabel(d.status)}
                     </span>
                   </header>
@@ -517,8 +528,8 @@ export default function SecurityExcellencePage() {
                       <span style={{ fontSize: 13, color: tone.color }} role="status">{t('Načítám…', 'Loading…')}</span>
                     ) : (
                       <>
-                        <span style={{ fontSize: 22, fontWeight: 700, color: GRADE_COLORS[gradeFor(d.score ?? 0)] }}>{d.score}</span>
-                        <span style={{ fontSize: 13, color: 'var(--text-secondary, #4b5563)', flex: 1 }}>
+                        <span style={{ fontSize: 22, fontWeight: 700, color: gradeTone(gradeFor(d.score ?? 0)).text }}>{d.score}</span>
+                        <span style={{ fontSize: 13, color: 'var(--text-secondary)', flex: 1 }}>
                           {language === 'cs' ? d.metricCs : d.metricEn}
                         </span>
                       </>

--- a/openbank-admin-ui/src/test/security-excellence-theme-performance.guard.test.ts
+++ b/openbank-admin-ui/src/test/security-excellence-theme-performance.guard.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(path.resolve(__dirname, '../app/security/excellence/page.tsx'), 'utf8')
+const rawColour = /#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}(?![0-9a-fA-F])|rgba?\(/
+const legacyFallback = /var\(--[^,)]+,\s*#[0-9a-fA-F]{3,6}\)/
+
+describe('Security Excellence presentation and snapshot contract', () => {
+  it('uses shared semantics for grades and domain states', () => {
+    expect(source).not.toMatch(rawColour)
+    expect(source).not.toMatch(legacyFallback)
+    for (const tone of ['success', 'warning', 'danger', 'info']) {
+      expect(source).toContain(`var(--${tone}-text)`)
+      expect(source).toContain(`var(--${tone}-bg)`)
+      expect(source).toContain(`var(--${tone}-border)`)
+    }
+  })
+
+  it('shares one KPI snapshot across every KPI-derived domain per refresh', () => {
+    expect(source.match(/fetchKpis\(\)/g)).toHaveLength(2) // declaration + one request per refresh
+    expect(source.match(/const kpisSnapshot = fetchKpis\(\)/g)).toHaveLength(1)
+    expect(source).not.toMatch(/const snap = await fetchKpis\(\)/)
+    for (const domain of ['segmentation', 'freshness', 'credentials', 'fuzz', 'threatmodels', 'mttr']) {
+      expect(source).toContain(`${domain}: async () =>`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary\n\n- replace hard-coded Security Excellence grade and status palettes with shared semantic theme triplets for consistent light/dark rendering\n- share one /api/security/kpis snapshot promise across all six KPI-derived domains per refresh, preserving parallel fan-out while removing duplicate requests and snapshot drift\n- add a focused guard for semantic theme coverage and the single-request snapshot contract\n\n## Preserved behavior\n\n- system:view RBAC boundary and read-only backend fan-out\n- weighted score and unavailable-domain exclusion\n- progressive card rendering and drill-through links\n- existing KPI thresholds and backend contracts\n\n## Verification\n\n- npm run test -- --run src/test/security-excellence-theme-performance.guard.test.ts src/test/security-summary.test.ts src/test/roles.test.ts src/test/security-kpis-route.test.ts src/test/security-kpis-metrics-route.test.ts (5 files, 36 tests)\n- npm run type-check\n- npx eslint src/app/security/excellence/page.tsx src/test/security-excellence-theme-performance.guard.test.ts\n- npm run build (97 routes)\n- git diff --check\n\nCloses #9507\nRefs #7654