### PR TITLE
fix(ci): allowlist the communication-service first-registration placeholder

### DIFF
--- a/.github/scripts/fleet-attestation-placeholders.txt
+++ b/.github/scripts/fleet-attestation-placeholders.txt
@@ -27,5 +27,24 @@
 # referral sandbox-d92d20f5) had reached exactly that state — every pin has since moved to a
 # real built tag — and two of them additionally justified themselves with prose main
 # contradicts (vop's "no Dockerfile ... absent from auto-deploy's ALL_SERVICES": it has both).
-# The file is deliberately empty of entries; the gate reports 0 allowlisted placeholders and
-# that is the correct reading, not a missing file.
+# The file was deliberately empty of entries for a while; the gate reporting 0 allowlisted
+# placeholders was the correct reading then, and is again the moment the entry below goes.
+
+# openbank-communication-service :: sandbox-000000000 (ADR-0285).
+#
+# Classified ABSENT by the gate, not UNATTESTED — the distinction this file's STRICT SCOPE turns
+# on. `sandbox-000000000` is the first-registration placeholder: the service's gitops manifest
+# pins a tag that has never been built or pushed, so there is no image in ECR to attest. The gate
+# reads `FLEET ATTESTATION GATE: FAIL — 1 of 66 declared image(s) not deployable`, and because
+# that job runs on every pull request, one unbuilt service reddens the whole queue.
+#
+# The justification, stated so a later reader can falsify it — the earlier vop entry is on record
+# above for asserting the opposite of what main said:
+#   * openbank-communication-service HAS a Dockerfile (checked on origin/main).
+#   * It IS in auto-deploy.yml's ALL_SERVICES (checked on origin/main).
+#   * It HAS a version.txt (0.1.0), so it is a registered released component.
+# So this is NOT "a service that cannot be built" — it is one that simply has not been built yet.
+# Its first real deploy replaces the pin with a built tag, at which point this entry stops
+# matching and `--check-placeholders` fails on it until it is deleted. Self-clearing by design;
+# do not pre-emptively remove it while the pin still reads sandbox-000000000.
+265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-communication-service:sandbox-000000000


### PR DESCRIPTION
## Summary

`Verify fleet attestations` is failing on **every open PR**, not on any one PR's changes:

```
ABSENT   openbank-communication-service:sandbox-000000000  <-- declared in gitops but NOT in the registry
FLEET ATTESTATION GATE: FAIL — 1 of 66 declared image(s) not deployable.
```

`openbank-infra/gitops/components/communication/communication-service.yaml` pins the
first-registration placeholder `sandbox-000000000` — a tag that has never been built or pushed —
and `.github/scripts/fleet-attestation-placeholders.txt` is currently empty. That job runs per PR,
so one service that has not shipped yet reddens the whole queue.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — found while triaging the open-PR backlog; the gate names the condition itself and the
allowlist file documents this exact case as its reason for existing.

## Changes

- One entry in `.github/scripts/fleet-attestation-placeholders.txt` for
  `openbank-communication-service:sandbox-000000000`, with the justification written out.

`ABSENT` is the only class this allowlist may cover; the file's STRICT SCOPE keeps `UNATTESTED`
(present in ECR, no attestation) fatal with no allowlist, and that is untouched.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated. — the script's own `--self-test` already covers both placeholder
      directions; no new case is needed for one data row.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — no Kotlin touched.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated — the justification lives in the file it governs.

Verified locally against current `main`:
- `check-fleet-attestations.sh --check-placeholders` -> `PASS — 1 entr(y/ies), 0 stale`
- `check-fleet-attestations.sh --self-test` -> `ok` on 18 cases, including
  `live placeholder is not stale -> exit 0` and `entry whose image is gone -> exit 1`

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — the ECR registry id
      and image path were already in the tracked gitops manifest this entry quotes.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

This does **not** weaken supply-chain enforcement. It records that a specific image does not exist
yet; an image that exists without an attestation is still a hard failure, which is the class that
caused the 2026-07-12 admission failures and the reason the scope is written as strictly as it is.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — CI-only.
- Rollback plan: delete the entry; the gate returns to failing on the same ABSENT image.
- Data migration reversible: N/A

## Reviewer notes

The entry is self-clearing and cannot rot: the moment communication-service's first real deploy
moves the pin to a built tag, `--check-placeholders` fails on the now-stale entry until it is
removed. That reverse ratchet is why the justification is spelled out in the file rather than
left to this PR description — the file's own header records an earlier entry that justified itself
with prose `main` contradicted ("no Dockerfile … absent from ALL_SERVICES": it had both), so this
one states the three checks and where they were read.
