### PR TITLE
feat(observability): make credential delivery and stuck node drains visible

### DIFF
--- a/openbank-infra/gitops/components/observability/podmonitor-external-secrets.yaml
+++ b/openbank-infra/gitops/components/observability/podmonitor-external-secrets.yaml
@@ -1,0 +1,42 @@
+# Scrape the external-secrets controller. Nothing did, and the cost was thirteen days of a
+# fleet-wide credential outage nobody could see (#9689).
+#
+# Measured 2026-09-11: seven `*-db-dynamic` ExternalSecrets (accounts, audit, balances, fx,
+# ledger, notifications, payments) had been `Ready=False SecretSyncedError` continuously since
+# 2026-08-29T10:00:22Z because OpenBao's storage backend is wedged and cannot issue a dynamic
+# database credential to anything. The controller knew the whole time — its own /metrics carries
+# `externalsecret_status_condition{condition="Ready",status="False"} 1` per failing secret and
+# `externalsecret_sync_calls_error{name="accounts-db-dynamic"} 297`, one per hourly refresh — and
+# no scraper existed, so none of it reached Prometheus. The fault surfaced sideways, as an
+# `ArgoCDAppDegraded` rollup on seven applications whose own workloads were healthy.
+#
+# Why it stayed quiet for so long is the part worth keeping: the pods run on the STATIC
+# `*-db-app` Secret, so every probe is green and every service serves. What fails is only the
+# refresh, and a refresh that fails is silent by construction — same family as the CNPG archiver
+# that returns success while writing to nowhere, and the disabled push adapter whose skip
+# counted as a delivery.
+#
+# external-secrets publishes no Service for the controller (only the webhook has one), so this is
+# a PodMonitor rather than a ServiceMonitor — the container declares port `metrics` (8080)
+# directly. The cluster Prometheus has empty podMonitor selectors, so it is discovered
+# automatically; same discovery path as servicemonitor-karpenter.yaml.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: external-secrets
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: external-secrets
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - external-secrets
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: true

--- a/openbank-infra/gitops/components/observability/prometheus-rules-capacity.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-capacity.yaml
@@ -162,3 +162,38 @@ spec:
           annotations:
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} Pending and unschedulable for ~30m"
             description: "Unschedulable for ~30 minutes (a 15m staleness clause plus a 15m `for:`). Check KarpenterNodePoolAtLimit first (cap bind), then taints/tolerations, then image pull. kubectl describe pod for the scheduler event."
+        # A node that cannot finish draining is the mirror image of the rule above: there, work
+        # cannot land; here, work cannot leave. Nothing named this condition, and the cost was
+        # three nodes terminating for 9 to 15 days (#9691) — found only because the leftover pods
+        # made two DaemonSets report `misscheduled`, which reads as a DaemonSet problem and is not
+        # one.
+        #
+        # `kube_node_deletion_timestamp` exists only while a node is mid-deletion, so the series
+        # IS the condition; measured 2026-09-11 it carried exactly the three stuck nodes and
+        # nothing else. `kube_node_spec_unschedulable` is NOT a substitute — it read 0 for all
+        # three, because Karpenter's disruption taint is not a cordon.
+        #
+        # 1h is chosen to sit clear of normal churn: a healthy Karpenter consolidation drains and
+        # removes a node in minutes, and the shortest of the three real cases had already been
+        # stuck for nine days. The usual blocker is a PodDisruptionBudget that can never permit a
+        # disruption — a single-instance CNPG cluster behind `minAvailable: 1` pins
+        # `disruptionsAllowed` at 0 forever, which is what all three of these were.
+        - alert: NodeStuckTerminating
+          expr: |
+            (time() - kube_node_deletion_timestamp) > 3600
+          for: 30m
+          labels:
+            severity: warning
+            detector: capacity
+            team: platform
+          annotations:
+            summary: "Node {{ $labels.node }} has been draining for over an hour"
+            description: >-
+              Deletion was requested {{ $value | humanizeDuration }} ago and eviction has not
+              finished. The node still holds workload, still counts against capacity, and whatever
+              remains on it will move on the cluster's schedule rather than yours once the drain
+              clears. Find the blocker before forcing anything — `kubectl get pods -A
+              --field-selector spec.nodeName={{ $labels.node }}`, then check each remaining pod's
+              PDB (`ALLOWED DISRUPTIONS 0` on a single-replica stateful workload is the common
+              one). Forcing the eviction of a database primary with no replica is how this becomes
+              an outage instead of a delay.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-secret-delivery.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-secret-delivery.yaml
@@ -1,0 +1,83 @@
+# Alerts over the external-secrets controller (scraped by podmonitor-external-secrets.yaml).
+#
+# These exist because #9689 ran for thirteen days with no signal. The controller was publishing
+# the fault the whole time; nothing scraped it, so the estate had no way to say "credential
+# delivery is broken" and the fault surfaced only as an ArgoCDAppDegraded rollup on seven
+# applications whose own workloads were fine.
+#
+# Measured on the live controller 2026-09-11 before writing these, so the series and label names
+# below are observed rather than assumed:
+#
+#   externalsecret_status_condition{condition="Ready",name="accounts-db-dynamic",
+#                                   namespace="accounts",status="False"}  1
+#   externalsecret_sync_calls_error{name="accounts-db-dynamic",namespace="accounts"}  297
+#   externalsecret_provider_api_calls_count{provider="HashiCorp/Vault",
+#                                           call="ReadSecretData",status="error"}  2079
+#
+# Note the shape of `externalsecret_status_condition`: it is emitted for BOTH status="True" and
+# status="False" as 0/1, so a healthy secret is a present series reading 0, not an absent one.
+# That is what makes `== 1` safe here — absence would mean the controller is not scraped at all,
+# which is the condition ExternalSecretControllerUnscraped below covers instead.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-secret-delivery
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: openbank.secret-delivery
+      rules:
+        - alert: ExternalSecretNotReady
+          # 1h, not minutes: a refresh is hourly here (refreshInterval: 1h), so a single missed
+          # cycle is not yet a story. What this must catch is the sustained case — the one that
+          # ran 13 days unseen — and at 1h it would have fired on 2026-08-29, the same day.
+          expr: |
+            max by (namespace, name) (
+              externalsecret_status_condition{condition="Ready", status="False"}
+            ) == 1
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} has not synced for over an hour"
+            description: >-
+              The external-secrets controller cannot materialise this Secret. Nothing has
+              necessarily broken YET: a workload already holding the previous value keeps running,
+              which is precisely why this failure is silent and why it is worth alerting on
+              directly. What has stopped is renewal — the failure surfaces on the next rotation,
+              new consumer, or reschedule. Check the ExternalSecret's status message and its
+              provider (`kubectl -n {{ $labels.namespace }} describe externalsecret {{ $labels.name }}`).
+        - alert: ExternalSecretProviderErrors
+          # The provider counter is the only signal that distinguishes "this one secret is
+          # misconfigured" from "the provider is refusing everyone", which is what #9689 was.
+          expr: |
+            sum by (provider, call) (
+              rate(externalsecret_provider_api_calls_count{status="error"}[15m])
+            ) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "external-secrets is getting errors from provider {{ $labels.provider }} on {{ $labels.call }}"
+            description: >-
+              Sustained errors from the secret provider itself rather than from one ExternalSecret.
+              If this is firing alongside several ExternalSecretNotReady, the provider is the
+              subject and the individual secrets are symptoms — triage the provider first.
+        - alert: ExternalSecretControllerUnscraped
+          # The control that keeps the two alerts above honest. They are `== 1` and `> 0` over
+          # series that simply vanish if the PodMonitor is removed or its selector stops matching,
+          # and a vanished series is silence, not health — the exact state this whole rule file
+          # was written in response to. absent() is the only formulation that can see it.
+          expr: absent(externalsecret_status_condition)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "No external-secrets metrics are reaching Prometheus"
+            description: >-
+              `externalsecret_status_condition` has no series, so every alert in this group is
+              blind. Either the controller is down or podmonitor-external-secrets.yaml is no
+              longer selecting it. This is what #9689 looked like for thirteen days.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-secret-delivery.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-secret-delivery.yaml
@@ -53,14 +53,27 @@ spec:
         - alert: ExternalSecretProviderErrors
           # The provider counter is the only signal that distinguishes "this one secret is
           # misconfigured" from "the provider is refusing everyone", which is what #9689 was.
+          #
+          # The window is 2h against a 1h subject period, and that is not padding. Measured
+          # 2026-09-11: all 167 ExternalSecrets refresh at `refreshInterval: 1h`, so a given
+          # secret contacts the provider — and fails — once an hour. Their refresh times are
+          # spread across the hour but not evenly (94 of them land in :00-:10 and :40-:55,
+          # while :15-:35 carries about six), so a window narrower than the period sits inside
+          # a quiet stretch and reads zero while the provider is refusing everyone.
+          #
+          # The first draft of this rule was `[15m]` with `for: 30m`, which is worse than
+          # imprecise: a `for:` at or above the window can never mature, because the condition
+          # has to hold continuously for longer than the window can observe it. Window wider
+          # than the period, `for:` comfortably shorter than the window.
           expr: |
             sum by (provider, call) (
-              rate(externalsecret_provider_api_calls_count{status="error"}[15m])
+              rate(externalsecret_provider_api_calls_count{status="error"}[2h])
             ) > 0
           for: 30m
           labels:
             severity: warning
           annotations:
+            subject_period: 1h
             summary: "external-secrets is getting errors from provider {{ $labels.provider }} on {{ $labels.call }}"
             description: >-
               Sustained errors from the secret provider itself rather than from one ExternalSecret.


### PR DESCRIPTION
## Summary
Two faults found in the 2026-09-11 estate audit ran for **13 and 15 days with no alert**. In both cases the signal already existed and nothing was reading it. This PR adds the reading.

It is the "so it does not happen again" half of #9688 — that one stopped two alerts firing on state they cannot clear; this one starts two conditions being visible at all.

## 1. external-secrets was never scraped

`#9689`: seven `*-db-dynamic` ExternalSecrets have been `Ready=False SecretSyncedError` since 2026-08-29T10:00:22Z. The controller knew the whole time. Read off the live pod before writing anything here:

```
externalsecret_status_condition{condition="Ready",name="accounts-db-dynamic",status="False"}  1
externalsecret_sync_calls_error{name="accounts-db-dynamic",namespace="accounts"}            297
externalsecret_provider_api_calls_count{provider="HashiCorp/Vault",call="ReadSecretData",
                                        status="error"}                                    2079
```

297 errors ≈ one per hourly refresh for 13 days. None of it reached Prometheus: **no ServiceMonitor, no PodMonitor, 0 series**. The fault surfaced sideways as `ArgoCDAppDegraded` on seven applications whose own workloads were healthy — which is how it got mistaken for an Argo problem for nearly two weeks.

external-secrets publishes no Service for the controller (only the webhook has one), so this is a **PodMonitor** on the container's own `metrics` port, not a ServiceMonitor.

Three alerts, each with a job the others cannot do:

| alert | catches |
|---|---|
| `ExternalSecretNotReady` | the sustained per-secret failure — at `for: 1h` it would have fired on 2026-08-29, the day it broke |
| `ExternalSecretProviderErrors` | "the provider refuses everyone" vs "one secret is misconfigured" — #9689 was the former, and only the provider counter separates them |
| `ExternalSecretControllerUnscraped` | `absent()` control, so the two above cannot go silently blind the way the whole subsystem just did |

**Why it was silent is the part worth keeping:** workloads bind the *static* `*-db-app` Secret, so every probe stayed green and every service served. Only **renewal** failed, and a renewal that fails is silent by construction — the same family as the CNPG archiver returning success while writing to nowhere, and the disabled push adapter whose skip counted as a delivery.

## 2. Nothing named "a node that cannot finish draining"

`#9691`: three nodes terminating for **9 to 15 days**, found only because their leftover pods made `falco` and `alloy` report `misscheduled`, which reads as a DaemonSet rollout fault and is not one (both are `12/12` ready and fully updated).

`NodeStuckTerminating` is the mirror image of the `PodPendingUnschedulable` rule it sits next to: there, work cannot land; here, work cannot leave.

Two measurement notes that decided the expression:
- `kube_node_deletion_timestamp` exists **only** while a node is mid-deletion, so the series *is* the condition — no threshold on a gauge that means something else when idle.
- `kube_node_spec_unschedulable` is **not** a substitute: it read `0` for all three, because Karpenter's disruption taint is not a cordon. A rule built on it would have been green throughout.

Evaluated live, the proposed expression returns exactly the three real nodes and nothing else:

```
ip-10-80-55-133    15.4 days
ip-10-80-35-82     13.8 days   <- hosts notifications-db-1, a CNPG primary
ip-10-80-104-161    9.6 days
```

The 1h threshold sits clear of normal churn (healthy consolidation drains in minutes) and the shortest real case was nine days, so there is a lot of room. The description points at the blocker rather than the symptom — in all three cases it is a single-instance CNPG cluster behind `minAvailable: 1`, which pins `disruptionsAllowed` at 0 permanently.

## Test plan
- [x] `promtool check rules` OK on `openbank-secret-delivery` and `openbank-capacity-cap-alerts`
- [x] `yamllint` clean under the CI gate's own config (extracted from `gates.yaml`, since the repo ships no `.yamllint` file — linting with a non-existent config silently produces empty output, which is not the same as clean)
- [x] Every series and label name verified against the live controller's `/metrics` before the rules were written, including that `externalsecret_status_condition` is emitted for both `status="True"` and `status="False"` as 0/1 — so a healthy secret is a present series reading 0, which is what makes `== 1` safe
- [x] `NodeStuckTerminating` evaluated against live Prometheus: 3 series, the 3 real nodes
- [ ] After merge: confirm the PodMonitor is discovered (`externalsecret_status_condition` acquires series) and that `ExternalSecretNotReady` fires for the seven known-bad secrets rather than staying quiet

Refs #9689, #9691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
