### PR TITLE
fix(admin-ui): verify ledger query evidence

### DIFF
--- a/openbank-admin-ui/e2e/ledger-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/ledger-recovery.spec.ts
@@ -10,6 +10,7 @@ const journalPage = {
     valueDate: '2026-08-31',
     description: 'Customer transfer settlement',
     status: 'POSTED',
+    synthetic: false,
     createdAt: '2026-08-31T12:00:00Z',
     lines: [
       { id: 'line-debit', glAccountId: 'gl-debit-12345678', side: 'DEBIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 1 },

--- a/openbank-admin-ui/src/app/ledger/page.tsx
+++ b/openbank-admin-ui/src/app/ledger/page.tsx
@@ -4,22 +4,32 @@
 
 'use client'
 
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Search, ChevronDown, ChevronRight } from 'lucide-react'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
-import type { JournalEntry, CursorPage } from '@/types'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { StatusBadge } from '@/components/ui'
+import { parseLedgerJournalPage, type LedgerJournalPage } from '@/lib/ledger/ledgerJournalContract'
 import { ContextualInsights } from '@/components/insights/ContextualInsights'
 import { LEDGER_INSIGHTS } from '@/components/insights/catalog'
 
-const STATUS_PILL: Record<string, string> = {
-  POSTED:   'pill pill-success',
-  PENDING:  'pill pill-warning',
-  REVERSED: 'pill pill-neutral',
-  DRAFT:    'pill pill-info',
+const PAGE_SIZE = 20
+const BFF_FAILURES = new Set<UnavailableKind>([
+  'not_deployed',
+  'scaled_to_zero',
+  'unauthorized',
+  'unreachable',
+  'not_found',
+  'error',
+])
+
+function unavailableKind(error: unknown): UnavailableKind {
+  return error instanceof Error && BFF_FAILURES.has(error.message as UnavailableKind)
+    ? error.message as UnavailableKind
+    : 'unreachable'
 }
 
 export default function LedgerPage() {
@@ -27,7 +37,8 @@ export default function LedgerPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [toDate, setToDate]     = useState(() => new Date().toISOString().slice(0, 10))
-  const [result, setResult]     = useState<CursorPage<JournalEntry> | null>(null)
+  const [result, setResult]     = useState<LedgerJournalPage | null>(null)
+  const [resultWindow, setResultWindow] = useState<{ from: string; to: string } | null>(null)
   const [loading, setLoading]   = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
@@ -35,47 +46,90 @@ export default function LedgerPage() {
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [moreError, setMoreError] = useState<string | null>(null)
+  const activeRequest = useRef<AbortController | null>(null)
+  const queryChanged = resultWindow !== null && (resultWindow.from !== fromDate || resultWindow.to !== toDate)
 
-  async function loadPage(cursor?: string) {
+  useEffect(() => () => {
+    const controller = activeRequest.current
+    activeRequest.current = null
+    controller?.abort()
+  }, [])
+
+  function updateWindow(setter: (value: string) => void, value: string) {
+    const controller = activeRequest.current
+    activeRequest.current = null
+    controller?.abort()
+    setLoading(false)
+    setLoadingMore(false)
+    setter(value)
+  }
+
+  async function loadPage(from: string, to: string, signal: AbortSignal, cursor?: string) {
     try {
-      const res = await fetch(svcUrl('ledger-service', '/api/v1/journals', { fromDate, toDate, limit: '20', ...(cursor ? { cursor } : {}) }), {
-        signal: AbortSignal.timeout(8000),
+      const res = await fetch(svcUrl('ledger-service', '/api/v1/journals', { fromDate: from, toDate: to, limit: String(PAGE_SIZE), ...(cursor ? { cursor } : {}) }), {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(8000)]),
       })
       if (!res.ok) {
         throw new Error(await classifyBffFailure(res))
       }
-      return await res.json() as CursorPage<JournalEntry>
+      try {
+        return parseLedgerJournalPage(await res.json(), PAGE_SIZE)
+      } catch {
+        throw new Error('error')
+      }
     } catch (error) {
-      throw error instanceof Error ? error : new Error('unreachable')
+      throw new Error(unavailableKind(error))
     }
   }
 
   async function search() {
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+    setLoadingMore(false)
+    const requestedWindow = { from: fromDate, to: toDate }
     setLoading(true); setUnavailable(null); setMoreError(null)
     try {
-      const next = await loadPage()
+      const next = await loadPage(requestedWindow.from, requestedWindow.to, controller.signal)
+      if (controller.signal.aborted) return
       setResult(next)
+      setResultWindow(requestedWindow)
       setExpanded(null)
     } catch (error) {
       // Timeout / abort / network — the BFF or ledger-service didn't answer.
-      setUnavailable({ kind: (error as Error).message as UnavailableKind || 'unreachable' })
-    } finally { setLoading(false) }
+      if (!controller.signal.aborted) setUnavailable({ kind: unavailableKind(error) })
+    } finally {
+      if (activeRequest.current === controller) {
+        activeRequest.current = null
+        setLoading(false)
+      }
+    }
   }
 
   async function loadMore() {
+    if (queryChanged || !resultWindow) return
     const cursor = result?.pagination.nextCursor
     if (!cursor) return
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+    setLoading(false)
     setLoadingMore(true); setMoreError(null)
     try {
-      const next = await loadPage(cursor)
-      setResult(previous => previous ? {
-        data: [...previous.data, ...next.data],
-        pagination: next.pagination,
-      } : next)
+      const next = await loadPage(resultWindow.from, resultWindow.to, controller.signal, cursor)
+      if (controller.signal.aborted) return
+      const existing = new Set(result?.data.map(entry => entry.id) ?? [])
+      if (next.data.some(entry => existing.has(entry.id))) throw new Error('Duplicate ledger page')
+      setResult(previous => previous ? { data: [...previous.data, ...next.data], pagination: next.pagination } : next)
     } catch {
       // Keep already-read ledger records visible; a failed next page must not erase evidence.
-      setMoreError(t('Další stránku se nepodařilo načíst. Zkuste to znovu.', 'The next page could not be loaded. Try again.'))
-    } finally { setLoadingMore(false) }
+      if (!controller.signal.aborted) setMoreError(t('Další stránku se nepodařilo načíst. Zkuste to znovu.', 'The next page could not be loaded. Try again.'))
+    } finally {
+      if (activeRequest.current === controller) {
+        activeRequest.current = null
+        setLoadingMore(false)
+      }
+    }
   }
 
   return (
@@ -100,9 +154,9 @@ export default function LedgerPage() {
           display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap',
         }}>
           <label htmlFor="ledger-from-date" style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text-secondary)' }}>{t('Od', 'From')}</label>
-          <input id="ledger-from-date" type="date" className="input" style={{ width: '150px' }} value={fromDate} onChange={e => setFromDate(e.target.value)} />
+          <input id="ledger-from-date" type="date" className="input" style={{ width: '150px' }} value={fromDate} onChange={e => updateWindow(setFromDate, e.target.value)} />
           <label htmlFor="ledger-to-date" style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text-secondary)' }}>{t('Do', 'To')}</label>
-          <input id="ledger-to-date" type="date" className="input" style={{ width: '150px' }} value={toDate} onChange={e => setToDate(e.target.value)} />
+          <input id="ledger-to-date" type="date" className="input" style={{ width: '150px' }} value={toDate} onChange={e => updateWindow(setToDate, e.target.value)} />
           <button type="button" className="btn btn-primary" onClick={search} disabled={loading} aria-busy={loading}>
             <Search size={13} aria-hidden="true" />
             {loading ? t('Načítání…', 'Loading…') : t('Načíst záznamy', 'Load Entries')}
@@ -113,6 +167,15 @@ export default function LedgerPage() {
             </span>
           )}
         </div>
+
+        {queryChanged && resultWindow && (
+          <div role="status" aria-live="polite" style={{ margin: '10px 16px', padding: '10px 12px', borderRadius: 8, background: 'var(--warning-bg)', border: '1px solid var(--warning-border)', color: 'var(--warning-text)', fontSize: 12 }}>
+            {t(
+              `Zobrazený snapshot patří období ${resultWindow.from}–${resultWindow.to}. Pro nové období načtěte záznamy znovu; stránkování je do té doby uzamčeno.`,
+              `The visible snapshot belongs to ${resultWindow.from}–${resultWindow.to}. Load entries for the new period; pagination is locked until then.`,
+            )}
+          </div>
+        )}
 
         {/* Calm, explained unavailable state — never a raw HTTP status. */}
         {unavailable && !result && (
@@ -156,19 +219,20 @@ export default function LedgerPage() {
                 <th>{t('Datum záznamu', 'Entry Date')}</th>
                 <th>{t('Datum valuty', 'Value Date')}</th>
                 <th>{t('Stav', 'Status')}</th>
+                <th>{t('Původ', 'Origin')}</th>
                 <th>{t('Řádky', 'Lines')}</th>
                 <th>{t('Popis', 'Description')}</th>
               </tr>
             </thead>
             <tbody>
               {!result && !loading && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Vyberte období a klikněte na "Načíst záznamy".', 'Select a date range and click "Load Entries".')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Vyberte období a klikněte na "Načíst záznamy".', 'Select a date range and click "Load Entries".')}</div></td></tr>
               )}
               {loading && !result && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Načítání záznamů hlavní knihy…', 'Loading journal entries…')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Načítání záznamů hlavní knihy…', 'Loading journal entries…')}</div></td></tr>
               )}
               {!loading && result && result.data.length === 0 && (
-                <tr><td colSpan={8}><div className="empty-state">{t('Pro toto období nebyly nalezeny žádné záznamy.', 'No journal entries found for this period.')}</div></td></tr>
+                <tr><td colSpan={9}><div className="empty-state">{t('Pro toto období nebyly nalezeny žádné záznamy.', 'No journal entries found for this period.')}</div></td></tr>
               )}
               {result?.data.map(entry => {
                 const isOpen = expanded === entry.id
@@ -184,7 +248,8 @@ export default function LedgerPage() {
                       <td><span className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{entry.transactionId.slice(0, 8)}…</span></td>
                       <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{entry.entryDate}</span></td>
                       <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{entry.valueDate}</span></td>
-                      <td><span className={STATUS_PILL[entry.status] ?? 'pill pill-neutral'}>{entry.status}</span></td>
+                      <td><StatusBadge status={entry.status} /></td>
+                      <td><StatusBadge status={entry.synthetic ? 'SYNTHETIC' : 'BUSINESS'} tone={entry.synthetic ? 'info' : 'neutral'} label={entry.synthetic ? t('Canary', 'Canary') : t('Obchodní', 'Business')} /></td>
                       <td>
                         <span style={{
                           display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
@@ -203,7 +268,7 @@ export default function LedgerPage() {
                     </tr>
                     {isOpen && (
                       <tr>
-                        <td colSpan={8} style={{ padding: 0, background: 'var(--surface-2)' }}>
+                        <td colSpan={9} style={{ padding: 0, background: 'var(--surface-2)' }}>
                           <div id={`ledger-entry-${entry.id}`} style={{ padding: '12px 20px 12px 50px', borderBottom: '2px solid var(--accent-border)' }}>
                             <div style={{ fontSize: '11px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
                               {t('Řádky deníku', 'Journal Lines')}
@@ -212,6 +277,7 @@ export default function LedgerPage() {
                               <thead>
                                 <tr style={{ color: 'var(--text-tertiary)' }}>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Účet HK', 'GL Account')}</th>
+                                  <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Podúčet', 'Sub-account')}</th>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Strana', 'Side')}</th>
                                   <th style={{ textAlign: 'right', padding: '4px 12px 4px 0', fontWeight: 600 }}>{t('Částka', 'Amount')}</th>
                                   <th style={{ textAlign: 'left', padding: '4px 12px 4px 0', fontWeight: 600 }}>CCY</th>
@@ -224,6 +290,9 @@ export default function LedgerPage() {
                                   <tr key={line.id} style={{ borderTop: '1px solid var(--border)' }}>
                                     <td style={{ padding: '6px 12px 6px 0' }}>
                                       <span className="mono" style={{ fontSize: '11px' }}>{line.glAccountId.slice(0, 8)}…</span>
+                                    </td>
+                                    <td style={{ padding: '6px 12px 6px 0' }}>
+                                      <span className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{line.subAccountId ? `${line.subAccountId.slice(0, 8)}…` : '—'}</span>
                                     </td>
                                     <td style={{ padding: '6px 12px 6px 0' }}>
                                       <span style={{
@@ -260,7 +329,7 @@ export default function LedgerPage() {
         {result?.pagination.hasNextPage && (
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', textAlign: 'center' }}>
             {moreError && <p role="alert" style={{ margin: '0 0 8px', fontSize: '12px', color: 'var(--danger-text)' }}>{moreError}</p>}
-            <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={loadMore} disabled={loadingMore} aria-busy={loadingMore}>
+            <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={loadMore} disabled={loadingMore || queryChanged} aria-busy={loadingMore}>
               {loadingMore ? t('Načítám…', 'Loading…') : t('Načíst další', 'Load more')}
             </button>
           </div>

--- a/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.ts
+++ b/openbank-admin-ui/src/lib/ledger/ledgerJournalContract.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export type JournalStatus = 'PENDING' | 'POSTED' | 'REVERSED'
+
+export interface LedgerJournalLine {
+  id: string; glAccountId: string; side: 'DEBIT' | 'CREDIT'; amount: number
+  currencyCode: string; baseAmount: number; baseCurrencyCode: string; sequence: number
+  subAccountId: string | null
+}
+
+export interface LedgerJournalEntry {
+  id: string; entryNumber: number | null; transactionId: string; entryDate: string; valueDate: string
+  description: string | null; status: JournalStatus; lines: LedgerJournalLine[]; createdAt: string
+  synthetic: boolean
+}
+
+export interface LedgerJournalPage {
+  data: LedgerJournalEntry[]
+  pagination: { limit: number; hasNextPage: boolean; nextCursor?: string; previousCursor?: string }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function text(record: Record<string, unknown>, field: string, empty = false): string {
+  const value = record[field]
+  if (typeof value !== 'string' || (!empty && value.trim() === '')) throw new Error(`Invalid ledger ${field}`)
+  return value
+}
+
+function finite(record: Record<string, unknown>, field: string): number {
+  const value = record[field]
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid ledger ${field}`)
+  return value
+}
+
+function isoDate(record: Record<string, unknown>, field: string): string {
+  const value = text(record, field)
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00Z`) : null
+  if (!parsed || Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Invalid ledger ${field}`)
+  }
+  return value
+}
+
+function optionalText(record: Record<string, unknown>, field: string): string | undefined {
+  const value = record[field]
+  if (value === undefined || value === null) return undefined
+  return text(record, field)
+}
+
+function parseLine(value: unknown): LedgerJournalLine {
+  if (!isRecord(value)) throw new Error('Invalid ledger line')
+  const side = text(value, 'side')
+  const amount = finite(value, 'amount')
+  const baseAmount = finite(value, 'baseAmount')
+  const sequence = finite(value, 'sequence')
+  const currencyCode = text(value, 'currencyCode')
+  const baseCurrencyCode = text(value, 'baseCurrencyCode')
+  if (side !== 'DEBIT' && side !== 'CREDIT') throw new Error('Invalid ledger side')
+  if (amount < 0 || baseAmount < 0) throw new Error('Invalid ledger amount')
+  if (!Number.isInteger(sequence) || sequence < 0) throw new Error('Invalid ledger sequence')
+  if (!/^[A-Z]{3}$/.test(currencyCode) || !/^[A-Z]{3}$/.test(baseCurrencyCode)) throw new Error('Invalid ledger currency')
+  if (value.subAccountId !== null && value.subAccountId !== undefined && typeof value.subAccountId !== 'string') {
+    throw new Error('Invalid ledger subAccountId')
+  }
+  return {
+    id: text(value, 'id'), glAccountId: text(value, 'glAccountId'), side,
+    amount, currencyCode, baseAmount, baseCurrencyCode, sequence,
+    subAccountId: typeof value.subAccountId === 'string' ? value.subAccountId : null,
+  }
+}
+
+function parseEntry(value: unknown): LedgerJournalEntry {
+  if (!isRecord(value) || !Array.isArray(value.lines)) throw new Error('Invalid ledger entry')
+  const status = text(value, 'status')
+  if (!['PENDING', 'POSTED', 'REVERSED'].includes(status)) throw new Error('Invalid ledger status')
+  if (value.entryNumber !== null && (typeof value.entryNumber !== 'number' || !Number.isInteger(value.entryNumber) || value.entryNumber < 0)) {
+    throw new Error('Invalid ledger entryNumber')
+  }
+  if (value.description !== null && typeof value.description !== 'string') throw new Error('Invalid ledger description')
+  if (typeof value.synthetic !== 'boolean') throw new Error('Invalid ledger synthetic provenance')
+  const createdAt = text(value, 'createdAt')
+  if (!Number.isFinite(Date.parse(createdAt))) throw new Error('Invalid ledger createdAt')
+  const lines = value.lines.map(parseLine)
+  if (new Set(lines.map(line => line.id)).size !== lines.length) throw new Error('Duplicate ledger line')
+  if (new Set(lines.map(line => line.sequence)).size !== lines.length) throw new Error('Duplicate ledger sequence')
+  return {
+    id: text(value, 'id'), entryNumber: value.entryNumber as number | null,
+    transactionId: text(value, 'transactionId'), entryDate: isoDate(value, 'entryDate'), valueDate: isoDate(value, 'valueDate'),
+    description: value.description as string | null, status: status as JournalStatus,
+    lines, createdAt, synthetic: value.synthetic,
+  }
+}
+
+export function parseLedgerJournalPage(raw: unknown, expectedLimit: number): LedgerJournalPage {
+  if (!isRecord(raw) || !Array.isArray(raw.data) || !isRecord(raw.pagination)) throw new Error('Invalid ledger page')
+  if (raw.pagination.limit !== expectedLimit || raw.data.length > expectedLimit) throw new Error('Invalid ledger limit')
+  if (typeof raw.pagination.hasNextPage !== 'boolean') throw new Error('Invalid ledger hasNextPage')
+  const nextCursor = optionalText(raw.pagination, 'nextCursor')
+  const previousCursor = optionalText(raw.pagination, 'previousCursor')
+  if (raw.pagination.hasNextPage && !nextCursor) throw new Error('Invalid ledger nextCursor')
+  const data = raw.data.map(parseEntry)
+  if (new Set(data.map(entry => entry.id)).size !== data.length) throw new Error('Duplicate ledger entry')
+  return {
+    data,
+    pagination: {
+      limit: expectedLimit, hasNextPage: raw.pagination.hasNextPage,
+      ...(nextCursor ? { nextCursor } : {}), ...(previousCursor ? { previousCursor } : {}),
+    },
+  }
+}

--- a/openbank-admin-ui/src/test/ledger-journal-contract.test.ts
+++ b/openbank-admin-ui/src/test/ledger-journal-contract.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { parseLedgerJournalPage } from '@/lib/ledger/ledgerJournalContract'
+
+const line = {
+  id: 'line-1', glAccountId: 'gl-1', side: 'DEBIT', amount: 1250, currencyCode: 'EUR',
+  baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 1, subAccountId: 'account-1',
+}
+const entry = {
+  id: 'journal-1', entryNumber: 42, transactionId: 'transaction-1', entryDate: '2026-09-10', valueDate: '2026-09-10',
+  description: 'Customer transfer', status: 'POSTED', lines: [line], createdAt: '2026-09-10T06:00:00Z', synthetic: false,
+}
+
+describe('General Ledger evidence contract', () => {
+  it('preserves validated accounting and provenance evidence', () => {
+    expect(parseLedgerJournalPage({ data: [entry], pagination: { limit: 20, hasNextPage: true, nextCursor: 'next' } }, 20))
+      .toMatchObject({ data: [{ synthetic: false, lines: [{ subAccountId: 'account-1' }] }], pagination: { nextCursor: 'next' } })
+  })
+
+  it('rejects malformed states, amounts, currencies, dates, and provenance', () => {
+    for (const changed of [
+      { status: 'DRAFT' }, { synthetic: undefined }, { entryDate: '2026-02-30' },
+      { lines: [{ ...line, amount: Number.NaN }] }, { lines: [{ ...line, currencyCode: 'EURO' }] },
+    ]) expect(() => parseLedgerJournalPage({ data: [{ ...entry, ...changed }], pagination: { limit: 20, hasNextPage: false } }, 20)).toThrow()
+  })
+
+  it('rejects an unexpected window, unusable cursor, and duplicate evidence', () => {
+    expect(() => parseLedgerJournalPage({ data: [entry], pagination: { limit: 50, hasNextPage: false } }, 20)).toThrow('limit')
+    expect(() => parseLedgerJournalPage({ data: [entry], pagination: { limit: 20, hasNextPage: true } }, 20)).toThrow('nextCursor')
+    expect(() => parseLedgerJournalPage({ data: [entry, entry], pagination: { limit: 20, hasNextPage: false } }, 20)).toThrow('Duplicate ledger entry')
+    expect(() => parseLedgerJournalPage({ data: [{ ...entry, lines: [line, line] }], pagination: { limit: 20, hasNextPage: false } }, 20)).toThrow('Duplicate ledger line')
+  })
+})

--- a/openbank-admin-ui/src/test/ledger-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/ledger-pagination.test.tsx
@@ -13,11 +13,11 @@ vi.mock('@/components/auth/AuthGuard', () => ({
 }))
 
 const firstPage = {
-  data: [{ id: 'entry-1', transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page' }],
+  data: [{ id: 'entry-1', entryNumber: 1, transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page', createdAt: '2026-08-01T12:00:00Z', synthetic: false }],
   pagination: { limit: 20, hasNextPage: true, nextCursor: 'cursor-1' },
 }
 const secondPage = {
-  data: [{ id: 'entry-2', transactionId: 'transaction-2', entryDate: '2026-08-02', valueDate: '2026-08-02', status: 'POSTED', lines: [], description: 'Second page' }],
+  data: [{ id: 'entry-2', entryNumber: 2, transactionId: 'transaction-2', entryDate: '2026-08-02', valueDate: '2026-08-02', status: 'POSTED', lines: [], description: 'Second page', createdAt: '2026-08-02T12:00:00Z', synthetic: true }],
   pagination: { limit: 20, hasNextPage: false },
 }
 
@@ -79,5 +79,52 @@ describe('General Ledger pagination', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('next page could not be loaded'))
     expect(screen.getByText('First page')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Load more' })).toBeTruthy()
+  })
+
+  it('maps an unknown network failure to the reachable-service recovery state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('network down')))
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Ledger-service is not responding'))
+  })
+
+  it('rejects a duplicate next page without erasing the verified snapshot', async () => {
+    const duplicatePage = { data: [firstPage.data[0]], pagination: { limit: 20, hasNextPage: false } }
+    const fetchMock = vi.fn().mockResolvedValueOnce(response(firstPage)).mockResolvedValueOnce(response(duplicatePage))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    await screen.findByText('First page')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('next page could not be loaded'))
+    expect(screen.getAllByText('First page')).toHaveLength(1)
+  })
+
+  it('labels a retained snapshot after the operator changes the date window and locks pagination', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response(firstPage)))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    await screen.findByText('First page')
+
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-01-01' } })
+    expect(screen.getByRole('status').textContent).toContain('visible snapshot belongs to')
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeDisabled()
+  })
+
+  it('does not commit a search superseded by a date-window change', async () => {
+    let resolveFetch!: (value: Response) => void
+    vi.stubGlobal('fetch', vi.fn().mockReturnValueOnce(new Promise<Response>(resolve => { resolveFetch = resolve })))
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-01-01' } })
+    resolveFetch(response(firstPage))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load Entries' })).not.toBeDisabled())
+    expect(screen.queryByText('First page')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- validate the ledger journal response at runtime before presenting it as accounting evidence
- preserve the exact queried date window, abort superseded requests, and lock pagination when filters change
- label business versus canary provenance and expose sub-account evidence
- retain verified entries when a later page or repeat search fails

## Verification

- 507 test files passed; 2764 tests passed, 1 skipped (full admin-ui suite before the final network-error regression)
- focused ledger suite: 2 files, 10 tests passed
- TypeScript type-check passed
- ESLint passed with zero errors
- production build passed, 97/97 routes generated
- Playwright Chromium ledger recovery E2E passed
- commit signature verified locally

Closes #9570