### PR TITLE
fix(ci): a rate-limited gate call is UNRESOLVED, not a policy violation

### DIFF
--- a/.github/scripts/check-ruleset-bypass-actors.py
+++ b/.github/scripts/check-ruleset-bypass-actors.py
@@ -78,6 +78,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -112,19 +113,39 @@ class Unreadable(RuntimeError):
     """
 
 
-def gh_api(path: str) -> list | dict:
-    """`gh api <path>`, parsed. Raises RuntimeError on every failure mode.
+# A rate limit is not a broken call: the subject was never read, exactly as in the
+# missing-admin-scope case. `gh` reports it on stderr; the primary limit says "API rate limit
+# exceeded", the secondary one "secondary rate limit" / "exceeded a secondary rate limit".
+# Matched on the message rather than the status, because `gh api` exits 1 for every HTTP error
+# and does not surface the code separately here.
+_RATE_LIMITED = re.compile(r"rate limit exceeded|exceeded a secondary rate limit", re.IGNORECASE)
 
-    A missing `gh` binary, a network error, a rate limit and a non-JSON body all become one
-    exception type, so the caller's single `except RuntimeError` covers them. A gate that
-    cannot reach its subject must say so, never report a clean pass.
+
+def gh_api(path: str) -> list | dict:
+    """`gh api <path>`, parsed. Raises Unreadable on a rate limit, RuntimeError otherwise.
+
+    A missing `gh` binary, a network error and a non-JSON body are BROKEN — the gate could not
+    do its job and must go red. A rate limit is different in kind: nothing is wrong with the
+    call, the subject simply was not read, which is the UNRESOLVED case this gate already models
+    for a token without admin scope. Collapsing the two made an org-wide API budget problem
+    render as a policy violation on an unrelated PR: measured 2026-09-11, `lint-supplychain-security`
+    was red on 6 open PRs for this reason, gating the required `Validate manifests` context.
+    A gate that cannot reach its subject must still never report a clean pass — UNRESOLVED is
+    neither pass nor fail, and run-gates skips the min_subjects floor for it.
     """
     try:
         p = subprocess.run(["gh", "api", path], capture_output=True, text=True, timeout=30)
     except (OSError, subprocess.SubprocessError) as exc:
         raise RuntimeError(f"could not run `gh api {path}`: {exc}") from exc
     if p.returncode != 0:
-        raise RuntimeError(f"gh api {path} failed (rc={p.returncode}): {p.stderr.strip()}")
+        stderr = p.stderr.strip()
+        if _RATE_LIMITED.search(stderr):
+            raise Unreadable(
+                f"gh api {path} was RATE LIMITED (rc={p.returncode}): {stderr}. The subject was "
+                f"never read, so this run says nothing about bypass actors either way — it is "
+                f"UNRESOLVED, not a finding and not a pass."
+            )
+        raise RuntimeError(f"gh api {path} failed (rc={p.returncode}): {stderr}")
     try:
         return json.loads(p.stdout)
     except json.JSONDecodeError as exc:
@@ -279,6 +300,47 @@ def self_test() -> int:
         if rc != 1:
             fails.append(f"a broken API call must still exit 1, got {rc}")
 
+        # A RATE LIMIT is the third state, and both halves of the split have to be held or the
+        # change is untested: the limit must NOT go red, and everything else must still go red.
+        def _rate_limited(path):
+            raise Unreadable("gh api ... was RATE LIMITED (rc=1): API rate limit exceeded for installation")
+
+        globals()["gh_api"] = _rate_limited
+        rc = _run_main(["--enforce"])
+        if rc != 0:
+            fails.append(f"a rate-limited subject must exit 0 (UNRESOLVED), got {rc}")
+
+        # The classifier itself, not just the exception plumbing: the real gh_api decides by
+        # matching stderr, so a message that is NOT a rate limit must stay a RuntimeError. Without
+        # this, widening the pattern to `.*` would pass every case above.
+        _real_gh_api = _real
+        for msg, want_unreadable in (
+            ("API rate limit exceeded for installation", True),
+            ("You have exceeded a secondary rate limit", True),
+            ("Bad credentials", False),
+            ("Not Found", False),
+        ):
+            class _FakeProc:
+                returncode = 1
+                stdout = ""
+                stderr = msg
+
+            _saved_run = subprocess.run
+            try:
+                subprocess.run = lambda *a, **k: _FakeProc()
+                globals()["gh_api"] = _real_gh_api
+                try:
+                    _real_gh_api("x")
+                    fails.append(f"gh_api must raise for rc=1 ({msg!r})")
+                except Unreadable:
+                    if not want_unreadable:
+                        fails.append(f"{msg!r} must be a RuntimeError, not Unreadable")
+                except RuntimeError:
+                    if want_unreadable:
+                        fails.append(f"{msg!r} must be Unreadable (rate limited), not a bare RuntimeError")
+            finally:
+                subprocess.run = _saved_run
+
         globals()["gh_api"] = _fake_detail(
             {"conditions": {"ref_name": {"include": [TARGET_REF]}}}  # back to unreadable
         )
@@ -304,7 +366,7 @@ def self_test() -> int:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: ruleset-bypass-actors is falsifiable (12 cases, both directions, exit codes included)")
+    print("self-test ok: ruleset-bypass-actors is falsifiable (17 cases, both directions, exit codes and the rate-limit classifier included)")
     return 0
 
 
@@ -322,13 +384,26 @@ def main() -> int:
     except Unreadable as exc:
         # NOT a pass: say out loud that nothing was checked, and let the runner's floor logic know
         # the corpus was never read, so this run cannot be mistaken for a clean one.
-        gatelib.subjects_unresolved("bypass_actors is not visible to this token (admin scope required)")
+        #
+        # Name the ACTUAL reason. There are two, they need different actions, and a message that
+        # names the wrong one sends the reader after the wrong fix — the rate-limit case reads as
+        # a permissions problem nobody can reproduce locally, because locally there is no limit.
+        rate_limited = "RATE LIMITED" in str(exc)
+        if rate_limited:
+            gatelib.subjects_unresolved("the rulesets API was rate limited — the subject was never read")
+        else:
+            gatelib.subjects_unresolved("bypass_actors is not visible to this token (admin scope required)")
         print(f"::warning::ruleset-bypass-actors: {exc}")
+        remedy = (
+            "wait for the limit to reset, or reduce what spends the installation's API budget"
+            if rate_limited
+            else "run it with an admin token to get a verdict"
+        )
         print(
-            "ruleset-bypass-actors: NOT EVALUATED on this run. The check has teeth only where the "
-            "token can read `bypass_actors` — run it with an admin token to get a verdict. Treating "
-            "an unreadable subject as red would make the gate permanently and uninformatively red; "
-            "treating it as green would be a lie. UNRESOLVED is neither."
+            f"ruleset-bypass-actors: NOT EVALUATED on this run. The check has teeth only where it "
+            f"can actually READ `bypass_actors` — {remedy}. Treating an unreadable subject as red "
+            f"would make the gate permanently and uninformatively red; treating it as green would "
+            f"be a lie. UNRESOLVED is neither."
         )
         return 0
     except RuntimeError as exc:


### PR DESCRIPTION
## What

`ruleset-bypass-actors` collapsed every `gh api` failure into one `RuntimeError` and returned 1.
So `API rate limit exceeded for installation` — an org-wide budget problem with nothing to do
with the PR under test — rendered as an enforced-gate failure.

Measured 2026-09-11: red on **6 open PRs**, and since this gate sits in the
`lint-supplychain-security` shard it gated the **required** `Validate manifests` context on all
of them.

## Why UNRESOLVED is the right answer

The distinction already existed in this file; the rate limit was simply on the wrong side of it.
A token without admin scope cannot READ `bypass_actors`, and that is deliberately
`Unreadable` → UNRESOLVED → exit 0, with run-gates skipping the `min_subjects` floor. The gate's
own words:

> Treating an unreadable subject as red would make the gate permanently and uninformatively red;
> treating it as green would be a lie. UNRESOLVED is neither.

A rate limit is the same shape: nothing is broken, the subject was never read. A missing `gh`, a
network error and a non-JSON body stay `RuntimeError` and stay red — those *are* broken.

## Verified by effect, both directions

The sabotages are the point. A green self-test alone would not establish that either half still
bites:

```
self-test (17 cases)                               exit 0
real run, live repo, admin token                   exit 0, 1 live / 0 undeclared / 0 stale
SABOTAGE: pattern widened to match everything      exit 1
  -> 'Bad credentials' must be a RuntimeError, not Unreadable
  -> 'Not Found' must be a RuntimeError, not Unreadable
SABOTAGE: rate-limit branch disabled               exit 1
  -> 'API rate limit exceeded for installation' must be Unreadable
  -> 'You have exceeded a secondary rate limit' must be Unreadable
restored                                           exit 0
```

Four new self-test cases assert the **classifier** against the real `gh_api` — two rate-limit
messages that must be `Unreadable`, two ordinary errors that must not. Without them, widening the
pattern to match everything would have passed every other case.

## Also fixed: the message named the wrong cause

The UNRESOLVED line hard-coded *"bypass_actors is not visible to this token (admin scope
required)"*. So a rate-limited run announced a permissions problem — one that cannot be
reproduced locally, because locally there is no limit. Each cause now names itself and its own
remedy (`wait for the limit to reset, or reduce what spends the installation's API budget`).

This is not incidental to the bug: I misdiagnosed this gate twice from its own output before
reading the artifact, and a message naming the wrong cause is how that happens.

## What this does NOT change

A genuinely undeclared live bypass actor still exits 1 under `--enforce`. That case is held by its
own self-test assertion, unmodified — #4828 is a real concern and this keeps the teeth for it.

Refs #9681
