### PR TITLE
fix(admin-ui): make infrastructure topology theme adaptive

### DIFF
--- a/openbank-admin-ui/e2e/infrastructure-topology.spec.ts
+++ b/openbank-admin-ui/e2e/infrastructure-topology.spec.ts
@@ -2,6 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
 import { expect, test } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
 import { signInAsOperator } from './helpers/auth'
 
 const STATUS = {
@@ -46,3 +47,26 @@ test('filters the live infrastructure map and keeps a DOWN state semantically ex
   await refresh.click()
   await expect(refresh).toHaveAttribute('aria-busy', 'false')
 })
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`keeps the semantic topology legible and accessible in ${theme} mode`, async ({ page }) => {
+    await page.goto('/infrastructure/topology')
+    await page.locator('html').evaluate((element, selectedTheme) => {
+      element.classList.toggle('dark', selectedTheme === 'dark')
+    }, theme)
+
+    const topology = page.locator('main').getByRole('button', { name: 'ArgoCD' })
+    await expect(topology).toBeVisible()
+    await topology.click()
+
+    const details = page.getByRole('region', { name: 'Infrastructure component details' })
+    await expect(details).toBeVisible()
+    await expect(details.getByText('Platform / control plane')).toBeVisible()
+
+    const scan = await new AxeBuilder({ page })
+      .include('main')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+    expect(scan.violations).toEqual([])
+  })
+}

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -9,7 +9,7 @@ import {
   Cloud, GitBranch, Database, Eye, Server, X,
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
+import { edgeGeometry, pathId } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
@@ -40,11 +40,11 @@ type NodeDef = { id: string; group: GroupKey; label: string; descCs: string; des
 type EdgeDef = { from: string; to: string; type: EdgeType }
 
 // Group metadata — colour + bilingual label. Icons render in the detail panel (HTML).
-const GROUPS: Record<GroupKey, { color: string; cs: string; en: string; Icon: typeof Cloud }> = {
-  aws:           { color: '#f97316', cs: 'AWS substrát',            en: 'AWS substrate',        Icon: Cloud },
-  platform:      { color: '#7c3aed', cs: 'Platforma / control plane', en: 'Platform / control plane', Icon: GitBranch },
-  data:          { color: '#2563eb', cs: 'Data / backing služby',   en: 'Data / backing services', Icon: Database },
-  observability: { color: '#0d9488', cs: 'Observabilita',           en: 'Observability',         Icon: Eye },
+const GROUPS: Record<GroupKey, { color: string; textColor: string; cs: string; en: string; Icon: typeof Cloud }> = {
+  aws:           { color: 'var(--warning)', textColor: 'var(--warning-text)', cs: 'AWS substrát',            en: 'AWS substrate',        Icon: Cloud },
+  platform:      { color: 'var(--accent)', textColor: 'var(--accent-text)', cs: 'Platforma / control plane', en: 'Platform / control plane', Icon: GitBranch },
+  data:          { color: 'var(--info)', textColor: 'var(--info-text)', cs: 'Data / backing služby',   en: 'Data / backing services', Icon: Database },
+  observability: { color: 'var(--success)', textColor: 'var(--success-text)', cs: 'Observabilita',           en: 'Observability',         Icon: Eye },
 }
 const GROUP_ORDER: GroupKey[] = ['aws', 'platform', 'data', 'observability']
 
@@ -153,7 +153,8 @@ const EDGE_CAT: Record<EdgeType, EdgeCat> = {
   manages: 'data', uses: 'data', 'backs-up': 'data', secrets: 'data', pulls: 'data', routes: 'data', auth: 'data',
   scales: 'flow', scrapes: 'flow', queries: 'flow', alerts: 'flow', mesh: 'flow',
 }
-const CAT_COLOR: Record<EdgeCat, string> = { control: '#7c3aed', data: '#2563eb', flow: '#0d9488' }
+const CAT_COLOR: Record<EdgeCat, string> = { control: 'var(--accent)', data: 'var(--info)', flow: 'var(--success)' }
+const CAT_TEXT_COLOR: Record<EdgeCat, string> = { control: 'var(--accent-text)', data: 'var(--info-text)', flow: 'var(--success-text)' }
 const CAT_DASHED: Record<EdgeCat, boolean> = { control: false, data: false, flow: true }
 const edgeTypeLabel = (type: EdgeType, t: (cs: string, en: string) => string): string => ({
   deploys: t('nasazuje', 'deploys'), provisions: t('provisiony', 'provisions'), admits: t('admission', 'admits'),
@@ -216,7 +217,10 @@ export default function InfraTopologyPage() {
       setIsChecking(false)
     }
   }
-  useEffect(() => { load() }, [])
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0)
+    return () => window.clearTimeout(timer)
+  }, [])
 
   const nodeMap = Object.fromEntries(NODES.map(n => [n.id, n]))
   const activeNode = selected ?? hovered
@@ -257,9 +261,9 @@ export default function InfraTopologyPage() {
             <button key={key} type="button" onClick={() => setFilter(key)} aria-pressed={filter === key}
               style={{
                 padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
-                border: `1px solid ${filter === key ? 'var(--accent)' : 'var(--border)'}`,
-                background: filter === key ? 'var(--accent)' : 'var(--surface)',
-                color: filter === key ? '#fff' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
+                border: `1px solid ${filter === key ? 'var(--accent-text)' : 'var(--border)'}`,
+                background: filter === key ? 'var(--accent-text)' : 'var(--surface)',
+                color: filter === key ? 'var(--text-inverse)' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
               }}>
               {key === 'all' ? t('Vše', 'All') : groupLabel(key)}
             </button>
@@ -270,8 +274,8 @@ export default function InfraTopologyPage() {
             style={{
               display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
               borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
-              border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
-              background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+              border: `1px solid ${flow ? 'var(--accent-text)' : 'var(--border)'}`,
+              background: flow ? 'var(--accent-text)' : 'var(--surface)', color: flow ? 'var(--text-inverse)' : 'var(--text-secondary)',
             }}>
             {flow ? <Pause aria-hidden="true" size={13} /> : <Play aria-hidden="true" size={13} />}{t('Tok dat', 'Data flow')}
           </button>
@@ -299,8 +303,8 @@ export default function InfraTopologyPage() {
               return (
                 <g key={b.key}>
                   <rect x={CANVAS_PAD - 14} y={b.y} width={WIDTH - (CANVAS_PAD - 14) * 2} height={b.h} rx="16"
-                    fill={`${meta.color}0a`} stroke={`${meta.color}33`} strokeWidth="1" />
-                  <text x={CANVAS_PAD} y={b.y + 20} fontSize="11" fill={meta.color} fontWeight="700" letterSpacing="0.08em">
+                    fill={`color-mix(in srgb, ${meta.color} 4%, transparent)`} stroke={`color-mix(in srgb, ${meta.color} 20%, transparent)`} strokeWidth="1" />
+                  <text x={CANVAS_PAD} y={b.y + 20} fontSize="11" fill={meta.textColor} fontWeight="700" letterSpacing="0.08em">
                     {groupLabel(b.key).toUpperCase()}
                   </text>
                 </g>
@@ -319,7 +323,7 @@ export default function InfraTopologyPage() {
               const pid = pathId('ix', e.from, e.to, i)
               return (
                 <g key={i} opacity={dim ? 0.1 : touches ? 1 : 0.5} style={{ transition: 'opacity 0.15s' }}>
-                  <path id={pid} d={d} fill="none" stroke={touches ? mixHex(color, '#000000', 0.15) : color}
+                  <path id={pid} d={d} fill="none" stroke={touches ? `color-mix(in srgb, ${color} 85%, var(--text-primary))` : color}
                     strokeWidth={touches ? 2 : 1.3} strokeDasharray={CAT_DASHED[cat] ? '5,4' : undefined}
                     markerEnd={`url(#ix-arrow-${cat})`} />
                   {flow && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 5) * 0.26} begin={(i % 7) * 0.18} />}
@@ -329,8 +333,8 @@ export default function InfraTopologyPage() {
                     return (
                       <g>
                         <rect x={mx - lbl.length * 3.1 - 5} y={my - 9} width={lbl.length * 6.2 + 10} height="15" rx="7.5"
-                          fill="var(--surface)" stroke={`${color}55`} strokeWidth="0.75" opacity="0.97" />
-                        <text x={mx} y={my + 2} fontSize="9" fill={color} textAnchor="middle" fontWeight="600">{lbl}</text>
+                          fill="var(--surface)" stroke={`color-mix(in srgb, ${color} 34%, transparent)`} strokeWidth="0.75" opacity="0.97" />
+                        <text x={mx} y={my + 2} fontSize="9" fill={CAT_TEXT_COLOR[cat]} textAnchor="middle" fontWeight="600">{lbl}</text>
                       </g>
                     )
                   })()}
@@ -355,16 +359,16 @@ export default function InfraTopologyPage() {
                   onFocus={() => setHovered(n.id)}
                   onMouseEnter={() => setHovered(n.id)} onMouseLeave={() => setHovered(h => h === n.id ? null : h)}>
                   <rect x={x} y={y} width={p.w} height={PILL_H} rx={PILL_H / 2}
-                    fill={isSel ? meta.color : 'var(--surface)'} stroke={meta.color} strokeWidth={isSel ? 1.9 : 1.3}
+                    fill={isSel ? meta.textColor : 'var(--surface)'} stroke={meta.color} strokeWidth={isSel ? 1.9 : 1.3}
                     filter="url(#ix-shadow)" />
                   <circle cx={x + 15} cy={p.cy} r={4} fill={meta.color} />
-                  <text x={x + 26} y={p.cy + 4} fontSize="11" fontWeight="600" fill={isSel ? '#fff' : 'var(--text-primary)'}>{n.label}</text>
+                  <text x={x + 26} y={p.cy + 4} fontSize="11" fontWeight="600" fill={isSel ? 'var(--text-inverse)' : 'var(--text-primary)'}>{n.label}</text>
                   {st && (
                     <g transform={`translate(${x + p.w - 12}, ${y + 2})`}>
                       <circle cx="0" cy="0" r="6.5" fill={liveStatusFill(st)} stroke="var(--surface)" strokeWidth="1.5" />
-                      {st === 'UP' && <path d="M-2.5,0 L-0.8,1.8 L2.6,-2.2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />}
-                      {st === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" />}
-                      {st === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="#fff" textAnchor="middle" fontWeight="bold">?</text>}
+                      {st === 'UP' && <path d="M-2.5,0 L-0.8,1.8 L2.6,-2.2" fill="none" stroke="var(--text-inverse)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />}
+                      {st === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="var(--text-inverse)" strokeWidth="1.4" strokeLinecap="round" />}
+                      {st === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="var(--text-inverse)" textAnchor="middle" fontWeight="bold">?</text>}
                     </g>
                   )}
                 </g>
@@ -392,7 +396,7 @@ export default function InfraTopologyPage() {
         {selectedNode && (
           <div id="infra-topology-selection" className="card" role="region" aria-label={t('Detail infrastrukturní komponenty', 'Infrastructure component details')} style={{ padding: '20px', alignSelf: 'start' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
-              <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `${GROUPS[selectedNode.group].color}1a`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: GROUPS[selectedNode.group].color }}>
+              <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `color-mix(in srgb, ${GROUPS[selectedNode.group].color} 10%, transparent)`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: GROUPS[selectedNode.group].textColor }}>
                 {(() => { const I = GROUPS[selectedNode.group].Icon; return <I aria-hidden="true" size={16} /> })()}
               </div>
               <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{selectedNode.label}</div>
@@ -412,7 +416,7 @@ export default function InfraTopologyPage() {
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
               <div>
                 <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('VRSTVA', 'LAYER')}</div>
-                <div style={{ fontSize: '12px', color: GROUPS[selectedNode.group].color, fontWeight: 600 }}>{groupLabel(selectedNode.group)}</div>
+                <div style={{ fontSize: '12px', color: GROUPS[selectedNode.group].textColor, fontWeight: 600 }}>{groupLabel(selectedNode.group)}</div>
               </div>
               <div>
                 <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('POPIS', 'DESCRIPTION')}</div>
@@ -442,12 +446,13 @@ export default function InfraTopologyPage() {
                   {selectedEdges.map((e, i) => {
                     const out = e.from === selectedNode.id
                     const other = nodeMap[out ? e.to : e.from]
-                    const color = CAT_COLOR[EDGE_CAT[e.type]]
+                    const cat = EDGE_CAT[e.type]
+                    const color = CAT_COLOR[cat]
                     return (
                       <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
                         <span style={{ color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{out ? '→' : '←'}</span>
-                        <span style={{ color: GROUPS[other?.group ?? 'data'].color, fontWeight: 600 }}>{other?.label}</span>
-                        <span style={{ marginLeft: 'auto', fontSize: '10px', color, background: `${color}18`, padding: '2px 6px', borderRadius: '4px' }}>{edgeTypeLabel(e.type, t)}</span>
+                        <span style={{ color: GROUPS[other?.group ?? 'data'].textColor, fontWeight: 600 }}>{other?.label}</span>
+                        <span style={{ marginLeft: 'auto', fontSize: '10px', color: CAT_TEXT_COLOR[cat], background: `color-mix(in srgb, ${color} 9%, transparent)`, padding: '2px 6px', borderRadius: '4px' }}>{edgeTypeLabel(e.type, t)}</span>
                       </div>
                     )
                   })}

--- a/openbank-admin-ui/src/test/infrastructure-topology-semantic-theme.guard.test.ts
+++ b/openbank-admin-ui/src/test/infrastructure-topology-semantic-theme.guard.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/infrastructure/topology/page.tsx'), 'utf8')
+
+describe('infrastructure topology semantic theme contract', () => {
+  it('derives every architecture layer and edge category from adaptive theme tokens', () => {
+    expect(page).toContain("aws:           { color: 'var(--warning)', textColor: 'var(--warning-text)'")
+    expect(page).toContain("platform:      { color: 'var(--accent)', textColor: 'var(--accent-text)'")
+    expect(page).toContain("data:          { color: 'var(--info)', textColor: 'var(--info-text)'")
+    expect(page).toContain("observability: { color: 'var(--success)', textColor: 'var(--success-text)'")
+    expect(page).toContain("{ control: 'var(--accent)', data: 'var(--info)', flow: 'var(--success)' }")
+    expect(page).toContain("{ control: 'var(--accent-text)', data: 'var(--info-text)', flow: 'var(--success-text)' }")
+  })
+
+  it('uses token-safe color mixing and contains no fixed presentation colors', () => {
+    expect(page).toContain('color-mix(in srgb,')
+    expect(page).toContain("'var(--text-inverse)'")
+    expect(page).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+    expect(page).not.toMatch(/rgba?\(/i)
+    expect(page).not.toContain('mixHex')
+  })
+})


### PR DESCRIPTION
## Summary

Makes the interactive infrastructure topology consistently legible in both supported themes. Graphical strokes keep the shared semantic palette while every textual use now uses its contrast-safe semantic counterpart; the change also removes a synchronous initial effect update.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #9626

## Changes

- replace all 12 fixed presentation colours with adaptive semantic theme tokens and token-safe CSS colour mixing
- separate graphical and contrast-safe text variants for topology layers and edge categories
- add light/dark production-browser WCAG coverage and a source guard against fixed colours

## Definition of Done

- [x] Hexagonal layering preserved (UI-only change).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (production-browser UI journey).
- [x] Contract tests updated (no public API change).
- [x] Focused Vitest, type-check, zero-warning ESLint and production build pass.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A).
- [x] Flyway migration added + rollback note (N/A).
- [x] Avro schema versioned backward-compatibly (N/A).
- [x] Docs updated (no architecture change).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code unchanged.
- [x] PII path unchanged.
- [x] Cardholder data path unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling through the existing admin-ui GitOps release path
- Rollback plan: revert the squash commit and let the existing GitOps workflow roll back the image
- Data migration reversible: N/A

## Screenshots / demo

Production Chromium exercised the live-shaped topology journey in light and dark modes. Both themes have zero automated WCAG A/AA violations.

## Reviewer notes

Please verify that the layer/edge distinction remains clear while the text variants meet contrast in both themes. Topology data, probe status, filters, keyboard selection, RBAC and animation are unchanged.
