### PR TITLE
fix(admin-ui): validate security KPI evidence

### DIFF
--- a/openbank-admin-ui/src/app/api/security/kpis/metrics/route.ts
+++ b/openbank-admin-ui/src/app/api/security/kpis/metrics/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { parseSecurityKpis } from '@/lib/security/kpiContract'
 
 // ── Security KPIs: Prometheus text exposition of the CI-generated snapshot ───
 //
@@ -113,7 +114,7 @@ export async function GET(): Promise<NextResponse> {
   let gauges: Gauge[] = []
   try {
     const raw = await fs.readFile(snapshotFile(), 'utf-8')
-    gauges = gaugesFromSnapshot(JSON.parse(raw) as Record<string, unknown>)
+    gauges = gaugesFromSnapshot(parseSecurityKpis(JSON.parse(raw)) as unknown as Record<string, unknown>)
   } catch {
     // Absent/corrupt snapshot: still 200, with zero series. Prometheus records the
     // target as up with no samples; SecurityKpiSnapshotStale/absent() semantics

--- a/openbank-admin-ui/src/app/api/security/kpis/route.ts
+++ b/openbank-admin-ui/src/app/api/security/kpis/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { parseSecurityKpis } from '@/lib/security/kpiContract'
 
 // ── Security KPIs: READ-ONLY serving of the CI-generated snapshot ────────────
 //
@@ -44,11 +45,11 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json(payload, { status: 200 })
   }
   try {
-    const kpis = JSON.parse(raw)
+    const kpis = parseSecurityKpis(JSON.parse(raw))
     const payload: KpisEnvelope = { available: true, kpis }
     return NextResponse.json(payload, { status: 200 })
   } catch {
-    const payload: KpisEnvelope = { available: false, reason: 'error', detail: 'Invalid JSON in security-kpis.json' }
+    const payload: KpisEnvelope = { available: false, reason: 'error', detail: 'Invalid or contradictory security-kpis.json evidence' }
     return NextResponse.json(payload, { status: 200 })
   }
 }

--- a/openbank-admin-ui/src/app/security/excellence/page.tsx
+++ b/openbank-admin-ui/src/app/security/excellence/page.tsx
@@ -30,6 +30,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
+import { parseSecurityKpis, type SecurityKpis } from '@/lib/security/kpiContract'
 
 // ── Doménové stavy ───────────────────────────────────────────────────────────
 
@@ -234,20 +235,14 @@ async function fetchSbom(): Promise<Patch> {
 
 // ── ADR-0279 KPI domény: čtou jeden CI-generovaný snapshot (/api/security/kpis) ──
 
-interface KpisSnapshot {
-  netpol?: { available?: boolean; coveragePct?: number; covered?: number; total?: number }
-  freshness?: { available?: boolean; fleetScore?: number; unknownModules?: number }
-  credentials?: { available?: boolean; staticSecrets?: number; withDeadline?: number; overdue?: number }
-  fuzz?: { available?: boolean; inScope?: number; tested?: number; coveragePct?: number; totalExercised?: number; excludedCount?: number; runDate?: string }
-  threatModels?: { available?: boolean; moneyPathTotal?: number; withModel?: number; staleCount?: number; oldestDays?: number }
-  mttr?: { available?: boolean; fixedCount?: number; medianFixDays?: number | null; openCount?: number; oldestOpenDays?: number }
-}
+type KpisSnapshot = SecurityKpis
 
 async function fetchKpis(): Promise<KpisSnapshot | null> {
   const { ok, body } = await safeJson('/api/security/kpis')
   if (!ok) return null
-  const env = body as { available?: boolean; kpis?: KpisSnapshot }
-  return env.available && env.kpis ? env.kpis : null
+  const env = body as { available?: unknown; kpis?: unknown }
+  if (env.available !== true) return null
+  try { return parseSecurityKpis(env.kpis) } catch { return null }
 }
 
 async function fetchSegmentation(snap: KpisSnapshot | null): Promise<Patch> {

--- a/openbank-admin-ui/src/lib/security/kpiContract.ts
+++ b/openbank-admin-ui/src/lib/security/kpiContract.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+type Unavailable = { available: false; reason: string }
+export type SecurityKpis = {
+  generatedAt: string
+  netpol: Unavailable | { available: true; covered: number; total: number; coveragePct: number; gateGreen: boolean }
+  freshness: Unavailable | { available: true; fleetScore: number; scoredModules: number; unknownModules: number }
+  credentials: Unavailable | { available: true; totalSecrets: number; staticSecrets: number; withDeadline: number; overdue: number; undeclared: number; overdueFound: boolean }
+  fuzz: Unavailable | { available: true; inScope: number; tested: number; coveragePct: number; totalExercised: number; excludedCount: number; runDate: string }
+  threatModels: Unavailable | { available: true; moneyPathTotal: number; withModel: number; staleCount: number; oldestDays: number }
+  mttr: Unavailable | { available: true; fixedCount: number; medianFixDays: number | null; openCount: number; oldestOpenDays: number }
+}
+
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+const DATE = /^\d{4}-\d{2}-\d{2}$/
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Expected object')
+  return value as Record<string, unknown>
+}
+function integer(value: unknown, max = Number.MAX_SAFE_INTEGER): number {
+  if (!Number.isInteger(value) || (value as number) < 0 || (value as number) > max) throw new Error('Invalid count')
+  return value as number
+}
+function percent(value: unknown): number { return integer(value, 100) }
+function bool(value: unknown): boolean {
+  if (typeof value !== 'boolean') throw new Error('Invalid boolean')
+  return value
+}
+function unavailable(section: Record<string, unknown>): Unavailable | null {
+  if (section.available !== false) return null
+  if (typeof section.reason !== 'string' || section.reason.trim() === '' || section.reason.length > 500) throw new Error('Invalid unavailable reason')
+  return { available: false, reason: section.reason }
+}
+function ratio(actual: number, total: number): number { return total === 0 ? 0 : Math.round(100 * actual / total) }
+
+export function parseSecurityKpis(value: unknown): SecurityKpis {
+  const raw = object(value)
+  if (typeof raw.generatedAt !== 'string' || !RFC3339.test(raw.generatedAt) || !Number.isFinite(Date.parse(raw.generatedAt))) throw new Error('Invalid generatedAt')
+
+  const netpolRaw = object(raw.netpol); const netpolUnavailable = unavailable(netpolRaw)
+  const netpol = netpolUnavailable ?? (() => {
+    if (netpolRaw.available !== true) throw new Error('Invalid netpol availability')
+    const covered = integer(netpolRaw.covered); const total = integer(netpolRaw.total); const coveragePct = percent(netpolRaw.coveragePct)
+    if (covered > total || coveragePct !== ratio(covered, total)) throw new Error('Contradictory netpol coverage')
+    return { available: true as const, covered, total, coveragePct, gateGreen: bool(netpolRaw.gateGreen) }
+  })()
+
+  const freshnessRaw = object(raw.freshness); const freshnessUnavailable = unavailable(freshnessRaw)
+  const freshness = freshnessUnavailable ?? (() => {
+    if (freshnessRaw.available !== true) throw new Error('Invalid freshness availability')
+    const scoredModules = integer(freshnessRaw.scoredModules); const unknownModules = integer(freshnessRaw.unknownModules)
+    return { available: true as const, fleetScore: percent(freshnessRaw.fleetScore), scoredModules, unknownModules }
+  })()
+
+  const credentialsRaw = object(raw.credentials); const credentialsUnavailable = unavailable(credentialsRaw)
+  const credentials = credentialsUnavailable ?? (() => {
+    if (credentialsRaw.available !== true) throw new Error('Invalid credentials availability')
+    const totalSecrets = integer(credentialsRaw.totalSecrets); const staticSecrets = integer(credentialsRaw.staticSecrets)
+    const withDeadline = integer(credentialsRaw.withDeadline); const overdue = integer(credentialsRaw.overdue); const undeclared = integer(credentialsRaw.undeclared)
+    if (staticSecrets > totalSecrets || withDeadline + overdue + undeclared !== staticSecrets) throw new Error('Contradictory credential counts')
+    const overdueFound = bool(credentialsRaw.overdueFound)
+    if (overdueFound !== (overdue > 0)) throw new Error('Contradictory credential verdict')
+    return { available: true as const, totalSecrets, staticSecrets, withDeadline, overdue, undeclared, overdueFound }
+  })()
+
+  const fuzzRaw = object(raw.fuzz); const fuzzUnavailable = unavailable(fuzzRaw)
+  const fuzz = fuzzUnavailable ?? (() => {
+    if (fuzzRaw.available !== true) throw new Error('Invalid fuzz availability')
+    const inScope = integer(fuzzRaw.inScope); const tested = integer(fuzzRaw.tested); const coveragePct = percent(fuzzRaw.coveragePct)
+    if (tested > inScope || coveragePct !== ratio(tested, inScope)) throw new Error('Contradictory fuzz coverage')
+    if (typeof fuzzRaw.runDate !== 'string' || (fuzzRaw.runDate !== '' && !DATE.test(fuzzRaw.runDate))) throw new Error('Invalid fuzz date')
+    return { available: true as const, inScope, tested, coveragePct, totalExercised: integer(fuzzRaw.totalExercised), excludedCount: integer(fuzzRaw.excludedCount), runDate: fuzzRaw.runDate }
+  })()
+
+  const threatRaw = object(raw.threatModels); const threatUnavailable = unavailable(threatRaw)
+  const threatModels = threatUnavailable ?? (() => {
+    if (threatRaw.available !== true) throw new Error('Invalid threat-model availability')
+    const moneyPathTotal = integer(threatRaw.moneyPathTotal); const withModel = integer(threatRaw.withModel); const staleCount = integer(threatRaw.staleCount)
+    if (withModel > moneyPathTotal || staleCount > withModel) throw new Error('Contradictory threat-model counts')
+    return { available: true as const, moneyPathTotal, withModel, staleCount, oldestDays: integer(threatRaw.oldestDays) }
+  })()
+
+  const mttrRaw = object(raw.mttr); const mttrUnavailable = unavailable(mttrRaw)
+  const mttr = mttrUnavailable ?? (() => {
+    if (mttrRaw.available !== true) throw new Error('Invalid MTTR availability')
+    const median = mttrRaw.medianFixDays
+    if (median !== null && (typeof median !== 'number' || !Number.isFinite(median) || median < 0)) throw new Error('Invalid median fix time')
+    return { available: true as const, fixedCount: integer(mttrRaw.fixedCount), medianFixDays: median as number | null, openCount: integer(mttrRaw.openCount), oldestOpenDays: integer(mttrRaw.oldestOpenDays) }
+  })()
+
+  return { generatedAt: raw.generatedAt, netpol, freshness, credentials, fuzz, threatModels, mttr }
+}

--- a/openbank-admin-ui/src/test/security-kpi-contract.test.ts
+++ b/openbank-admin-ui/src/test/security-kpi-contract.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseSecurityKpis } from '@/lib/security/kpiContract'
+
+const snapshot = {
+  generatedAt: '2026-09-10T02:00:00Z',
+  netpol: { available: true, covered: 8, total: 10, coveragePct: 80, gateGreen: true },
+  freshness: { available: true, fleetScore: 75, scoredModules: 12, unknownModules: 2 },
+  credentials: { available: true, totalSecrets: 12, staticSecrets: 10, withDeadline: 6, overdue: 1, undeclared: 3, overdueFound: true },
+  fuzz: { available: true, inScope: 4, tested: 3, coveragePct: 75, totalExercised: 120, excludedCount: 1, runDate: '2026-09-09' },
+  threatModels: { available: true, moneyPathTotal: 6, withModel: 5, staleCount: 2, oldestDays: 110 },
+  mttr: { available: true, fixedCount: 8, medianFixDays: 2.5, openCount: 1, oldestOpenDays: 4 },
+}
+
+describe('security KPI evidence contract', () => {
+  it('accepts a complete internally consistent snapshot', () => {
+    expect(parseSecurityKpis(snapshot)).toEqual(snapshot)
+  })
+
+  it.each([
+    ['network coverage', { netpol: { ...snapshot.netpol, coveragePct: 90 } }],
+    ['credential inventory', { credentials: { ...snapshot.credentials, undeclared: 4 } }],
+    ['credential verdict', { credentials: { ...snapshot.credentials, overdueFound: false } }],
+    ['fuzz coverage', { fuzz: { ...snapshot.fuzz, tested: 4 } }],
+    ['threat-model totals', { threatModels: { ...snapshot.threatModels, staleCount: 6 } }],
+  ])('rejects contradictory %s evidence', (_label, override) => {
+    expect(() => parseSecurityKpis({ ...snapshot, ...override })).toThrow('Contradictory')
+  })
+
+  it.each([
+    ['future-shaped percentage', { freshness: { ...snapshot.freshness, fleetScore: 101 } }],
+    ['negative count', { mttr: { ...snapshot.mttr, openCount: -1 } }],
+    ['non-finite duration', { mttr: { ...snapshot.mttr, medianFixDays: Number.NaN } }],
+    ['invalid timestamp', { generatedAt: 'today' }],
+  ])('rejects %s rather than exporting a metric', (_label, override) => {
+    expect(() => parseSecurityKpis({ ...snapshot, ...override })).toThrow()
+  })
+
+  it('preserves a degraded collector without inventing zero values', () => {
+    const result = parseSecurityKpis({ ...snapshot, mttr: { available: false, reason: 'source unavailable' } })
+    expect(result.mttr).toEqual({ available: false, reason: 'source unavailable' })
+  })
+})

--- a/openbank-admin-ui/src/test/security-kpis-metrics-route.test.ts
+++ b/openbank-admin-ui/src/test/security-kpis-metrics-route.test.ts
@@ -106,13 +106,14 @@ describe('GET /api/security/kpis/metrics', () => {
     expect(body).toContain('openbank_security_kpi_generated_timestamp_seconds')
   })
 
-  it('omits non-numeric field values instead of emitting NaN', async () => {
+  it('withholds the whole snapshot when one collector claims malformed evidence', async () => {
     const snapshot = {
       ...FULL_SNAPSHOT,
       netpol: { available: true, coveragePct: 'eighty' },
     }
     const { body } = await scrape(JSON.stringify(snapshot))
     expect(body).not.toContain('openbank_security_kpi_netpol_coverage_pct')
+    expect(body).not.toContain('openbank_security_kpi_dependency_freshness_score')
     expect(body).not.toContain('NaN')
   })
 
@@ -128,10 +129,11 @@ describe('GET /api/security/kpis/metrics', () => {
     expect(body).not.toContain('openbank_security_kpi_')
   })
 
-  it('omits the timestamp gauge when generatedAt is missing or unparseable', async () => {
+  it('withholds every gauge when the snapshot timestamp is missing or unparseable', async () => {
     const { generatedAt: _omit, ...rest } = FULL_SNAPSHOT
     const { body } = await scrape(JSON.stringify(rest))
     expect(body).not.toContain('openbank_security_kpi_generated_timestamp_seconds')
+    expect(body).not.toContain('openbank_security_kpi_netpol_coverage_pct')
     const { body: badTs } = await scrape(JSON.stringify({ ...FULL_SNAPSHOT, generatedAt: 'not-a-date' }))
     expect(badTs).not.toContain('openbank_security_kpi_generated_timestamp_seconds')
   })

--- a/openbank-admin-ui/src/test/security-kpis-route.test.ts
+++ b/openbank-admin-ui/src/test/security-kpis-route.test.ts
@@ -33,7 +33,10 @@ describe('GET /api/security/kpis', () => {
       generatedAt: '2026-09-04T21:00:00Z',
       netpol: { available: true, covered: 59, total: 73, coveragePct: 81, gateGreen: true },
       freshness: { available: false, reason: 'skipped' },
-      credentials: { available: true, staticSecrets: 158, withDeadline: 0, overdue: 0 },
+      credentials: { available: true, totalSecrets: 165, staticSecrets: 158, withDeadline: 0, overdue: 0, undeclared: 158, overdueFound: false },
+      fuzz: { available: false, reason: 'no fleet artifact' },
+      threatModels: { available: false, reason: 'collector unavailable' },
+      mttr: { available: false, reason: 'token unavailable' },
     }
     const file = path.join(tmpDir, 'security-kpis.json')
     await fs.writeFile(file, JSON.stringify(snapshot))
@@ -59,6 +62,25 @@ describe('GET /api/security/kpis', () => {
     const file = path.join(tmpDir, 'security-kpis.json')
     await fs.writeFile(file, '{not json')
     process.env.OPENBANK_SECURITY_KPIS = file
+    const res = await (await loadGet())()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ available: false, reason: 'error' })
+  })
+
+  it('rejects a contradictory snapshot instead of serving authoritative-looking KPI data', async () => {
+    const snapshot = {
+      generatedAt: '2026-09-04T21:00:00Z',
+      netpol: { available: true, covered: 59, total: 73, coveragePct: 100, gateGreen: true },
+      freshness: { available: false, reason: 'skipped' },
+      credentials: { available: false, reason: 'skipped' },
+      fuzz: { available: false, reason: 'skipped' },
+      threatModels: { available: false, reason: 'skipped' },
+      mttr: { available: false, reason: 'skipped' },
+    }
+    const file = path.join(tmpDir, 'security-kpis.json')
+    await fs.writeFile(file, JSON.stringify(snapshot))
+    process.env.OPENBANK_SECURITY_KPIS = file
+
     const res = await (await loadGet())()
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toMatchObject({ available: false, reason: 'error' })


### PR DESCRIPTION
## Summary

Validate the weekly six-collector security KPI snapshot once and reuse that contract across the JSON BFF, Security Excellence console, and Prometheus exporter. A malformed or contradictory snapshot is withheld instead of becoming an authoritative-looking score or alert metric.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #9542

## Changes

- validate snapshot time, non-negative bounded counts, percentages, booleans, dates, and legitimate unavailable collector reasons
- enforce NetworkPolicy/fuzz ratios, credential inventory composition and overdue verdict, and threat-model count invariants
- serve contradictory JSON as typed unavailable error and omit all Prometheus series from an untrusted snapshot
- preserve independently unavailable collectors without manufacturing zero values

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit, BFF, and metrics tests added/updated.
- [x] No public API expansion or data migration.
- [x] No new lint warnings or dependencies.

## Security checklist

- [x] No secrets, tokens, passwords, private hostnames, or PII added.
- [x] No suppression or unsafe Any cast.
- [x] Security telemetry path changed; independent security-minded review requested.

## Compliance impact

- [x] DORA

Invalid KPI evidence can no longer produce a console grade or Prometheus signal. Legitimately unavailable collectors remain explicitly unavailable.

## Verification

- focused Vitest: 23/23
- TypeScript type-check
- ESLint, zero warnings
- Next.js production build, 97/97 routes
- git diff --check

## Rollout / Rollback

- Deployment strategy: rolling Admin UI image
- Rollback plan: revert the squash commit and deploy the prior image
- Data migration reversible: N/A

## Reviewer notes

Please focus on collector-specific invariants and the deliberate whole-snapshot fail-closed behavior shared by JSON and Prometheus consumers.