### PR TITLE
refactor(admin-ui): unify compliance education theme

### DIFF
--- a/openbank-admin-ui/e2e/compliance-theme.spec.ts
+++ b/openbank-admin-ui/e2e/compliance-theme.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for details.
+
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test.describe('/docs/compliance — semantic theme', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${theme} theme keeps the report understandable and WCAG A/AA`, async ({ page }) => {
+      await page.goto('/docs/compliance')
+      await expect(page.getByRole('heading', { level: 1, name: /Compliance Report|Report compliance/i })).toBeVisible()
+
+      await page.evaluate(selectedTheme => {
+        document.documentElement.classList.toggle('dark', selectedTheme === 'dark')
+        document.documentElement.dataset.theme = selectedTheme
+      }, theme)
+      await page.waitForTimeout(300)
+
+      await expect(page.getByText('PSD2 / RTS on SCA').first()).toBeVisible()
+      await expect(page.getByText('GDPR', { exact: true }).first()).toBeVisible()
+      await expect(page.getByText(/Full regulatory compliance also requires legal documentation|Plná regulatorní compliance vyžaduje také právní dokumentaci/i)).toBeVisible()
+      await expect(page.getByText(/Compliant|V souladu/i).first()).toBeVisible()
+      await expect(page.getByText(/Warnings|Upozornění/i).first()).toBeVisible()
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze()
+      expect(results.violations).toEqual([])
+    })
+  }
+})

--- a/openbank-admin-ui/src/app/docs/compliance/page.tsx
+++ b/openbank-admin-ui/src/app/docs/compliance/page.tsx
@@ -121,15 +121,15 @@ const COMPLIANCE_AREAS: ComplianceArea[] = [
 ]
 
 const STATUS_CONFIG: Record<string, { label: Bilingual; color: string; bg: string; border: string; icon: React.ReactNode }> = {
-  compliant: { label: ['V souladu', 'Compliant'], color: '#16a34a', bg: '#f0fdf4', border: '#86efac', icon: <CheckCircle2 size={14} /> },
-  partial:   { label: ['Částečně', 'Partial'],    color: '#d97706', bg: '#fffbeb', border: '#fde68a', icon: <AlertTriangle size={14} /> },
-  gap:       { label: ['Mezera', 'Gap'],          color: '#dc2626', bg: '#fef2f2', border: '#fecaca', icon: <XCircle size={14} /> },
+  compliant: { label: ['V souladu', 'Compliant'], color: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)', icon: <CheckCircle2 size={14} /> },
+  partial:   { label: ['Částečně', 'Partial'],    color: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)', icon: <AlertTriangle size={14} /> },
+  gap:       { label: ['Mezera', 'Gap'],          color: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)', icon: <XCircle size={14} /> },
 }
 
 const ITEM_STATUS = {
-  ok:   { color: '#16a34a', icon: <CheckCircle2 size={12} /> },
-  warn: { color: '#d97706', icon: <AlertTriangle size={12} /> },
-  fail: { color: '#dc2626', icon: <XCircle size={12} /> },
+  ok:   { color: 'var(--success-text)', icon: <CheckCircle2 size={12} /> },
+  warn: { color: 'var(--warning-text)', icon: <AlertTriangle size={12} /> },
+  fail: { color: 'var(--danger-text)', icon: <XCircle size={12} /> },
 }
 
 export default function CompliancePage() {
@@ -155,19 +155,19 @@ export default function CompliancePage() {
       {/* Summary */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '12px', marginBottom: '24px' }}>
         {([
-          { id: 'compliant', label: ['V souladu', 'Compliant'] as Bilingual, value: okItems, total: totalItems, color: '#16a34a', bg: '#f0fdf4' },
-          { id: 'warnings', label: ['Upozornění', 'Warnings'] as Bilingual, value: warnItems, total: totalItems, color: '#d97706', bg: '#fffbeb' },
-          { id: 'coverage', label: ['Pokrytí', 'Coverage'] as Bilingual, value: `${Math.round(okItems/totalItems*100)}%`, total: null, color: '#2563eb', bg: '#eff6ff' },
-          { id: 'frameworks', label: ['Rámce', 'Frameworks'] as Bilingual, value: COMPLIANCE_AREAS.length, total: null, color: '#7c3aed', bg: '#faf5ff' },
+          { id: 'compliant', label: ['V souladu', 'Compliant'] as Bilingual, value: okItems, total: totalItems, color: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)' },
+          { id: 'warnings', label: ['Upozornění', 'Warnings'] as Bilingual, value: warnItems, total: totalItems, color: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)' },
+          { id: 'coverage', label: ['Pokrytí', 'Coverage'] as Bilingual, value: `${Math.round(okItems/totalItems*100)}%`, total: null, color: 'var(--info-text)', bg: 'var(--info-bg)', border: 'var(--info-border)' },
+          { id: 'frameworks', label: ['Rámce', 'Frameworks'] as Bilingual, value: COMPLIANCE_AREAS.length, total: null, color: 'var(--accent-text)', bg: 'var(--accent-bg)', border: 'var(--accent-border)' },
         ]).map(stat => (
           <div key={stat.id} style={{
-            padding: '16px', background: stat.bg, border: `1px solid ${stat.color}30`,
+            padding: '16px', background: stat.bg, border: `1px solid ${stat.border}`,
             borderRadius: 'var(--r-lg)',
           }}>
             <div style={{ fontSize: '24px', fontWeight: 700, color: stat.color }}>
-              {stat.value}{stat.total ? <span style={{ fontSize: '14px', opacity: 0.6 }}>/{stat.total}</span> : ''}
+              {stat.value}{stat.total ? <span style={{ fontSize: '14px' }}>/{stat.total}</span> : ''}
             </div>
-            <div style={{ fontSize: '12px', color: stat.color, opacity: 0.8, marginTop: '2px' }}>{t(...stat.label)}</div>
+            <div style={{ fontSize: '12px', color: stat.color, fontWeight: 600, marginTop: '2px' }}>{t(...stat.label)}</div>
           </div>
         ))}
       </div>
@@ -175,11 +175,11 @@ export default function CompliancePage() {
       {/* Disclaimer */}
       <div style={{
         padding: '12px 16px', marginBottom: '20px',
-        background: '#eff6ff', border: '1px solid #bfdbfe',
+        background: 'var(--info-bg)', border: '1px solid var(--info-border)',
         borderRadius: 'var(--r-lg)', display: 'flex', gap: '10px',
       }}>
-        <Info size={14} style={{ color: '#2563eb', flexShrink: 0, marginTop: '1px' }} />
-        <div style={{ fontSize: '12px', color: '#1e40af', lineHeight: 1.5 }}>
+        <Info size={14} style={{ color: 'var(--info-text)', flexShrink: 0, marginTop: '1px' }} />
+        <div style={{ fontSize: '12px', color: 'var(--text-primary)', lineHeight: 1.5 }}>
           {t('Tento report reflektuje technickou implementaci databázových schémat a API. Plná regulatorní compliance vyžaduje také právní dokumentaci, interní politiky, školení zaměstnanců a pravidelné audity. Doporučujeme konzultaci s regulatorním právníkem před podáním žádosti o bankovní licenci u ČNB.', 'This report reflects the technical implementation of database schemas and APIs. Full regulatory compliance also requires legal documentation, internal policies, staff training and regular audits. We recommend consulting a regulatory lawyer before applying for a banking licence with the CNB.')}
         </div>
       </div>

--- a/openbank-admin-ui/src/test/compliance-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/compliance-semantic-theme.guard.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/docs/compliance/page.tsx'), 'utf8')
+
+describe('compliance education semantic theme contract', () => {
+  it('uses shared semantic status tokens without fixed presentation colours', () => {
+    // Issue references such as "#2370" are content, not colour literals.
+    expect(page).not.toMatch(/['"]#[0-9a-f]{3,8}\b/i)
+    expect(page).not.toContain('rgba(')
+    for (const token of ['success', 'warning', 'danger', 'info', 'accent']) {
+      expect(page).toContain(`var(--${token}-text)`)
+      expect(page).toContain(`var(--${token}-bg)`)
+      expect(page).toContain(`var(--${token}-border)`)
+    }
+  })
+
+  it('preserves the regulatory education and technical disclaimer', () => {
+    for (const framework of ['PSD2 / RTS on SCA', 'AML / 5AMLD / 6AMLD', 'KYC / CDD / EDD', 'GDPR', 'EBA ICT Risk Guidelines', 'FATCA / CRS']) {
+      expect(page).toContain(framework)
+    }
+    expect(page).toContain('Full regulatory compliance also requires legal documentation')
+    expect(page).toContain('issue #2370')
+  })
+})


### PR DESCRIPTION
## Summary

- replace 23 fixed presentation colours with shared semantic status tokens on the compliance education page
- remove opacity-based status text that failed WCAG contrast while preserving regulatory meaning and technical disclaimers
- add source-level regression coverage and production-browser light/dark accessibility coverage

## Validation

- focused Vitest: 5/5 passed
- TypeScript: passed
- focused ESLint: passed
- production build: 97/97 routes
- Chromium production E2E: 2/2 passed (light + dark)
- axe WCAG A/AA: zero violations in both themes
- fixed colour literals on page: 23 -> 0

Closes #9597