### PR TITLE
fix(admin-ui): reveal loaded Grafana insight panels

### DIFF
--- a/openbank-admin-ui/src/components/insights/ContextualInsights.tsx
+++ b/openbank-admin-ui/src/components/insights/ContextualInsights.tsx
@@ -142,7 +142,7 @@ function GrafanaPanel({ src, title, tall }: { src: string; title: string; tall: 
       <Activity size={18} aria-hidden="true" />
       <span>{t('Panel teď není dostupný', 'Panel is unavailable right now')}</span>
     </div>}
-    <iframe ref={frame} src={src} title={title} loading="lazy" scrolling="no"
+    <iframe ref={frame} src={src} title={title} scrolling="no" onLoad={() => setState('ready')}
       className={state === 'ready' ? styles.frameReady : styles.frameHidden} />
   </div>
 }

--- a/openbank-admin-ui/src/test/contextual-insights.test.tsx
+++ b/openbank-admin-ui/src/test/contextual-insights.test.tsx
@@ -53,6 +53,17 @@ it('recovers when Grafana becomes ready after the slow-connection warning', () =
   expect(screen.queryByText('Connection is taking longer; still trying…')).not.toBeInTheDocument()
 })
 
+it('reveals a panel when its Grafana frame finishes loading', () => {
+  render(<LanguageProvider initialLanguage="en">
+    <ContextualInsights dashboardUid="openbank-slo" panels={PAYMENT_INSIGHTS.slice(0, 1)}
+      titleCs="Dopad" titleEn="Impact" descriptionCs="Stav" descriptionEn="Health" defaultOpen />
+  </LanguageProvider>)
+  const panel = screen.getByTitle('Payment success rate')
+  fireEvent.load(panel)
+  expect(panel).toBeVisible()
+  expect(screen.queryByText('Loading data…')).not.toBeInTheDocument()
+})
+
 it('keeps optional operational context collapsed until requested', () => {
   render(<LanguageProvider initialLanguage="en">
     <ContextualInsights dashboardUid="openbank-evb" panels={PAYMENT_INSIGHTS.slice(0, 1)}


### PR DESCRIPTION
Closes #9551\n\nGrafana panels were successfully fetched but could remain hidden because readiness depended on Grafana's internal DOM. The UI now reveals a panel from the iframe load event and loads all selected panels as soon as the insight section opens.\n\nValidation: focused Vitest (4 passing), TypeScript check, focused ESLint.