### PR TITLE
ci(fleet): batch spot retry reconciliation

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2223,6 +2223,20 @@ gates:
     run: |
       bash .github/scripts/spot-kill-retry.sh --self-test
 
+  - id: ci-reconcile-selector-selftest
+    name: "CI reconciler selects only recent retry and flake candidates (issue #9645, enforced)"
+    group: registry
+    mode: enforced
+    selftest_exempt: >-
+      is-a-test-suite — the run: below exercises the selector with eligible, irrelevant,
+      expired, and duplicate runs and asserts the exact retry and flake matrices.
+    budget_seconds: 10
+    rationale: "The scheduled reconciler replaces a per-completion listener; a broad or duplicate candidate set would recreate the API and runner amplification it removes."
+    review_after: "2027-03-11"
+    min_subjects: 3
+    run: |
+      python3 .github/scripts/select-ci-reconcile-candidates.py --self-test
+
   - id: gh-retry-selftest
     name: "the shared gh transient-retry library classifies and backs off as documented (issues #6853, #7976, enforced)"
     group: registry

--- a/.github/scripts/record-rerun-flake.py
+++ b/.github/scripts/record-rerun-flake.py
@@ -55,6 +55,7 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 RECORD_MARKER = "<!-- flake-record:"
+RECORD_ID_MARKER = "<!-- flake-record-id:"
 
 
 # --------------------------------------------------------------------------------------------
@@ -200,6 +201,7 @@ def render_comment(record: dict) -> str:
         f"| head | `{(record.get('head_sha') or '')[:9]}` on `{record.get('head_branch') or ''}` |\n"
         f"| detected | {record['detected_at']} |\n\n"
         f"Tests found failing at the prior attempt:\n{test_lines}\n\n"
+        f"{RECORD_ID_MARKER}{record['run_id']}:{record['final_attempt']} -->\n"
         f"{RECORD_MARKER}{json.dumps(record, sort_keys=True)} -->\n"
     )
     return body
@@ -411,6 +413,7 @@ def self_test() -> int:
     }
     comment = render_comment(record)
     check("rendered comment names the job", record["job"] in comment)
+    check("rendered comment carries a stable run-attempt identity marker", "flake-record-id:123:2" in comment)
     check("rendered comment embeds a machine-readable JSON payload", RECORD_MARKER in comment)
     roundtrip = extract_records_from_comments([comment, "an unrelated human comment with no marker"])
     check("exactly one record recovered from two comments, one with no marker", len(roundtrip) == 1)

--- a/.github/scripts/select-ci-reconcile-candidates.py
+++ b/.github/scripts/select-ci-reconcile-candidates.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Select recent CI runs that need spot-retry or flake recording (#9645)."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+WATCHED = {"Services CI", "Security scan", "Dependency submission"}
+
+
+def parse_time(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def select(runs: list[dict], now: dt.datetime, lookback_minutes: int) -> dict[str, list[dict]]:
+    cutoff = now - dt.timedelta(minutes=lookback_minutes)
+    retry: dict[int, dict] = {}
+    flakes: dict[int, dict] = {}
+    for run in runs:
+        if run.get("name") not in WATCHED or run.get("status") != "completed":
+            continue
+        if parse_time(run["updated_at"]) < cutoff:
+            continue
+        item = {
+            "run_id": int(run["id"]),
+            "run_url": run["html_url"],
+            "conclusion": run.get("conclusion") or "",
+            "run_attempt": int(run.get("run_attempt") or 1),
+            "workflow_name": run["name"],
+            "head_sha": run.get("head_sha") or "",
+            "head_branch": run.get("head_branch") or "",
+        }
+        if item["run_attempt"] == 1 and item["conclusion"] in {"failure", "cancelled"}:
+            retry[item["run_id"]] = item
+        elif item["run_attempt"] > 1 and item["conclusion"] == "success":
+            flakes[item["run_id"]] = item
+    key = lambda item: item["run_id"]
+    return {"retry": sorted(retry.values(), key=key), "flakes": sorted(flakes.values(), key=key)}
+
+
+def self_test() -> int:
+    now = parse_time("2026-09-11T00:30:00Z")
+    base = {"status": "completed", "updated_at": "2026-09-11T00:29:00Z", "html_url": "u", "head_sha": "s", "head_branch": "b"}
+    runs = [
+        base | {"id": 1, "name": "Services CI", "conclusion": "cancelled", "run_attempt": 1},
+        base | {"id": 2, "name": "Security scan", "conclusion": "failure", "run_attempt": 1},
+        base | {"id": 3, "name": "Dependency submission", "conclusion": "success", "run_attempt": 2},
+        base | {"id": 4, "name": "Services CI", "conclusion": "success", "run_attempt": 1},
+        base | {"id": 5, "name": "Other", "conclusion": "failure", "run_attempt": 1},
+        (base | {"id": 6, "name": "Services CI", "conclusion": "failure", "run_attempt": 1, "updated_at": "2026-09-10T22:00:00Z"}),
+        base | {"id": 1, "name": "Services CI", "conclusion": "cancelled", "run_attempt": 1},
+    ]
+    got = select(runs, now, 90)
+    assert [x["run_id"] for x in got["retry"]] == [1, 2]
+    assert [x["run_id"] for x in got["flakes"]] == [3]
+    print("SUBJECTS=3")
+    print("select-ci-reconcile-candidates self-test: 3 passed, 0 failed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs-file", type=Path)
+    parser.add_argument("--now")
+    parser.add_argument("--lookback-minutes", type=int, default=90)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return self_test()
+    if not args.runs_file or not args.now:
+        parser.error("--runs-file and --now are required")
+    runs = json.loads(args.runs_file.read_text())
+    print(json.dumps(select(runs, parse_time(args.now), args.lookback_minutes), separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -13,10 +13,13 @@
 # conclusions, so the rerun is always the full one.
 #
 # WHAT THIS DOES
-# When one of the watched workflows completes `cancelled`, this re-runs it automatically,
-# bounded to one retry (run_attempt 1 only — see LOOP SAFETY below). A spot reclaim then costs
-# one queued re-run instead of a human round-trip; the job lands on a fresh spot node (or the
-# on-demand warm pool) and proceeds.
+# One five-minute reconciliation run reads completed runs from each watched workflow with one
+# paginated query per workflow, then re-runs qualifying spot kills automatically. The 30-minute
+# lookback tolerates delayed schedules and overlaps intentionally; `run_attempt == 1` and the
+# flake ledger marker make repeated scans idempotent. Before #9645, `workflow_run: completed`
+# created a new Actions run for every watched completion, including ordinary successes whose
+# jobs were all skipped. A PR burst exhausted the installation's 5,000-call API quota and made
+# unrelated security gates fail with rate-limit 403s.
 #
 # ALSO `failure` — a reclaim that takes only PART of a multi-job run (issue #2841).
 # A spot kill sets the killed STEP to `cancelled`, which makes its JOB `failure`, which makes
@@ -50,7 +53,7 @@
 # killed job, which is a different and larger change.
 #
 # LOOP SAFETY
-# github.event.workflow_run.run_attempt is 1 for the original run and 2 for the first rerun,
+# GitHub's run_attempt is 1 for the original run and 2 for the first rerun,
 # so gating on run_attempt == 1 gives exactly one automatic retry per run — a cancelled retry
 # (run_attempt 2) never re-triggers, and a run cancelled for a real reason (superseded by a
 # newer push to the same PR — the concurrency group's normal operation) is only retried once,
@@ -101,17 +104,62 @@
 name: Auto-retry spot-killed CI runs
 
 on:
-  workflow_run:
-    workflows: ["Services CI", "Security scan", "Dependency submission"]
-    types: [completed]
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-reconcile
+  cancel-in-progress: false
 
 permissions:
-  actions: write   # re-run the cancelled workflow
+  contents: read
+  actions: read
 
 jobs:
+  discover:
+    name: Find recent runs requiring reconciliation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      retry: ${{ steps.select.outputs.retry }}
+      flakes: ${{ steps.select.outputs.flakes }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          sparse-checkout: .github/scripts/select-ci-reconcile-candidates.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Read recent completions from the three watched workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          for workflow in services-ci.yml security.yml dependency-submission.yml; do
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
+              -f status=completed -f per_page=100 -f "created=>=${cutoff}" --paginate --slurp \
+              | jq 'map(.workflow_runs) | add' > "${RUNNER_TEMP}/${workflow}.json"
+          done
+          jq -s 'add' "${RUNNER_TEMP}"/*.yml.json > "${RUNNER_TEMP}/runs.json"
+      - name: Select bounded, deduplicated candidates
+        id: select
+        run: |
+          set -euo pipefail
+          candidates=$(python3 .github/scripts/select-ci-reconcile-candidates.py \
+            --runs-file "${RUNNER_TEMP}/runs.json" --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --lookback-minutes 30)
+          echo "retry=$(jq -c '.retry' <<< "${candidates}")" >> "${GITHUB_OUTPUT}"
+          echo "flakes=$(jq -c '.flakes' <<< "${candidates}")" >> "${GITHUB_OUTPUT}"
+
   retry:
     name: Re-run spot-killed run (once)
+    needs: discover
+    if: needs.discover.outputs.retry != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     # A rate-limit wait is now "until the limit resets" (capped at GH_RETRY_MAX_WAIT_SECONDS,
     # 600s here) rather than a flat 15s, because a 45-second budget cannot outlast an
     # installation limit whose window is minutes — that is #6853/#7976 and it reproduced on run
@@ -119,12 +167,8 @@ jobs:
     # the job sit for the 360-min default. ubuntu-latest is free on a public repo, so the trade
     # is a concurrency slot against a reclaimed CI run that otherwise needs a human.
     timeout-minutes: 50
-    # `failure` is admitted here only so the step below can inspect the jobs; the decision to
-    # re-run is made there, not by this expression. A job-level `if:` cannot reach the jobs API.
-    if: >-
-      (github.event.workflow_run.conclusion == 'cancelled' ||
-       github.event.workflow_run.conclusion == 'failure') &&
-      github.event.workflow_run.run_attempt == 1
+    # Candidate selection is batched in `discover`; the script still owns the job-level
+    # spot-kill classification and is the final authority on whether a rerun is issued.
     steps:
       # A SPARSE checkout, added by #6255. The header note above says this job has none, and
       # that was true and load-bearing while the decision logic lived inline in this file. It
@@ -160,9 +204,7 @@ jobs:
           # `gh` call added later that forgets it, and is what check-gh-repo-context.py reads
           # at PR time.
           GH_REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RETRY_CANDIDATES: ${{ needs.discover.outputs.retry }}
           # Cap on a SINGLE wait inside gh-retry.sh. Kept under the job's timeout-minutes above
           # with room for four of them plus the calls themselves.
           GH_RETRY_MAX_WAIT_SECONDS: "600"
@@ -175,11 +217,22 @@ jobs:
         # control could not do its job, which routes to raise-issue below. The script's header
         # carries the full rationale, including why an unreadable jobs API is NOT a pass here
         # and why a rate limit must be told from a permission denial by message text.
-        run: bash .github/scripts/spot-kill-retry.sh
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS=$'\t' read -r run_id run_url conclusion; do
+            echo "::group::Classify ${run_url}"
+            if ! RUN_ID="${run_id}" RUN_URL="${run_url}" CONCLUSION="${conclusion}" \
+                 bash .github/scripts/spot-kill-retry.sh; then
+              failed=1
+            fi
+            echo "::endgroup::"
+          done < <(jq -r '.[] | [.run_id, .run_url, .conclusion] | @tsv' <<< "${RETRY_CANDIDATES}")
+          exit "${failed}"
 
   # ── The alarm (issue #2901) ───────────────────────────────────────────────────
   # Why this exists: this workflow failed 208 times without anyone noticing. It is
-  # `workflow_run`-triggered, so there is no PR to show a red check on and no commit status
+  # schedule-triggered, so there is no PR to show a red check on and no commit status
   # anyone reads — its red is addressed to nobody, the same blind spot dependency-submission
   # sat in for three days before it grew a raise-issue job.
   #
@@ -229,9 +282,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TARGET_URL: ${{ github.event.workflow_run.html_url }}
-          TARGET_NAME: ${{ github.event.workflow_run.name }}
-          TARGET_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_NAME: batched CI reconciliation
+          TARGET_CONCLUSION: one or more retry candidates failed processing
         run: |
           set -euo pipefail
           TITLE="Spot-kill auto-retry is failing — reclaimed CI runs are not being re-run"
@@ -308,8 +361,8 @@ jobs:
   # Why this lives HERE, in the workflow that already re-runs things, and not in a new listener:
   # the flake evidence exists exactly once, at the moment a re-run's FINAL attempt concludes --
   # after that, a query over run conclusions sees only `success` and the fact that attempt 1 was
-  # genuinely red is gone. This job is the second `workflow_run` listener on the same three
-  # workflows (`retry` above is the first), triggered independently by the SAME event.
+  # genuinely red is gone. The reconciler selects successful later attempts in the same bounded
+  # query that selects retry candidates, then this matrix records each one idempotently.
   #
   # NOT every re-run is a flake. `retry` re-runs a run for one of two reasons -- a whole-run
   # spot-kill (`cancelled`, at least one job's steps show it was running when reclaimed) or a
@@ -327,9 +380,12 @@ jobs:
   # `success` catches both.
   record-flake:
     name: Record a flake if a re-run turned a genuine failure green
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.run_attempt > 1
+    needs: discover
+    if: needs.discover.outputs.flakes != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover.outputs.flakes) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5 # API + a handful of small artifact downloads
     permissions:
@@ -339,12 +395,12 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
-      RUN_ID: ${{ github.event.workflow_run.id }}
-      RUN_URL: ${{ github.event.workflow_run.html_url }}
-      FINAL_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-      WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      RUN_ID: ${{ matrix.run_id }}
+      RUN_URL: ${{ matrix.run_url }}
+      FINAL_ATTEMPT: ${{ matrix.run_attempt }}
+      WORKFLOW_NAME: ${{ matrix.workflow_name }}
+      HEAD_SHA: ${{ matrix.head_sha }}
+      HEAD_BRANCH: ${{ matrix.head_branch }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -460,6 +516,15 @@ jobs:
           existing=$(bash .github/scripts/resolve-tracking-issue.sh \
             --title "$TITLE" --pinned "$LEDGER_ISSUE")
 
+          # The 30-minute lookback deliberately overlaps scheduler ticks. Pinning identity
+          # to run id + final attempt makes those overlaps idempotent instead of duplicating ledger rows.
+          comments=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${existing}/comments?per_page=100" \
+            --jq '.[].body')
+          marker="<!-- flake-record-id:${RUN_ID}:${FINAL_ATTEMPT} -->"
+          if grep -Fq "${marker}" <<< "${comments}"; then
+            echo "Run ${RUN_ID} attempt ${FINAL_ATTEMPT} is already present in #${existing}; skipping."
+            exit 0
+          fi
           for f in "${RUNNER_TEMP}"/comments/record-*.json; do
             [ -e "$f" ] || continue
             python3 .github/scripts/record-rerun-flake.py render --record "$f" \


### PR DESCRIPTION
A burst of pull requests completed enough watched workflows to create hundreds of `workflow_run` listener records. The listener ran even for ordinary successes whose jobs were all skipped; the installation then exhausted its 5,000-call API quota and unrelated security checks failed with rate-limit 403s.

This replaces the per-completion listener with one five-minute reconciler. It reads the three watched workflows in bounded paginated queries, selects only recent failed/cancelled first attempts or successful reruns, and processes retry candidates sequentially in one runner job. The existing spot-kill classifier remains the final authority and still permits at most one rerun. Flake records now carry a stable `run_id:final_attempt` marker, so overlapping scheduler windows are idempotent.

Measured during the incident, a 30-minute production dry-run selected 26 retry candidates. The old matrix-shaped implementation would have requested 26 runner jobs; this implementation handles them in one batch job. Normal operation creates one reconciliation run per five minutes instead of three listener runs per PR completion set.

Closes #9645

no-test-justification: This changes GitHub Actions orchestration. Its pure candidate selector, existing retry classifier, and flake renderer have offline self-tests; actionlint and the governance gate runner validate the workflow wiring.

Validation:
- `actionlint .github/workflows/auto-retry-cancelled.yml`
- `run-gates.py --only ci-reconcile-selector-selftest --only spot-kill-retry-selftest`
- `record-rerun-flake.py --self-test`
- `check-gate-lifecycle-metadata.py --today 2026-09-11`
- `check-gate-subject-floor.py --enforce`
- live read-only dry-run against the three GitHub workflow-run endpoints
- `git diff --check`
