### PR TITLE
fix(admin-ui): bind account detail evidence

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -13,6 +13,7 @@ import { EntityChip } from '@/components/entities/EntityChip'
 import { Can } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { validateAccountBalance, validateAccountDetail } from '@/lib/accounts/detailContract'
 import type { Account, AccountBalance } from '@/types'
 
 const STATUS_PILL: Record<string, string> = {
@@ -34,25 +35,38 @@ export default function AccountDetailPage() {
   const [actionError, setActionError] = useState<string | null>(null)
   const [acting, setActing]     = useState(false)
   const actionInFlight = useRef(false)
+  const loadSequence = useRef(0)
   const [actionIntent, setActionIntent] = useState<'freeze' | 'unfreeze' | 'close' | null>(null)
   const [actionReason, setActionReason] = useState('')
 
   async function load() {
+    const sequence = ++loadSequence.current
     setLoading(true); setError(null)
     try {
       const [acc, bal] = await Promise.allSettled([
         accountApi.get(id),
         accountApi.getBalance(id),
       ])
-      if (acc.status === 'fulfilled') setAccount(acc.value)
-      else throw new Error(acc.reason?.message ?? 'Failed to load account')
-      if (bal.status === 'fulfilled') setBalance(bal.value)
+      if (sequence !== loadSequence.current) return
+      if (acc.status !== 'fulfilled') throw new Error(acc.reason?.message ?? 'Failed to load account')
+      const verifiedAccount = validateAccountDetail(acc.value, id)
+      if (!verifiedAccount) {
+        throw new Error(t('Služba vrátila neověřitelná data účtu.', 'The service returned unverifiable account data.'))
+      }
+      setAccount(verifiedAccount)
+      setBalance(bal.status === 'fulfilled' ? validateAccountBalance(bal.value, verifiedAccount) : null)
     } catch (e: unknown) {
+      if (sequence !== loadSequence.current) return
       setError(e instanceof Error ? e.message : 'Failed to load account')
-    } finally { setLoading(false) }
+    } finally {
+      if (sequence === loadSequence.current) setLoading(false)
+    }
   }
 
-  useEffect(() => { load() }, [id])
+  useEffect(() => {
+    void load()
+    return () => { loadSequence.current += 1 }
+  }, [id])
 
   function requestAction(action: 'freeze' | 'unfreeze' | 'close') {
     setActionIntent(action)

--- a/openbank-admin-ui/src/lib/accounts/detailContract.ts
+++ b/openbank-admin-ui/src/lib/accounts/detailContract.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import type { Account, AccountBalance, AccountStatus, AccountType } from '@/types'
+
+const ACCOUNT_TYPES = new Set<AccountType>([
+  'CURRENT', 'SAVINGS', 'TERM_DEPOSIT', 'NOSTRO',
+  'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE',
+])
+const ACCOUNT_STATUSES = new Set<AccountStatus>(['PENDING_ACTIVATION', 'ACTIVE', 'DORMANT', 'FROZEN', 'CLOSED'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isTimestamp(value: unknown): value is string {
+  return isNonEmptyString(value) && Number.isFinite(Date.parse(value))
+}
+
+export function validateAccountDetail(value: unknown, requestedId: string): Account | null {
+  if (!isRecord(value) || value.id !== requestedId) return null
+  if (!isNonEmptyString(value.accountNumber) || !isNonEmptyString(value.partyId) || !isNonEmptyString(value.productId)) return null
+  if (!isNonEmptyString(value.currencyCode) || !ACCOUNT_TYPES.has(value.accountType as AccountType)) return null
+  if (!ACCOUNT_STATUSES.has(value.status as AccountStatus) || !isTimestamp(value.openedAt)) return null
+  if (value.closedAt !== undefined && !isTimestamp(value.closedAt)) return null
+  return value as unknown as Account
+}
+
+export function validateAccountBalance(
+  value: unknown,
+  account: Pick<Account, 'id' | 'currencyCode'>,
+): AccountBalance | null {
+  if (!isRecord(value) || value.accountId !== account.id || value.currencyCode !== account.currencyCode) return null
+  if (!['availableBalance', 'currentBalance', 'reservedBalance', 'pendingBalance'].every(key =>
+    typeof value[key] === 'number' && Number.isFinite(value[key]),
+  )) return null
+  if (!isTimestamp(value.lastUpdatedAt)) return null
+  return value as unknown as AccountBalance
+}

--- a/openbank-admin-ui/src/test/account-detail-contract.test.ts
+++ b/openbank-admin-ui/src/test/account-detail-contract.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { validateAccountBalance, validateAccountDetail } from '@/lib/accounts/detailContract'
+
+const account = {
+  id: 'account-7',
+  accountNumber: 'TEST-ACCOUNT-0007',
+  accountType: 'CURRENT',
+  partyId: 'party-2',
+  productId: 'product-1',
+  currencyCode: 'CZK',
+  status: 'ACTIVE',
+  openedAt: '2026-09-10T08:30:00Z',
+}
+
+const balance = {
+  accountId: account.id,
+  availableBalance: 1250,
+  currentBalance: 1300,
+  reservedBalance: 50,
+  pendingBalance: 0,
+  currencyCode: account.currencyCode,
+  lastUpdatedAt: '2026-09-10T08:31:00Z',
+}
+
+describe('account detail evidence contract', () => {
+  it('accepts account and balance evidence bound to the requested account', () => {
+    const verifiedAccount = validateAccountDetail(account, account.id)
+    expect(verifiedAccount).toEqual(account)
+    expect(validateAccountBalance(balance, verifiedAccount!)).toEqual(balance)
+  })
+
+  it('rejects an account returned for a different route identity', () => {
+    expect(validateAccountDetail(account, 'account-8')).toBeNull()
+  })
+
+  it('rejects malformed account evidence', () => {
+    expect(validateAccountDetail({ ...account, status: 'UNKNOWN' }, account.id)).toBeNull()
+    expect(validateAccountDetail({ ...account, openedAt: 'not-a-date' }, account.id)).toBeNull()
+    expect(validateAccountDetail({ ...account, accountNumber: '' }, account.id)).toBeNull()
+  })
+
+  it('rejects balance evidence for another account or currency', () => {
+    expect(validateAccountBalance({ ...balance, accountId: 'account-8' }, account)).toBeNull()
+    expect(validateAccountBalance({ ...balance, currencyCode: 'EUR' }, account)).toBeNull()
+  })
+
+  it('rejects non-finite amounts and invalid timestamps', () => {
+    expect(validateAccountBalance({ ...balance, availableBalance: Number.NaN }, account)).toBeNull()
+    expect(validateAccountBalance({ ...balance, lastUpdatedAt: 'later' }, account)).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/account-detail-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/account-detail-loading.guard.test.ts
@@ -10,4 +10,12 @@ describe('account detail loading contract', () => {
     expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
     expect(source).toContain("t('Načítám účet…', 'Loading account…')")
   })
+
+  it('prevents a superseded account request from replacing newer route evidence', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/accounts/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('const loadSequence = useRef(0)')
+    expect(source).toContain('const sequence = ++loadSequence.current')
+    expect(source).toContain('if (sequence !== loadSequence.current) return')
+    expect(source).toContain('return () => { loadSequence.current += 1 }')
+  })
 })


### PR DESCRIPTION
## Summary

- reject account detail responses that do not match the requested route identity or required display contract
- show balance evidence only when account identity, currency, finite amounts, and timestamp are valid
- prevent superseded route loads from replacing newer account evidence
- preserve the existing lifecycle RBAC and mutation flow

## Verification

- focused account detail suite: 10 passed
- full Admin UI suite: 475 files passed, 2592 tests passed, 1 skipped
- type-check: passed
- lint: 0 errors (existing warnings only)
- production build: 97/97 routes

Closes #9562