### PR TITLE
fix(admin-ui): own lending evidence loads

### DIFF
--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -24,7 +24,7 @@
 
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { RefreshCw, TrendingUp, Layers, Wallet, AlertTriangle, Clock } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -93,8 +93,14 @@ export default function LendingPage() {
    *  refresh must not turn a previously-confirmed figure into a dash, and a stale-but-confirmed
    *  figure is more useful than a placeholder (#7918). */
   const [loaded, setLoaded] = useState(false)
+  // Own one load at a time. A route change or a newer refresh aborts the old four-request batch,
+  // so a late response can neither overwrite fresher evidence nor update React after unmount.
+  const activeLoad = useRef<AbortController | null>(null)
 
   const load = useCallback(async () => {
+    activeLoad.current?.abort()
+    const controller = new AbortController()
+    activeLoad.current = controller
     setLoading(true)
     try {
       // The lists still load: the rows are the drill-down, and the summaries carry no identities.
@@ -103,16 +109,18 @@ export default function LendingPage() {
       // take the console with it.
       const okJson = (r: Response) => (r.ok ? r.json() : null)
       const [appsRes, loansRes, appSum, loanSum] = await Promise.all([
-        fetch(svcUrl('lending-service', '/api/v1/lending/applications/recent', { limit: String(LIMIT) }), { cache: 'no-store' }),
-        fetch(svcUrl('lending-service', '/api/v1/lending/loans/active', { limit: String(LIMIT) }), { cache: 'no-store' }),
-        fetch(svcUrl('lending-service', '/api/v1/lending/applications/summary'), { cache: 'no-store' })
+        fetch(svcUrl('lending-service', '/api/v1/lending/applications/recent', { limit: String(LIMIT) }), { cache: 'no-store', signal: controller.signal }),
+        fetch(svcUrl('lending-service', '/api/v1/lending/loans/active', { limit: String(LIMIT) }), { cache: 'no-store', signal: controller.signal }),
+        fetch(svcUrl('lending-service', '/api/v1/lending/applications/summary'), { cache: 'no-store', signal: controller.signal })
           .then(okJson).catch(() => null),
-        fetch(svcUrl('lending-service', '/api/v1/lending/loans/summary'), { cache: 'no-store' })
+        fetch(svcUrl('lending-service', '/api/v1/lending/loans/summary'), { cache: 'no-store', signal: controller.signal })
           .then(okJson).catch(() => null),
       ])
+      if (controller.signal.aborted) return
       if (!appsRes.ok || !loansRes.ok) throw new Error(`${appsRes.status}/${loansRes.status}`)
       const apps = await appsRes.json()
       const ln = await loansRes.json()
+      if (controller.signal.aborted) return
       setApplications(Array.isArray(apps) ? apps : [])
       setLoans(Array.isArray(ln) ? ln : [])
       setAppSummary(Array.isArray(appSum) ? appSum : null)
@@ -120,13 +128,24 @@ export default function LendingPage() {
       setError(null)
       setLoaded(true)
     } catch {
+      if (controller.signal.aborted) return
       setError('unreachable')
     } finally {
-      setLoading(false)
+      if (activeLoad.current === controller) {
+        activeLoad.current = null
+        setLoading(false)
+      }
     }
   }, [])
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => {
+    void load()
+    return () => {
+      const controller = activeLoad.current
+      activeLoad.current = null
+      controller?.abort()
+    }
+  }, [load])
 
   const label = (s: string) => {
     const l = STATE_LABELS[s]

--- a/openbank-admin-ui/src/test/origination-pipeline.test.tsx
+++ b/openbank-admin-ui/src/test/origination-pipeline.test.tsx
@@ -162,4 +162,22 @@ describe('lending console', () => {
     // A filter that leaves everything visible is a filter that lied about being applied.
     expect(screen.queryByText('250,000 CZK')).toBeNull()
   })
+
+  it('aborts every in-flight evidence request when the console unmounts', async () => {
+    const signals: AbortSignal[] = []
+    vi.stubGlobal('fetch', vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal
+      if (!signal) throw new Error('lending request must be abortable')
+      signals.push(signal)
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    }))
+
+    const view = render(React.createElement(Providers, null, React.createElement(LendingPage)))
+    await waitFor(() => expect(signals).toHaveLength(4))
+    view.unmount()
+
+    expect(signals.every(signal => signal.aborted)).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- give the four-request lending evidence load one explicit AbortController owner
- abort superseded refreshes and detach then abort on route unmount
- prevent aborted or stale loads from updating React data, error, or loading state
- add a regression test proving all four evidence requests are cancellable and aborted

Closes #9560

## Verification
- focused origination-pipeline test: 10/10 passed repeatedly
- full Vitest: 474 files passed; 2,587 passed, 1 skipped; no unhandled errors
- TypeScript type-check: passed
- ESLint: passed with zero errors
- production Next.js build: 97/97 routes generated
- git diff --check: passed

## Risk
Request-lifecycle ownership only. No lending domain, API, RBAC, evidence semantics, or mutation behavior changes.