### PR TITLE
fix(admin-ui): hydrate Playwright under development CSP

### DIFF
--- a/openbank-admin-ui/src/lib/security/contentSecurityPolicy.ts
+++ b/openbank-admin-ui/src/lib/security/contentSecurityPolicy.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+/**
+ * Next's development webpack runtime uses evaluated modules for React Refresh. Production never
+ * needs that capability: keep `unsafe-eval` tied to the development build mode, while both modes
+ * retain the per-request nonce and strict-dynamic trust chain.
+ */
+export function scriptSourceDirective(nonce: string, development: boolean): string {
+  const developmentRuntime = development ? " 'unsafe-eval'" : ''
+  return `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${developmentRuntime}`
+}

--- a/openbank-admin-ui/src/proxy.ts
+++ b/openbank-admin-ui/src/proxy.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server"
 import { auth } from "@/auth"
 import { hasPermission, permissionForPath } from "@/lib/auth/roles"
 import { isPublicSurface } from "@/lib/auth/publicSurface"
+import { scriptSourceDirective } from "@/lib/security/contentSecurityPolicy"
 
 // ADR-0080 P1 (F-AUTH-06): per-request CSP with a nonce + 'strict-dynamic' instead of
 // 'unsafe-inline' on script-src. A static next.config header can't carry a fresh nonce, so the
@@ -23,7 +24,7 @@ const GLITCHTIP_ORIGIN = (() => {
 function buildCsp(nonce: string): string {
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    scriptSourceDirective(nonce, process.env.NODE_ENV === 'development'),
     "style-src 'self' 'unsafe-inline'",
     "font-src 'self'",
     "img-src 'self' data: blob:",

--- a/openbank-admin-ui/src/test/content-security-policy.test.ts
+++ b/openbank-admin-ui/src/test/content-security-policy.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { scriptSourceDirective } from '@/lib/security/contentSecurityPolicy'
+
+describe('admin UI script CSP', () => {
+  it('permits the evaluated React Refresh runtime only in development', () => {
+    expect(scriptSourceDirective('test-nonce', true)).toContain("'unsafe-eval'")
+    expect(scriptSourceDirective('test-nonce', false)).not.toContain("'unsafe-eval'")
+  })
+
+  it('keeps nonce trust and never permits inline scripts in either mode', () => {
+    for (const development of [true, false]) {
+      const directive = scriptSourceDirective('test-nonce', development)
+      expect(directive).toContain("'nonce-test-nonce'")
+      expect(directive).toContain("'strict-dynamic'")
+      expect(directive).not.toContain("'unsafe-inline'")
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- allow Next.js React Refresh evaluation only while NODE_ENV is development
- keep the production script policy nonce-based, strict-dynamic, and free of unsafe-eval/unsafe-inline
- centralize and directly test the environment-specific script directive

## Verification

- CSP + reporting proxy tests: 4 passed
- TypeScript type-check passed
- ESLint passed with zero errors
- exact Playwright-config development server hydrated successfully
- Chromium party recovery workflow passed
- production build passed, 97/97 routes generated
- commit signature verified locally

Closes #9576