### PR TITLE
refactor(admin-ui): unify data lineage theme

### DIFF
--- a/openbank-admin-ui/e2e/lineage-theme.spec.ts
+++ b/openbank-admin-ui/e2e/lineage-theme.spec.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const services = [
+  {
+    serviceName: 'account-service', dataDomain: 'core', dataLineageRole: 'producer',
+    lineage: {
+      downstream: [{ serviceName: 'ledger-service', relationType: 'api' }],
+      interfaces: { apis: ['/api/v1/accounts'], topics: ['account.events'], datastores: ['accounts'] },
+    },
+  },
+  {
+    serviceName: 'ledger-service', dataDomain: 'payments', dataLineageRole: 'consumer',
+    lineage: { upstream: [{ serviceName: 'account-service', relationType: 'api' }] },
+  },
+]
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test.describe('/docs/lineage — semantic theme', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${theme} theme preserves lineage meaning and WCAG A/AA`, async ({ page }) => {
+      await page.route('**/api/catalog/governance', route => route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ available: true, services }),
+      }))
+      await page.goto('/docs/lineage')
+      await expect(page.getByRole('heading', { level: 1, name: /Data Lineage Flow|Tok datové lineage/i })).toBeVisible()
+
+      await page.evaluate(selectedTheme => {
+        document.documentElement.classList.toggle('dark', selectedTheme === 'dark')
+        document.documentElement.dataset.theme = selectedTheme
+      }, theme)
+      await page.waitForTimeout(300)
+
+      await expect(page.getByText('account', { exact: true })).toBeVisible()
+      await page.getByText('account', { exact: true }).click()
+      await expect(page.getByText('producer', { exact: true })).toBeVisible()
+      await expect(page.getByText('API: /api/v1/accounts', { exact: true })).toBeVisible()
+      await expect(page.getByText('DB: accounts', { exact: true })).toBeVisible()
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze()
+      expect(results.violations).toEqual([])
+    })
+  }
+})

--- a/openbank-admin-ui/src/app/docs/lineage/page.tsx
+++ b/openbank-admin-ui/src/app/docs/lineage/page.tsx
@@ -8,7 +8,7 @@ import { Network, RefreshCw, Play, Pause, ArrowRight, ArrowLeft, BookOpen } from
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
+import { edgeGeometry, pathId } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
@@ -32,16 +32,16 @@ import {
 // ---------------------------------------------------------------------------
 
 const DOMAIN_META: Record<Domain, { color: string; cs: string; en: string }> = {
-  core:           { color: '#2563eb', cs: 'Jádro',         en: 'Core' },
-  payments:       { color: '#7c3aed', cs: 'Platby',        en: 'Payments' },
-  compliance:     { color: '#dc2626', cs: 'Compliance',    en: 'Compliance' },
-  identity:       { color: '#059669', cs: 'Identita',      en: 'Identity' },
-  'open-banking': { color: '#d97706', cs: 'Open Banking',  en: 'Open Banking' },
-  platform:       { color: '#6b7280', cs: 'Platforma',     en: 'Platform' },
+  core:           { color: 'var(--map-core)', cs: 'Jádro',         en: 'Core' },
+  payments:       { color: 'var(--map-payment)', cs: 'Platby',        en: 'Payments' },
+  compliance:     { color: 'var(--map-compliance)', cs: 'Compliance',    en: 'Compliance' },
+  identity:       { color: 'var(--map-identity)', cs: 'Identita',      en: 'Identity' },
+  'open-banking': { color: 'var(--map-psd2)', cs: 'Open Banking',  en: 'Open Banking' },
+  platform:       { color: 'var(--map-platform)', cs: 'Platforma',     en: 'Platform' },
 }
 const DOMAIN_ORDER: Domain[] = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
 
-const REL_COLOR: Record<Rel, string> = { api: '#2563eb', topic: '#8b5cf6', datastore: '#059669', unknown: '#94a3b8' }
+const REL_COLOR: Record<Rel, string> = { api: 'var(--map-core)', topic: 'var(--map-payment)', datastore: 'var(--map-identity)', unknown: 'var(--map-platform)' }
 const REL_DASHED: Record<Rel, boolean> = { api: false, topic: true, datastore: false, unknown: false }
 const relLabel = (r: Rel, t: (cs: string, en: string) => string) => ({ api: 'API', topic: t('téma', 'topic'), datastore: t('úložiště', 'datastore'), unknown: t('jiné', 'other') }[r])
 const roleLabel = (r: Role | null, t: (cs: string, en: string) => string) =>
@@ -191,8 +191,8 @@ export default function LineageFlowPage() {
                   style={{
                     padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
                     border: `1px solid ${domFilter === key ? 'var(--accent)' : 'var(--border)'}`,
-                    background: domFilter === key ? 'var(--accent)' : 'var(--surface)',
-                    color: domFilter === key ? '#fff' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
+                    color: domFilter === key ? 'var(--accent-text)' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
+                    background: domFilter === key ? 'var(--accent-bg)' : 'var(--surface)',
                   }}>
                   {key === 'all' ? t('Vše', 'All') : domLabel(key)}
                 </button>
@@ -206,8 +206,8 @@ export default function LineageFlowPage() {
                   style={{
                     padding: '4px 10px', fontSize: '11px', fontWeight: 600, borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
                     border: `1px solid ${relFilter === r ? (r === 'all' ? 'var(--accent)' : REL_COLOR[r as Rel]) : 'var(--border)'}`,
-                    background: relFilter === r ? (r === 'all' ? 'var(--accent)' : REL_COLOR[r as Rel]) : 'var(--surface)',
-                    color: relFilter === r ? '#fff' : 'var(--text-secondary)',
+                    background: relFilter === r ? `color-mix(in srgb, ${r === 'all' ? 'var(--accent)' : REL_COLOR[r as Rel]} 14%, var(--surface))` : 'var(--surface)',
+                    color: relFilter === r ? (r === 'all' ? 'var(--accent-text)' : REL_COLOR[r as Rel]) : 'var(--text-secondary)',
                   }}>
                   {r === 'all' ? t('Vše', 'All') : relLabel(r as Rel, t)}
                 </button>
@@ -219,7 +219,7 @@ export default function LineageFlowPage() {
                   display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
                   borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
                   border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
-                  background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+                  background: flow ? 'var(--accent-bg)' : 'var(--surface)', color: flow ? 'var(--accent-text)' : 'var(--text-secondary)',
                 }}>
                 {flow ? <Pause aria-hidden="true" size={13} /> : <Play aria-hidden="true" size={13} />}{t('Tok', 'Flow')}
               </button>
@@ -244,7 +244,7 @@ export default function LineageFlowPage() {
                 {LAYOUT.bands.map(b => (
                   <g key={b.key}>
                     <rect x={CANVAS_PAD - 12} y={b.y} width={WIDTH - (CANVAS_PAD - 12) * 2} height={b.h} rx="16"
-                      fill={`${DOMAIN_META[b.key].color}0a`} stroke={`${DOMAIN_META[b.key].color}33`} strokeWidth="1" />
+                      fill={`color-mix(in srgb, ${DOMAIN_META[b.key].color} 4%, transparent)`} stroke={`color-mix(in srgb, ${DOMAIN_META[b.key].color} 24%, var(--border))`} strokeWidth="1" />
                     <text x={CANVAS_PAD} y={b.y + 19} fontSize="11" fill={DOMAIN_META[b.key].color} fontWeight="700" letterSpacing="0.08em">
                       {domLabel(b.key).toUpperCase()} · {b.count}
                     </text>
@@ -262,7 +262,7 @@ export default function LineageFlowPage() {
                   const pid = pathId('ln', e.from, e.to, i)
                   return (
                     <g key={i} opacity={dim ? 0.08 : touches ? 1 : 0.42} style={{ transition: 'opacity 0.15s' }}>
-                      <path id={pid} d={d} fill="none" stroke={touches ? mixHex(color, '#000000', 0.15) : color}
+                      <path id={pid} d={d} fill="none" stroke={touches ? `color-mix(in srgb, ${color} 85%, var(--text-primary))` : color}
                         strokeWidth={touches ? 2 : 1.2} strokeDasharray={REL_DASHED[e.type] ? '5,4' : undefined}
                         markerEnd={`url(#ln-arrow-${e.type})`} />
                       {flow && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 6) * 0.24} begin={(i % 8) * 0.16} r={2.3} />}
@@ -283,9 +283,9 @@ export default function LineageFlowPage() {
                       onClick={() => setSelected(v => v === s.serviceName ? null : s.serviceName)}
                       onMouseEnter={() => setHovered(s.serviceName)} onMouseLeave={() => setHovered(h => h === s.serviceName ? null : h)}>
                       <rect x={x} y={y} width={p.w} height={PILL_H} rx={PILL_H / 2}
-                        fill={isSel ? color : 'var(--surface)'} stroke={color} strokeWidth={isSel ? 1.9 : 1.2} filter="url(#ln-shadow)" />
+                        fill={isSel ? `color-mix(in srgb, ${color} 16%, var(--surface))` : 'var(--surface)'} stroke={color} strokeWidth={isSel ? 1.9 : 1.2} filter="url(#ln-shadow)" />
                       <circle cx={x + 13} cy={p.cy} r={3.5} fill={color} />
-                      <text x={x + 23} y={p.cy + 4} fontSize="10.5" fontWeight="600" fill={isSel ? '#fff' : 'var(--text-primary)'}>{prettyName(s.serviceName)}</text>
+                      <text x={x + 23} y={p.cy + 4} fontSize="10.5" fontWeight="600" fill="var(--text-primary)">{prettyName(s.serviceName)}</text>
                     </g>
                   )
                 })}
@@ -309,7 +309,7 @@ export default function LineageFlowPage() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
                   <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: DOMAIN_META[domainOf(selectedSvc)].color }} />
                   <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{prettyName(selectedSvc.serviceName)}</div>
-                  <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: `${DOMAIN_META[domainOf(selectedSvc)].color}1a`, color: DOMAIN_META[domainOf(selectedSvc)].color }}>
+                  <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: `color-mix(in srgb, ${DOMAIN_META[domainOf(selectedSvc)].color} 12%, transparent)`, color: 'var(--text-primary)' }}>
                     {roleLabel(selectedSvc.dataLineageRole, t)}
                   </div>
                 </div>
@@ -321,9 +321,9 @@ export default function LineageFlowPage() {
                   <div>
                     <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '4px' }}>{t('ROZHRANÍ', 'INTERFACES')}</div>
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
-                      {(selectedSvc.lineage?.interfaces?.apis ?? []).map((a, i) => <span key={`a${i}`} style={{ fontSize: '10px', background: '#dbeafe', color: '#1e40af', padding: '2px 6px', borderRadius: '4px' }}>API: {a}</span>)}
-                      {(selectedSvc.lineage?.interfaces?.topics ?? []).map((tp, i) => <span key={`t${i}`} style={{ fontSize: '10px', background: '#f3e8ff', color: '#6b21a8', padding: '2px 6px', borderRadius: '4px' }}>{t('téma', 'topic')}: {tp}</span>)}
-                      {(selectedSvc.lineage?.interfaces?.datastores ?? []).map((ds, i) => <span key={`d${i}`} style={{ fontSize: '10px', background: '#dcfce7', color: '#166534', padding: '2px 6px', borderRadius: '4px' }}>DB: {ds}</span>)}
+                      {(selectedSvc.lineage?.interfaces?.apis ?? []).map((a, i) => <span key={`a${i}`} style={{ fontSize: '10px', background: 'var(--info-bg)', color: 'var(--info-text)', padding: '2px 6px', borderRadius: '4px' }}>API: {a}</span>)}
+                      {(selectedSvc.lineage?.interfaces?.topics ?? []).map((tp, i) => <span key={`t${i}`} style={{ fontSize: '10px', background: 'var(--accent-bg)', color: 'var(--accent-text)', padding: '2px 6px', borderRadius: '4px' }}>{t('téma', 'topic')}: {tp}</span>)}
+                      {(selectedSvc.lineage?.interfaces?.datastores ?? []).map((ds, i) => <span key={`d${i}`} style={{ fontSize: '10px', background: 'var(--success-bg)', color: 'var(--success-text)', padding: '2px 6px', borderRadius: '4px' }}>DB: {ds}</span>)}
                       {!(selectedSvc.lineage?.interfaces?.apis?.length || selectedSvc.lineage?.interfaces?.topics?.length || selectedSvc.lineage?.interfaces?.datastores?.length) && (
                         <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('žádná deklarovaná', 'none declared')}</span>
                       )}
@@ -366,8 +366,8 @@ export default function LineageFlowPage() {
                   <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('Propojení', 'Connections')}: {selectedEdges.length}</div>
                   <a href={`/services/${prettyName(selectedSvc.serviceName)}/docs`} style={{
                     display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', padding: '8px 12px',
-                    background: 'var(--accent-bg)', color: 'var(--accent)', borderRadius: 'var(--r-md)', fontSize: '12px',
-                    fontWeight: 600, textDecoration: 'none', marginTop: '4px', border: '1px solid var(--accent-border, transparent)',
+                    background: 'var(--accent-bg)', color: 'var(--accent-text)', borderRadius: 'var(--r-md)', fontSize: '12px',
+                    fontWeight: 600, textDecoration: 'none', marginTop: '4px', border: '1px solid var(--accent-border)',
                   }}>
                     <BookOpen size={14} /> {t('Dokumentace služby', 'Service documentation')}
                   </a>

--- a/openbank-admin-ui/src/test/lineage-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/lineage-semantic-theme.guard.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'src/app/docs/lineage/page.tsx'), 'utf8')
+
+describe('data lineage semantic theme guard', () => {
+  it('keeps domain, relationship, and interface colours on shared tokens', () => {
+    expect(source).not.toMatch(/["']#[0-9a-f]{3,8}\b/i)
+    expect(source).toContain('var(--map-core)')
+    expect(source).toContain('var(--map-payment)')
+    expect(source).toContain('var(--map-compliance)')
+    expect(source).toContain('var(--map-identity)')
+    expect(source).toContain('var(--info-bg)')
+    expect(source).toContain('var(--success-bg)')
+  })
+
+  it('uses token-safe colour mixing instead of appending alpha hex suffixes', () => {
+    expect(source).toContain('color-mix(in srgb,')
+    expect(source).not.toMatch(/\.color}\d[a-f0-9]/i)
+  })
+})


### PR DESCRIPTION
## Summary
- move lineage domains, relationships, selected nodes, and interface badges onto shared semantic theme tokens
- replace CSS-variable-incompatible alpha suffix composition with token-safe `color-mix()`
- preserve the verified-snapshot, authorization purge, filters, graph, and service-documentation behavior
- add focused theme guards and production-browser accessibility coverage

## Validation
- focused Vitest: 11/11
- TypeScript: passed
- focused ESLint: passed
- production Next.js build: 97/97 routes
- production Chromium Playwright: 2/2 (light + dark)
- axe WCAG A/AA: zero violations in both themes
- fixed colour literals in page: 21 -> 0

Closes #9609