### PR TITLE
fix(admin-ui): revert @vitest/coverage-v8 to ^4.1.11, matching the installed vitest major

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -65,7 +65,7 @@
         "@types/react-dom": "19.2.7",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^6.1.1",
-        "@vitest/coverage-v8": "^5.0.0",
+        "@vitest/coverage-v8": "^4.1.11",
         "autoprefixer": "10.5.4",
         "eslint": "9.39.5",
         "eslint-config-next": "16.3.4",
@@ -6369,27 +6369,29 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
-      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/istanbul-lib-coverage": "^1.0.0",
-        "@vitest/istanbul-lib-report": "^1.0.0",
-        "ast-v8-to-istanbul": "^1.0.5",
-        "magicast": "^0.5.4",
-        "obug": "^2.1.4",
-        "std-env": "^4.2.0",
-        "tinyrainbow": "^3.1.1"
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "5.0.0",
-        "vitest": "5.0.0"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -6413,29 +6415,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/istanbul-lib-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
-      "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@vitest/istanbul-lib-report": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
-      "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/istanbul-lib-coverage": "1.0.1"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@vitest/mocker": {
@@ -10331,6 +10310,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -11063,6 +11049,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -11791,6 +11816,35 @@
         "@babel/parser": "^7.29.7",
         "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {
@@ -13681,7 +13735,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -83,7 +83,7 @@
     "@types/react-dom": "19.2.7",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.1.1",
-    "@vitest/coverage-v8": "^5.0.0",
+    "@vitest/coverage-v8": "^4.1.11",
     "autoprefixer": "10.5.4",
     "eslint": "9.39.5",
     "eslint-config-next": "16.3.4",


### PR DESCRIPTION
## Summary

`npm ci` in `openbank-admin-ui` has been broken on `main` since #9002 merged — it bumped
`@vitest/coverage-v8` to `^5.0.0` alone, which peer-requires `vitest@5.0.0`, while
`vitest` itself is still pinned `^4.1.10`. `npm ci` (no `--legacy-peer-deps`) fails
ERESOLVE, breaking the required `Validate manifests` check (`governance-manifest` and
`mermaid-parses` both need it) for **every** open PR — including two unrelated ones
(#9071 gitops-only, #9112 Kotlin libs-runtime only) that showed the identical failure.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #9624

## Changes

- `openbank-admin-ui/package.json`: `@vitest/coverage-v8` `^5.0.0` → `^4.1.11` (the value
  before #9002).
- `openbank-admin-ui/package-lock.json`: regenerated (`npm install --package-lock-only`)
  to match.

## Why revert the coverage package instead of bumping `vitest` itself

Vitest 5 is its own migration, not a drop-in: the v5 release notes list breaking changes
(Node 22 / Vite 6.4 now required, `sequential` test option removed, deprecated entry
points removed). Doing that under a fleet-wide CI outage, same-day, untested, is a worse
trade than reverting the half of the bump that was never supposed to move alone.
`vitest` can still be bumped to v5 deliberately, later, as its own PR.

## Verification

```
rm -rf node_modules && npm ci
# was: npm error code ERESOLVE ...
# now: added 1058 packages, audited 1059 packages — clean

npm test -- --coverage
#  Test Files  512 passed (512)
#       Tests  2774 passed | 1 skipped (2775)
```

Coverage report generated successfully (confirms `@vitest/coverage-v8` itself loads and
runs, not just that install succeeds).

## Definition of Done

- [ ] Hexagonal layering preserved. — N/A, dependency pin only
- [ ] Unit tests added/updated. — N/A, no behavior changed
- [ ] Integration tests. — N/A
- [ ] Contract tests. — N/A
- [x] `./gradlew ...` — N/A, no Kotlin touched
- [x] No new lint warnings. — N/A (no lint surface touched)
- [ ] OpenAPI / Flyway / Avro — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`/equivalent.
- [ ] No new third-party dependency — this REMOVES a version bump rather than adding one;
  net effect is a downgrade to the previously-working pin, not a new dependency surface.
- [ ] Auth / crypto / payment — no.
- [ ] PII / cardholder data — no.

## Compliance impact

- [x] None — build tooling only.

## Rollout / Rollback

- Deployment strategy: merges into admin-ui's dev/test tooling only; no runtime image
  changes, no deploy.
- Rollback plan: revert the commit (re-applies #9002's original bump) — but that restores
  the ERESOLVE breakage, so only do that alongside a real `vitest@5` migration.
- Data migration reversible: N/A

## Reviewer notes

This is a same-day, narrow, well-evidenced revert of one unpaired half of a Dependabot
bump — not a judgment call about whether vitest 5 is the right target eventually, only
that it can't land as a silent side effect of a coverage-package bump alone. #9624 has
the full failure log and root-cause trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
