### PR TITLE
fix(analytics-sink): stop reporting an erasure the build cannot perform

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/ErasureService.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/ErasureService.kt
@@ -21,16 +21,44 @@ import java.time.Instant
  * statutory hold (AML/accounting, Art. 17(3)(b)) overrides erasure; [legalBasis] explains why and is
  * the documented, defensible position to show a supervisor / the data subject.
  */
+enum class ErasureOutcome {
+    /** Key material was destroyed by a real backend. */
+    ERASED,
+
+    /** A statutory hold overrides erasure (GDPR Art. 17(3)(b)). */
+    REFUSED_LEGAL_HOLD,
+
+    /**
+     * No erasure backend is present in this build, so nothing was destroyed.
+     *
+     * Its own value rather than a `false` shared with [REFUSED_LEGAL_HOLD], because the two are
+     * opposite kinds of answer: one is a defensible legal position, the other is a gap in the
+     * deployment. Folding them together is the same mistake as the `erased` flag it replaces —
+     * see #4348, where `PushResult.skipped()` carrying `success = true` counted undelivered
+     * pushes as delivered until a customer reported it.
+     */
+    NO_BACKEND,
+}
+
 data class ErasureDecision(
     val aggregateType: String,
     val aggregateId: String,
-    val erased: Boolean,
+    val outcome: ErasureOutcome,
     val rowsAffected: Long,
     val legalBasis: String,
     val explanation: String,
     val decidedAt: Instant,
     val decidedBy: String,
-)
+) {
+    /**
+     * Kept for the wire and for readers, but DERIVED — it cannot disagree with [outcome].
+     *
+     * It used to be a constructor parameter passed the literal `true` on every non-refusal path,
+     * which is how a no-op erasure reported success (#9671).
+     */
+    val erased: Boolean
+        get() = outcome == ErasureOutcome.ERASED
+}
 
 /**
  * Applies the per-category retention policy to an erasure request. The legal gate (is this category
@@ -70,7 +98,7 @@ class ErasureService {
             return ErasureDecision(
                 aggregateType = aggregateType,
                 aggregateId = aggregateId,
-                erased = false,
+                outcome = ErasureOutcome.REFUSED_LEGAL_HOLD,
                 rowsAffected = 0,
                 legalBasis = policy.basis.name,
                 explanation = "Erasure refused: $category is under a ${policy.basis} hold " +
@@ -80,6 +108,14 @@ class ErasureService {
                 decidedBy = requestedBy,
             )
         }
+
+        // The category is erasable, so the legal gate is open. Whether anything is actually
+        // destroyed is a property of the BINDING, and this build may not have a real one: the
+        // vault adapter is `@IfBuildProperty(openbank.analytics.erasure.backend=vault)`, resolved
+        // at augmentation, and the default is a logged no-op. Asking the port rather than assuming
+        // is the whole fix for #9671 — `rows == 0` cannot stand in for it, because a real backend
+        // returns 0 for a subject with no warehouse data.
+        if (!cryptoErasure.performsErasure) return noBackendDecision(aggregateType, aggregateId, requestedBy, now)
 
         val rows = cryptoErasure.erase(AggregateKey(aggregateType, aggregateId))
         log.infof(
@@ -93,10 +129,45 @@ class ErasureService {
         return ErasureDecision(
             aggregateType = aggregateType,
             aggregateId = aggregateId,
-            erased = true,
+            outcome = ErasureOutcome.ERASED,
             rowsAffected = rows,
             legalBasis = (if (policy.basis == LegalBasis.CONSENT) "CONSENT_WITHDRAWN" else policy.basis.name),
             explanation = "Crypto-shredded analytics data for $category (no statutory hold).",
+            decidedAt = now,
+            decidedBy = requestedBy,
+        )
+    }
+
+    /**
+     * The category is erasable and the legal gate is open, but this build has no backend that can
+     * destroy key material — so the request stands unfulfilled and must not be reported as done.
+     *
+     * Extracted because inlining it pushed [erase] past detekt's `LongMethod` (67 vs 60); the class
+     * has room for another function where [AnalyticsConsumer] did not.
+     */
+    private fun noBackendDecision(
+        aggregateType: String,
+        aggregateId: String,
+        requestedBy: String,
+        now: Instant,
+    ): ErasureDecision {
+        val category = RetentionPolicies.categoryForAggregateType(aggregateType)
+        log.warnf(
+            "erasure NOT PERFORMED (no backend in this build) %s/%s category=%s by=%s",
+            aggregateType.sanitizeForLog(),
+            aggregateId.sanitizeForLog(),
+            category,
+            requestedBy.sanitizeForLog(),
+        )
+        return ErasureDecision(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            outcome = ErasureOutcome.NO_BACKEND,
+            rowsAffected = 0,
+            legalBasis = RetentionPolicies.of(category).basis.name,
+            explanation = "No erasure backend is configured in this build, so no analytics data " +
+                "was crypto-shredded for $category. This is NOT a refusal on legal grounds: the " +
+                "category is erasable and the request stands unfulfilled (ADR-0023 F6, #9671).",
             decidedAt = now,
             decidedBy = requestedBy,
         )

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/ErasurePort.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/ErasurePort.kt
@@ -22,4 +22,19 @@ import com.openbank.libs.analytics.AggregateKey
 interface CryptoErasure {
     /** Crypto-shred/tokenise all analytics data for [key]. Idempotent. Returns rows/keys affected. */
     suspend fun erase(key: AggregateKey): Long
+
+    /**
+     * Whether this binding can actually destroy key material.
+     *
+     * A row count cannot answer this: a real backend legitimately returns 0 for a subject with no
+     * warehouse data, so `0` is indistinguishable from "this build has no erasure backend at all".
+     * [ErasureService][com.openbank.analytics.application.ErasureService] needs the difference,
+     * because one is a completed erasure and the other is nothing having happened — and #9671 is
+     * what it costs when the caller cannot tell: the deployed image carried the no-op and every
+     * Art. 17 response still said `erased: true` and "Crypto-shredded analytics data".
+     *
+     * Defaults to `true`, so a real adapter needs no change; only a stub overrides it.
+     */
+    val performsErasure: Boolean
+        get() = true
 }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/erasure/NoOpCryptoErasure.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/erasure/NoOpCryptoErasure.kt
@@ -24,6 +24,9 @@ class NoOpCryptoErasure : CryptoErasure {
     // so an attacker can't forge additional log lines (log forging, CWE-117).
     private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
 
+    /** No key material is destroyed here, so no caller may report an erasure on this binding. */
+    override val performsErasure: Boolean = false
+
     override suspend fun erase(key: AggregateKey): Long {
         log.warnf(
             "CryptoErasure no-op: would crypto-shred analytics data for %s/%s. Bind the KMS adapter in production (ADR-0023 F6).",

--- a/openbank-analytics-sink/src/main/resources/docs/03-api.cs.md
+++ b/openbank-analytics-sink/src/main/resources/docs/03-api.cs.md
@@ -38,7 +38,7 @@ Role: `ROLE_COMPLIANCE`, `ROLE_ADMIN`.
 
 | Metoda | Path | Popis |
 |---|---|---|
-| `POST` | `/` | GDPR Art. 17 výmaz vůči analytické vrstvě. Tělo `ErasureRequestDto { aggregateType, aggregateId }`. Vrací `ErasureDecision`: buď crypto-shred (`erased=true`), nebo **odmítnutí** pod zákonným hold (Art. 17(3)(b)) s auditovatelným `legalBasis`/`explanation`. |
+| `POST` | `/` | GDPR Art. 17 výmaz vůči analytické vrstvě. Tělo `ErasureRequestDto { aggregateType, aggregateId }`. Vrací `ErasureDecision`, jehož `outcome` má tři hodnoty: `ERASED` (crypto-shred), `REFUSED_LEGAL_HOLD` (zákonná překážka podle Art. 17(3)(b) výmaz přebíjí, s auditovatelným `legalBasis`/`explanation`) a `NO_BACKEND` (tento build nemá backend pro výmaz, žádost tedy zůstává nevyřízená — **není** to odmítnutí z právního důvodu, viz #9671). `erased` je odvozené z `outcome` a je true jen pro `ERASED`. |
 
 ## Chybový model
 

--- a/openbank-analytics-sink/src/main/resources/docs/03-api.en.md
+++ b/openbank-analytics-sink/src/main/resources/docs/03-api.en.md
@@ -38,7 +38,7 @@ Roles: `ROLE_COMPLIANCE`, `ROLE_ADMIN`.
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/` | GDPR Art. 17 erasure against the analytics layer. Body `ErasureRequestDto { aggregateType, aggregateId }`. Returns an `ErasureDecision`: either crypto-shredded (`erased=true`) or **refused** under a statutory hold (Art. 17(3)(b)) with an auditable `legalBasis`/`explanation`. |
+| `POST` | `/` | GDPR Art. 17 erasure against the analytics layer. Body `ErasureRequestDto { aggregateType, aggregateId }`. Returns an `ErasureDecision` whose `outcome` is one of three: `ERASED` (crypto-shredded), `REFUSED_LEGAL_HOLD` (a statutory hold under Art. 17(3)(b) overrides erasure, with an auditable `legalBasis`/`explanation`), or `NO_BACKEND` (this build has no erasure backend, so the request stands unfulfilled — NOT a legal refusal, see #9671). `erased` is derived from `outcome` and is true only for `ERASED`. |
 
 ## Error model
 

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/ErasureServiceTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/ErasureServiceTest.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+import com.openbank.analytics.application.port.out.CryptoErasure
+import com.openbank.libs.analytics.AggregateKey
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * What [ErasureService] is allowed to claim (#9671).
+ *
+ * `ErasureDecision` is described in its own KDoc as the position to show a supervisor or the data
+ * subject, and it used to carry `erased = true` on every path that was not a statutory refusal —
+ * a literal, not a measurement. The deployed image contains `NoOpCryptoErasure` (the vault adapter
+ * is `@IfBuildProperty(openbank.analytics.erasure.backend=vault)`, resolved at augmentation, and
+ * the property is set only in `docker-compose.yml`), so every Art. 17 request answered
+ * `erased: true, rowsAffected: 0` with the explanation "Crypto-shredded analytics data".
+ *
+ * There was no test over this class at all before this one, which is how a literal survived.
+ *
+ * **`rowsAffected` cannot be the discriminator, and the third test is what says so.** A real
+ * backend returns 0 for a subject with no warehouse data, so `0` is shared by "erased nothing
+ * because there was nothing" and "erased nothing because this build cannot". Only asking the port
+ * separates them, and only that test fails if someone reintroduces a row-count heuristic.
+ */
+class ErasureServiceTest {
+
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-09-11T10:00:00Z"), ZoneOffset.UTC)
+
+    /** Stands in for the deployed default: logs, destroys nothing, reports zero. */
+    private class StubErasure : CryptoErasure {
+        override val performsErasure = false
+        var called = false
+        override suspend fun erase(key: AggregateKey): Long {
+            called = true
+            return 0
+        }
+    }
+
+    /** A real backend that happens to find nothing for this subject. */
+    private class RealErasureFindingNothing : CryptoErasure {
+        override suspend fun erase(key: AggregateKey): Long = 0
+    }
+
+    private class RealErasure(private val rows: Long) : CryptoErasure {
+        override suspend fun erase(key: AggregateKey): Long = rows
+    }
+
+    private fun serviceWith(backend: CryptoErasure) = ErasureService().apply {
+        cryptoErasure = backend
+        clock = this@ErasureServiceTest.clock
+    }
+
+    /** An erasable category, so the legal gate is open and the backend decides the outcome. */
+    private val erasableType = "CONSENT"
+
+    @Test
+    fun `a build with no erasure backend reports NO_BACKEND, never an erasure`(): Unit = runBlocking {
+        val backend = StubErasure()
+
+        val d = serviceWith(backend).erase(erasableType, "subject-1", "dpo@openbank.cz")
+
+        assertThat(d.outcome).isEqualTo(ErasureOutcome.NO_BACKEND)
+        assertThat(d.erased).isFalse()
+        assertThat(d.rowsAffected).isZero()
+        // The text is the part a supervisor reads, so it must not assert a shred either.
+        assertThat(d.explanation).doesNotContain("Crypto-shredded")
+        assertThat(d.explanation).contains("No erasure backend")
+        // And it must not read as a legal refusal, which is a defensible position this is not.
+        assertThat(d.explanation).contains("NOT a refusal")
+        // No point calling a backend that cannot erase.
+        assertThat(backend.called).isFalse()
+    }
+
+    @Test
+    fun `a real backend that erased rows reports ERASED`(): Unit = runBlocking {
+        val d = serviceWith(RealErasure(rows = 7)).erase(erasableType, "subject-2", "dpo@openbank.cz")
+
+        assertThat(d.outcome).isEqualTo(ErasureOutcome.ERASED)
+        assertThat(d.erased).isTrue()
+        assertThat(d.rowsAffected).isEqualTo(7)
+        assertThat(d.explanation).contains("Crypto-shredded")
+    }
+
+    @Test
+    fun `a real backend finding nothing still reports ERASED, so rowsAffected is not the signal`(): Unit = runBlocking {
+        val d = serviceWith(RealErasureFindingNothing())
+            .erase(erasableType, "subject-3", "dpo@openbank.cz")
+
+        // Same rowsAffected as the NO_BACKEND case above, opposite outcome. Reintroduce a
+        // `rows == 0` heuristic in place of `performsErasure` and this is the test that goes red.
+        assertThat(d.rowsAffected).isZero()
+        assertThat(d.outcome).isEqualTo(ErasureOutcome.ERASED)
+        assertThat(d.erased).isTrue()
+    }
+
+    @Test
+    fun `a category under a statutory hold is refused, and that is distinct from NO_BACKEND`(): Unit = runBlocking {
+        // TRANSACTION-shaped data is held for the accounting/AML retention period.
+        val d = serviceWith(RealErasure(rows = 99)).erase("TRANSACTION", "subject-4", "dpo@openbank.cz")
+
+        assertThat(d.outcome).isEqualTo(ErasureOutcome.REFUSED_LEGAL_HOLD)
+        assertThat(d.erased).isFalse()
+        assertThat(d.rowsAffected).isZero()
+        assertThat(d.explanation).contains("Art. 17(3)(b)")
+    }
+}


### PR DESCRIPTION
## Summary

A GDPR Art. 17 erasure request against the **deployed** analytics-sink answered `erased: true`, logged `erasure PERFORMED`, and explained *"Crypto-shredded analytics data"* — while nothing was shredded. The image contains `NoOpCryptoErasure`, which logs and returns `0`. This makes the report truthful; it does not decide whether the deployed image should carry a real backend.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9671, #8792

## The defect

`erased` was a literal on every path that was not a statutory refusal:

```kotlin
val rows = cryptoErasure.erase(AggregateKey(aggregateType, aggregateId))
log.infof("erasure PERFORMED %s/%s category=%s rows=%d by=%s", ...)
return ErasureDecision(
    erased = true,
    rowsAffected = rows,
    explanation = "Crypto-shredded analytics data for $category (no statutory hold).",
```

`VaultCryptoErasure` is `@Alternative @Priority(100)` behind `@IfBuildProperty(openbank.analytics.erasure.backend = "vault")`; `application.yaml` reads `${ANALYTICS_ERASURE_BACKEND:}` (empty) and the property is set in exactly one place in the tree — `openbank-infra/docker-compose.yml:607` — and **nowhere under `openbank-infra/gitops/`**. The repo's own gate prints the build-time value:

```
$ python3 .github/scripts/check-build-time-bean-selection.py --verbose
  openbank-analytics-sink:openbank.analytics.erasure.backend      build=''
  openbank-analytics-sink:openbank.analytics.sink.type            build='clickhouse'
```

`sink.type` has a real build value; `erasure.backend` is empty. `@IfBuildProperty` resolves at augmentation and ArC removes the losing bean, so **no Deployment env var can change this** — the image would have to be rebuilt.

`ErasureDecision`'s own KDoc calls it *"the documented, defensible position to show a supervisor / the data subject"*, which is what makes a false affirmative worse here than in an ordinary stub.

## Why the existing gate is green, and correctly so

`check-build-time-bean-selection.py` (#6057 / PR #6081) exists for exactly this family, and its docstring names the failure mode verbatim: *"When the loser is a `@Default` no-op that returns the winner's success value, nothing anywhere disagrees."* It passes here (`rc=0`, 30 sites, 3 excluded).

Its question is **"does a gitops env var ask for a bean the image does not contain?"** Analytics erasure asks for nothing, so there is no contradiction to find. The defect is the adjacent one: *nobody asks, the no-op wins, and the caller reports success anyway.* That distinction is why this survived a gate written for its own pattern — worth knowing before assuming the gate covers the whole family.

## The fix, and why it is shaped this way

Following #4348's recorded remedy rather than inventing one — a skipped outcome gets its **own value**, never a flag shared with success:

- `ErasureOutcome` = `ERASED` / `REFUSED_LEGAL_HOLD` / `NO_BACKEND`
- `erased` is now **derived** (`outcome == ERASED`), so the two cannot drift; it used to be the constructor parameter that carried the lie
- `CryptoErasure.performsErasure` defaults to `true`, so a real adapter needs no change; only the stub overrides it

**`NO_BACKEND` is deliberately not folded into the refusal.** One is a defensible legal position, the other is a gap in the deployment — conflating them would repeat the exact mistake being fixed. The explanation says so in words too, since that string is what a supervisor reads.

**`rowsAffected` cannot be the discriminator.** A real backend returns 0 for a subject with no warehouse data, so `0` is shared by "erased nothing because there was nothing" and "erased nothing because this build cannot". Only the port can answer.

## Verification — falsified twice, on the shipped code

There was **no test over `ErasureService` at all** before this one (only `VaultCryptoErasureTest`/`IT`), which is how a literal survived on a regulatory path.

The measurements were repeated after `noBackendDecision` was extracted for detekt's `LongMethod` (67 vs 60) and after `ktlintFormat`, because both changed the code under test:

| sabotage | real exit code | which test goes red |
|---|---|---|
| guard removed — the original bug | **1** | `a build with no erasure backend reports NO_BACKEND, never an erasure` |
| guard keyed on `rows == 0L` instead of the port | **1** | `a real backend finding nothing still reports ERASED, so rowsAffected is not the signal` |
| restored | 0 | 4 tests, 0 failures |

The second row is the one that forbids the plausible shortcut. The full module suite is green, and `ktlintCheck` + `detekt` were run separately after the tests per the root `CLAUDE.md` note that Gradle stops at the first failing task.

## Note on #8792 acceptance 4

That criterion — *"every new store anonymises in place on `PARTY_ERASED`"* — cannot be closed as written, and this PR does not close it. A fleet grep for `Party(Erased|Deleted|Anonymised|Anonymized)` over `*/src/main/kotlin` returns nothing and `bronze_events` holds 0 events matching `%Erased%`: erasure is a REST request, not an event. And "anonymise in place" contradicts ADR-0023 F6, which crypto-shreds the key *"without mutating the immutable bronze log"* precisely to honour Art. 17 against an append-only store (ADR-0022). The criterion needs restating against the mechanism that exists.

## Changes

- `ErasurePort.kt` — `CryptoErasure.performsErasure`, defaulting to `true`
- `NoOpCryptoErasure.kt` — overrides it to `false`
- `ErasureService.kt` — `ErasureOutcome`, derived `erased`, the `NO_BACKEND` branch in `noBackendDecision`
- `ErasureServiceTest.kt` — 4 tests (new file)
- `docs/03-api.{en,cs}.md` — the response is a trinary now, not "shredded or refused"

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — module-scoped: full `test`, then `ktlintCheck` + `detekt`
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — **analytics-sink has no `openapi.yaml`**; the response gains a field, which is additive for JSON consumers
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). — both API doc languages

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — the new WARN line carries aggregate type/id and requester, all already sanitised for CR/LF by the existing `sanitizeForLog`
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. — none added
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → **it touches the erasure decision, not crypto itself.** No key handling, signing or payment path changes; `VaultCryptoErasure` is untouched. Flagging it here because the subject matter is GDPR Art. 17 and a reviewer should see that deliberately.
- [x] PII path changed? → **the erasure path's REPORT changed, in the honest direction.** No personal data is read, written or retained differently; a request that previously reported success now reports `NO_BACKEND`.
- [x] Cardholder data path changed? → no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR — Art. 17. The response to an erasure request stops asserting a shred that did not happen. This does not make the deployed service erase; it stops it claiming to.
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
