### PR TITLE
ci(fleet): double service build parallelism

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -371,13 +371,14 @@ jobs:
       # is the event that changed. It is NOT stale for `contract`, which is still self-hosted
       # and still bounded by the same ARC pool (12 runners, Phase 1, #4319) — max-parallel is
       # a single number governing the WHOLE matrix, so it bounds both jobs' concurrency at
-      # once, and 4 stays comfortably under both the 20-job hosted cap (leaving headroom for
-      # other concurrent CI in the account) and the 12-runner ARC pool.
+      # once. Eight stays below both the 20-job hosted cap (leaving 12 slots for other CI)
+      # and the 12-runner ARC pool (leaving four slots for targeted verification/deploy work).
       #
-      # The number itself is UNCHANGED from before this split (kept conservative rather than
-      # re-tuned on an unmeasured guess) — raising it is a candidate follow-up once real
-      # dispatch data exists for the new hosted-build shape, not asserted here.
-      max-parallel: 4
+      # Measured on successful full-fleet run 34476896912 after the hosted-build split:
+      # 50 build jobs, median 7.8 min, P90 10.4 min, 381 runner-minutes. Four lanes impose
+      # a ~95 min work floor before queueing; eight cut that floor to ~48 min without
+      # saturating either pool. Re-measure before raising it again.
+      max-parallel: 8
       matrix:
         service: ${{ fromJSON(needs.changes.outputs.services) }}
     uses: ./.github/workflows/_service-ci.yml


### PR DESCRIPTION
## What

Raise the Services CI matrix cap from 4 to 8. Successful full-fleet run 34476896912 measured 50 build jobs, 7.8 minute median, 10.4 minute P90, and 381 runner-minutes: four lanes impose an approximately 95 minute work floor, while eight reduce it to approximately 48 minutes.

Eight lanes remain below both hard capacities: 20 account-wide GitHub-hosted jobs and 12 ARC contract runners. This leaves 12 hosted slots and four ARC slots for unrelated CI and targeted verification.

## Validation

- `actionlint -ignore SC2001 -ignore SC2086 .github/workflows/services-ci.yml`
- `python3 .github/scripts/check-ruleset-context-parity.py --self-test`
- signed commit

Refs #2039
