### PR TITLE
fix(infra): langfuse retention defaultMode was a STRING, not a mode

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/langfuse-retention-cronjob.yaml
+++ b/openbank-infra/gitops/components/ai-platform/langfuse-retention-cronjob.yaml
@@ -160,6 +160,9 @@ spec:
             - name: scripts
               configMap:
                 name: langfuse-retention-sweep
-                defaultMode: 0o555
+                # 0555 and not 0o555: this is parsed by YAML 1.1 (Kubernetes, SnakeYAML, Trivy's
+                # scanner), which has no `0o` prefix — it reads that as the STRING "0o555" against
+                # an int32 field. The seven sibling manifests in this tree all spell it 0555.
+                defaultMode: 0555
             - name: home
               emptyDir: {}


### PR DESCRIPTION
## What

`openbank-infra/gitops/components/ai-platform/langfuse-retention-cronjob.yaml` line 163 said
`defaultMode: 0o555`. That is Python's octal literal. YAML 1.1 — the dialect Kubernetes,
SnakeYAML and Trivy's scanner all parse — has no `0o` prefix, so the scalar is the **string**
`"0o555"` against an int32 field.

Measured with pyyaml against `origin/main`, both sides:

```
before:  defaultMode = '0o555'   (str)
after:   defaultMode = 365       (int, 0555 = r-xr-xr-x)
```

## Why it reaches the cluster

`gitops/apps/litellm.yaml` points a **directory** Application at `components/ai-platform` with
no kustomization, so every file in that directory is in the sync set. Nothing excludes this one.

## The second cost

Trivy's kubernetes scanner aborts the whole file on it:

```
ERROR [kubernetes scanner] Failed to parse file
  file_path="gitops/components/ai-platform/langfuse-retention-cronjob.yaml"
  err="unmarshal yaml: failed to parse int: strconv.Atoi: parsing \"0o555\": invalid syntax"
```

So this CronJob has never been scanned, and the only thing that said so was one ERROR line
inside a job whose own conclusion was decided by something else entirely (an installation API
rate limit). A parse error that skips a subject reads as clean.

## Scope

`0o` appears exactly once in the whole gitops tree. The seven sibling manifests that mount a
script ConfigMap — analytics, openbao (x4), temporal (x2) — all spell it `0555`.

Refs #8881
