### PR TITLE
fix(admin-ui): distinguish agent failure states

### DIFF
--- a/openbank-admin-ui/e2e/system-agent-failure-truth.spec.ts
+++ b/openbank-admin-ui/e2e/system-agent-failure-truth.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+for (const scenario of [
+  { status: 401, title: 'Session expired' },
+  { status: 404, title: 'Agent-service (MCP) is not deployed in this environment' },
+  { status: 502, title: 'Agent-service (MCP) is not responding' },
+  { status: 500, title: 'Failed to load: MCP tools' },
+] as const) {
+  test(`explains an MCP ${scenario.status} without leaking the upstream response`, async ({ page }) => {
+    await page.route('**/api/agent/mcp', route => route.fulfill({
+      status: scenario.status,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: { code: 'PRIVATE_UPSTREAM_DETAIL', message: 'internal-host:8109 failed' } }),
+    }))
+
+    await page.goto('/system/agent')
+
+    await expect(page.getByText(scenario.title, { exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible()
+    await expect(page.getByText(/PRIVATE_UPSTREAM_DETAIL|internal-host/)).toHaveCount(0)
+  })
+}
+
+test('recovers in place when retry reaches the MCP server', async ({ page }) => {
+  let requests = 0
+  await page.route('**/api/agent/mcp', async route => {
+    requests += 1
+    if (requests === 1) {
+      await route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'unreachable' }) })
+      return
+    }
+    const request = route.request().postDataJSON() as { method: string }
+    const result = request.method === 'initialize'
+      ? { serverInfo: { name: 'openbank-agent-service', version: '1.0.0' }, protocolVersion: '2024-11-05' }
+      : { tools: [] }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ jsonrpc: '2.0', id: 1, result }) })
+  })
+  await page.route('**/api/agent/chat', route => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }))
+
+  await page.goto('/system/agent')
+  await expect(page.getByText('Agent-service (MCP) is not responding', { exact: true })).toBeVisible()
+  await page.getByRole('button', { name: 'Try again' }).click()
+
+  await expect(page.getByText('openbank-agent-service', { exact: true })).toBeVisible()
+  await expect(page.getByText('0 tools available', { exact: true })).toBeVisible()
+})
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`keeps the explained failure accessible in ${theme} mode`, async ({ page }) => {
+    await page.route('**/api/agent/mcp', route => route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'unreachable' }),
+    }))
+    await page.goto('/system/agent')
+    await page.locator('html').evaluate((element, selectedTheme) => {
+      element.classList.toggle('dark', selectedTheme === 'dark')
+    }, theme)
+    await expect(page.getByText('Agent-service (MCP) is not responding', { exact: true })).toBeVisible()
+    await page.waitForTimeout(450)
+
+    const scan = await new AxeBuilder({ page })
+      .include('main')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+    expect(scan.violations).toEqual([])
+  })
+}

--- a/openbank-admin-ui/src/app/system/agent/page.tsx
+++ b/openbank-admin-ui/src/app/system/agent/page.tsx
@@ -10,7 +10,9 @@ import { cn } from '@/lib/utils'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { StatusBadge } from '@/components/ui/StatusBadge'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
+import { AgentCallError, classifyAgentFailure, type AgentFailureKind } from '@/lib/agent/mcpFailure'
 
 interface ToolDef {
   name: string
@@ -34,47 +36,56 @@ interface ToolResult {
 interface ModelInfo { id: string; provider: string; sensitivity: string }
 interface ModelGateway { default: string; models: ModelInfo[] }
 
-async function mcpCall(method: string, params?: unknown) {
-  const res = await fetch('/api/agent/mcp', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
-  })
-  const json = await res.json()
-  if (json.error) throw new Error(`${json.error.code}: ${json.error.message}`)
-  return json.result
+async function mcpCall<T>(method: string, params?: unknown): Promise<T> {
+  let res: Response
+  try {
+    res = await fetch('/api/agent/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    })
+  } catch {
+    throw new AgentCallError('unreachable')
+  }
+  const json = await res.json().catch(() => null) as { error?: unknown; result?: T } | null
+  if (!res.ok) throw new AgentCallError(classifyAgentFailure(res.status))
+  if (!json || json.error) throw new AgentCallError('error')
+  return json.result as T
 }
 
 export default function AgentPage() {
   const { t, language } = useLanguage()
   const [tools, setTools]           = useState<ToolDef[]>([])
   const [loading, setLoading]       = useState(true)
-  const [error, setError]           = useState<string | null>(null)
+  const [failure, setFailure]       = useState<AgentFailureKind | null>(null)
   const [expanded, setExpanded]     = useState<string | null>(null)
   const [serverInfo, setServerInfo] = useState<{ name: string; version: string; protocolVersion: string } | null>(null)
   const [gateway, setGateway]       = useState<ModelGateway | null>(null)
 
   const loadTools = useCallback(async () => {
-    setLoading(true); setError(null)
+    setLoading(true); setFailure(null)
     try {
-      const init = await mcpCall('initialize', {
+      const init = await mcpCall<{ serverInfo: { name: string; version: string }; protocolVersion: string }>('initialize', {
         protocolVersion: '2024-11-05',
         clientInfo: { name: 'openbank-admin-ui', version: '0.1.0' },
         capabilities: {},
       })
       setServerInfo({ name: init.serverInfo.name, version: init.serverInfo.version, protocolVersion: init.protocolVersion })
-      const list = await mcpCall('tools/list')
+      const list = await mcpCall<{ tools?: ToolDef[] }>('tools/list')
       setTools(list.tools ?? [])
       try {
         const gw = await fetch('/api/agent/chat').then(r => r.json())
         if (!gw.error) setGateway({ default: gw.default, models: gw.models ?? [] })
       } catch { /* gateway is best-effort; tools still render */ }
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to connect to agent-service')
+      setFailure(e instanceof AgentCallError ? e.kind : 'error')
     } finally { setLoading(false) }
   }, [])
 
-  useEffect(() => { loadTools() }, [loadTools])
+  useEffect(() => {
+    const timer = window.setTimeout(() => void loadTools(), 0)
+    return () => window.clearTimeout(timer)
+  }, [loadTools])
 
   return <AuthGuard permission="agent:view">
     <div>
@@ -111,9 +122,9 @@ export default function AgentPage() {
               border: '1px solid var(--accent-border)',
               borderRadius: '6px',
             }}>
-              <span style={{ fontSize: '11px', color: 'var(--accent)', opacity: 0.7 }}>{c.label}:</span>
+              <span style={{ fontSize: '11px', color: 'var(--accent-text)', opacity: 0.85 }}>{c.label}:</span>
               <span style={{
-                fontSize: '12px', fontWeight: 600, color: 'var(--accent)',
+                fontSize: '12px', fontWeight: 600, color: 'var(--accent-text)',
                 fontFamily: c.mono ? 'JetBrains Mono, monospace' : 'inherit',
               }}>{c.value}</span>
             </div>
@@ -122,7 +133,7 @@ export default function AgentPage() {
       )}
 
       {/* Model gateway — provider-agnostic registry (ADR-0031 D6) */}
-      {!loading && !error && gateway && (
+      {!loading && !failure && gateway && (
         <div style={{ marginBottom: '30px' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
             <Cpu size={14} style={{ color: 'var(--accent)' }} />
@@ -135,7 +146,7 @@ export default function AgentPage() {
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)', fontFamily: 'JetBrains Mono, monospace' }}>{m.id}</span>
                   {m.id === gateway.default && (
-                    <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', textTransform: 'uppercase', background: 'var(--accent-light)', color: 'var(--accent)', border: '1px solid var(--accent-border)' }}>{t('výchozí', 'default')}</span>
+                    <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', textTransform: 'uppercase', background: 'var(--accent-light)', color: 'var(--accent-text)', border: '1px solid var(--accent-border)' }}>{t('výchozí', 'default')}</span>
                   )}
                 </div>
                 <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
@@ -148,35 +159,34 @@ export default function AgentPage() {
         </div>
       )}
 
-      {/* Unavailable state — agent-service is part of the planned fleet and is
-          not deployed in every environment, so a connect failure is "not
-          deployed", not an app fault. Render the calm shared panel rather than
-          a raw JSON-RPC error string. */}
-      {error && (
+      {/* Keep operational truth explicit: only a 404 means the endpoint is not
+          deployed. Authentication, reachability and unexpected failures have
+          distinct safe copy without exposing upstream or JSON-RPC details. */}
+      {failure && (
         <div className="card" style={{ padding: 0, marginBottom: '20px' }}>
           <DataUnavailable
-            kind="not_deployed"
+            kind={failure}
             service={t('Agent-service (MCP)', 'Agent-service (MCP)')}
             feature={t('MCP nástroje', 'MCP tools')}
             lang={language}
-            detail={
-              language === 'cs'
-                ? 'Tato obrazovka vyžaduje běžící agent-service (MCP server na portu 8109). V tomto prostředí zatím nasazená není — jakmile ji ArgoCD nasadí, nástroje i model gateway se načtou automaticky.'
-                : 'This screen needs a running agent-service (MCP server on port 8109). It isn’t deployed here yet — once ArgoCD rolls it out, the tools and model gateway load automatically.'
-            }
-          />
+          >
+            <button type="button" className="btn btn-secondary" onClick={loadTools} disabled={loading}>
+              <RefreshCw size={13} aria-hidden="true" />
+              {t('Zkusit znovu', 'Try again')}
+            </button>
+          </DataUnavailable>
         </div>
       )}
 
       {/* Loading */}
-      {loading && !error && (
+      {loading && !failure && (
         <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px' }}>
           <RefreshCw size={15} aria-hidden="true" className="animate-spin" style={{ color: 'var(--accent)' }} />
           {t('Připojování k MCP serveru…', 'Connecting to MCP server…')}
         </div>
       )}
 
-      {!loading && !error && (
+      {!loading && !failure && (
         <div style={{ marginBottom: '30px' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
             <Server size={14} style={{ color: 'var(--accent)' }} />
@@ -213,7 +223,7 @@ export default function AgentPage() {
                     </div>
                     <span style={{
                       fontSize: '10px', fontWeight: 600, padding: '3px 6px', borderRadius: '4px', textTransform: 'uppercase',
-                      background: 'var(--success-bg)', color: 'var(--success)', border: '1px solid var(--success-border)'
+                      background: 'var(--success-bg)', color: 'var(--success-text)', border: '1px solid var(--success-border)'
                     }}>
                       {t('Dostupné', 'Available')}
                     </span>
@@ -232,7 +242,7 @@ export default function AgentPage() {
       )}
 
       {/* Tools list */}
-      {!loading && !error && (
+      {!loading && !failure && (
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
             <Zap size={13} style={{ color: 'var(--accent)' }} />
@@ -267,40 +277,43 @@ export default function AgentPage() {
             {
               nameCs: 'OpenBank Agent Service',
               nameEn: 'OpenBank Agent Service',
-              isLive: true,
-              descCs: 'Primární MCP server — vystavuje banking nástroje (účty, platby, party, audit, sca) AI agentům. JSON-RPC 2.0 přes HTTP, OPA gate na každém tool callu (ADR-0031). Dostupný na portu 8109 v namespace platform.',
-              descEn: 'Primary MCP server — exposes banking tools (accounts, payments, party, audit, sca) to AI agents. JSON-RPC 2.0 over HTTP, OPA gate on every tool call (ADR-0031). Available on port 8109 in the platform namespace.',
+              status: serverInfo && !failure ? 'UP' : failure === 'not_deployed' ? 'NOT-DEPLOYED' : failure ? 'DEGRADED' : 'UNKNOWN',
+              statusCs: serverInfo && !failure ? 'Dostupný' : failure === 'not_deployed' ? 'Nenasazený' : failure ? 'Nedostupný' : 'Ověřuji',
+              statusEn: serverInfo && !failure ? 'Available' : failure === 'not_deployed' ? 'Not deployed' : failure ? 'Unavailable' : 'Checking',
+              tone: undefined,
+              descCs: 'Primární MCP server — vystavuje banking nástroje (účty, platby, party, audit, sca) AI agentům. JSON-RPC 2.0 přes HTTP, OPA gate na každém tool callu (ADR-0031). Po nasazení je cílový endpoint na portu 8109 v namespace platform.',
+              descEn: 'Primary MCP server — exposes banking tools (accounts, payments, party, audit, sca) to AI agents. JSON-RPC 2.0 over HTTP, OPA gate on every tool call (ADR-0031). When deployed, its target endpoint is port 8109 in the platform namespace.',
               endpoint: 'platform.svc:8109/mcp',
               adr: 'ADR-0031',
-              color: '#6366f1',
+              color: 'var(--accent)',
+              textColor: 'var(--accent-text)',
             },
             {
               nameCs: 'Grafana MCP Server',
               nameEn: 'Grafana MCP Server',
-              isLive: true,
+              status: 'INTEGRATED',
+              statusCs: 'Integrováno',
+              statusEn: 'Integrated',
+              tone: 'info' as const,
               descCs: 'Grafana Labs open-source MCP server (grafana/mcp-grafana) zpřístupňuje dashboardy, datasources, alerting a Prometheus query AI agentům. Umožňuje AI copilotovi klást přirozené dotazy jako „jaká je latence SEPA plateb za poslední hodinu?" přímo do Prometheus. Běží v observability namespace, připojuje se k Grafana na portu 3000.',
               descEn: 'Grafana Labs open-source MCP server (grafana/mcp-grafana) exposes dashboards, datasources, alerting and Prometheus query to AI agents. Lets an AI copilot ask natural questions like "what is the SEPA payment latency over the last hour?" directly into Prometheus. Running in the observability namespace, connected to Grafana on port 3000.',
               endpoint: 'observability.svc:3000 → MCP',
               adr: 'ADR-0088',
-              color: '#f59e0b',
+              color: 'var(--info)',
+              textColor: 'var(--info-text)',
             },
           ] as const).map((srv) => (
             <div key={srv.nameCs} className="card" style={{ padding: '16px', borderLeft: `3px solid ${srv.color}` }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8, gap: 8 }}>
                 <span style={{ fontSize: '13.5px', fontWeight: 700, color: 'var(--text-primary)' }}>{t(srv.nameCs, srv.nameEn)}</span>
-                <span style={{
-                  fontSize: '10px', fontWeight: 700, textTransform: 'uppercase', padding: '2px 8px', borderRadius: 20,
-                  color: '#059669', background: '#ecfdf5', border: '1px solid #6ee7b7', flexShrink: 0,
-                }}>
-                  {t('Live', 'Live')}
-                </span>
+                <StatusBadge status={srv.status} tone={srv.tone} label={t(srv.statusCs, srv.statusEn)} />
               </div>
               <p style={{ fontSize: '12.5px', color: 'var(--text-secondary)', lineHeight: 1.6, margin: '0 0 10px' }}>
                 {t(srv.descCs, srv.descEn)}
               </p>
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <span style={{ fontSize: '11px', fontFamily: 'JetBrains Mono, monospace', color: 'var(--text-secondary)', background: 'var(--surface-2)', border: '1px solid var(--border)', padding: '2px 8px', borderRadius: 5 }}>{srv.endpoint}</span>
-                <span style={{ fontSize: '11px', fontWeight: 600, color: srv.color, background: `${srv.color}15`, border: `1px solid ${srv.color}40`, padding: '2px 8px', borderRadius: 5 }}>{srv.adr}</span>
+                <span style={{ fontSize: '11px', fontWeight: 600, color: srv.textColor, background: `color-mix(in srgb, ${srv.color} 8%, transparent)`, border: `1px solid color-mix(in srgb, ${srv.color} 25%, transparent)`, padding: '2px 8px', borderRadius: 5 }}>{srv.adr}</span>
               </div>
             </div>
           ))}
@@ -323,7 +336,7 @@ function ToolCard({ tool, expanded, onToggle }: { tool: ToolDef; expanded: boole
   const run = async () => {
     setRunning(true); setResult(null)
     try {
-      const res: ToolResult = await mcpCall('tools/call', { name: tool.name, arguments: args })
+      const res = await mcpCall<ToolResult>('tools/call', { name: tool.name, arguments: args })
       setResult(res)
     } catch (e) {
       setResult({ content: [{ type: 'text', text: e instanceof Error ? e.message : 'Error' }], isError: true })
@@ -428,13 +441,13 @@ function ToolCard({ tool, expanded, onToggle }: { tool: ToolDef; expanded: boole
                 padding: '8px 12px',
                 borderBottom: `1px solid ${result.isError ? 'var(--danger-border)' : 'var(--success-border)'}`,
                 display: 'flex', alignItems: 'center', gap: '7px',
-                background: result.isError ? '#fef2f2' : '#f0fdf4',
+                background: result.isError ? 'var(--danger-bg)' : 'var(--success-bg)',
               }}>
                 {result.isError
                   ? <XCircle size={13} style={{ color: 'var(--danger)' }}/>
                   : <CheckCircle2 size={13} style={{ color: 'var(--success)' }}/>
                 }
-                <span style={{ fontSize: '12px', fontWeight: 600, color: result.isError ? 'var(--danger)' : 'var(--success)' }}>
+                <span style={{ fontSize: '12px', fontWeight: 600, color: result.isError ? 'var(--danger-text)' : 'var(--success-text)' }}>
                   {result.isError ? t('Chyba', 'Error') : t('Výsledek', 'Result')}
                 </span>
               </div>

--- a/openbank-admin-ui/src/lib/agent/mcpFailure.ts
+++ b/openbank-admin-ui/src/lib/agent/mcpFailure.ts
@@ -1,0 +1,17 @@
+import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
+
+export type AgentFailureKind = Extract<UnavailableKind, 'not_deployed' | 'unreachable' | 'unauthorized' | 'error'>
+
+export class AgentCallError extends Error {
+  constructor(readonly kind: AgentFailureKind) {
+    super('Agent request failed')
+    this.name = 'AgentCallError'
+  }
+}
+
+export function classifyAgentFailure(status: number): AgentFailureKind {
+  if (status === 401 || status === 403) return 'unauthorized'
+  if (status === 404) return 'not_deployed'
+  if (status === 408 || status === 502 || status === 503 || status === 504) return 'unreachable'
+  return 'error'
+}

--- a/openbank-admin-ui/src/test/system-agent-failure-classification.test.ts
+++ b/openbank-admin-ui/src/test/system-agent-failure-classification.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { AgentCallError, classifyAgentFailure } from '@/lib/agent/mcpFailure'
+
+describe('agent failure classification', () => {
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'unauthorized'],
+    [404, 'not_deployed'],
+    [408, 'unreachable'],
+    [502, 'unreachable'],
+    [503, 'unreachable'],
+    [504, 'unreachable'],
+    [400, 'error'],
+    [409, 'error'],
+    [500, 'error'],
+  ] as const)('maps HTTP %i to %s', (status, expected) => {
+    expect(classifyAgentFailure(status)).toBe(expected)
+  })
+
+  it('keeps the public error generic and carries only the safe UI classification', () => {
+    const failure = new AgentCallError('unreachable')
+    expect(failure.kind).toBe('unreachable')
+    expect(failure.message).toBe('Agent request failed')
+  })
+})

--- a/openbank-admin-ui/src/test/system-agent-tools-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-agent-tools-a11y.guard.test.ts
@@ -15,4 +15,15 @@ describe('system agent tool cards accessibility', () => {
     expect(source).toContain('<Play size={13} aria-hidden="true"')
     expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
   })
+
+  it('renders a safe, classified failure state instead of claiming every failure is undeployed', () => {
+    const source = read()
+    expect(source).toContain("setFailure(e instanceof AgentCallError ? e.kind : 'error')")
+    expect(source).toContain('kind={failure}')
+    expect(source).toContain("{t('Zkusit znovu', 'Try again')}")
+    expect(source).not.toContain('kind="not_deployed"')
+    expect(source).not.toContain('setError(')
+    expect(source).not.toContain('setFailure(e instanceof Error ? e.message')
+    expect(source).not.toMatch(/#[0-9a-f]{6}\b/i)
+  })
 })


### PR DESCRIPTION
## Summary

Makes the Agent Service console tell operators what is actually known. Only an MCP 404 is presented as not deployed; authorization, reachability and unexpected failures now use distinct shared states without exposing upstream details, and the operator can recover in place.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #9628

## Changes

- introduce a small typed MCP failure classifier for safe UI states
- replace raw error retention and the universal “not deployed” claim with truthful shared feedback and retry
- derive the OpenBank MCP registry badge from observed runtime state and label unprobed Grafana MCP as integrated rather than live
- remove fixed page colours and use contrast-safe theme/status tokens
- add unit/guard coverage plus production Chromium scenarios for every failure class, recovery, and light/dark WCAG

## Definition of Done

- [x] Hexagonal layering preserved (UI-only typed boundary helper).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated.
- [x] Contract tests updated (no public API change).
- [x] Focused tests, type-check, zero-warning lint and production build pass.
- [x] No new lint warnings.
- [x] OpenAPI/Flyway/Avro changes are N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] Upstream and JSON-RPC error details are not rendered in the main console.
- [x] No new suppressions, unsafe casts, or third-party dependencies.
- [x] Existing auth/RBAC and MCP request behavior are preserved.
- [x] PII and cardholder-data paths are unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling via the existing admin-ui GitOps release path
- Rollback plan: revert the squash commit and allow GitOps to roll back the image
- Data migration reversible: N/A

## Screenshots / demo

Production Chromium: 7/7 scenarios passed (401, 404, 502, 500, in-place recovery, light WCAG, dark WCAG).

## Reviewer notes

Please focus on the status mapping and verify that no branch weakens `agent:view` / `agent:execute` enforcement. A network exception is intentionally `unreachable`; malformed success/JSON-RPC errors are `error`; no upstream string reaches the primary page state.
