### PR TITLE
fix(admin-ui): preserve dashboard health evidence

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -63,7 +63,7 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     await page.route('**/api/services/governance', route =>
       route.fulfill({
         status: 200,
-        body: JSON.stringify({ items: [
+        body: JSON.stringify({ available: true, timestamp: '2026-09-10T03:00:00Z', items: [
           { serviceName: 'account-service', dataDomain: 'core' },
           { serviceName: 'ledger-service', dataDomain: 'core' },
           { serviceName: 'aml-service', dataDomain: 'compliance' },

--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -16,14 +16,13 @@ import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
 import { fleetHealthState, summarizeFleetHealth } from '@/lib/dashboard/fleetHealth'
 import styles from './Dashboard.module.css'
 import { ExplorerGuide } from '@/components/brand/ExplorerGuide'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { FLEET_GROUPS, parseDashboardHealth, parseGovernanceFleet } from '@/lib/dashboard/clientContract'
 
 // Tri-state per fleet member. `deployed=false` is NEUTRAL (planned, not an outage) —
 // it must never be counted as an error, or the 23 not-yet-deployed services in the
 // sandbox would read as an 85% error rate. `up` is only meaningful when deployed.
 interface SvcStatus { name: string; label: string; group: string; deployed: boolean; up: boolean; latencyMs: number | null }
-
-// Shape of one entry in /api/services/health `services[]` (k8s discovery, ADR-0051).
-interface HealthEntry { name: string; port: number; label: string; group: string; container: string; status: string; latencyMs: number | null }
 
 // Canonical intended fleet (ADR-0029 governance manifest) — the authoritative roster
 // of every service the platform is designed to run, independent of what is currently
@@ -69,36 +68,27 @@ export default function DashboardPage() {
   const [statuses, setStatuses] = useState<SvcStatus[]>([])
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const [evidenceFailure, setEvidenceFailure] = useState<'governance' | 'health' | null>(null)
   const loadingRef = useRef(false)
 
   const load = useCallback(async () => {
     if (loadingRef.current) return
     loadingRef.current = true
     setLoading(true)
+    setEvidenceFailure(null)
     // Governance and live health are independent reads. Start them together so a
     // slow health probe cannot delay the canonical roster (and vice versa).
     const governanceRequest = fetch('/api/services/governance', { cache: 'no-store' }).catch(() => null)
     const healthRequest = fetch('/api/services/health', { signal: AbortSignal.timeout(10000), cache: 'no-store' }).catch(() => null)
     const [govRes, res] = await Promise.all([governanceRequest, healthRequest])
 
-    // Canonical fleet from the code-derived governance manifest (ADR-0071).
-    let fleet: { name: string; group: string }[] = []
-    if (govRes?.ok) {
-      try {
-        const g = await govRes.json() as { items?: { serviceName: string; dataDomain: string }[] }
-        fleet = (g.items ?? []).map(e => ({ name: e.serviceName, group: e.dataDomain }))
-      } catch { /* fleet stays empty → roster degrades calmly, no blank crash */ }
-    }
-
     try {
+      if (!govRes?.ok) throw new Error('governance')
+      const fleet = parseGovernanceFleet(await govRes.json())
+      if (!res?.ok) throw new Error('health')
       // Live discovery (ADR-0051) keyed by bare deployment name. Empty on failure —
-      // the fleet still renders, every member simply shows as not-deployed rather
-      // than the page going blank.
-      const discovered = new Map<string, HealthEntry>()
-      if (res?.ok) {
-        const data = await res.json() as { services: HealthEntry[] }
-        for (const e of (data.services ?? [])) discovered.set(e.name, e)
-      }
+      // the fleet stays distinct from a verified not-deployed state.
+      const discovered = new Map(parseDashboardHealth(await res.json()).map(entry => [entry.name, entry]))
       // Overlay discovery on the canonical fleet: every intended service appears,
       // with deployed/healthy resolved from the cluster. A roster member absent from
       // discovery is NOT-DEPLOYED (neutral), never DOWN (which is a real outage).
@@ -114,11 +104,11 @@ export default function DashboardPage() {
         }
       })
       setStatuses(results)
-    } catch {
-      // Keep the fleet visible (all not-deployed) instead of a blank dashboard.
-      setStatuses(fleet.map(f => ({ name: f.name, label: titleCase(f.name), group: f.group, deployed: false, up: false, latencyMs: null })))
+      setLastRefresh(new Date())
+    } catch (error) {
+      setStatuses([])
+      setEvidenceFailure(error instanceof Error && error.message === 'governance' ? 'governance' : 'health')
     }
-    setLastRefresh(new Date())
     setLoading(false)
     loadingRef.current = false
   }, [])
@@ -154,7 +144,7 @@ export default function DashboardPage() {
   const workspace = workspaceFor(persona).filter(link => hasPermission(roles, link.permission))
   const personaLanguage = language === 'cs' ? 'cs' : 'en'
 
-  const groups = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
+  const groups = FLEET_GROUPS
 
   return (
     <div className={styles.dashboard}>
@@ -206,6 +196,24 @@ export default function DashboardPage() {
         </div>
       </section>
 
+      {evidenceFailure ? (
+        <section className="card" aria-label={t('Dostupnost evidence platformy', 'Platform evidence availability')}>
+          <DataUnavailable
+            kind="unreachable"
+            service={evidenceFailure === 'governance' ? t('Governance katalog', 'Governance catalogue') : t('Přehled zdraví platformy', 'Platform health overview')}
+            lang={language}
+            title={t('Aktuální stav platformy nelze ověřit', 'Current platform state cannot be verified')}
+            detail={t(
+              'Poslední odpověď nebyla úplná nebo důvěryhodná. Služby proto neoznačujeme jako zdravé ani nenasažené, dokud nezískáme novou ověřenou evidenci.',
+              'The latest response was incomplete or untrustworthy. Services are therefore not labelled healthy or not deployed until fresh verified evidence is available.',
+            )}
+          >
+            <button type="button" className="btn btn-secondary btn-sm" onClick={load} disabled={loading}>
+              <RefreshCw size={13} aria-hidden="true" /> {t('Zkusit znovu', 'Try again')}
+            </button>
+          </DataUnavailable>
+        </section>
+      ) : <>
       {/* These are intentionally current health facts, not estimated operational or compliance metrics. */}
       <section className={styles.metrics} aria-label={t('Klíčové metriky platformy', 'Platform key metrics')}>
         <StatCard className={styles.metric} icon={<Server size={15} />} label={t('Zdravé služby', 'Healthy services')} value={`${health.healthy}/${health.deployed}`} tone={healthTone}
@@ -297,6 +305,7 @@ export default function DashboardPage() {
           )
         })}
       </section>
+      </>}
 
       {/* Only show destinations the operator can already access; dashboard shortcuts must not create 403 traps. */}
       <section className={`card ${styles.quickAccess}`} aria-labelledby="quick-access-heading">

--- a/openbank-admin-ui/src/lib/dashboard/clientContract.ts
+++ b/openbank-admin-ui/src/lib/dashboard/clientContract.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const FLEET_GROUPS = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform'] as const
+export type FleetGroup = typeof FLEET_GROUPS[number]
+
+export type GovernanceFleetMember = { name: string; group: FleetGroup }
+export type DashboardHealthEntry = {
+  name: string
+  label: string
+  group: FleetGroup
+  status: 'UP' | 'DOWN' | 'UNKNOWN'
+  latencyMs: number | null
+}
+
+const IDENTIFIER = /^[a-z][a-z0-9-]{0,127}$/
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Expected object')
+  return value as Record<string, unknown>
+}
+
+function text(value: unknown, max = 200): string {
+  if (typeof value !== 'string' || value.trim() === '' || value.length > max) throw new Error('Invalid text')
+  return value
+}
+
+function identifier(value: unknown): string {
+  const result = text(value, 128)
+  if (!IDENTIFIER.test(result)) throw new Error('Invalid service identifier')
+  return result
+}
+
+function group(value: unknown): FleetGroup {
+  if (typeof value !== 'string' || !FLEET_GROUPS.includes(value as FleetGroup)) throw new Error('Invalid fleet group')
+  return value as FleetGroup
+}
+
+function unique<T>(items: T[], key: (item: T) => string): T[] {
+  if (new Set(items.map(key)).size !== items.length) throw new Error('Duplicate service')
+  return items
+}
+
+export function parseGovernanceFleet(value: unknown): GovernanceFleetMember[] {
+  const body = record(value)
+  if (body.available !== true || !Array.isArray(body.items) || body.items.length === 0 || body.items.length > 100) {
+    throw new Error('Governance evidence unavailable')
+  }
+  if (typeof body.timestamp !== 'string' || !RFC3339.test(body.timestamp) || !Number.isFinite(Date.parse(body.timestamp))) {
+    throw new Error('Invalid governance timestamp')
+  }
+  return unique(body.items.map(value => {
+    const item = record(value)
+    return { name: identifier(item.serviceName), group: group(item.dataDomain) }
+  }), item => item.name)
+}
+
+export function parseDashboardHealth(value: unknown): DashboardHealthEntry[] {
+  const body = record(value)
+  if (!Array.isArray(body.services) || body.services.length > 100) throw new Error('Health evidence unavailable')
+  return unique(body.services.map(value => {
+    const item = record(value)
+    const status = item.status
+    if (status !== 'UP' && status !== 'DOWN' && status !== 'UNKNOWN') throw new Error('Invalid health status')
+    const latencyMs = item.latencyMs
+    if (latencyMs !== null && (typeof latencyMs !== 'number' || !Number.isFinite(latencyMs) || latencyMs < 0)) {
+      throw new Error('Invalid health latency')
+    }
+    return {
+      name: identifier(item.name),
+      label: text(item.label),
+      group: group(item.group),
+      status,
+      latencyMs,
+    }
+  }), item => item.name)
+}

--- a/openbank-admin-ui/src/test/dashboard-client-contract.test.ts
+++ b/openbank-admin-ui/src/test/dashboard-client-contract.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseDashboardHealth, parseGovernanceFleet } from '@/lib/dashboard/clientContract'
+
+const governance = {
+  available: true,
+  timestamp: '2026-09-10T03:00:00Z',
+  items: [{ serviceName: 'account-service', dataDomain: 'core' }],
+}
+
+const health = {
+  services: [{ name: 'account-service', label: 'Accounts', group: 'core', status: 'UP', latencyMs: 12 }],
+}
+
+describe('dashboard evidence contract', () => {
+  it('accepts a governed roster and bounded current health sample', () => {
+    expect(parseGovernanceFleet(governance)).toEqual([{ name: 'account-service', group: 'core' }])
+    expect(parseDashboardHealth(health)).toEqual(health.services)
+  })
+
+  it('rejects an unavailable catalogue instead of turning it into an empty fleet', () => {
+    expect(() => parseGovernanceFleet({ ...governance, available: false, items: [] })).toThrow()
+  })
+
+  it('rejects malformed, duplicate and stale-looking evidence shapes', () => {
+    expect(() => parseGovernanceFleet({ ...governance, timestamp: 'today' })).toThrow()
+    expect(() => parseGovernanceFleet({ ...governance, items: [...governance.items, ...governance.items] })).toThrow()
+    expect(() => parseDashboardHealth({ services: [{ ...health.services[0], status: 'HEALTHY' }] })).toThrow()
+    expect(() => parseDashboardHealth({ services: [{ ...health.services[0], latencyMs: -1 }] })).toThrow()
+  })
+
+  it('keeps an empty successful discovery distinct from a malformed response', () => {
+    expect(parseDashboardHealth({ services: [] })).toEqual([])
+    expect(() => parseDashboardHealth({ services: null })).toThrow()
+  })
+})

--- a/openbank-admin-ui/src/test/dashboard-evidence-presentation.test.tsx
+++ b/openbank-admin-ui/src/test/dashboard-evidence-presentation.test.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import DashboardPage from '@/app/dashboard/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { roles: ['admin'] } } }),
+}))
+
+const governance = {
+  available: true,
+  timestamp: '2026-09-10T03:00:00Z',
+  items: [{ serviceName: 'account-service', dataDomain: 'core' }],
+}
+const health = {
+  services: [{ name: 'account-service', label: 'Accounts', group: 'core', status: 'UP', latencyMs: 12 }],
+}
+
+const wrap = (child: React.ReactNode) => <LanguageProvider initialLanguage="en">{child}</LanguageProvider>
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('dashboard evidence presentation', () => {
+  it('does not label services healthy or not deployed when governance evidence is unavailable', async () => {
+    const fetchMock = vi.fn((url: string) => Promise.resolve(Response.json(
+      url.endsWith('/governance') ? { ...governance, available: false, items: [] } : health,
+    )))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(wrap(<DashboardPage />))
+
+    expect(await screen.findByText('Current platform state cannot be verified')).toBeInTheDocument()
+    expect(screen.getByText(/not labelled healthy or not deployed/)).toBeInTheDocument()
+    expect(screen.queryByText('Healthy services')).not.toBeInTheDocument()
+    expect(screen.queryByText('Current health by group')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
+  })
+
+  it('renders measured health only after both response contracts validate', async () => {
+    vi.stubGlobal('fetch', vi.fn((url: string) => Promise.resolve(Response.json(
+      url.endsWith('/governance') ? governance : health,
+    ))))
+
+    render(wrap(<DashboardPage />))
+
+    expect(await screen.findByText('Healthy services')).toBeInTheDocument()
+    expect(screen.getAllByText('1/1')).toHaveLength(2)
+    expect(screen.queryByText('Current platform state cannot be verified')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- validate governance roster and current health snapshots before rendering fleet metrics
- keep unknown evidence distinct from a verified not-deployed service
- preserve permission-scoped work queues while showing an educational retry state
- reject invalid groups, identities, timestamps, statuses, duplicates and latency samples

## Verification
- `npm test -- --run src/test/dashboard-client-contract.test.ts src/test/dashboard-evidence-presentation.test.tsx src/test/dashboard-refresh.guard.test.ts src/test/dashboard-parallel-load.guard.test.ts src/test/fleet-health.test.ts --reporter=dot` (11 passed)
- `npm test -- --reporter=dot` (2,591 passed, 1 skipped)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build` (97/97 pages)
- `git diff --check`

Closes #9546