### PR TITLE
refactor(admin-ui): make service map theme semantic

### DIFF
--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -10,7 +10,7 @@ import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
-import { edgeGeometry, mixHex, pathId, type Pt, type Half } from '@/components/topology/geometry'
+import { edgeGeometry, pathId, type Pt, type Half } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
@@ -24,47 +24,47 @@ import {
 // Service definitions with positions for the map
 const SERVICES = [
   // Core Banking
-  { id: 'account',     name: 'Account Service',      port: 8100, group: 'core',    x: 125, y: 100,  color: '#2563eb', desc: 'Account lifecycle management, IBAN assignment' },
-  { id: 'ledger',      name: 'Ledger Service',       port: 8101, group: 'core',    x: 250, y: 100,  color: '#2563eb', desc: 'Double-entry bookkeeping, GL accounts, journal entries' },
-  { id: 'transaction', name: 'Transaction Service',  port: 8102, group: 'core',    x: 375, y: 100,  color: '#2563eb', desc: 'Transaction processing, partitioned by booking_date' },
-  { id: 'catalog',     name: 'Product Catalog',      port: 8104, group: 'core',    x: 500, y: 100,  color: '#2563eb', desc: 'Banking products, pricing, limits' },
-  { id: 'balance',     name: 'Balance Service',      port: 8103, group: 'core',    x: 125, y: 220,  color: '#2563eb', desc: 'Real-time balance tracking, holds management' },
-  { id: 'interest',    name: 'Interest Service',     port: 8125, group: 'core',    x: 250, y: 220,  color: '#2563eb', desc: 'Interest calculation and accrual' },
-  { id: 'fx',          name: 'FX Service',           port: 8119, group: 'core',    x: 375, y: 220,  color: '#2563eb', desc: 'Foreign exchange rates and conversion' },
+  { id: 'account',     name: 'Account Service',      port: 8100, group: 'core',    x: 125, y: 100,  color: 'var(--map-core)', desc: 'Account lifecycle management, IBAN assignment' },
+  { id: 'ledger',      name: 'Ledger Service',       port: 8101, group: 'core',    x: 250, y: 100,  color: 'var(--map-core)', desc: 'Double-entry bookkeeping, GL accounts, journal entries' },
+  { id: 'transaction', name: 'Transaction Service',  port: 8102, group: 'core',    x: 375, y: 100,  color: 'var(--map-core)', desc: 'Transaction processing, partitioned by booking_date' },
+  { id: 'catalog',     name: 'Product Catalog',      port: 8104, group: 'core',    x: 500, y: 100,  color: 'var(--map-core)', desc: 'Banking products, pricing, limits' },
+  { id: 'balance',     name: 'Balance Service',      port: 8103, group: 'core',    x: 125, y: 220,  color: 'var(--map-core)', desc: 'Real-time balance tracking, holds management' },
+  { id: 'interest',    name: 'Interest Service',     port: 8125, group: 'core',    x: 250, y: 220,  color: 'var(--map-core)', desc: 'Interest calculation and accrual' },
+  { id: 'fx',          name: 'FX Service',           port: 8119, group: 'core',    x: 375, y: 220,  color: 'var(--map-core)', desc: 'Foreign exchange rates and conversion' },
   // Identity
-  { id: 'pid',         name: 'PID Service',          port: 8105, group: 'identity', x: 650, y: 100,  color: '#059669', desc: 'Party identity documents, external IDs' },
-  { id: 'party',       name: 'Party Service',        port: 8111, group: 'identity', x: 750, y: 100,  color: '#059669', desc: 'Customer/company master data, PEP/sanctions flags' },
+  { id: 'pid',         name: 'PID Service',          port: 8105, group: 'identity', x: 650, y: 100,  color: 'var(--map-identity)', desc: 'Party identity documents, external IDs' },
+  { id: 'party',       name: 'Party Service',        port: 8111, group: 'identity', x: 750, y: 100,  color: 'var(--map-identity)', desc: 'Customer/company master data, PEP/sanctions flags' },
   // Platform
-  { id: 'agent',       name: 'Agent Service',        port: 8109, group: 'platform', x: 900, y: 100,  color: '#6b7280', desc: 'AI agent MCP server, OpenBank tools for LLMs' },
-  { id: 'notification',name: 'Notification Service', port: 8112, group: 'platform', x: 1000,y: 100,  color: '#6b7280', desc: 'Email/SMS/Push notifications, template engine' },
-  { id: 'security-scanner',name: 'Security Scanner', port: 8120, group: 'platform', x: 1100,y: 100,  color: '#6b7280', desc: 'Continuous vulnerability scanning' },
+  { id: 'agent',       name: 'Agent Service',        port: 8109, group: 'platform', x: 900, y: 100,  color: 'var(--map-platform)', desc: 'AI agent MCP server, OpenBank tools for LLMs' },
+  { id: 'notification',name: 'Notification Service', port: 8112, group: 'platform', x: 1000,y: 100,  color: 'var(--map-platform)', desc: 'Email/SMS/Push notifications, template engine' },
+  { id: 'security-scanner',name: 'Security Scanner', port: 8120, group: 'platform', x: 1100,y: 100,  color: 'var(--map-platform)', desc: 'Continuous vulnerability scanning' },
   // Cards
-  { id: 'card-issuance',name: 'Card Issuance',       port: 8118, group: 'cards',    x: 650, y: 260,  color: '#db2777', desc: 'Card issuance and lifecycle management' },
-  { id: 'dispute',     name: 'Dispute Service',      port: 8135, group: 'cards',    x: 750, y: 260,  color: '#db2777', desc: 'Card disputes and chargebacks' },
+  { id: 'card-issuance',name: 'Card Issuance',       port: 8118, group: 'cards',    x: 650, y: 260,  color: 'var(--map-cards)', desc: 'Card issuance and lifecycle management' },
+  { id: 'dispute',     name: 'Dispute Service',      port: 8135, group: 'cards',    x: 750, y: 260,  color: 'var(--map-cards)', desc: 'Card disputes and chargebacks' },
   // Compliance
-  { id: 'audit',       name: 'Audit Service',        port: 8113, group: 'compliance', x: 920, y: 260,  color: '#dc2626', desc: 'Immutable audit trail, EBA ICT Risk compliance' },
-  { id: 'kyc',         name: 'KYC Service',          port: 8114, group: 'compliance', x: 1080,y: 260,  color: '#dc2626', desc: 'KYC/CDD/EDD case management, document verification' },
-  { id: 'aml',         name: 'AML Service',          port: 8117, group: 'compliance', x: 920, y: 380,  color: '#dc2626', desc: 'AML screening, SAR filing' },
-  { id: 'sanctions',   name: 'Sanctions Service',    port: 8123, group: 'compliance', x: 1080,y: 380,  color: '#dc2626', desc: 'Real-time sanctions list screening' },
-  { id: 'fraud',       name: 'Fraud Service',        port: 8115, group: 'compliance', x: 920, y: 500,  color: '#dc2626', desc: 'Real-time fraud detection & transaction monitoring (ADR-0084)' },
+  { id: 'audit',       name: 'Audit Service',        port: 8113, group: 'compliance', x: 920, y: 260,  color: 'var(--map-compliance)', desc: 'Immutable audit trail, EBA ICT Risk compliance' },
+  { id: 'kyc',         name: 'KYC Service',          port: 8114, group: 'compliance', x: 1080,y: 260,  color: 'var(--map-compliance)', desc: 'KYC/CDD/EDD case management, document verification' },
+  { id: 'aml',         name: 'AML Service',          port: 8117, group: 'compliance', x: 920, y: 380,  color: 'var(--map-compliance)', desc: 'AML screening, SAR filing' },
+  { id: 'sanctions',   name: 'Sanctions Service',    port: 8123, group: 'compliance', x: 1080,y: 380,  color: 'var(--map-compliance)', desc: 'Real-time sanctions list screening' },
+  { id: 'fraud',       name: 'Fraud Service',        port: 8115, group: 'compliance', x: 920, y: 500,  color: 'var(--map-compliance)', desc: 'Real-time fraud detection & transaction monitoring (ADR-0084)' },
   // Payments
-  { id: 'sepa',        name: 'SEPA Payment',         port: 8115, group: 'payment', x: 125, y: 380,  color: '#7c3aed', desc: 'SEPA Credit Transfer, SCT Inst, SEPA Direct Debit' },
-  { id: 'sepa-instant',name: 'SEPA Instant',         port: 8127, group: 'payment', x: 250, y: 380,  color: '#7c3aed', desc: 'Real-time EUR payment processing' },
-  { id: 'domestic',    name: 'Domestic Payment',     port: 8116, group: 'payment', x: 375, y: 380,  color: '#7c3aed', desc: 'Czech domestic payments' },
-  { id: 'standing-order',name:'Standing Order',      port: 8121, group: 'payment', x: 500, y: 380,  color: '#7c3aed', desc: 'Recurring payments and scheduled transfers' },
-  { id: 'swift',       name: 'SWIFT Service',        port: 8122, group: 'payment', x: 125, y: 500,  color: '#7c3aed', desc: 'SWIFT MT/MX messaging' },
-  { id: 'clearing',    name: 'Clearing Service',     port: 8124, group: 'payment', x: 250, y: 500,  color: '#7c3aed', desc: 'Interbank clearing and settlement' },
+  { id: 'sepa',        name: 'SEPA Payment',         port: 8115, group: 'payment', x: 125, y: 380,  color: 'var(--map-payment)', desc: 'SEPA Credit Transfer, SCT Inst, SEPA Direct Debit' },
+  { id: 'sepa-instant',name: 'SEPA Instant',         port: 8127, group: 'payment', x: 250, y: 380,  color: 'var(--map-payment)', desc: 'Real-time EUR payment processing' },
+  { id: 'domestic',    name: 'Domestic Payment',     port: 8116, group: 'payment', x: 375, y: 380,  color: 'var(--map-payment)', desc: 'Czech domestic payments' },
+  { id: 'standing-order',name:'Standing Order',      port: 8121, group: 'payment', x: 500, y: 380,  color: 'var(--map-payment)', desc: 'Recurring payments and scheduled transfers' },
+  { id: 'swift',       name: 'SWIFT Service',        port: 8122, group: 'payment', x: 125, y: 500,  color: 'var(--map-payment)', desc: 'SWIFT MT/MX messaging' },
+  { id: 'clearing',    name: 'Clearing Service',     port: 8124, group: 'payment', x: 250, y: 500,  color: 'var(--map-payment)', desc: 'Interbank clearing and settlement' },
   // PSD2
-  { id: 'consent',     name: 'Consent Service',      port: 8106, group: 'psd2',   x: 125, y: 660,  color: '#d97706', desc: 'PSD2 consent management' },
-  { id: 'sca',         name: 'SCA Service',          port: 8110, group: 'psd2',   x: 250, y: 660,  color: '#d97706', desc: 'Strong Customer Authentication' },
-  { id: 'psd2',        name: 'PSD2 Service',         port: 8107, group: 'psd2',   x: 375, y: 660,  color: '#d97706', desc: 'PSD2 API gateway' },
-  { id: 'tpp',         name: 'TPP Registry',         port: 8108, group: 'psd2',   x: 500, y: 660,  color: '#d97706', desc: 'Third Party Provider registry' },
+  { id: 'consent',     name: 'Consent Service',      port: 8106, group: 'psd2',   x: 125, y: 660,  color: 'var(--map-psd2)', desc: 'PSD2 consent management' },
+  { id: 'sca',         name: 'SCA Service',          port: 8110, group: 'psd2',   x: 250, y: 660,  color: 'var(--map-psd2)', desc: 'Strong Customer Authentication' },
+  { id: 'psd2',        name: 'PSD2 Service',         port: 8107, group: 'psd2',   x: 375, y: 660,  color: 'var(--map-psd2)', desc: 'PSD2 API gateway' },
+  { id: 'tpp',         name: 'TPP Registry',         port: 8108, group: 'psd2',   x: 500, y: 660,  color: 'var(--map-psd2)', desc: 'Third Party Provider registry' },
   // Extended / reporting — were silently missing from the map before ADR-0071.
-  { id: 'lending',     name: 'Lending Service',      port: 8128, group: 'core',    x: 500, y: 220,  color: '#2563eb', desc: 'Loan products and origination' },
-  { id: 'statement',   name: 'Statement Service',    port: 8136, group: 'core',    x: 625, y: 220,  color: '#2563eb', desc: 'Account statement generation (EoM)' },
-  { id: 'onboarding',  name: 'Onboarding Service',   port: 8130, group: 'identity', x: 750, y: 220,  color: '#059669', desc: 'Customer onboarding journey (ADR-0069)' },
-  { id: 'anacredit',   name: 'AnaCredit Service',    port: 8137, group: 'compliance', x: 1080, y: 500, color: '#dc2626', desc: 'AnaCredit regulatory reporting (ECB)' },
-  { id: 'sdd',         name: 'SEPA Direct Debit',    port: 8129, group: 'payment', x: 375, y: 500,  color: '#7c3aed', desc: 'SEPA Direct Debit mandates and collections' },
+  { id: 'lending',     name: 'Lending Service',      port: 8128, group: 'core',    x: 500, y: 220,  color: 'var(--map-core)', desc: 'Loan products and origination' },
+  { id: 'statement',   name: 'Statement Service',    port: 8136, group: 'core',    x: 625, y: 220,  color: 'var(--map-core)', desc: 'Account statement generation (EoM)' },
+  { id: 'onboarding',  name: 'Onboarding Service',   port: 8130, group: 'identity', x: 750, y: 220,  color: 'var(--map-identity)', desc: 'Customer onboarding journey (ADR-0069)' },
+  { id: 'anacredit',   name: 'AnaCredit Service',    port: 8137, group: 'compliance', x: 1080, y: 500, color: 'var(--map-compliance)', desc: 'AnaCredit regulatory reporting (ECB)' },
+  { id: 'sdd',         name: 'SEPA Direct Debit',    port: 8129, group: 'payment', x: 375, y: 500,  color: 'var(--map-payment)', desc: 'SEPA Direct Debit mandates and collections' },
 ]
 
 // Service dependencies (edges)
@@ -110,13 +110,13 @@ const SERVICE_NAME_TO_ID = Object.fromEntries(Object.entries(SERVICE_ID_TO_NAME)
 const CATALOG_PRESENT = Object.values(SERVICE_ID_TO_NAME)
 
 const GROUP_LABELS: Record<string, { label: string; color: string }> = {
-  core:       { label: 'Core Banking',    color: '#2563eb' },
-  payment:    { label: 'Payments',        color: '#7c3aed' },
-  compliance: { label: 'Compliance',      color: '#dc2626' },
-  identity:   { label: 'Identity',        color: '#059669' },
-  psd2:       { label: 'PSD2 / Open Banking', color: '#d97706' },
-  platform:   { label: 'Platform',        color: '#6b7280' },
-  cards:      { label: 'Cards',           color: '#db2777' },
+  core:       { label: 'Core Banking',    color: 'var(--map-core)' },
+  payment:    { label: 'Payments',        color: 'var(--map-payment)' },
+  compliance: { label: 'Compliance',      color: 'var(--map-compliance)' },
+  identity:   { label: 'Identity',        color: 'var(--map-identity)' },
+  psd2:       { label: 'PSD2 / Open Banking', color: 'var(--map-psd2)' },
+  platform:   { label: 'Platform',        color: 'var(--map-platform)' },
+  cards:      { label: 'Cards',           color: 'var(--map-cards)' },
 }
 type HealthStatus = 'UP' | 'DOWN' | 'UNKNOWN'
 type EvidenceState = 'loading' | 'ok' | 'unreachable' | 'not_deployed' | 'scaled_to_zero' | 'unauthorized' | 'error'
@@ -188,7 +188,7 @@ const LAYOUT: { nodes: Record<string, Pt>; groups: GroupBox[]; width: number; he
       const w = colWidth[c]
       const h = PAD_TOP + rows * CELL_H + PAD_BOT
       const meta = GROUP_LABELS[g]
-      groups.push({ key: g, label: meta?.label ?? g, color: meta?.color ?? '#64748b', x: colX[c], y, w, h })
+      groups.push({ key: g, label: meta?.label ?? g, color: meta?.color ?? 'var(--map-infrastructure)', x: colX[c], y, w, h })
       const gridW = cols * CELL_W
       const startX = colX[c] + (w - gridW) / 2 + CELL_W / 2
       list.forEach((s, i) => {
@@ -239,10 +239,12 @@ const STUD_W = 10
 const STUD_H = 6
 const BRICK_H = 21
 
-const lightFace = (c: string) => mixHex(c, '#ffffff', 0.72)
-const studTop = (c: string) => mixHex(c, '#ffffff', 0.84)
-const studHi = (c: string) => mixHex(c, '#ffffff', 0.45)
-const shadeFace = (c: string) => mixHex(c, '#000000', 0.12)
+const tint = (color: string, amount: number) => `color-mix(in srgb, ${color} ${amount}%, var(--surface))`
+const fade = (color: string, amount: number) => `color-mix(in srgb, ${color} ${amount}%, transparent)`
+const lightFace = (color: string) => tint(color, 28)
+const studTop = (color: string) => tint(color, 16)
+const studHi = (color: string) => tint(color, 55)
+const shadeFace = (color: string) => `color-mix(in srgb, ${color} 88%, var(--text-primary))`
 
 // Number of studs (brick length) from the service's connection degree.
 function brickStuds(degree: number): number {
@@ -270,7 +272,7 @@ function LegoBrick({ cx, cy, color, degree, selected }: { cx: number; cy: number
       <g key={c}>
         <path d={`M ${x0} ${y} L ${x0} ${y - STUD_H + 2.5} Q ${x0} ${y - STUD_H} ${x0 + 2.5} ${y - STUD_H} L ${x0 + STUD_W - 2.5} ${y - STUD_H} Q ${x0 + STUD_W} ${y - STUD_H} ${x0 + STUD_W} ${y - STUD_H + 2.5} L ${x0 + STUD_W} ${y} Z`}
           fill={studFill} stroke={color} strokeWidth={1} />
-        <line x1={x0 + 2} y1={y - STUD_H + 2} x2={x0 + STUD_W - 2} y2={y - STUD_H + 2} stroke="#fff" strokeWidth={1.2} opacity={0.6} />
+        <line x1={x0 + 2} y1={y - STUD_H + 2} x2={x0 + STUD_W - 2} y2={y - STUD_H + 2} stroke="var(--surface)" strokeWidth={1.2} opacity={0.6} />
       </g>,
     )
   }
@@ -278,8 +280,8 @@ function LegoBrick({ cx, cy, color, degree, selected }: { cx: number; cy: number
     <g filter="url(#node-shadow)">
       {studs}
       <rect x={x} y={y} width={w} height={h} rx={3} fill={face} stroke={color} strokeWidth={1.4} />
-      <rect x={x + 2} y={y + 2} width={w - 4} height={h * 0.32} rx={2} fill="#ffffff" opacity={0.22} />
-      <rect x={x + 2} y={y + h - h * 0.3} width={w - 4} height={h * 0.28} rx={2} fill={selected ? '#000000' : shadeFace(color)} opacity={selected ? 0.12 : 0.18} />
+      <rect x={x + 2} y={y + 2} width={w - 4} height={h * 0.32} rx={2} fill="var(--surface)" opacity={0.22} />
+      <rect x={x + 2} y={y + h - h * 0.3} width={w - 4} height={h * 0.28} rx={2} fill={selected ? 'var(--text-primary)' : shadeFace(color)} opacity={selected ? 0.12 : 0.18} />
     </g>
   )
 }
@@ -293,26 +295,26 @@ function LegoBrick({ cx, cy, color, degree, selected }: { cx: number; cy: number
 type TierMeta = { color: string; Icon: typeof Database; labelCs: string; labelEn: string; descCs: string; descEn: string }
 
 const INFRA_META: Record<string, TierMeta> = {
-  'infra:postgres': { color: '#0ea5e9', Icon: Database, labelCs: 'PostgreSQL', labelEn: 'PostgreSQL', descCs: 'Perzistentní stav služeb (účty, ledger, transakce). Podvojné úložiště, reactive Vert.x klient.', descEn: 'Per-service persistent state (accounts, ledger, transactions). Reactive Vert.x client.' },
-  'infra:kafka': { color: '#6366f1', Icon: Boxes, labelCs: 'Apache Kafka', labelEn: 'Apache Kafka', descCs: 'Asynchronní páteř událostí — produkce/konzumace topiců, outbox dispatch mezi službami.', descEn: 'Async event backbone — topic produce/consume, cross-service outbox dispatch.' },
-  'infra:keycloak': { color: '#0891b2', Icon: KeyRound, labelCs: 'Keycloak (OIDC)', labelEn: 'Keycloak (OIDC)', descCs: 'Vydavatel identit a tokenů (OIDC). Ověřuje operátory i M2M client-credentials tok.', descEn: 'Identity & token issuer (OIDC). Authenticates operators and M2M client-credentials flows.' },
-  'infra:opa': { color: '#16a34a', Icon: ShieldCheck, labelCs: 'OPA (autorizace)', labelEn: 'OPA (authz)', descCs: 'Rozhodovací bod autorizace (ADR-0034). Sidecar vyhodnocuje rest.rego politiky per požadavek.', descEn: 'Authorization decision point (ADR-0034). Sidecar evaluates rest.rego per request.' },
+  'infra:postgres': { color: 'var(--map-external)', Icon: Database, labelCs: 'PostgreSQL', labelEn: 'PostgreSQL', descCs: 'Perzistentní stav služeb (účty, ledger, transakce). Podvojné úložiště, reactive Vert.x klient.', descEn: 'Per-service persistent state (accounts, ledger, transactions). Reactive Vert.x client.' },
+  'infra:kafka': { color: 'var(--accent)', Icon: Boxes, labelCs: 'Apache Kafka', labelEn: 'Apache Kafka', descCs: 'Asynchronní páteř událostí — produkce/konzumace topiců, outbox dispatch mezi službami.', descEn: 'Async event backbone — topic produce/consume, cross-service outbox dispatch.' },
+  'infra:keycloak': { color: 'var(--map-edge-auth)', Icon: KeyRound, labelCs: 'Keycloak (OIDC)', labelEn: 'Keycloak (OIDC)', descCs: 'Vydavatel identit a tokenů (OIDC). Ověřuje operátory i M2M client-credentials tok.', descEn: 'Identity & token issuer (OIDC). Authenticates operators and M2M client-credentials flows.' },
+  'infra:opa': { color: 'var(--success)', Icon: ShieldCheck, labelCs: 'OPA (autorizace)', labelEn: 'OPA (authz)', descCs: 'Rozhodovací bod autorizace (ADR-0034). Sidecar vyhodnocuje rest.rego politiky per požadavek.', descEn: 'Authorization decision point (ADR-0034). Sidecar evaluates rest.rego per request.' },
 }
 const EXT_META: Record<string, TierMeta> = {
-  'ext:apple-apns': { color: '#0f172a', Icon: Send, labelCs: 'Apple APNs', labelEn: 'Apple APNs', descCs: 'Push notifikace na iOS zařízení (adapter v notification-service).', descEn: 'Push notifications to iOS devices (notification-service adapter).' },
-  'ext:firebase-fcm': { color: '#f59e0b', Icon: Send, labelCs: 'Firebase FCM', labelEn: 'Firebase FCM', descCs: 'Push notifikace přes Google FCM.', descEn: 'Push notifications via Google FCM.' },
-  'ext:slack': { color: '#7c3aed', Icon: Send, labelCs: 'Slack webhook', labelEn: 'Slack webhook', descCs: 'Odchozí oversight signály (ADR-0059).', descEn: 'Outbound oversight signals (ADR-0059).' },
-  'ext:cnb': { color: '#dc2626', Icon: Cloud, labelCs: 'ČNB', labelEn: 'Czech National Bank', descCs: 'Veřejné feedy ČNB — seznam bank (JERR) a devizové kurzy.', descEn: 'CNB public feeds — bank registry (JERR) and FX rates.' },
-  'ext:github': { color: '#0f172a', Icon: Cloud, labelCs: 'GitHub API', labelEn: 'GitHub API', descCs: 'Rozhraní pro platformní/agentní služby (release, governance).', descEn: 'Interface for platform/agent services (release, governance).' },
-  'ext:llm-gateway': { color: '#0d9488', Icon: Cloud, labelCs: 'LLM brána', labelEn: 'LLM gateway', descCs: 'Externí LLM poskytovatelé (DeepInfra, Groq, NVIDIA) pro AI agenty.', descEn: 'External LLM providers (DeepInfra, Groq, NVIDIA) for AI agents.' },
-  'ext:s3': { color: '#f97316', Icon: Cloud, labelCs: 'AWS S3', labelEn: 'AWS S3', descCs: 'Objektové úložiště (export analytiky, artefakty).', descEn: 'Object store (analytics export, artifacts).' },
+  'ext:apple-apns': { color: 'var(--text-primary)', Icon: Send, labelCs: 'Apple APNs', labelEn: 'Apple APNs', descCs: 'Push notifikace na iOS zařízení (adapter v notification-service).', descEn: 'Push notifications to iOS devices (notification-service adapter).' },
+  'ext:firebase-fcm': { color: 'var(--warning)', Icon: Send, labelCs: 'Firebase FCM', labelEn: 'Firebase FCM', descCs: 'Push notifikace přes Google FCM.', descEn: 'Push notifications via Google FCM.' },
+  'ext:slack': { color: 'var(--map-payment)', Icon: Send, labelCs: 'Slack webhook', labelEn: 'Slack webhook', descCs: 'Odchozí oversight signály (ADR-0059).', descEn: 'Outbound oversight signals (ADR-0059).' },
+  'ext:cnb': { color: 'var(--map-compliance)', Icon: Cloud, labelCs: 'ČNB', labelEn: 'Czech National Bank', descCs: 'Veřejné feedy ČNB — seznam bank (JERR) a devizové kurzy.', descEn: 'CNB public feeds — bank registry (JERR) and FX rates.' },
+  'ext:github': { color: 'var(--text-primary)', Icon: Cloud, labelCs: 'GitHub API', labelEn: 'GitHub API', descCs: 'Rozhraní pro platformní/agentní služby (release, governance).', descEn: 'Interface for platform/agent services (release, governance).' },
+  'ext:llm-gateway': { color: 'var(--map-edge-llm)', Icon: Cloud, labelCs: 'LLM brána', labelEn: 'LLM gateway', descCs: 'Externí LLM poskytovatelé (DeepInfra, Groq, NVIDIA) pro AI agenty.', descEn: 'External LLM providers (DeepInfra, Groq, NVIDIA) for AI agents.' },
+  'ext:s3': { color: 'var(--map-edge-push)', Icon: Cloud, labelCs: 'AWS S3', labelEn: 'AWS S3', descCs: 'Objektové úložiště (export analytiky, artefakty).', descEn: 'Object store (analytics export, artifacts).' },
 }
 const tierMeta = (id: string): TierMeta | undefined => INFRA_META[id] ?? EXT_META[id]
 
 // Edge-type palette + bilingual label for the legend / detail panel.
 const EDGE_TYPE_COLOR: Record<string, string> = {
-  db: '#38bdf8', broker: '#818cf8', auth: '#22d3ee', authz: '#4ade80',
-  push: '#fb923c', webhook: '#a78bfa', registry: '#f87171', api: '#94a3b8', llm: '#2dd4bf',
+  db: 'var(--map-edge-db)', broker: 'var(--map-edge-async-active)', auth: 'var(--map-edge-auth)', authz: 'var(--map-edge-authz)',
+  push: 'var(--map-edge-push)', webhook: 'var(--map-payment)', registry: 'var(--map-edge-registry)', api: 'var(--map-edge-sync)', llm: 'var(--map-edge-llm)',
 }
 const edgeTypeLabel = (type: string, t: (cs: string, en: string) => string): string => ({
   db: t('perzistence', 'persistence'), broker: t('události', 'events'), auth: t('identita', 'auth'),
@@ -351,7 +353,7 @@ function TierChip({ pos, color, label, active, dim, faded, onClick, onEnter, onL
         fill={active ? color : 'var(--surface)'} stroke={color} strokeWidth={active ? 1.8 : 1.3}
         strokeDasharray={faded ? '4,3' : undefined} opacity={faded ? 0.75 : 1} filter="url(#node-shadow)" />
       <circle cx={x + 15} cy={cy} r={4} fill={color} opacity={faded ? 0.5 : 1} />
-      <text x={x + 27} y={cy + 4} fontSize="11" fontWeight="600" fill={active ? '#fff' : 'var(--text-primary)'}>{label}</text>
+      <text x={x + 27} y={cy + 4} fontSize="11" fontWeight="600" fill={active ? 'var(--text-inverse)' : 'var(--text-primary)'}>{label}</text>
     </g>
   )
 }
@@ -657,7 +659,7 @@ export default function ServiceMapPage() {
                 padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
                 border: `1px solid ${filter === key ? 'var(--accent)' : 'var(--border)'}`,
                 background: filter === key ? 'var(--accent)' : 'var(--surface)',
-                color: filter === key ? '#fff' : 'var(--text-secondary)',
+                color: filter === key ? 'var(--text-inverse)' : 'var(--text-secondary)',
                 cursor: 'pointer', fontFamily: 'inherit',
               }}>{label}</button>
           ))}
@@ -676,7 +678,7 @@ export default function ServiceMapPage() {
                 borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
                 border: `1px solid ${c.on ? 'var(--accent)' : 'var(--border)'}`,
                 background: c.on ? 'var(--accent)' : 'var(--surface)',
-                color: c.on ? '#fff' : 'var(--text-secondary)',
+                color: c.on ? 'var(--text-inverse)' : 'var(--text-secondary)',
               }}>
               {c.icon}{c.label}
             </button>
@@ -699,10 +701,10 @@ export default function ServiceMapPage() {
         <div className="card" style={{ padding: '0', overflow: 'hidden' }}>
           <svg viewBox={`0 0 ${LAYOUT.width} ${svgHeight}`} style={{ width: '100%', height: 'auto', display: 'block', background: 'var(--surface)' }}>
             <defs>
-              <ArrowMarker id="arrow-sync" color="#94a3b8" />
-              <ArrowMarker id="arrow-sync-hi" color="#475569" />
-              <ArrowMarker id="arrow-async" color="#c4b5fd" />
-              <ArrowMarker id="arrow-async-hi" color="#8b5cf6" />
+              <ArrowMarker id="arrow-sync" color="var(--map-edge-sync)" />
+              <ArrowMarker id="arrow-sync-hi" color="var(--map-edge-sync-active)" />
+              <ArrowMarker id="arrow-async" color="var(--map-edge-async)" />
+              <ArrowMarker id="arrow-async-hi" color="var(--map-edge-async-active)" />
               <NodeShadow id="node-shadow" />
             </defs>
 
@@ -710,7 +712,7 @@ export default function ServiceMapPage() {
             {LAYOUT.groups.map(g => (
               <g key={g.key}>
                 <rect x={g.x} y={g.y} width={g.w} height={g.h} rx="16"
-                  fill={`${g.color}0a`} stroke={`${g.color}33`} strokeWidth="1" />
+                  fill={fade(g.color, 4)} stroke={fade(g.color, 20)} strokeWidth="1" />
                 <text x={g.x + 18} y={g.y + 26} fontSize="11" fill={g.color} fontWeight="700" letterSpacing="0.08em">
                   {groupLabel(g.key).toUpperCase()}
                 </text>
@@ -729,12 +731,12 @@ export default function ServiceMapPage() {
                   {/* Tier bands (infra + external) — full-width backgrounds below the grid */}
                   {bandBoxes.map(band => {
                     const meta = band.key === 'infra'
-                      ? { color: '#64748b', label: t('Infrastruktura', 'Infrastructure') }
-                      : { color: '#0ea5e9', label: t('Externí / 3. strany', 'External / 3rd parties') }
+                      ? { color: 'var(--map-infrastructure)', label: t('Infrastruktura', 'Infrastructure') }
+                      : { color: 'var(--map-external)', label: t('Externí / 3. strany', 'External / 3rd parties') }
                     return (
                       <g key={band.key}>
                         <rect x={band.x} y={band.y} width={band.w} height={band.h} rx="16"
-                          fill={`${meta.color}0a`} stroke={`${meta.color}33`} strokeWidth="1" strokeDasharray="4,4" />
+                          fill={fade(meta.color, 4)} stroke={fade(meta.color, 20)} strokeWidth="1" strokeDasharray="4,4" />
                         <text x={band.x + 18} y={band.y + 20} fontSize="11" fill={meta.color} fontWeight="700" letterSpacing="0.08em">
                           {meta.label.toUpperCase()}
                         </text>
@@ -751,7 +753,7 @@ export default function ServiceMapPage() {
                     const aHalf = { hw: brickSize(degrees[e.fromId] ?? 0).w / 2, hh: hhAll }
                     const bHalf = { hw: b.w / 2, hh: CHIP_H / 2 }
                     const { d } = edgeGeometry(a, b, aHalf, bHalf)
-                    const color = EDGE_TYPE_COLOR[e.type] ?? '#94a3b8'
+                    const color = EDGE_TYPE_COLOR[e.type] ?? 'var(--map-edge-sync)'
                     const dashed = e.type === 'broker' || e.type === 'push' || e.type === 'webhook'
                     const off = e.kind === 'external' && e.enabled === false
                     const touches = !!activeNode && (e.fromId === activeNode || e.to === activeNode)
@@ -759,7 +761,7 @@ export default function ServiceMapPage() {
                     const pid = pathId('fx', e.fromId, e.to, 10000 + i)
                     return (
                       <g key={`t${i}`} opacity={off ? 0.3 : dim ? 0.12 : touches ? 1 : 0.55} style={{ transition: 'opacity 0.15s' }}>
-                        <path id={pid} d={d} fill="none" stroke={off ? '#94a3b8' : color}
+                        <path id={pid} d={d} fill="none" stroke={off ? 'var(--map-edge-sync)' : color}
                           strokeWidth={touches ? 2 : 1.3}
                           strokeDasharray={off ? '2,4' : dashed ? '5,4' : undefined} />
                         {flow && !off && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 4) * 0.3} begin={(i % 6) * 0.2} r={2.3} />}
@@ -778,8 +780,8 @@ export default function ServiceMapPage() {
                     const aHalf = { hw: brickSize(degrees[e.from] ?? 0).w / 2, hh: hhAll }
                     const bHalf = { hw: brickSize(degrees[e.to] ?? 0).w / 2, hh: hhAll }
                     const { d, lx, ly } = edgeGeometry(a, b, aHalf, bHalf)
-                    const baseColor = isAsync ? '#c4b5fd' : '#cbd5e1'
-                    const hiColor = isAsync ? '#8b5cf6' : '#64748b'
+                    const baseColor = isAsync ? 'var(--map-edge-async)' : 'var(--border-strong)'
+                    const hiColor = isAsync ? 'var(--map-edge-async-active)' : 'var(--map-infrastructure)'
                     const pid = pathId('fx', e.from, e.to, i)
                     return (
                       <g key={i} opacity={dim ? 0.08 : touches ? 1 : 0.5} style={{ transition: 'opacity 0.15s' }}>
@@ -795,7 +797,7 @@ export default function ServiceMapPage() {
                           return (
                             <g>
                               <rect x={lx - lbl.length * 3.1 - 5} y={ly - 9} width={lbl.length * 6.2 + 10} height="15"
-                                rx="7.5" fill="var(--surface)" stroke={`${hiColor}55`} strokeWidth="0.75" opacity="0.97" />
+                                rx="7.5" fill="var(--surface)" stroke={fade(hiColor, 33)} strokeWidth="0.75" opacity="0.97" />
                               <text x={lx} y={ly + 2} fontSize="9" fill={hiColor} textAnchor="middle" fontWeight="600">{lbl}</text>
                             </g>
                           )
@@ -830,11 +832,11 @@ export default function ServiceMapPage() {
                         {health && (
                           <g transform={`translate(${p.cx + bw / 2 - 1}, ${p.cy - (bh + STUD_H) / 2 + 2})`}>
                             <circle cx="0" cy="0" r="7"
-                              fill={health === 'UP' ? '#10b981' : health === 'DOWN' ? '#ef4444' : '#94a3b8'}
+                              fill={health === 'UP' ? 'var(--success)' : health === 'DOWN' ? 'var(--danger)' : 'var(--map-edge-sync)'}
                               stroke="var(--surface)" strokeWidth="1.5" />
-                            {health === 'UP' && <path d="M-3,0 L-1,2 L3,-2.5" fill="none" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />}
-                            {health === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" />}
-                            {health === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="#fff" textAnchor="middle" fontWeight="bold">?</text>}
+                            {health === 'UP' && <path d="M-3,0 L-1,2 L3,-2.5" fill="none" stroke="var(--text-inverse)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />}
+                            {health === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="var(--text-inverse)" strokeWidth="1.5" strokeLinecap="round" />}
+                            {health === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="var(--text-inverse)" textAnchor="middle" fontWeight="bold">?</text>}
                           </g>
                         )}
                       </g>
@@ -846,7 +848,7 @@ export default function ServiceMapPage() {
                     const p = tierPos[n.id]
                     if (!p) return null
                     const meta = tierMeta(n.id)
-                    const color = meta?.color ?? '#64748b'
+                    const color = meta?.color ?? 'var(--map-infrastructure)'
                     const isSel = selected === n.id
                     const rel = !!activeNode && (activeNode === n.id
                       || tierEdges.some(e => e.to === n.id && (e.fromId === activeNode || e.to === activeNode)))
@@ -870,23 +872,23 @@ export default function ServiceMapPage() {
           {/* Legend */}
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#94a3b8" strokeWidth="1.5" markerEnd="url(#arrow-sync)" /></svg>
+              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="var(--map-edge-sync)" strokeWidth="1.5" markerEnd="url(#arrow-sync)" /></svg>
               {t('Synchronní volání', 'Synchronous call')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#c4b5fd" strokeWidth="1.5" strokeDasharray="5,3" /></svg>
+              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="var(--map-edge-async)" strokeWidth="1.5" strokeDasharray="5,3" /></svg>
               {t('Async (události Kafka)', 'Async (Kafka events)')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="#64748b" strokeWidth="1.3" /></svg>
+              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="var(--map-infrastructure)" strokeWidth="1.3" /></svg>
               {t('Infrastruktura (DB · Kafka · OIDC · OPA)', 'Infrastructure (DB · Kafka · OIDC · OPA)')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="#0ea5e9" strokeWidth="1.3" /></svg>
+              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="var(--map-external)" strokeWidth="1.3" /></svg>
               {t('Externí 3. strany (push · API)', 'External 3rd parties (push · API)')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#94a3b8" strokeWidth="1.3" strokeDasharray="2,4" /></svg>
+              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="var(--map-edge-sync)" strokeWidth="1.3" strokeDasharray="2,4" /></svg>
               {t('Zapojená, ale vypnutá integrace', 'Wired but disabled integration')}
             </div>
           </div>
@@ -908,8 +910,8 @@ export default function ServiceMapPage() {
                   borderRadius: '12px',
                   fontSize: '11px',
                   fontWeight: 600,
-                  background: healthStatuses[selectedSvc.id] === 'UP' ? '#d1fae5' : healthStatuses[selectedSvc.id] === 'DOWN' ? '#fee2e2' : '#f3f4f6',
-                  color: healthStatuses[selectedSvc.id] === 'UP' ? '#059669' : healthStatuses[selectedSvc.id] === 'DOWN' ? '#dc2626' : '#4b5563'
+                  background: healthStatuses[selectedSvc.id] === 'UP' ? 'var(--success-bg)' : healthStatuses[selectedSvc.id] === 'DOWN' ? 'var(--danger-bg)' : 'var(--surface-3)',
+                  color: healthStatuses[selectedSvc.id] === 'UP' ? 'var(--map-identity)' : healthStatuses[selectedSvc.id] === 'DOWN' ? 'var(--map-compliance)' : 'var(--text-secondary)'
                 }}>
                   {healthStatuses[selectedSvc.id] === 'UP' && <CheckCircle2 size={12} />}
                   {healthStatuses[selectedSvc.id] === 'DOWN' && <XCircle size={12} />}
@@ -1056,13 +1058,13 @@ export default function ServiceMapPage() {
                           </div>
                           <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
                             {govEntry.lineage?.interfaces?.apis?.map((api, i) => (
-                              <span key={`api-${i}`} style={{ fontSize: '10px', background: '#dbeafe', color: '#1e40af', padding: '2px 6px', borderRadius: '4px', border: '1px solid #bfdbfe' }}>{t('API', 'API')}: {api}</span>
+                              <span key={`api-${i}`} style={{ fontSize: '10px', background: 'var(--info-bg)', color: 'var(--info-text)', padding: '2px 6px', borderRadius: '4px', border: '1px solid var(--info-border)' }}>{t('API', 'API')}: {api}</span>
                             ))}
                             {govEntry.lineage?.interfaces?.topics?.map((topic, i) => (
-                              <span key={`topic-${i}`} style={{ fontSize: '10px', background: '#f3e8ff', color: '#6b21a8', padding: '2px 6px', borderRadius: '4px', border: '1px solid #e9d5ff' }}>{t('Téma', 'Topic')}: {topic}</span>
+                              <span key={`topic-${i}`} style={{ fontSize: '10px', background: 'var(--accent-bg)', color: 'var(--accent-text)', padding: '2px 6px', borderRadius: '4px', border: '1px solid var(--accent-border)' }}>{t('Téma', 'Topic')}: {topic}</span>
                             ))}
                             {govEntry.lineage?.interfaces?.datastores?.map((ds, i) => (
-                              <span key={`ds-${i}`} style={{ fontSize: '10px', background: '#dcfce7', color: '#166534', padding: '2px 6px', borderRadius: '4px', border: '1px solid #bbf7d0' }}>{t('DB', 'DB')}: {ds}</span>
+                              <span key={`ds-${i}`} style={{ fontSize: '10px', background: 'var(--success-bg)', color: 'var(--success-text)', padding: '2px 6px', borderRadius: '4px', border: '1px solid var(--success-border)' }}>{t('DB', 'DB')}: {ds}</span>
                             ))}
                           </div>
                         </div>
@@ -1105,18 +1107,18 @@ export default function ServiceMapPage() {
         {/* Detail panel — infra/external tier node */}
         {selectedTier && !selectedSvc && (() => {
           const meta = tierMeta(selectedTier.id)
-          const color = meta?.color ?? '#64748b'
+          const color = meta?.color ?? 'var(--map-infrastructure)'
           const isExt = selectedTier.kind === 'external'
           const anyEnabled = tierConsumers.some(c => c.enabled)
           const Icon = meta?.Icon ?? Server
           return (
             <div className="card" style={{ padding: '20px', alignSelf: 'start' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
-                <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `${color}1a`, display: 'flex', alignItems: 'center', justifyContent: 'center', color }}>
+                <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: fade(color, 10), display: 'flex', alignItems: 'center', justifyContent: 'center', color }}>
                   <Icon size={16} />
                 </div>
                 <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{chipLabel(selectedTier.id, selectedTier.label)}</div>
-                <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: `${color}1a`, color }}>
+                <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: fade(color, 10), color }}>
                   {isExt ? t('3. strana', '3rd party') : t('Infra', 'Infra')}
                 </div>
               </div>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -116,6 +116,28 @@
   --info-border:          #93c5fd;
   --info-text:            #1d4ed8;
 
+  /* Service topology palette. Domain meaning lives here so the SVG remains
+   * readable in both themes without embedding presentation colours in data. */
+  --map-core: #2563eb;
+  --map-payment: #7c3aed;
+  --map-compliance: #dc2626;
+  --map-identity: #059669;
+  --map-psd2: #d97706;
+  --map-platform: #64748b;
+  --map-cards: #db2777;
+  --map-infrastructure: #64748b;
+  --map-external: #0284c7;
+  --map-edge-sync: #94a3b8;
+  --map-edge-sync-active: #475569;
+  --map-edge-async: #c4b5fd;
+  --map-edge-async-active: #8b5cf6;
+  --map-edge-db: #38bdf8;
+  --map-edge-auth: #22d3ee;
+  --map-edge-authz: #4ade80;
+  --map-edge-push: #fb923c;
+  --map-edge-registry: #f87171;
+  --map-edge-llm: #2dd4bf;
+
   /* ── Shadows ── */
   --shadow-xs:  0 1px 2px rgba(15,23,42,.03);
   --shadow-sm:  0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.02);
@@ -205,6 +227,25 @@
   --info-bg: #172554;
   --info-border: #1d4ed8;
   --info-text: #bfdbfe;
+  --map-core: #60a5fa;
+  --map-payment: #c4b5fd;
+  --map-compliance: #f87171;
+  --map-identity: #34d399;
+  --map-psd2: #fbbf24;
+  --map-platform: #94a3b8;
+  --map-cards: #f472b6;
+  --map-infrastructure: #94a3b8;
+  --map-external: #38bdf8;
+  --map-edge-sync: #64748b;
+  --map-edge-sync-active: #cbd5e1;
+  --map-edge-async: #8b5cf6;
+  --map-edge-async-active: #c4b5fd;
+  --map-edge-db: #38bdf8;
+  --map-edge-auth: #22d3ee;
+  --map-edge-authz: #4ade80;
+  --map-edge-push: #fb923c;
+  --map-edge-registry: #f87171;
+  --map-edge-llm: #2dd4bf;
   --sidebar-bg: #090e17;
   --sidebar-hover-bg: rgba(255,255,255,0.08);
   --sidebar-active-bg: rgba(165,180,252,0.18);

--- a/openbank-admin-ui/src/test/service-map-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/service-map-semantic-theme.guard.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/docs/service-map/page.tsx'), 'utf8')
+const globals = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8')
+const mapTokens = [
+  'core', 'payment', 'compliance', 'identity', 'psd2', 'platform', 'cards',
+  'infrastructure', 'external', 'edge-sync', 'edge-sync-active',
+  'edge-async', 'edge-async-active', 'edge-db', 'edge-auth', 'edge-authz',
+  'edge-push', 'edge-registry', 'edge-llm',
+]
+
+describe('service map semantic theme contract', () => {
+  it('keeps presentation colours out of topology data and rendering', () => {
+    expect(page).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+    expect(page).not.toMatch(/\$\{[^}]*color\}[0-9a-f]{2}/i)
+    expect(page).toContain('color-mix(in srgb')
+  })
+
+  it('defines every map token for both light and dark themes', () => {
+    const darkTheme = globals.slice(globals.indexOf('.dark {'))
+    for (const token of mapTokens) {
+      expect(globals).toContain(`--map-${token}:`)
+      expect(darkTheme).toContain(`--map-${token}:`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Moves the Service Map's 112 embedded colour literals into a central light/dark semantic topology palette. Preserves topology, evidence, health, governance, animation, keyboard and authorization behavior while making the full SVG and detail panels theme-aware.

## Type of change

- [x] refactor (no behavior change)

## Linked issues

Closes #9578

## Changes

- define semantic Service Map tokens for both light and dark themes
- replace embedded SVG, status, edge, group and lineage colours with tokens and color-mix
- add a focused guard preventing raw colours or incomplete theme definitions from returning

## Definition of Done

- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] No new lint warnings.
- [x] No REST API, database, event or dependency change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] No auth, crypto, payment, PII or cardholder data path changed.

## Compliance impact

- [x] None

## Verification

- 20 focused Vitest tests across topology, evidence, governance, accessibility and theme contract
- TypeScript type-check
- ESLint: 0 errors, existing warnings only
- Next.js production build: 97/97 routes
- Chromium production-server E2E: service-map evidence/authorization boundary
- raw-colour subjects: 1591 -> 1479 (-112)

## Rollout / Rollback

- Deployment strategy: rolling via existing Admin UI GitOps flow
- Rollback plan: revert the squash commit; no persisted state changes
- Data migration reversible: N/A

## Reviewer notes

Please verify light/dark contrast, SVG state semantics, keyboard behavior, and that evidence is still purged after authorization loss.