### PR TITLE
fix(libs): register ENGAGEMENT_FEATURES in FeatureCatalogues as offline-only

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/feature/FeatureCatalogues.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/feature/FeatureCatalogues.kt
@@ -52,6 +52,12 @@ object FeatureCatalogues {
             "updater exists because no decision path reads a settled money-flow feature at request " +
             "time yet. The online writer belongs with the first consumer, not ahead of it — a store " +
             "nobody reads cannot be shown to be right, and its parity test would assert nothing.",
+        "ENGAGEMENT_FEATURES" to
+            "#8888 / ADR-0201 D3 / ADR-0282 phase 1. Declared for campaign targeting; no production " +
+            "code references ENGAGEMENT_FEATURES, ENGAGEMENT_RECENCY_DAYS or ENGAGEMENT_COUNT_D30 " +
+            "outside this declaration, so there is no FeatureOnlineUpdater writing it and no decision " +
+            "path reading it. Same reason as MONEY_FLOW_FEATURES: the online writer belongs with the " +
+            "first consumer, not ahead of it.",
     )
 
     /** Every catalogue this module declares, by name. */

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/feature/FeatureCatalogueCoverageTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/feature/FeatureCatalogueCoverageTest.kt
@@ -85,7 +85,9 @@ class FeatureCatalogueCoverageTest {
         val declared = declaredFeatures()
         assertTrue(declared.size >= 2, "parsed only ${declared.size} features — the probe is broken")
 
-        val reachable = (FeatureCatalogues.ONLINE_SERVED_FEATURES + MONEY_FLOW_FEATURES).map { it.name }.toSet()
+        val reachable = (FeatureCatalogues.ONLINE_SERVED_FEATURES + MONEY_FLOW_FEATURES + ENGAGEMENT_FEATURES).map {
+            it.name
+        }.toSet()
         assertTrue(
             reachable.size >= declared.size,
             "declared ${declared.size} feature(s) in source but only ${reachable.size} are reachable " +
@@ -97,7 +99,7 @@ class FeatureCatalogueCoverageTest {
     /** Two features sharing a store key would overwrite each other in the online store. */
     @Test
     fun `feature names are unique across every catalogue`() {
-        val all = FeatureCatalogues.ONLINE_SERVED_FEATURES + MONEY_FLOW_FEATURES
+        val all = FeatureCatalogues.ONLINE_SERVED_FEATURES + MONEY_FLOW_FEATURES + ENGAGEMENT_FEATURES
         val dupes = all.map { it.name }.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
         assertTrue(dupes.isEmpty(), "duplicate feature names: $dupes")
     }


### PR DESCRIPTION
## Summary

`FeatureCatalogueCoverageTest` has been failing on `main` since #8888 landed — that PR declared
`ENGAGEMENT_FEATURES` (`ENGAGEMENT_RECENCY_DAYS`, `ENGAGEMENT_COUNT_D30`) but never registered
it in `FeatureCatalogues`. Confirmed on a clean `origin/main` checkout: fails identically,
unrelated to any pending PR's diff.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Changes

- `FeatureCatalogues.kt`: register `"ENGAGEMENT_FEATURES"` in `OFFLINE_ONLY` with a substantive
  reason (>60 chars, matching the `every offline-only catalogue carries a substantive reason`
  test).
- `FeatureCatalogueCoverageTest.kt`: add `ENGAGEMENT_FEATURES` to the reachable-features
  allowlist in both places it appears (`every declared feature belongs to a catalogue`,
  `feature names are unique across every catalogue`).

## Why offline-only, not online-served

```
grep -rln "ENGAGEMENT_FEATURES\|ENGAGEMENT_COUNT_D30\|ENGAGEMENT_RECENCY_DAYS" \
  --include='*.kt' . | grep -v /test/
openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/feature/EngagementFeatures.kt
```

Only the declaration file itself. No `FeatureOnlineUpdater` writes it, no decision path reads
it. The file's own KDoc says these features "live beside `VELOCITY_TXN_COUNT_H1`... for exactly
that reason" — that states the ADR-0201 D3 architectural intent, not what is actually wired
today; treating it as evidence would be exactly the "comment asserting current wiring" trap this
repo's `CLAUDE.md` already documents. `FeatureCatalogues.kt`'s own doc for `MONEY_FLOW_FEATURES`
states the precedent directly: *"The online writer belongs with the first consumer, not ahead of
it."* Same shape, same reason.

## The second half of the fix

Registering the catalogue string in `OFFLINE_ONLY` alone is not enough — `Feature
CatalogueCoverageTest`'s reachable-features check (`every declared feature belongs to a
catalogue`) is a literal Kotlin-val allowlist (`ONLINE_SERVED_FEATURES + MONEY_FLOW_FEATURES`),
not derived from `OFFLINE_ONLY`'s map keys. `ENGAGEMENT_FEATURES` had to be added to that
allowlist in both places it appears, mirroring how `MONEY_FLOW_FEATURES` was already there.

## Verification

```
./gradlew :openbank-libs-domain:test :openbank-libs-domain:ktlintCheck :openbank-libs-domain:detekt
```
`FeatureCatalogueCoverageTest`: 5/5 passing (`build/test-results/test/TEST-….xml`,
`tests="5" failures="0" errors="0"`). ktlintCheck and detekt clean after a `ktlintFormat` pass
(one line exceeded 120 chars — let the formatter wrap it rather than hand-wrapping).

## Definition of Done

- [ ] Hexagonal layering preserved. — N/A, this only touches an already-domain-layer registry + its own test
- [x] Unit tests added/updated. (the coverage test itself, extended to name the new catalogue)
- [ ] Integration tests. — N/A, offline-only catalogue has no online path to integration-test
- [ ] Contract tests. — N/A
- [x] `./gradlew ... build` — ran the module-scoped equivalent above
- [x] No new lint warnings. (ktlintCheck + detekt clean)
- [ ] OpenAPI / Flyway / Avro — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`/equivalent.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment — no.
- [ ] PII / cardholder data — no.

## Compliance impact

- [x] None — a test-coverage registration fix, no behavior change to any feature computation.

## Rollout / Rollback

- Deployment strategy: library-only change, ships with the next release-please cut of
  `openbank-libs-domain`.
- Rollback plan: revert the commit — the test goes back to red, same as it is on `main` today.
- Data migration reversible: N/A

## Reviewer notes

Found this while chasing an unrelated failing `build (openbank-libs-domain)` check on #9112 —
it's genuinely pre-existing on `main`, not caused by that PR, and blocks the required
`all-green` check for any PR that happens to build this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
