### PR TITLE
fix(admin-ui): validate AML case evidence

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -13,30 +13,22 @@ import { useServiceResource } from '@/lib/services/useServiceResource'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader, StatusBadge } from '@/components/ui'
 import { StatCard } from '@/components/ui/StatCard'
-
-interface AmlCase {
-  id: string;
-  customerName: string;
-  customerType: string;
-  riskLevel: string;
-  status: string;
-  score: number;
-  timestamp: string;
-}
+import { parseAmlCaseSnapshot, type AmlCaseSnapshot } from '@/lib/aml/cases'
 
 export default function AmlPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
   const [lastSuccessfulAt, setLastSuccessfulAt] = useState<Date | null>(null)
-  const { data, loading, unavailable, waking, reload } = useServiceResource<AmlCase[]>(
+  const { data, loading, unavailable, waking, reload } = useServiceResource<AmlCaseSnapshot>(
     svcUrl('aml-service', '/api/v1/aml/cases'),
     { select: (raw) => {
       setLastSuccessfulAt(new Date())
-      return Array.isArray(raw) ? (raw as AmlCase[]) : ((raw as { cases?: AmlCase[] }).cases ?? [])
+      return parseAmlCaseSnapshot(raw)
     } },
   )
-  const cases = data ?? []
+  const cases = data?.cases ?? []
+  const excludedCount = data?.excludedCount ?? 0
   const hasSnapshot = data !== null
   const showingRetainedSnapshot = unavailable !== null && hasSnapshot
   const filtered = cases.filter(c =>
@@ -91,6 +83,13 @@ export default function AmlPage() {
           {t('Aktualizuji AML případy; poslední snapshot zůstává dostupný.', 'Refreshing AML cases; the last snapshot remains available.')}
         </p>}
 
+        {hasSnapshot && excludedCount > 0 && <p role="alert" style={{ margin: '0 0 20px', padding: '10px 12px', borderRadius: 8, color: 'var(--warning-text)', background: 'var(--warning-bg)', border: '1px solid var(--warning-border)', fontSize: 12 }}>
+          {t(
+            `${excludedCount} neplatných AML záznamů bylo z přehledu vyřazeno; zobrazené souhrny počítají pouze ověřené záznamy.`,
+            `${excludedCount} invalid AML record${excludedCount === 1 ? ' was' : 's were'} excluded; displayed totals use validated records only.`,
+          )}
+        </p>}
+
         {hasSnapshot && escalated.length > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
             background: 'var(--danger-bg)', border: '1px solid var(--danger-border)',
@@ -115,8 +114,8 @@ export default function AmlPage() {
             { label: t('Případů celkem', 'Total Cases'), value: cases.length, icon: <ShieldAlert size={16} />, color: 'var(--accent)' },
             { label: t('Vysoké riziko', 'High Risk'), value: highRisk.length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
             { label: t('Čeká na review', 'Pending Review'), value: pending.length, icon: <Clock size={16} />, color: 'var(--warning)' },
-            { label: t('Eskalováno', 'Escalated'), value: escalated.length, icon: <AlertOctagon size={16} />, color: '#dc2626' },
-          ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.color === 'var(--danger)' || k.color === '#dc2626' ? 'danger' : k.color === 'var(--warning)' ? 'warning' : undefined} />)}
+            { label: t('Eskalováno', 'Escalated'), value: escalated.length, icon: <AlertOctagon size={16} />, color: 'var(--danger)' },
+          ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.color === 'var(--danger)' ? 'danger' : k.color === 'var(--warning)' ? 'warning' : undefined} />)}
         </div>}
 
         <div className="card">

--- a/openbank-admin-ui/src/lib/aml/cases.ts
+++ b/openbank-admin-ui/src/lib/aml/cases.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export interface AmlCase {
+  id: string
+  customerName: string
+  customerType: string
+  riskLevel: string
+  status: string
+  score: number
+  timestamp: string
+}
+
+export interface AmlCaseSnapshot {
+  cases: AmlCase[]
+  excludedCount: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const isAmlCase = (value: unknown): value is AmlCase => {
+  if (!isRecord(value)) return false
+  return isNonEmptyString(value.id)
+    && isNonEmptyString(value.customerName)
+    && isNonEmptyString(value.customerType)
+    && isNonEmptyString(value.riskLevel)
+    && isNonEmptyString(value.status)
+    && typeof value.score === 'number'
+    && Number.isFinite(value.score)
+    && value.score >= 0
+    && value.score <= 100
+    && isNonEmptyString(value.timestamp)
+    && !Number.isNaN(Date.parse(value.timestamp))
+}
+
+/** Keep usable evidence while making partial upstream corruption measurable to the operator. */
+export function parseAmlCaseSnapshot(raw: unknown): AmlCaseSnapshot {
+  const candidate = Array.isArray(raw)
+    ? raw
+    : isRecord(raw) && Array.isArray(raw.cases)
+      ? raw.cases
+      : []
+  const cases = candidate.filter(isAmlCase)
+  return { cases, excludedCount: candidate.length - cases.length }
+}

--- a/openbank-admin-ui/src/test/aml-case-evidence.test.ts
+++ b/openbank-admin-ui/src/test/aml-case-evidence.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { parseAmlCaseSnapshot } from '@/lib/aml/cases'
+
+const pageSource = readFileSync(path.resolve(__dirname, '../app/aml/page.tsx'), 'utf8')
+
+const validCase = {
+  id: 'case-1',
+  customerName: 'Example Customer',
+  customerType: 'PERSON',
+  riskLevel: 'HIGH',
+  status: 'PENDING_REVIEW',
+  score: 82,
+  timestamp: '2026-09-09T12:00:00Z',
+}
+
+describe('AML case evidence boundary', () => {
+  it('accepts the supported list and envelope response shapes', () => {
+    expect(parseAmlCaseSnapshot([validCase])).toEqual({ cases: [validCase], excludedCount: 0 })
+    expect(parseAmlCaseSnapshot({ cases: [validCase] })).toEqual({ cases: [validCase], excludedCount: 0 })
+  })
+
+  it('retains valid cases and counts malformed evidence', () => {
+    const result = parseAmlCaseSnapshot({ cases: [
+      validCase,
+      { ...validCase, id: '' },
+      { ...validCase, score: 101 },
+      { ...validCase, status: null },
+      { ...validCase, timestamp: 'not-a-date' },
+    ] })
+
+    expect(result).toEqual({ cases: [validCase], excludedCount: 4 })
+  })
+
+  it('does not invent rows for an invalid response envelope', () => {
+    expect(parseAmlCaseSnapshot({ cases: 'invalid' })).toEqual({ cases: [], excludedCount: 0 })
+    expect(parseAmlCaseSnapshot(null)).toEqual({ cases: [], excludedCount: 0 })
+  })
+
+  it('discloses exclusions and uses the shared danger semantic', () => {
+    expect(pageSource).toContain('excludedCount > 0')
+    expect(pageSource).toContain('displayed totals use validated records only.')
+    expect(pageSource).toContain("color: 'var(--warning-text)'")
+    expect(pageSource).not.toContain('#dc2626')
+  })
+})


### PR DESCRIPTION
## Summary\n\n- validate AML case rows at the Admin UI trust boundary instead of casting unknown BFF payloads\n- retain valid evidence when individual rows are malformed and disclose the excluded count to operators\n- calculate AML totals only from validated rows and replace the remaining hard-coded escalation colour with the shared danger semantic\n- cover list/envelope payloads, malformed fields, score bounds, timestamps, disclosure copy, and theme semantics\n\n## Preserved behavior\n\n- compliance:view RBAC and read-only endpoint\n- unavailable, waking, retained-snapshot, refresh, search, and empty states\n- existing AML risk/status meanings and score thresholds\n- no automated scan or mutation action added\n\n## Verification\n\n- npm run test -- --run src/test/aml-case-evidence.test.ts src/test/aml-scan-a11y.guard.test.ts (2 files, 5 tests)\n- npm run type-check\n- npx eslint src/app/aml/page.tsx src/lib/aml/cases.ts src/test/aml-case-evidence.test.ts\n- npm run build (97 routes)\n- git diff --check\n\nCloses #9510\nRefs #7654