### PR TITLE
refactor(admin-ui): unify product studio theme

### DIFF
--- a/openbank-admin-ui/e2e/product-studio-theme.spec.ts
+++ b/openbank-admin-ui/e2e/product-studio-theme.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/**', route => {
+    if (new URL(route.request().url()).pathname.startsWith('/api/auth/')) return route.continue()
+    return route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'temporarily unavailable' }) })
+  })
+})
+
+test('Product Studio remains understandable and accessible in both themes', async ({ page }) => {
+  await page.goto('/product-studio')
+  await expect(page.getByRole('heading', { level: 1, name: /Od nápadu k důvěryhodné nabídce|From product idea to a trusted offer/ })).toBeVisible()
+  await expect(page.getByRole('navigation', { name: /Životní cyklus nabídky|Offer lifecycle/ })).toBeVisible()
+  await expect(page.getByText(/Inteligence radí, člověk rozhoduje|Intelligence advises; people decide/)).toBeVisible()
+
+  for (const dark of [false, true]) {
+    await page.locator('html').evaluate((element, enabled) => element.classList.toggle('dark', enabled), dark)
+    if (dark) await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark')
+    const scan = await new AxeBuilder({ page })
+      .include('#main-content')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze()
+    expect(scan.violations, scan.violations.map(violation =>
+      `${violation.id}: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`,
+    ).join('\n')).toEqual([])
+  }
+})

--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -3,12 +3,12 @@
   overflow: hidden;
   padding: 28px;
   border-radius: 24px;
-  color: white;
+  color: var(--sidebar-active-text);
   background:
-    radial-gradient(circle at 82% 2%, rgba(129, 140, 248, .52), transparent 30%),
-    radial-gradient(circle at 20% 130%, rgba(56, 189, 248, .22), transparent 38%),
-    linear-gradient(122deg, #10182d 0%, #18245b 54%, #4338ca 135%);
-  box-shadow: 0 20px 45px rgba(30, 41, 59, .18);
+    radial-gradient(circle at 82% 2%, color-mix(in srgb, var(--accent) 52%, transparent), transparent 30%),
+    radial-gradient(circle at 20% 130%, color-mix(in srgb, var(--info) 22%, transparent), transparent 38%),
+    linear-gradient(122deg, var(--sidebar-bg) 0%, color-mix(in srgb, var(--sidebar-bg) 72%, var(--accent)) 54%, var(--accent-hover) 135%);
+  box-shadow: var(--shadow-xl);
 }
 .hero::after {
   content: '';
@@ -18,38 +18,38 @@
   right: -130px;
   bottom: -215px;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, .14);
-  box-shadow: 0 0 0 32px rgba(255, 255, 255, .04), 0 0 0 64px rgba(255, 255, 255, .025);
+  border: 1px solid color-mix(in srgb, var(--sidebar-active-text) 14%, transparent);
+  box-shadow: 0 0 0 32px color-mix(in srgb, var(--sidebar-active-text) 4%, transparent), 0 0 0 64px color-mix(in srgb, var(--sidebar-active-text) 2.5%, transparent);
 }
 .heroTop { position: relative; z-index: 1; display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; }
-.eyebrow { display: inline-flex; align-items: center; gap: 7px; color: #c7d2fe; font-size: 11px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.eyebrow { display: inline-flex; align-items: center; gap: 7px; color: var(--accent-border); font-size: 11px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
 .heroTitle { margin-top: 9px; max-width: 720px; font-size: clamp(25px, 3.2vw, 37px); letter-spacing: -.045em; line-height: 1.08; }
-.heroCopy { max-width: 680px; margin-top: 10px; color: #dbeafe; font-size: 13px; line-height: 1.65; }
-.refresh { flex: 0 0 auto; border-color: rgba(255,255,255,.25) !important; background: rgba(255,255,255,.11) !important; color: white !important; backdrop-filter: blur(12px); }
+.heroCopy { max-width: 680px; margin-top: 10px; color: var(--sidebar-text); font-size: 13px; line-height: 1.65; }
+.refresh { flex: 0 0 auto; border-color: color-mix(in srgb, var(--sidebar-active-text) 25%, transparent) !important; background: color-mix(in srgb, var(--sidebar-active-text) 11%, transparent) !important; color: var(--sidebar-active-text) !important; backdrop-filter: blur(12px); }
 .metrics { position: relative; z-index: 1; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: 24px; }
-.metric { padding: 13px 14px; border: 1px solid rgba(255,255,255,.15); border-radius: 14px; background: rgba(255,255,255,.085); backdrop-filter: blur(10px); }
-.metricLabel { color: #c7d2fe; font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.metric { padding: 13px 14px; border: 1px solid color-mix(in srgb, var(--sidebar-active-text) 15%, transparent); border-radius: 14px; background: color-mix(in srgb, var(--sidebar-active-text) 8.5%, transparent); backdrop-filter: blur(10px); }
+.metricLabel { color: var(--accent-border); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .metricValue { margin-top: 4px; font-size: 21px; font-weight: 800; letter-spacing: -.04em; }
-.metricNote { margin-top: 2px; color: #dbeafe; font-size: 11px; }
+.metricNote { margin-top: 2px; color: var(--sidebar-text); font-size: 11px; }
 .journey { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; margin: 18px 0; overflow: hidden; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); box-shadow: var(--shadow-sm); }
 .journeyStep { display: flex; align-items: center; gap: 9px; padding: 13px 14px; border-right: 1px solid var(--border); color: var(--text-secondary); }
 .journeyStep:last-child { border-right: 0; }
 .journeyNumber { display: grid; width: 23px; height: 23px; place-items: center; border-radius: 50%; background: var(--surface-3); color: var(--text-secondary); font-size: 11px; font-weight: 800; }
-.journeyActive { background: linear-gradient(90deg, #eef2ff, #fafaff); color: var(--ob-accent-text); }
-.journeyActive .journeyNumber { background: var(--ob-accent); color: white; }
+.journeyActive { background: linear-gradient(90deg, var(--accent-light), var(--surface)); color: var(--ob-accent-text); }
+.journeyActive .journeyNumber { background: var(--ob-accent); color: var(--surface); }
 .journeyText strong { display: block; color: var(--text-primary); font-size: 12px; }
-.journeyText span { display: block; margin-top: 1px; color: var(--text-tertiary); font-size: 10px; }
+.journeyText span { display: block; margin-top: 1px; color: var(--text-secondary); font-size: 10px; }
 .workspace { display: grid; grid-template-columns: minmax(250px, .75fr) minmax(330px, 1.1fr) minmax(340px, 1.25fr); gap: 14px; }
 .panel { overflow: hidden; padding: 0; }
 .panelHead { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 17px 17px 14px; border-bottom: 1px solid var(--border); }
-.panelKicker { color: var(--text-tertiary); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.panelKicker { color: var(--text-secondary); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .panelTitle { display: flex; align-items: center; gap: 7px; margin-top: 3px; color: var(--text-primary); font-size: 15px; letter-spacing: -.015em; }
 .panelBody { padding: 15px 17px 17px; }
-.smallLabel { display: block; margin: 11px 0 5px; color: var(--text-tertiary); font-size: 10px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.smallLabel { display: block; margin: 11px 0 5px; color: var(--text-secondary); font-size: 10px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .schemaHint { margin-top: 10px; padding: 10px; border-radius: 10px; background: var(--surface-2); color: var(--text-secondary); font-size: 11px; line-height: 1.55; }
-.marketContext { margin-top: 10px; padding: 11px; border: 1px solid #d9d8ee; border-radius: 11px; background: linear-gradient(135deg, #fbfbff, #f4f8ff); }
-.marketTitle { display: flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
-.marketContext p { margin: 5px 0 9px; color: #5b5b86; font-size: 10px; line-height: 1.45; }
+.marketContext { margin-top: 10px; padding: 11px; border: 1px solid var(--border); border-radius: 11px; background: linear-gradient(135deg, var(--surface), var(--surface-2)); }
+.marketTitle { display: flex; align-items: center; gap: 6px; color: var(--accent-text); font-size: 11px; font-weight: 800; }
+.marketContext p { margin: 5px 0 9px; color: var(--text-secondary); font-size: 10px; line-height: 1.45; }
 .marketGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
 .marketGrid label { display: grid; gap: 3px; color: var(--text-tertiary); font-size: 9px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
 .marketGrid input { min-width: 0; font-size: 11px; }
@@ -58,35 +58,35 @@
 .revision:hover { background: var(--surface-2); border-color: var(--border); }
 .revisionSelected { background: var(--ob-accent-light); border-color: var(--ob-accent-border); }
 .draftBanner { display: flex; gap: 9px; padding: 11px; border: 1px solid var(--ob-accent-border); border-radius: 10px; background: var(--ob-accent-light); color: var(--ob-accent-text); font-size: 11px; line-height: 1.5; }
-.composition { margin-top: 11px; padding: 12px; border: 1px solid #c9d7ef; border-radius: 12px; background: linear-gradient(135deg, #f7fbff, #f4f3ff); }
+.composition { margin-top: 11px; padding: 12px; border: 1px solid var(--info-border); border-radius: 12px; background: linear-gradient(135deg, var(--surface-2), var(--accent-bg)); }
 .compositionHead { display: flex; justify-content: space-between; gap: 9px; }
-.compositionHead span { display: inline-flex; align-items: center; gap: 6px; color: #1e3a8a; font-size: 12px; font-weight: 800; }
-.compositionHead p { margin: 4px 0 0; color: #52607b; font-size: 10px; line-height: 1.45; }
+.compositionHead span { display: inline-flex; align-items: center; gap: 6px; color: var(--info-text); font-size: 12px; font-weight: 800; }
+.compositionHead p { margin: 4px 0 0; color: var(--text-secondary); font-size: 10px; line-height: 1.45; }
 .compositionControls { display: grid; grid-template-columns: 118px minmax(0, 1fr) auto; gap: 7px; margin-top: 10px; }
 .compositionControls select { min-width: 0; font-size: 11px; }
-.bundleProposals { margin-top: 10px; padding: 9px; border: 1px dashed #b9c9e6; border-radius: 10px; background: rgba(255,255,255,.56); }
+.bundleProposals { margin-top: 10px; padding: 9px; border: 1px dashed var(--border-strong); border-radius: 10px; background: color-mix(in srgb, var(--surface) 56%, transparent); }
 .bundleProposalsHead { display: grid; gap: 3px; }
-.bundleProposalsHead span { display: inline-flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
-.bundleProposalsHead small { color: #5b5b86; font-size: 10px; line-height: 1.4; }
+.bundleProposalsHead span { display: inline-flex; align-items: center; gap: 6px; color: var(--accent-text); font-size: 11px; font-weight: 800; }
+.bundleProposalsHead small { color: var(--text-secondary); font-size: 10px; line-height: 1.4; }
 .bundleProposalEmpty { margin-top: 7px; color: var(--text-tertiary); font-size: 10px; }
 .bundleProposalList { display: grid; gap: 5px; margin-top: 8px; }
-.bundleProposal { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px; border: 1px solid #d6dfef; border-radius: 8px; background: white; }
+.bundleProposal { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
 .bundleProposal > div { min-width: 0; }
 .bundleProposal strong, .bundleProposal small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .bundleProposal strong { color: var(--text-primary); font-size: 11px; }
 .bundleProposal small { margin-top: 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9px; }
-.bundleProposal em { display: block; margin-top: 4px; color: #475569; font-size: 9px; font-style: normal; line-height: 1.35; }
+.bundleProposal em { display: block; margin-top: 4px; color: var(--text-secondary); font-size: 9px; font-style: normal; line-height: 1.35; }
 .bundleProposal button { flex: 0 0 auto; padding: 6px 8px; font-size: 10px; }
 .compositionEmpty { margin-top: 9px; color: var(--text-tertiary); font-size: 10px; }
 .relationships { display: grid; gap: 5px; margin-top: 9px; }
-.relationship { display: flex; align-items: center; gap: 7px; min-width: 0; padding: 7px 8px; border: 1px solid #d6dfef; border-radius: 8px; background: rgba(255,255,255,.75); color: var(--text-secondary); font-size: 11px; }
+.relationship { display: flex; align-items: center; gap: 7px; min-width: 0; padding: 7px 8px; border: 1px solid var(--border); border-radius: 8px; background: color-mix(in srgb, var(--surface) 75%, transparent); color: var(--text-secondary); font-size: 11px; }
 .relationship > span:nth-child(2) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .removeRelationship { display: grid; width: 24px; height: 24px; margin-left: auto; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--text-tertiary); cursor: pointer; }
-.removeRelationship:hover { background: #fee2e2; color: var(--danger); }
-.guidedForm { margin-top: 10px; padding: 12px; border: 1px solid #d8d5ff; border-radius: 12px; background: linear-gradient(135deg, #fbfbff, #f3f8ff); }
-.guidedHead { display: grid; gap: 3px; color: #312e81; font-size: 12px; font-weight: 800; }
+.removeRelationship:hover { background: var(--danger-bg); color: var(--danger); }
+.guidedForm { margin-top: 10px; padding: 12px; border: 1px solid var(--accent-border); border-radius: 12px; background: linear-gradient(135deg, var(--surface), var(--surface-2)); }
+.guidedHead { display: grid; gap: 3px; color: var(--accent-text); font-size: 12px; font-weight: 800; }
 .guidedHead span { display: inline-flex; align-items: center; gap: 6px; }
-.guidedHead small { color: #5b5b86; font-size: 10px; font-weight: 500; line-height: 1.45; }
+.guidedHead small { color: var(--text-secondary); font-size: 10px; font-weight: 500; line-height: 1.45; }
 .fieldGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; margin-top: 11px; }
 .field { display: grid; gap: 4px; color: var(--text-secondary); font-size: 10px; font-weight: 800; letter-spacing: .03em; }
 .field b { color: var(--danger); }
@@ -96,11 +96,11 @@
 .expertDetails .editor { margin-top: 9px; }
 .editor { min-height: 320px; resize: vertical; font-family: var(--font-mono); font-size: 11px; line-height: 1.55; }
 .actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
-.approvalPanel { margin-top: 14px; padding: 13px; border: 1px solid #b9dfce; border-radius: 12px; background: linear-gradient(135deg, #f4fffa, #effcf7); }
-.approvalHead { display: flex; align-items: center; gap: 7px; color: #166534; font-size: 12px; font-weight: 800; }
-.approvalPanel p { margin: 6px 0 9px; color: #3f6655; font-size: 11px; line-height: 1.5; }
-.approvalMeta { display: flex; flex-wrap: wrap; gap: 6px 12px; margin-bottom: 9px; color: #47715d; font-size: 10px; }
-.approvalMeta b { color: #166534; }
+.approvalPanel { margin-top: 14px; padding: 13px; border: 1px solid var(--success-border); border-radius: 12px; background: linear-gradient(135deg, var(--success-bg), var(--surface-2)); }
+.approvalHead { display: flex; align-items: center; gap: 7px; color: var(--success-text); font-size: 12px; font-weight: 800; }
+.approvalPanel p { margin: 6px 0 9px; color: var(--text-secondary); font-size: 11px; line-height: 1.5; }
+.approvalMeta { display: flex; flex-wrap: wrap; gap: 6px 12px; margin-bottom: 9px; color: var(--text-secondary); font-size: 10px; }
+.approvalMeta b { color: var(--success-text); }
 .readiness { margin-bottom: 12px; padding: 11px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface-2); }
 .readinessHead { display: flex; align-items: center; gap: 7px; margin-bottom: 6px; color: var(--text-primary); font-size: 11px; font-weight: 800; }
 .readinessRow { display: grid; grid-template-columns: 16px 1fr auto; align-items: center; gap: 5px; padding: 4px 0; color: var(--text-secondary); font-size: 10px; }
@@ -111,14 +111,14 @@
 .insight { padding: 9px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-2); }
 .insight b { display: block; color: var(--text-primary); font-size: 16px; letter-spacing: -.03em; }
 .insight span { display: block; margin-top: 2px; color: var(--text-tertiary); font-size: 10px; }
-.aiPanel { margin-top: 14px; padding: 16px; border: 1px solid #d8d5ff; border-radius: 16px; background: linear-gradient(135deg, #f7f7ff 0%, #f0f9ff 100%); }
+.aiPanel { margin-top: 14px; padding: 16px; border: 1px solid var(--accent-border); border-radius: 16px; background: linear-gradient(135deg, var(--surface-2) 0%, var(--info-bg) 100%); }
 .aiHead { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
-.aiTitle { display: flex; align-items: center; gap: 7px; color: #312e81; font-size: 13px; font-weight: 800; }
-.aiCopy { margin-top: 4px; color: #5b5b86; font-size: 11px; line-height: 1.5; }
-.aiGuard { display: inline-flex; align-items: center; gap: 4px; padding: 4px 7px; border-radius: 999px; background: white; color: #4f46e5; font-size: 10px; font-weight: 800; white-space: nowrap; }
-.aiUnavailable { display: flex; gap: 7px; margin-top: 10px; padding: 9px; border: 1px solid #d7d8e8; border-radius: 9px; background: rgba(255, 255, 255, .72); color: #5b5b86; font-size: 10px; line-height: 1.45; }
-.aiUnavailable svg { flex: 0 0 auto; margin-top: 1px; color: #4f46e5; }
-.finding { margin-top: 9px; padding: 10px; border: 1px solid var(--border); border-left: 3px solid var(--info); border-radius: 9px; background: white; }
+.aiTitle { display: flex; align-items: center; gap: 7px; color: var(--accent-text); font-size: 13px; font-weight: 800; }
+.aiCopy { margin-top: 4px; color: var(--text-secondary); font-size: 11px; line-height: 1.5; }
+.aiGuard { display: inline-flex; align-items: center; gap: 4px; padding: 4px 7px; border-radius: 999px; background: var(--surface); color: var(--accent); font-size: 10px; font-weight: 800; white-space: nowrap; }
+.aiUnavailable { display: flex; gap: 7px; margin-top: 10px; padding: 9px; border: 1px solid var(--border); border-radius: 9px; background: color-mix(in srgb, var(--surface) 72%, transparent); color: var(--text-secondary); font-size: 10px; line-height: 1.45; }
+.aiUnavailable svg { flex: 0 0 auto; margin-top: 1px; color: var(--accent); }
+.finding { margin-top: 9px; padding: 10px; border: 1px solid var(--border); border-left: 3px solid var(--info); border-radius: 9px; background: var(--surface); }
 .findingHigh { border-left-color: var(--danger); }
 .findingWarning { border-left-color: var(--warning); }
 .findingTitle { display: flex; justify-content: space-between; gap: 8px; color: var(--text-primary); font-size: 11px; font-weight: 800; }
@@ -128,15 +128,15 @@
 .lowerGrid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 14px; margin-top: 14px; }
 .diffList { max-height: 178px; overflow: auto; margin: 10px 0 0; padding-left: 18px; color: var(--text-secondary); }
 .diffList li { margin: 4px 0; font-size: 11px; }
-.preview { display: flex; flex-direction: column; min-height: 100%; padding: 20px; border-radius: 15px; background: linear-gradient(145deg, #f8fafc, #eef2ff); }
-.previewContext { margin-bottom: 12px; padding: 11px; border: 1px solid #d9d8ee; border-radius: 11px; background: linear-gradient(135deg, #fbfbff, #f4f8ff); }
-.previewContextTitle { display: flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
-.previewContext p { margin: 5px 0 9px; color: #5b5b86; font-size: 10px; line-height: 1.45; }
+.preview { display: flex; flex-direction: column; min-height: 100%; padding: 20px; border-radius: 15px; background: linear-gradient(145deg, var(--surface-2), var(--accent-light)); }
+.previewContext { margin-bottom: 12px; padding: 11px; border: 1px solid var(--border); border-radius: 11px; background: linear-gradient(135deg, var(--surface), var(--surface-2)); }
+.previewContextTitle { display: flex; align-items: center; gap: 6px; color: var(--accent-text); font-size: 11px; font-weight: 800; }
+.previewContext p { margin: 5px 0 9px; color: var(--text-secondary); font-size: 10px; line-height: 1.45; }
 .previewContextGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
 .previewContextGrid label { display: grid; gap: 3px; color: var(--text-tertiary); font-size: 9px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
 .previewContextGrid input { min-width: 0; font-size: 11px; }
 .selectionList { display: grid; gap: 5px; margin-bottom: 12px; }
-.selection { display: grid; grid-template-columns: 28px 1fr auto; align-items: center; gap: 8px; width: 100%; padding: 9px; border: 1px solid #d6dfef; border-radius: 10px; background: white; color: var(--text-primary); cursor: pointer; text-align: left; }
+.selection { display: grid; grid-template-columns: 28px 1fr auto; align-items: center; gap: 8px; width: 100%; padding: 9px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); color: var(--text-primary); cursor: pointer; text-align: left; }
 .selection:hover, .selectionActive { border-color: var(--ob-accent-border); background: var(--ob-accent-light); }
 .selectionRank { display: grid; width: 23px; height: 23px; place-items: center; border-radius: 50%; background: var(--surface-2); color: var(--text-secondary); font-size: 10px; font-weight: 800; }
 .selectionCopy { min-width: 0; }
@@ -144,13 +144,13 @@
 .selectionCopy strong { font-size: 11px; }
 .selectionCopy small { margin-top: 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9px; }
 .explanation, .explanationHidden { margin-bottom: 12px; padding: 11px; border-radius: 11px; font-size: 10px; line-height: 1.5; }
-.explanation { border: 1px solid #b9dfce; background: linear-gradient(135deg, #f4fffa, #effcf7); color: #3f6655; }
-.explanationTitle { display: flex; align-items: center; gap: 6px; color: #166534; font-size: 11px; font-weight: 800; }
+.explanation { border: 1px solid var(--success-border); background: linear-gradient(135deg, var(--success-bg), var(--surface-2)); color: var(--text-secondary); }
+.explanationTitle { display: flex; align-items: center; gap: 6px; color: var(--success-text); font-size: 11px; font-weight: 800; }
 .explanation p { margin: 5px 0 8px; }
 .explanationTrace { display: flex; flex-wrap: wrap; gap: 4px; }
-.explanationTrace code { padding: 2px 5px; border-radius: 5px; background: rgba(255, 255, 255, .75); color: #166534; font-size: 9px; }
-.explanation small { display: block; margin-top: 8px; color: #47715d; }
-.explanationHidden { display: flex; gap: 6px; border: 1px solid #d7d8e8; background: var(--surface-2); color: var(--text-tertiary); }
+.explanationTrace code { padding: 2px 5px; border-radius: 5px; background: color-mix(in srgb, var(--surface) 75%, transparent); color: var(--success-text); font-size: 9px; }
+.explanation small { display: block; margin-top: 8px; color: var(--text-secondary); }
+.explanationHidden { display: flex; gap: 6px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-tertiary); }
 .explanationHidden svg { flex: 0 0 auto; margin-top: 1px; }
 .previewEyebrow { color: var(--ob-accent-text); font-size: 10px; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
 .previewName { margin-top: 8px; font-size: 22px; letter-spacing: -.035em; }

--- a/openbank-admin-ui/src/test/product-studio-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/product-studio-semantic-theme.guard.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const styles = readFileSync(join(process.cwd(), 'src/app/product-studio/page.module.css'), 'utf8')
+
+describe('Product Studio semantic theme contract', () => {
+  it('keeps page-local colour literals out of the authoring workflow', () => {
+    expect(styles).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+    expect(styles).not.toMatch(/rgba?\(/i)
+  })
+
+  it('uses shared surface, text, state and accent ownership', () => {
+    for (const token of ['surface', 'text-primary', 'text-secondary', 'border', 'accent', 'success', 'warning', 'danger', 'info']) {
+      expect(styles).toContain(`var(--${token}`)
+    }
+    expect(styles).toContain('color-mix(in srgb')
+  })
+
+  it('preserves truncation and pre-wrapped feedback behavior', () => {
+    expect(styles.match(/white-space: nowrap/g)).toHaveLength(4)
+    expect(styles).toContain('white-space: pre-wrap')
+  })
+})


### PR DESCRIPTION
## Summary

Makes Product Studio a coherent light/dark flagship workflow using the shared semantic design system. Authoring, composition, preview, validation, approval, degraded AI and lifecycle states retain their behavior while gaining consistent theme ownership and readable small-label contrast.

## Type of change

- [x] refactor (no behavior change)

## Linked issues

Closes #9583

## Changes

- replace all 63 local hex colours and fixed RGBA overlays with shared tokens and color-mix
- make hero, glass layers, authoring panels, previews, approval and AI states theme-aware
- raise 10px workflow labels from 3.86:1 to WCAG AA contrast
- add source regression guard and production-browser light/dark accessibility coverage

## Definition of Done

- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] No new lint warnings.
- [x] No API, database, event or dependency change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Product data, AI guardrails, maker-checker enforcement and RBAC are unchanged.

## Compliance impact

- [x] None

## Verification

- focused Vitest: 9/9
- TypeScript type-check
- focused ESLint: 0 errors/warnings
- Next.js production build: 97/97 routes
- Chromium production-server E2E: degraded backend, light + dark rendering and WCAG A/AA scan
- raw-colour debt: 1591 -> 1528 (-63)

## Rollout / Rollback

- Deployment strategy: rolling via existing Admin UI GitOps flow
- Rollback plan: revert the squash commit; no persisted state changes
- Data migration reversible: N/A

## Reviewer notes

Please verify the four-step authoring journey remains clear, validation/approval states remain distinct, and disabled AI remains visibly degraded rather than presented as successful.