### PR TITLE
ci(fleet): remove security reporting false reds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,29 +725,3 @@ jobs:
   # `edited` pull_request event (PR-body fixes re-evaluate the check) without
   # re-running this whole workflow on every description edit.
   # ---------------------------------------------------------------------------
-
-  # ---------------------------------------------------------------------------
-  # Dependency review — fails a PR that introduces a known-vulnerable dependency.
-  # Requires the Dependency Graph + GitHub Advanced Security, which on a PRIVATE
-  # repo is a paid GHAS add-on (not bundled with Free or Pro). The job therefore
-  # auto-skips while the repo is private and activates the moment it goes public
-  # (where GHAS is free). Until then, Trivy fs scan + Dependabot cover vulnerable
-  # dependency detection.
-  # ---------------------------------------------------------------------------
-  dependency-review:
-    name: Dependency review
-    if: github.event_name == 'pull_request' && github.event.repository.private == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Dependency review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
-        with:
-          fail-on-severity: high
-          # See dependency-review.yml for the full rationale: starlette is pinned
-          # below its patched versions by schemathesis==3.39.16's own dependency
-          # declaration, and schemathesis is only used as a CI-only fuzzing CLI
-          # (never serves traffic), so the flagged ASGI-server code paths don't
-          # apply here.
-          allow-ghsas: GHSA-wqp7-x3pw-xc5r, GHSA-82w8-qh3p-5jfq

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,9 +3,8 @@
 # Policy: auto-merge PATCH Dependabot PRs (gradle, npm) once CI is green.
 # Everything else stays open for human review:
 #   - Minor + major bumps (any ecosystem) — minors regularly carry new transitive
-#     dependencies; the Gradle graph has no PR-time vuln gate (dependency-review
-#     doesn't parse Gradle and there is no gradle.lockfile for Trivy fs), so an
-#     auto-merged minor is an uninspected supply-chain entry point.
+#     dependencies and deserve semantic review even though dependency-submission
+#     plus dependency-review scan the submitted Gradle graph for known CVEs.
 #   - github-actions bumps (any size) — a version bump swaps the pinned commit SHA
 #     for NEW action code that then runs in CI with contents:write/id-token:write.
 #     A human must eyeball the diff of what will execute with those permissions.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -163,9 +163,10 @@ jobs:
     # CodeQL uploads results to GitHub code scanning, which on a PRIVATE repo is a
     # paid GHAS add-on (not bundled with Free/Pro) — the init step errors with
     # "Code scanning is not enabled for this repository". So this job auto-skips
-    # while the repo is private and activates the moment it goes public (free GHAS),
-    # mirroring the dependency-review job in ci.yml. Until then Trivy fs + Dependabot
-    # cover vulnerable-dependency detection. (Aside: the CodeQL CLI also does not
+    # while the repo is private and activates the moment it goes public (free GHAS).
+    # Dependency review has its own workflow and submitted Gradle graph; while CodeQL
+    # is unavailable, Trivy fs + Dependabot cover the remaining detection layer.
+    # (Aside: the CodeQL CLI also does not
     # support linux/arm64, so it could not run on the arm64 sandbox runner anyway.)
     # Skip on gitops/docs-only PRs (run_codeql=false) — CodeQL isn't a required check
     # there, and the java-kotlin autobuild is the ~14 min tax that strands deploy PRs.
@@ -397,6 +398,10 @@ jobs:
       # this repo went public failed here). Distinct categories per file fixes it.
       - name: Upload Trivy fs SARIF
         if: always() && steps.verify-trivy.outcome == 'success' && github.event.repository.private == false
+        # The scan above is the blocking decision (`--exit-code 1`). SARIF upload is
+        # reporting only: GitHub's installation API rate limit can reject it after a
+        # clean scan, and must not turn that clean security decision into a false red.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: trivy-fs.sarif
@@ -404,6 +409,8 @@ jobs:
 
       - name: Upload Trivy config SARIF
         if: always() && steps.verify-trivy.outcome == 'success' && github.event.repository.private == false
+        # Keep reporting availability independent from the blocking IaC scan above.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: trivy-config.sarif


### PR DESCRIPTION
The general CI workflow duplicated the repository's dedicated dependency review. On PR #9636 the embedded copy false-failed with “Dependency review is not supported on this repository” while the dedicated workflow passed against the submitted Gradle graph.

This removes the weaker duplicate and corrects stale workflow comments. The dedicated `.github/workflows/dependency-review.yml` remains the single high-severity CVE gate, including Gradle snapshot basis validation and retry handling.

The same false-red pattern affected Trivy: both CLI scans passed, then GitHub rejected the SARIF uploads because the installation API rate limit was exhausted. SARIF publication is now best effort while the two CLI scans retain `--exit-code 1`, so actual HIGH/CRITICAL findings still block the PR.

Closes #9641

no-test-justification: The defect is GitHub's installation-scoped API rejecting otherwise valid SARIF uploads; local tests cannot reproduce that external rate-limit response. `actionlint` validates the workflow shape, and the blocking Trivy CLI steps remain unchanged.

Validation:
- `actionlint` on all affected workflows and `dependency-review.yml`
- YAML parse for all affected workflows
- `check-gate-invocation-reachability.py`
- `check-advisory-gate-registration.py`
- live `check-ruleset-context-parity.py`: 0 orphaned required contexts
- `git diff --check`
