### PR TITLE
ci(security): collapse regression gate API reads

### DIFF
--- a/.github/workflows/security-regression-test.yml
+++ b/.github/workflows/security-regression-test.yml
@@ -51,8 +51,10 @@ jobs:
             const body = pr.body || "";
 
             // Closing keywords only — Refs is a mention, not a resolution.
-            const closing = [...body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi)]
-              .map(m => Number(m[1]));
+            const closing = [...new Set(
+              [...body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi)]
+                .map(m => Number(m[1])),
+            )];
             if (closing.length === 0) {
               core.info("No closing issue references — rule does not apply.");
               return;
@@ -63,24 +65,65 @@ jobs:
               return;
             }
 
-            const securityIssues = [];
-            for (const n of closing) {
-              const { data: issue } = await github.rest.issues.get({
-                owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
-              });
-              if (issue.labels.some(l => (l.name || l) === "security")) securityIssues.push(n);
-            }
+            // One GraphQL request covers every referenced issue and the PR files. The previous
+            // N+1 REST shape shared the installation's core quota with the whole workflow fleet;
+            // once that quota reached zero this gate failed before evaluating the policy at all.
+            const issueFields = closing
+              .map((n, i) => `issue${i}: issue(number: ${n}) { labels(first: 100) { nodes { name } } }`)
+              .join("\n");
+            const data = await github.graphql(
+              `query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  ${issueFields}
+                  pullRequest(number: $pr) {
+                    files(first: 100) {
+                      nodes { path }
+                      pageInfo { hasNextPage endCursor }
+                    }
+                  }
+                }
+              }`,
+              { owner: context.repo.owner, repo: context.repo.repo, pr: pr.number },
+            );
+            const repository = data.repository;
+            const securityIssues = closing.filter((n, i) => {
+              const issue = repository[`issue${i}`];
+              if (!issue) throw new Error(`Closing issue #${n} was not found`);
+              return issue.labels.nodes.some(label => label.name === "security");
+            });
             if (securityIssues.length === 0) {
               core.info(`Closed issues ${closing.join(", ")} — none labeled 'security'.`);
               return;
             }
 
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number,
-              per_page: 100,
-            });
+            const fileConnection = repository.pullRequest?.files;
+            if (!fileConnection) throw new Error(`Pull request #${pr.number} was not found`);
+            const files = [...fileConnection.nodes];
+            let pageInfo = fileConnection.pageInfo;
+            while (pageInfo.hasNextPage) {
+              const page = await github.graphql(
+                `query($owner: String!, $repo: String!, $pr: Int!, $cursor: String!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      files(first: 100, after: $cursor) {
+                        nodes { path }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                    }
+                  }
+                }`,
+                {
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  pr: pr.number, cursor: pageInfo.endCursor,
+                },
+              );
+              const next = page.repository.pullRequest?.files;
+              if (!next) throw new Error(`Pull request #${pr.number} disappeared during pagination`);
+              files.push(...next.nodes);
+              pageInfo = next.pageInfo;
+            }
             const TEST_SURFACE = /src\/test\/|\/e2e\/|\.(spec|test)\.[tj]sx?$/;
-            const touchedTests = files.map(f => f.filename).filter(f => TEST_SURFACE.test(f));
+            const touchedTests = files.map(file => file.path).filter(path => TEST_SURFACE.test(path));
             if (touchedTests.length > 0) {
               core.info(`Test surface touched (${touchedTests.length} file(s)); security issue(s) ${securityIssues.join(", ")} close with a regression test.`);
               return;


### PR DESCRIPTION
## What

Collapse the security-regression gate's N+1 REST reads into one GraphQL request for ordinary PRs, fetching all closing-issue labels and the first 100 PR files together. The current gate consumes the shared installation core quota and fails before evaluating policy when that quota reaches zero; this keeps the rule fail-closed while moving it to the separate GraphQL budget. Repeated closing references are deduplicated and larger PRs paginate every remaining file so a regression test beyond page one cannot be missed.

Refs #9031. Refs #8590.

## Validation

- real GraphQL query against PR #9653 returned all 16 changed paths and the exact labels for closing issue #9647
- multi-issue alias query returned distinct label sets; existing security issues #9643/#9641/#9366 provide positive classifier fixtures
- missing issue and missing PR branches remain explicit errors
- `actionlint .github/workflows/security-regression-test.yml`
- `git diff --check`
- GPG-signed commit

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth, crypto, and payment code is unchanged; the security policy remains fail-closed.
- [x] PII paths are unchanged; no GDPR review label required.
- [x] Cardholder-data paths are unchanged; no PCI review label required.
