### PR TITLE
fix(ci): allowlist communication-service first-registration placeholder

### DIFF
--- a/.github/scripts/fleet-attestation-placeholders.txt
+++ b/.github/scripts/fleet-attestation-placeholders.txt
@@ -27,5 +27,5 @@
 # referral sandbox-d92d20f5) had reached exactly that state — every pin has since moved to a
 # real built tag — and two of them additionally justified themselves with prose main
 # contradicts (vop's "no Dockerfile ... absent from auto-deploy's ALL_SERVICES": it has both).
-# The file is deliberately empty of entries; the gate reports 0 allowlisted placeholders and
-# that is the correct reading, not a missing file.
+
+265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-communication-service:sandbox-000000000


### PR DESCRIPTION
## Summary
- `#9173` registered `openbank-communication-service` in gitops with tag `sandbox-000000000`; no image has ever been built/pushed for it (ECR repo doesn't exist).
- The fleet attestation gate isn't PR-scoped, so this reds **every** open PR — confirmed on #9071 and #9112 after `update-branch`, verified reproducible on a clean `origin/main` checkout.
- This is exactly the "deliberate first-registration placeholder" case `fleet-attestation-placeholders.txt` documents its own remedy for.

## Change
- Add `openbank-communication-service:sandbox-000000000` to the placeholder allowlist.
- `check-fleet-attestations.sh --check-placeholders` passes locally.

## Test plan
- [x] `bash .github/scripts/check-fleet-attestations.sh --check-placeholders` → PASS, 1 entry, 0 stale
- [ ] CI: `Verify fleet attestations` green fleet-wide once merged
- [ ] Remove this entry once `openbank-communication-service` is actually built and pushed

Closes the fleet-wide false-red currently blocking #9071 and #9112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
