### PR TITLE
fix(observability): stop two alerts firing on state they cannot clear

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-journey.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-journey.yaml
@@ -52,11 +52,26 @@ spec:
         # `max_over_time` because kube-state-metrics drops the series when the Job object is
         # garbage-collected (failedJobsHistoryLimit: 1), and an alert that vanishes with its
         # evidence is one nobody can triage.
+        #
+        # The 30m window does NOT bound the age of the failure, and that was the defect:
+        # `kube_job_status_failed` is a GAUGE that keeps reporting 1 for as long as the Job object
+        # exists, and these Jobs are retained for `ttlSecondsAfterFinished: 172800` (48h). So
+        # `max_over_time(...[30m])` re-reads the same retained 1 on every evaluation and the alert
+        # outlives its own window by two days. Measured 2026-09-11: five instances firing, of which
+        # one (`journey-public-edge-29817560`) was a 25h-old one-off whose every subsequent run had
+        # passed. The recency guard reads the Job's own start time instead of the window, so the
+        # evidence still survives GC while a failure that is two days stale stops paging.
         - alert: JourneyRunFailed
           expr: |
             max by (namespace, job_name) (
               max_over_time(kube_job_status_failed{namespace="observability", job_name=~"journey-.*"}[30m])
             ) > 0
+              and on (namespace, job_name)
+            (
+              time() - max by (namespace, job_name) (
+                kube_job_status_start_time{namespace="observability", job_name=~"journey-.*"}
+              ) < 3600
+            )
           for: 1m
           labels:
             severity: warning

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -328,6 +328,9 @@ spec:
             severity: warning
             service: '{{ $labels.service }}'
           annotations:
+            # The [1h] window measures payment intake, which is driven by real customer traffic
+            # rather than by any scheduler — there is no period to align the window to.
+            subject_period: continuous
             summary: "{{ $labels.service }} took payments for an hour and scored none of them"
             description: >-
               The fraud-scoring gauge on {{ $labels.service }} ({{ $labels.rail }}) has read

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -299,19 +299,41 @@ spec:
           # -1, the boot value, is a distinct state from a healthy 0 on purpose. This is the alert
           # that would have fired on the original defect: every consumer resolved fraud-service to
           # localhost, so scoring never happened, and "no fraud found" was indistinguishable from
-          # "no fraud scoring". A rail with genuinely no traffic for an hour is the false positive
-          # to expect here — which is itself worth knowing on a payment rail.
-          expr: openbank_fraud_scoring_degraded == -1
+          # "no fraud scoring".
+          #
+          # The gauge alone cannot express that. `-1` is per-pod state reset by every restart, so on
+          # a rail with no intake the condition is permanent and `for:` can never clear it: measured
+          # 2026-09-11, all four rails (DOMESTIC/SEPA/SCT_INST/FX) read -1 with zero payment POSTs in
+          # 12h, i.e. the alert fires an hour after every deploy of every rail and stays firing. An
+          # always-on alert on the control that exists to make dead scoring visible is the one thing
+          # that hides dead scoring, so the intake guard below is what makes the signal mean what the
+          # summary claims: payments arrived AND none of them was scored.
+          #
+          # Intake is REST for all four rails (DomesticPaymentResource, SepaPaymentResource,
+          # SctInstResource, FxResource all take @POST), so a POST on the pod's own HTTP server is
+          # the transport-accurate proxy for "this rail did work". Probe and management URIs are
+          # excluded; Micrometer creates the timer on first request, so no POST series means no
+          # intake rather than a suppressed defect. A rail that is idle is no longer an alert — that
+          # is what JourneyRunFailed and the rail's own SLO burn are for.
+          expr: |
+            openbank_fraud_scoring_degraded == -1
+              and on (namespace, pod)
+            (
+              sum by (namespace, pod) (
+                increase(http_server_requests_seconds_count{method="POST", uri!~"/q/.*|/health.*"}[1h])
+              ) > 0
+            )
           for: 1h
           labels:
             severity: warning
             service: '{{ $labels.service }}'
           annotations:
-            summary: "{{ $labels.service }} has never scored a payment for fraud since it started"
+            summary: "{{ $labels.service }} took payments for an hour and scored none of them"
             description: >-
               The fraud-scoring gauge on {{ $labels.service }} ({{ $labels.rail }}) has read
-              NEVER_ATTEMPTED for >1h. Either the rail has taken no traffic at all, or the scoring
-              call site is not being reached. Cross-check row growth in `fraud_scores`.
+              NEVER_ATTEMPTED for >1h while the pod was serving payment POSTs — so the rail is
+              taking traffic and the scoring call site is not being reached. Cross-check row growth
+              in `fraud_scores`.
         - alert: FraudScoringMostlySynthetic
           # The counters exist at 0.0 from the first scrape (registered eagerly, not on first
           # increment), so this ratio is well-defined from boot rather than absent until a failure.


### PR DESCRIPTION
## Summary
Two alert rules fire permanently on state they cannot clear. Both measured against the live sandbox on 2026-09-11 during an observability audit; neither is an incident, and both sit in the 44-alert standing set that makes the rest of the estate hard to read.

## `FraudScoringNeverAttempted`
`openbank_fraud_scoring_degraded == -1` is the per-pod boot value, reset by every restart. On a rail with no intake the condition is structurally permanent, so `for: 1h` can never clear it — the alert fires an hour after every deploy of every payment rail and stays firing.

Measured: all four rails (DOMESTIC / SEPA / SCT_INST / FX) read `-1`, with **zero payment POSTs in 12h** and `openbank_fraud_scoring_outcomes_total` = 0 on all 8 series (registered eagerly, so 0 ≠ absent). The scoring call sites are live code and Temporal is running — the path is reachable, it is simply never traversed.

Fix: gate on the pod's own intake, so the alert means what its summary claims — *payments arrived and none of them was scored*. Intake is REST for all four rails (`DomesticPaymentResource`, `SepaPaymentResource`, `SctInstResource`, `FxResource` all take `@POST`), so a POST on the pod's HTTP server is the transport-accurate proxy; probe and management URIs are excluded.

| | instances |
|---|---|
| current expr | **4** |
| proposed expr | **0** |

Falsified the guard rather than trusting it: `increase(http_server_requests_seconds_count{method="POST",...}[1h]) > 0` **does** resolve elsewhere in the fleet (keycloak), so the added condition is not structurally blind — it is dormant on idle rails and passes the moment intake resumes.

## `JourneyRunFailed`
The rule's comment says the 30m window bounds the failure, and it does not. `kube_job_status_failed` is a **gauge** that keeps reporting `1` for as long as the Job object exists, and these Jobs are retained for `ttlSecondsAfterFinished: 172800` (48h) — so `max_over_time(...[30m])` re-reads the same retained `1` on every evaluation and the alert outlives its own window by two days.

Measured: 5 instances firing, of which `journey-public-edge-29817560` was a **25h-old one-off** whose every subsequent run passed (latest run `rate=100.00%`, all three checks green).

Fix: bound on the Job's own `kube_job_status_start_time`. The `max_over_time` stays, so the evidence still survives kube-state-metrics dropping the series at GC — what changes is that a two-day-stale failure stops paging.

| | instances |
|---|---|
| current expr | **5** |
| proposed expr | **1** (the genuinely recent one) |

## Scope
Rule shape only — no thresholds relaxed, no signal deleted. The conditions each alert was written to catch still fire; what stops firing is the state that is not one.

## Test plan
- [x] `promtool check rules` OK on `openbank-fraud-scoring-alerts` and `openbank-journey-alerts`
- [x] `yamllint` clean under the repo config (0 violations, unchanged from `main`)
- [x] Both proposed expressions evaluated against live Prometheus; counts above are measured, not predicted
- [x] Guard falsified against a known-positive so it cannot be silently inert
- [ ] After merge: confirm the 4 fraud instances and the stale journey instance clear, and that no rail alert is lost when intake resumes

Refs #7324 (the product-catalog journey's missing credential, the one remaining `JourneyRunFailed` instance — not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
