### PR TITLE
refactor(admin-ui): unify QR-less readiness theme

### DIFF
--- a/openbank-admin-ui/e2e/qrlesspay-readiness-theme.spec.ts
+++ b/openbank-admin-ui/e2e/qrlesspay-readiness-theme.spec.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test.describe('/docs/qrlesspay-readiness — semantic theme', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${theme} theme preserves candid verdicts and WCAG A/AA`, async ({ page }) => {
+      await page.goto('/docs/qrlesspay-readiness')
+      await page.evaluate(selectedTheme => {
+        document.documentElement.classList.toggle('dark', selectedTheme === 'dark')
+        document.documentElement.dataset.theme = selectedTheme
+      }, theme)
+      await page.waitForTimeout(300)
+
+      await expect(page.getByRole('heading', { level: 1, name: /QRlessPay.*readiness assessment|QRlessPay.*posouzení připravenosti/i })).toBeVisible()
+      await expect(page.getByText(/self-assessment.*not an approval|sebehodnocení.*ne schválení/i)).toBeVisible()
+      await expect(page.getByText(/may change the design|může změnit návrh/i)).toBeVisible()
+      await expect(page.getByText(/not started|nezačato/i)).toBeVisible()
+      await expect(page.getByRole('heading', { name: /Recommended sequence|Doporučené pořadí/i })).toBeVisible()
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze()
+      expect(results.violations).toEqual([])
+    })
+  }
+})

--- a/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
@@ -9,7 +9,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 
-const ACCENT = '#6366f1'
+const ACCENT = 'var(--accent-text)'
 const INK = 'var(--text-primary)'
 const SUB = 'var(--text-secondary)'
 
@@ -17,10 +17,10 @@ type Bilingual = [string, string]
 type Verdict = 'pass' | 'conditional' | 'risk' | 'missing'
 
 const VERDICT_STYLE: Record<Verdict, { color: string; bg: string; border: string; cs: string; en: string }> = {
-  pass: { color: '#059669', bg: '#ecfdf5', border: '#6ee7b7', cs: 'projde', en: 'pass' },
-  conditional: { color: '#d97706', bg: '#fffbeb', border: '#fcd34d', cs: 'projde s podmínkami', en: 'pass with conditions' },
-  risk: { color: '#dc2626', bg: '#fef2f2', border: '#fecaca', cs: 'může změnit návrh', en: 'may change the design' },
-  missing: { color: '#64748b', bg: '#f8fafc', border: '#cbd5e1', cs: 'nezačato', en: 'not started' },
+  pass: { color: 'var(--success-text)', bg: 'var(--success-bg)', border: 'var(--success-border)', cs: 'projde', en: 'pass' },
+  conditional: { color: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)', cs: 'projde s podmínkami', en: 'pass with conditions' },
+  risk: { color: 'var(--danger-text)', bg: 'var(--danger-bg)', border: 'var(--danger-border)', cs: 'může změnit návrh', en: 'may change the design' },
+  missing: { color: 'var(--text-primary)', bg: 'var(--surface-3)', border: 'var(--border-strong)', cs: 'nezačato', en: 'not started' },
 }
 
 type Area = { id: string; Icon: React.ElementType; title: Bilingual; verdict: Verdict; summary: Bilingual; items: { label: Bilingual; note: Bilingual }[] }

--- a/openbank-admin-ui/src/test/qrlesspay-readiness-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/qrlesspay-readiness-semantic-theme.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'src/app/docs/qrlesspay-readiness/page.tsx'), 'utf8')
+
+describe('QR-less readiness semantic theme guard', () => {
+  it('uses shared verdict semantics instead of fixed presentation colours', () => {
+    expect(source).not.toMatch(/["']#[0-9a-f]{3,8}\b/i)
+    expect(source).not.toMatch(/rgba?\(\s*\d/i)
+    expect(source).toContain('var(--success-text)')
+    expect(source).toContain('var(--warning-text)')
+    expect(source).toContain('var(--danger-text)')
+    expect(source).toContain('var(--border-strong)')
+  })
+})


### PR DESCRIPTION
## Summary
- replace 13 fixed readiness verdict colours with shared semantic theme tokens
- preserve the candid self-assessment, recommended sequence, bilingual content, document links, and print support
- add a source guard and production light/dark browser accessibility coverage

## Verification
- focused Vitest: 4/4
- TypeScript type-check
- focused ESLint: zero warnings
- production build: 97/97 routes
- Chromium production E2E: 2/2 light and dark
- axe WCAG A/AA: zero violations

Closes #9620