### PR TITLE
fix(admin-ui): preserve onboarding analytics evidence

### DIFF
--- a/openbank-admin-ui/src/app/api/onboarding/funnel-analytics/route.ts
+++ b/openbank-admin-ui/src/app/api/onboarding/funnel-analytics/route.ts
@@ -9,12 +9,12 @@
 // split. Session-gated (NextAuth → Keycloak), like every other admin route. ClickHouse has no npm
 // client in this project, so we talk to its HTTP interface with fetch; URL + creds stay in env.
 //
-// House style (mirrors /api/test-results, /api/finops/costs): this route ALWAYS 200s with a typed
-// body. If ClickHouse is unreachable or empty, it returns `available: false` so the page degrades to
-// a calm DataUnavailable state instead of surfacing a raw HTTP error.
+// An empty successful query is distinct from an operational failure: the former is a 200 with
+// `available: false`; the latter is a safe 502 without leaking ClickHouse diagnostics.
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
+import { ONBOARDING_STEPS, type FunnelAnalytics, type FunnelStep, type SignOutcome, type FailReason, type KycMethod } from '@/lib/onboarding/funnelAnalyticsContract'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,34 +25,6 @@ const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD
 const DB = 'openbank_analytics'
 
 // Step order + Czech/English labels shared with the client via the payload.
-const STEP_ORDER = ['WELCOME', 'IDENTITY', 'EMAIL', 'AGREEMENT', 'PASSKEY', 'SIGN'] as const
-
-// ── Types returned to the client ────────────────────────────────────────────
-
-interface FunnelStep {
-  step: string
-  stepOrdinal: number
-  viewed: number
-  completed: number
-  holdAbandons: number
-  dropOffPct: number      // (viewed - completed) / viewed * 100
-  medianSeconds: number | null
-}
-interface SignOutcome { day: string; attempts: number; successes: number; failures: number }
-interface FailReason { reason: string; failures: number }
-interface KycMethod { method: string; sessions: number }
-
-export interface FunnelAnalytics {
-  available: boolean
-  from: string
-  to: string
-  steps: FunnelStep[]
-  signOutcomes: SignOutcome[]
-  failReasons: FailReason[]
-  kycMethods: KycMethod[]
-  error?: string
-}
-
 // ── ClickHouse HTTP helper ──────────────────────────────────────────────────
 
 /** Run one SQL statement over the ClickHouse HTTP interface and return the JSON `data` rows. */
@@ -156,7 +128,7 @@ export async function GET(req: NextRequest) {
 
     // Walk the canonical step order so the funnel is always complete + ordered, even if a step has
     // no rows yet in the selected range.
-    const steps: FunnelStep[] = STEP_ORDER.map((step, i) => {
+    const steps: FunnelStep[] = ONBOARDING_STEPS.map((step, i) => {
       const r = funnelByStep.get(step)
       const viewed = num(r?.viewed)
       const completed = num(r?.completed)
@@ -195,12 +167,13 @@ export async function GET(req: NextRequest) {
       available: hasData, from, to, steps, signOutcomes, failReasons, kycMethods,
     }
     return NextResponse.json(body, { headers: { 'Cache-Control': 'no-store' } })
-  } catch (e) {
-    // ClickHouse unreachable / query error → degrade to a calm empty state (never a raw 5xx).
-    console.error('onboarding funnel-analytics failed:', e)
+  } catch {
+    // Keep infrastructure diagnostics server-side and preserve the difference between no rows and
+    // a query that did not produce evidence at all.
+    console.error('onboarding funnel-analytics query failed')
     return NextResponse.json(
-      { ...empty, error: e instanceof Error ? e.message : String(e) },
-      { headers: { 'Cache-Control': 'no-store' } },
+      empty,
+      { status: 502, headers: { 'Cache-Control': 'no-store' } },
     )
   }
 }

--- a/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
@@ -19,7 +19,7 @@ import {
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell, LabelList,
   LineChart, Line, PieChart, Pie, Legend,
 } from 'recharts'
-import type { FunnelAnalytics } from '@/app/api/onboarding/funnel-analytics/route'
+import { parseFunnelAnalytics, type FunnelAnalytics } from '@/lib/onboarding/funnelAnalyticsContract'
 import { PageHeader } from '@/components/ui/PageHeader'
 
 // ── Step labels (contract order WELCOME→SIGN) ─────────────────────────────────
@@ -101,12 +101,8 @@ export default function OnboardingAnalyticsPage() {
         setFailure('operational')
         return
       }
-      const next = await res.json() as FunnelAnalytics
+      const next = parseFunnelAnalytics(await res.json(), from, to)
       if (requestGeneration !== generation.current) return
-      if (next.error || next.from !== from || next.to !== to) {
-        setFailure('operational')
-        return
-      }
       setData(next)
       loadedRange.current = requestedRange
       setRenderedRange(requestedRange)
@@ -223,11 +219,11 @@ export default function OnboardingAnalyticsPage() {
         </div>
       ) : !visibleData || visibleData.available === false ? (
         <div className="card" style={{ padding: 0 }}>
-          <DataUnavailable kind={failure === 'operational' || visibleData?.error ? 'unreachable' : 'no_data'}
+          <DataUnavailable kind={failure === 'operational' ? 'unreachable' : 'no_data'}
             service="Analytics-sink (ClickHouse)"
             feature={t('Konverze onboardingu', 'Onboarding conversion')}
             lang={language}
-            detail={failure === 'operational' || visibleData?.error
+            detail={failure === 'operational'
               ? t('ClickHouse gold marty nejsou dostupné.', 'ClickHouse gold marts are unavailable.')
               : t('V tomto období nejsou žádná data funnelu.', 'No funnel data in this period.')}>
             {failure === 'operational' && (

--- a/openbank-admin-ui/src/lib/onboarding/funnelAnalyticsContract.ts
+++ b/openbank-admin-ui/src/lib/onboarding/funnelAnalyticsContract.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const ONBOARDING_STEPS = ['WELCOME', 'IDENTITY', 'EMAIL', 'AGREEMENT', 'PASSKEY', 'SIGN'] as const
+
+export interface FunnelStep { step: string; stepOrdinal: number; viewed: number; completed: number; holdAbandons: number; dropOffPct: number; medianSeconds: number | null }
+export interface SignOutcome { day: string; attempts: number; successes: number; failures: number }
+export interface FailReason { reason: string; failures: number }
+export interface KycMethod { method: string; sessions: number }
+export interface FunnelAnalytics { available: boolean; from: string; to: string; steps: FunnelStep[]; signOutcomes: SignOutcome[]; failReasons: FailReason[]; kycMethods: KycMethod[] }
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/
+function record(value: unknown): Record<string, unknown> { if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Expected object'); return value as Record<string, unknown> }
+function text(value: unknown, max = 200): string { if (typeof value !== 'string' || value.trim() === '' || value.length > max) throw new Error('Invalid text'); return value }
+function count(value: unknown): number { if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) throw new Error('Invalid count'); return value }
+function finite(value: unknown): number { if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) throw new Error('Invalid metric'); return value }
+function day(value: unknown): string { const result = text(value, 10); if (!DATE.test(result) || Number.isNaN(Date.parse(`${result}T00:00:00Z`))) throw new Error('Invalid day'); return result }
+function list(value: unknown, max: number): unknown[] { if (!Array.isArray(value) || value.length > max) throw new Error('Invalid collection'); return value }
+
+export function parseFunnelAnalytics(value: unknown, expectedFrom: string, expectedTo: string): FunnelAnalytics {
+  const body = record(value)
+  if (typeof body.available !== 'boolean' || body.from !== expectedFrom || body.to !== expectedTo) throw new Error('Invalid analytics identity')
+  const steps = list(body.steps, ONBOARDING_STEPS.length).map((value, index): FunnelStep => {
+    const item = record(value); const viewed = count(item.viewed); const completed = count(item.completed)
+    const step = ONBOARDING_STEPS[index]
+    if (!step || item.step !== step || item.stepOrdinal !== index + 1 || completed > viewed) throw new Error('Invalid funnel step')
+    const medianSeconds = item.medianSeconds === null ? null : finite(item.medianSeconds)
+    return { step, stepOrdinal: index + 1, viewed, completed, holdAbandons: count(item.holdAbandons), dropOffPct: finite(item.dropOffPct), medianSeconds }
+  })
+  const signOutcomes = list(body.signOutcomes, 366).map((value): SignOutcome => { const item = record(value); const attempts = count(item.attempts); const successes = count(item.successes); const failures = count(item.failures); if (successes + failures > attempts) throw new Error('Invalid signature outcome'); return { day: day(item.day), attempts, successes, failures } })
+  const failReasons = list(body.failReasons, 10).map((value): FailReason => { const item = record(value); return { reason: text(item.reason), failures: count(item.failures) } })
+  const kycMethods = list(body.kycMethods, 100).map((value): KycMethod => { const item = record(value); return { method: text(item.method), sessions: count(item.sessions) } })
+  if (body.available ? steps.length !== ONBOARDING_STEPS.length : steps.length || signOutcomes.length || failReasons.length || kycMethods.length) throw new Error('Contradictory availability')
+  return { available: body.available, from: expectedFrom, to: expectedTo, steps, signOutcomes, failReasons, kycMethods }
+}

--- a/openbank-admin-ui/src/test/onboarding-analytics-contract.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-analytics-contract.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { ONBOARDING_STEPS, parseFunnelAnalytics } from '@/lib/onboarding/funnelAnalyticsContract'
+
+const from = '2026-08-01'; const to = '2026-09-01'
+const payload = {
+  available: true, from, to,
+  steps: ONBOARDING_STEPS.map((step, index) => ({ step, stepOrdinal: index + 1, viewed: 10, completed: 8, holdAbandons: 1, dropOffPct: 20, medianSeconds: 12 })),
+  signOutcomes: [{ day: '2026-08-31', attempts: 10, successes: 8, failures: 2 }],
+  failReasons: [{ reason: 'OTP_EXPIRED', failures: 2 }],
+  kycMethods: [{ method: 'BANK_ID', sessions: 8 }],
+}
+
+describe('onboarding analytics client contract', () => {
+  it('accepts a complete internally consistent analytics snapshot', () => expect(parseFunnelAnalytics(payload, from, to)).toEqual(payload))
+  it('rejects mismatched ranges and incomplete funnels', () => {
+    expect(() => parseFunnelAnalytics({ ...payload, from: '2026-07-01' }, from, to)).toThrow()
+    expect(() => parseFunnelAnalytics({ ...payload, steps: payload.steps.slice(1) }, from, to)).toThrow()
+  })
+  it('rejects impossible counts and unknown step identities', () => {
+    expect(() => parseFunnelAnalytics({ ...payload, steps: payload.steps.map((step, index) => index ? step : { ...step, completed: 11 }) }, from, to)).toThrow()
+    expect(() => parseFunnelAnalytics({ ...payload, steps: payload.steps.map((step, index) => index ? step : { ...step, step: 'START' }) }, from, to)).toThrow()
+    expect(() => parseFunnelAnalytics({ ...payload, signOutcomes: [{ day: '2026-08-31', attempts: 1, successes: 1, failures: 1 }] }, from, to)).toThrow()
+  })
+  it('accepts only an actually empty unavailable result', () => {
+    expect(parseFunnelAnalytics({ available: false, from, to, steps: [], signOutcomes: [], failReasons: [], kycMethods: [] }, from, to).available).toBe(false)
+    expect(() => parseFunnelAnalytics({ ...payload, available: false }, from, to)).toThrow()
+  })
+})

--- a/openbank-admin-ui/src/test/onboarding-analytics-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-analytics-recovery.test.tsx
@@ -29,6 +29,10 @@ const SNAPSHOT = {
   to: '2026-09-02',
   steps: [
     { step: 'WELCOME', stepOrdinal: 1, viewed: 40, completed: 30, holdAbandons: 0, dropOffPct: 25, medianSeconds: 12 },
+    { step: 'IDENTITY', stepOrdinal: 2, viewed: 30, completed: 28, holdAbandons: 0, dropOffPct: 6.7, medianSeconds: 20 },
+    { step: 'EMAIL', stepOrdinal: 3, viewed: 28, completed: 26, holdAbandons: 0, dropOffPct: 7.1, medianSeconds: 15 },
+    { step: 'AGREEMENT', stepOrdinal: 4, viewed: 26, completed: 24, holdAbandons: 0, dropOffPct: 7.7, medianSeconds: 18 },
+    { step: 'PASSKEY', stepOrdinal: 5, viewed: 24, completed: 20, holdAbandons: 0, dropOffPct: 16.7, medianSeconds: 30 },
     { step: 'SIGN', stepOrdinal: 6, viewed: 20, completed: 18, holdAbandons: 0, dropOffPct: 10, medianSeconds: 45 },
   ],
   signOutcomes: [{ day: '2026-08-31', attempts: 20, successes: 18, failures: 2 }],
@@ -66,7 +70,7 @@ describe('onboarding analytics recovery', () => {
     const recovered = { ...SNAPSHOT, steps: SNAPSHOT.steps.map(step => step.step === 'WELCOME' ? { ...step, viewed: 50 } : step) }
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(response(200, SNAPSHOT))
-      .mockResolvedValueOnce(response(200, { ...SNAPSHOT, available: false, error: 'ClickHouse timeout', steps: [] }))
+      .mockResolvedValueOnce(response(502, { available: false }))
       .mockResolvedValueOnce(response(200, recovered))
     vi.stubGlobal('fetch', fetchMock)
 

--- a/openbank-admin-ui/src/test/onboarding-analytics-route.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-analytics-route.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { authMock } = vi.hoisted(() => ({ authMock: vi.fn() }))
+vi.mock('@/auth', () => ({ auth: authMock }))
+
+import { GET } from '@/app/api/onboarding/funnel-analytics/route'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('onboarding analytics BFF evidence semantics', () => {
+  it('returns a safe non-success response when ClickHouse produces no evidence', async () => {
+    authMock.mockResolvedValue({ user: { accessToken: 'operator-token' } })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('private upstream diagnostic')))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await GET(new NextRequest('http://localhost/api/onboarding/funnel-analytics?from=2026-08-01&to=2026-09-01'))
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({
+      available: false,
+      from: '2026-08-01',
+      to: '2026-09-01',
+      steps: [],
+      signOutcomes: [],
+      failReasons: [],
+      kycMethods: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- distinguish an empty successful analytics period from a failed ClickHouse query
- return a safe 502 envelope without browser-visible infrastructure diagnostics
- validate the requested range, canonical six-step funnel and supporting count series
- preserve retained snapshots, request ownership and authorization purging

## Verification
- `npm test -- --run src/test/onboarding-analytics-contract.test.ts src/test/onboarding-analytics-route.test.ts src/test/onboarding-analytics-recovery.test.tsx src/test/onboarding-analytics-loading.guard.test.ts src/test/onboarding-analytics-refresh.guard.test.ts --reporter=dot` (15 passed)
- `npm test -- --reporter=dot` (2,590 passed, 1 skipped)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build` (97/97 pages)
- `git diff --check`

Closes #9548