### PR TITLE
ci(fleet): reconcile superseded queued runs

### DIFF
--- a/.github/scripts/check-superseded-pr-runs.py
+++ b/.github/scripts/check-superseded-pr-runs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Select queued pull-request runs whose exact head is no longer current."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def candidates(runs: list[dict[str, Any]], pulls: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    current = {
+        int(pull["number"]): str(pull["head"]["sha"])
+        for pull in pulls
+        if pull.get("number") is not None and isinstance(pull.get("head"), dict) and pull["head"].get("sha")
+    }
+    selected: list[dict[str, Any]] = []
+    for run in sorted(runs, key=lambda item: (item.get("created_at", ""), int(item.get("id", 0)))):
+        linked = run.get("pull_requests") or []
+        if run.get("event") != "pull_request" or not linked:
+            continue
+        number = linked[0].get("number")
+        run_id = run.get("id")
+        head_sha = run.get("head_sha")
+        if not isinstance(number, int) or not isinstance(run_id, int) or not isinstance(head_sha, str):
+            continue
+        if current.get(number) == head_sha:
+            continue
+        selected.append(
+            {
+                "runId": run_id,
+                "pr": number,
+                "headSha": head_sha,
+                "workflow": str(run.get("name", "")),
+                "createdAt": str(run.get("created_at", "")),
+            }
+        )
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def self_test() -> None:
+    pulls = [{"number": 7, "head": {"sha": "new"}}, {"number": 8, "head": {"sha": "same"}}]
+    runs = [
+        {"id": 4, "event": "push", "head_sha": "old", "pull_requests": [{"number": 7}]},
+        {"id": 3, "event": "pull_request", "head_sha": "new", "pull_requests": [{"number": 7}]},
+        {"id": 2, "event": "pull_request", "head_sha": "old", "pull_requests": [{"number": 7}], "name": "CI", "created_at": "2026-01-02"},
+        {"id": 1, "event": "pull_request", "head_sha": "closed", "pull_requests": [{"number": 9}], "name": "Security", "created_at": "2026-01-01"},
+        {"id": 5, "event": "pull_request", "head_sha": "same", "pull_requests": [{"number": 8}]},
+        {"id": 6, "event": "pull_request", "head_sha": "unknown", "pull_requests": []},
+    ]
+    actual = candidates(runs, pulls, 25)
+    assert [item["runId"] for item in actual] == [1, 2], actual
+    assert candidates(runs, pulls, 1) == [actual[0]]
+    assert candidates([], pulls, 25) == []
+    print("self-test ok: current/non-PR/unlinked runs stay; stale and closed heads are bounded")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=Path)
+    parser.add_argument("--pulls", type=Path)
+    parser.add_argument("--limit", type=int, default=25)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.runs is None or args.pulls is None:
+        parser.error("--runs and --pulls are required")
+    if args.limit < 1 or args.limit > 100:
+        parser.error("--limit must be between 1 and 100")
+    runs = json.loads(args.runs.read_text())
+    pulls = json.loads(args.pulls.read_text())
+    if not isinstance(runs, list) or not isinstance(pulls, list):
+        raise ValueError("runs and pulls inputs must both be JSON arrays")
+    print(json.dumps(candidates(runs, pulls, args.limit)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/service-build-stall-watch.yml
+++ b/.github/workflows/service-build-stall-watch.yml
@@ -20,6 +20,7 @@ permissions:
   contents: read
   actions: write
   issues: write
+  pull-requests: read
 
 concurrency:
   group: service-build-stall-watch
@@ -32,7 +33,56 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Self-test classifier
-        run: python3 .github/scripts/check-stuck-service-build.py --self-test
+        run: |
+          python3 .github/scripts/check-stuck-service-build.py --self-test
+          python3 .github/scripts/check-superseded-pr-runs.py --self-test
+      - name: Force-cancel only superseded queued PR runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          # Runs first, then PRs: a PR opened between the snapshots is present in the latter
+          # and therefore cannot be mistaken for a closed PR. Every candidate is re-read
+          # immediately before mutation as a second guard against reopen/update races.
+          gh api --paginate --slurp "repos/${REPO}/actions/runs?status=queued&per_page=100" \
+            | jq 'map(.workflow_runs[])' > /tmp/queued-pr-runs.json
+          gh api --paginate --slurp "repos/${REPO}/pulls?state=open&per_page=100" \
+            | jq 'map(.[] | {number, head: {sha: .head.sha}})' > /tmp/open-pr-heads.json
+          python3 .github/scripts/check-superseded-pr-runs.py \
+            --runs /tmp/queued-pr-runs.json --pulls /tmp/open-pr-heads.json --limit 25 \
+            > /tmp/superseded-pr-runs.json
+          jq -c '.[]' /tmp/superseded-pr-runs.json | while IFS= read -r candidate; do
+            run_id=$(jq -r '.runId' <<<"$candidate")
+            pr_number=$(jq -r '.pr' <<<"$candidate")
+            stale_sha=$(jq -r '.headSha' <<<"$candidate")
+            # Fail closed: an API/read failure aborts before force-cancel. A newly current
+            # head is retained even if the earlier snapshots called it stale.
+            live=$(gh api "repos/${REPO}/pulls/${pr_number}")
+            live_state=$(jq -r '.state' <<<"$live")
+            live_sha=$(jq -r '.head.sha' <<<"$live")
+            if [ "$live_state" = open ] && [ "$live_sha" = "$stale_sha" ]; then
+              echo "retaining run ${run_id}: PR #${pr_number} now points at ${stale_sha}"
+              continue
+            fi
+            if [ "$DRY_RUN" = true ]; then
+              echo "would force-cancel superseded run ${run_id} for PR #${pr_number} (${stale_sha})"
+              continue
+            fi
+            if ! cancel_error=$(gh api --method POST "repos/${REPO}/actions/runs/${run_id}/force-cancel" 2>&1); then
+              # A queued run may finish after the snapshots. That is already the desired
+              # terminal state; every other mutation failure remains fatal and visible.
+              live_run_status=$(gh api "repos/${REPO}/actions/runs/${run_id}" --jq '.status')
+              if [ "$live_run_status" = completed ]; then
+                echo "retaining run ${run_id}: it completed before force-cancel"
+                continue
+              fi
+              echo "$cancel_error" >&2
+              exit 1
+            fi
+            echo "force-cancelled superseded run ${run_id} for PR #${pr_number} (${stale_sha})"
+          done
       - name: Find and cancel only proved stalled service CI jobs
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Queued workflow runs for obsolete PR heads remain in the Actions queue even after GitHub's normal cancel endpoint reports success. They consume runner capacity while the current PR head waits behind work that can no longer produce a mergeable result.

This extends the existing 15-minute service-build watchdog to force-cancel only queued `pull_request` runs whose exact head SHA is no longer the head of an open PR. It snapshots runs before PR heads, re-reads each PR immediately before mutation, fails closed on API errors, processes the oldest candidates first, and caps each pass at 25. Manual dispatch remains a dry run by default.

Validation:
- classifier self-test covers current, non-PR, unlinked, stale, closed, ordered, and bounded cases
- all 13 existing stalled-build classifier cases pass
- `actionlint` passes
- workflow supply-chain validation passes across 80 workflow subjects
- live read-only dry run classified 18 stale runs from 258 queued runs and retained every current head

Refs #7477
