### PR TITLE
feat(analytics-sink): party activity over history, not current state

### DIFF
--- a/openbank-analytics-sink/src/main/resources/clickhouse/V16__party_activity_history.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V16__party_activity_history.sql
@@ -1,0 +1,78 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V16 — party activity over HISTORY, not current state (ADR-0282 phase 1, #8792 / #2891)
+--
+-- WHY THIS EXISTS, and why the obvious diagnosis was wrong. `silver_party_events` (V12) attributes
+-- events to a party two ways: the payload's own `partyId`, or — for rows that carry none — a join
+-- to `silver_party_accounts` on the account id. That join works: measured 2026-09-11,
+-- `AccountStatusChanged` appears in V12's view against 9 distinct parties while carrying no
+-- `partyId` of its own. So "ACCOUNT events have no party linkage" is NOT the reason party activity
+-- cannot be queried, and #2891's producer change would not on its own fix it.
+--
+-- The reason is the BASIS. Both legs of V12 read `silver_current_state`, which keeps only the
+-- LATEST event per aggregate, so 19 accounts yield at most 19 ACCOUNT rows. Measured on the same
+-- warehouse: `silver_party_events` holds 19 ACCOUNT rows across two event types, while
+-- `silver_history` holds 437 ACCOUNT rows — `BALANCE_UPDATED` (205), `HOLD_PLACED` (98) and
+-- `HOLD_RELEASED` (97) exist and are simply not reachable through a current-state view, whoever
+-- they belong to.
+--
+-- This view is the same attribution over `silver_history`. Nothing is imputed and nothing is
+-- aggregated here: one row per historical event per owning party, so a caller can count, window or
+-- cadence it without this file deciding which of those is wanted (ADR-0220 D5 — a rewards
+-- programme rendered from fabricated profiles is worse than a missing feature).
+--
+-- WHAT IT IS NOT. It is not a replacement for `silver_party_events`: "what is the party's current
+-- state" and "what has the party done" are different questions, and a history view answers the
+-- second badly if used for the first (an account closed yesterday still has 200 balance rows).
+-- V12 stays the current-state answer; this is the activity answer.
+--
+-- GRAIN, AND A TRAP IN IT. One row per bronze event per owning party. `aggregate_version` is
+-- projected because it is meaningful for some aggregates, but it MUST NOT be used as a sequence:
+-- measured 2026-09-11, all 205 `BALANCE_UPDATED` events in the warehouse carry `aggregate_version`
+-- = 0 while having 205 distinct `event_id`s, across only 21 distinct (aggregate_id, version) pairs.
+-- So (party, aggregate, version, event_type) is NOT a unique key here, and a caller that treats it
+-- as one collapses real activity. `silver_history` does not project `event_id`, so a caller needing
+-- a per-event key must join back to `bronze_events`; counting and time-windowing need none.
+--
+-- The `valid_to` column of `silver_history` is deliberately NOT projected. It is a
+-- `leadInFrame(...)` over the aggregate's own partition — the interval during which THAT row was
+-- the current state — and it means nothing once rows are re-keyed by party: two accounts owned by
+-- one party interleave, so a party-scoped `valid_to` would look like a validity interval while
+-- being an artefact of the partition it came from.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_party_activity AS
+-- The payload leg: the party is named in the event itself.
+SELECT
+    JSONExtractString(h.payload, 'partyId') AS party_id,
+    -- `silver_history` already folds this (V8), and the fold is restated rather than inherited:
+    -- a caller that gets case-folding by accident breaks the day the source view changes, and
+    -- nothing in the failure says why (#4604, and V12 states the same reasoning in place).
+    upper(h.aggregate_type)                 AS aggregate_type,
+    h.aggregate_id,
+    h.aggregate_version,
+    h.event_type,
+    h.valid_from                            AS occurred_at,
+    h.payload
+FROM openbank_analytics.silver_history AS h
+WHERE JSONExtractString(h.payload, 'partyId') != ''
+
+UNION ALL
+
+-- The account leg: rows the party owns through an account rather than through a payload key.
+-- The `= ''` guard is what keeps the union DISJOINT — without it a TRANSACTION row carrying both a
+-- `partyId` and an owned account id appears twice, and every count a caller builds doubles for
+-- exactly the best-instrumented events. V12 carries the same guard for the same reason; the bug it
+-- prevents is silent, since a doubled count looks like a busier customer.
+SELECT
+    pa.party_id                             AS party_id,
+    upper(h.aggregate_type)                 AS aggregate_type,
+    h.aggregate_id,
+    h.aggregate_version,
+    h.event_type,
+    h.valid_from                            AS occurred_at,
+    h.payload
+FROM openbank_analytics.silver_history AS h
+INNER JOIN openbank_analytics.silver_party_accounts AS pa
+    ON pa.account_id = h.aggregate_id
+WHERE upper(h.aggregate_type) IN ('ACCOUNT', 'TRANSACTION')
+  AND JSONExtractString(h.payload, 'partyId') = '';

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -1517,6 +1517,85 @@ data:
         max(occurred_at)         AS last_event_at
     FROM openbank_analytics.bronze_events
     GROUP BY day, aggregate_type;
+  16-party-activity-history.sql: |
+    -- ─────────────────────────────────────────────────────────────────────────────
+    -- V16 — party activity over HISTORY, not current state (ADR-0282 phase 1, #8792 / #2891)
+    --
+    -- WHY THIS EXISTS, and why the obvious diagnosis was wrong. `silver_party_events` (V12) attributes
+    -- events to a party two ways: the payload's own `partyId`, or — for rows that carry none — a join
+    -- to `silver_party_accounts` on the account id. That join works: measured 2026-09-11,
+    -- `AccountStatusChanged` appears in V12's view against 9 distinct parties while carrying no
+    -- `partyId` of its own. So "ACCOUNT events have no party linkage" is NOT the reason party activity
+    -- cannot be queried, and #2891's producer change would not on its own fix it.
+    --
+    -- The reason is the BASIS. Both legs of V12 read `silver_current_state`, which keeps only the
+    -- LATEST event per aggregate, so 19 accounts yield at most 19 ACCOUNT rows. Measured on the same
+    -- warehouse: `silver_party_events` holds 19 ACCOUNT rows across two event types, while
+    -- `silver_history` holds 437 ACCOUNT rows — `BALANCE_UPDATED` (205), `HOLD_PLACED` (98) and
+    -- `HOLD_RELEASED` (97) exist and are simply not reachable through a current-state view, whoever
+    -- they belong to.
+    --
+    -- This view is the same attribution over `silver_history`. Nothing is imputed and nothing is
+    -- aggregated here: one row per historical event per owning party, so a caller can count, window or
+    -- cadence it without this file deciding which of those is wanted (ADR-0220 D5 — a rewards
+    -- programme rendered from fabricated profiles is worse than a missing feature).
+    --
+    -- WHAT IT IS NOT. It is not a replacement for `silver_party_events`: "what is the party's current
+    -- state" and "what has the party done" are different questions, and a history view answers the
+    -- second badly if used for the first (an account closed yesterday still has 200 balance rows).
+    -- V12 stays the current-state answer; this is the activity answer.
+    --
+    -- GRAIN, AND A TRAP IN IT. One row per bronze event per owning party. `aggregate_version` is
+    -- projected because it is meaningful for some aggregates, but it MUST NOT be used as a sequence:
+    -- measured 2026-09-11, all 205 `BALANCE_UPDATED` events in the warehouse carry `aggregate_version`
+    -- = 0 while having 205 distinct `event_id`s, across only 21 distinct (aggregate_id, version) pairs.
+    -- So (party, aggregate, version, event_type) is NOT a unique key here, and a caller that treats it
+    -- as one collapses real activity. `silver_history` does not project `event_id`, so a caller needing
+    -- a per-event key must join back to `bronze_events`; counting and time-windowing need none.
+    --
+    -- The `valid_to` column of `silver_history` is deliberately NOT projected. It is a
+    -- `leadInFrame(...)` over the aggregate's own partition — the interval during which THAT row was
+    -- the current state — and it means nothing once rows are re-keyed by party: two accounts owned by
+    -- one party interleave, so a party-scoped `valid_to` would look like a validity interval while
+    -- being an artefact of the partition it came from.
+    -- ─────────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_party_activity AS
+    -- The payload leg: the party is named in the event itself.
+    SELECT
+        JSONExtractString(h.payload, 'partyId') AS party_id,
+        -- `silver_history` already folds this (V8), and the fold is restated rather than inherited:
+        -- a caller that gets case-folding by accident breaks the day the source view changes, and
+        -- nothing in the failure says why (#4604, and V12 states the same reasoning in place).
+        upper(h.aggregate_type)                 AS aggregate_type,
+        h.aggregate_id,
+        h.aggregate_version,
+        h.event_type,
+        h.valid_from                            AS occurred_at,
+        h.payload
+    FROM openbank_analytics.silver_history AS h
+    WHERE JSONExtractString(h.payload, 'partyId') != ''
+
+    UNION ALL
+
+    -- The account leg: rows the party owns through an account rather than through a payload key.
+    -- The `= ''` guard is what keeps the union DISJOINT — without it a TRANSACTION row carrying both a
+    -- `partyId` and an owned account id appears twice, and every count a caller builds doubles for
+    -- exactly the best-instrumented events. V12 carries the same guard for the same reason; the bug it
+    -- prevents is silent, since a doubled count looks like a busier customer.
+    SELECT
+        pa.party_id                             AS party_id,
+        upper(h.aggregate_type)                 AS aggregate_type,
+        h.aggregate_id,
+        h.aggregate_version,
+        h.event_type,
+        h.valid_from                            AS occurred_at,
+        h.payload
+    FROM openbank_analytics.silver_history AS h
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = h.aggregate_id
+    WHERE upper(h.aggregate_type) IN ('ACCOUNT', 'TRANSACTION')
+      AND JSONExtractString(h.payload, 'partyId') = '';
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
## Summary

`silver_party_events` (V12) answers *"what is this party's current state"*. Nothing answered *"what has this party done"* — both legs of that view read `silver_current_state`, which keeps only the **latest event per aggregate**. V16 applies the same attribution over `silver_history`.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8792, #2891

## Correcting the diagnosis this started from

#8792's first scope line asks for `partyId` on ACCOUNT events (#2891), and **I previously recorded in that issue that party activity is inexpressible *because* 418 of 437 ACCOUNT events carry none. That reason is false.** Measured 2026-09-11: V12 already resolves such rows through `silver_party_accounts` (`INNER JOIN pa.account_id = s.aggregate_id WHERE JSONExtractString(s.payload,'partyId') = ''`), and `AccountStatusChanged` sits in that view attributed to **9 distinct parties** while carrying no `partyId` of its own. Attribution by account works today.

The reason is the **basis**, not the attribution — which has a consequence worth stating plainly: **the producer change that scope line asks for would not, on its own, make activity queryable.** Adding `partyId` to the balance stream changes nothing about a current-state view. The correction is published on #8792.

## What it buys, measured

Applied to a **scratch database** reading the live source views — never to `openbank_analytics`, and verified afterwards that 0 objects of mine exist there:

| | rows reachable | event types |
|---|---|---|
| V12, current state | 19 | 2 |
| **V16, history** | **103** | **5** |

| event type | V16 rows | parties | in V12? |
|---|---|---|---|
| `BALANCE_UPDATED` | 41 | 9 | **no** |
| `AccountCreated` | 19 | 10 | 1 row |
| `AccountStatusChanged` | 18 | 9 | 18 rows |
| `HOLD_PLACED` | 13 | 2 | **no** |
| `HOLD_RELEASED` | 12 | 2 | **no** |

## Disjointness is measured and falsified, not asserted

The two legs must partition, or every count a caller builds doubles for exactly the best-instrumented events — and a doubled count looks like a busier customer, so the failure is silent.

- **Independent count:** payload leg `118` + account leg `84` = `202` = the view's own total. No row produced twice, none lost.
- **The overlap is real:** `19` rows carry BOTH a payload `partyId` and an owned account id.
- **Falsified:** removing the `= ''` guard takes the view from **202 → 221** (exactly those 19), restoring to 202. The guard is load-bearing.

## A trap found while verifying, documented in the file

All **205** `BALANCE_UPDATED` events carry `aggregate_version = 0` while having **205 distinct `event_id`s**, across only **21** distinct `(aggregate_id, version)` pairs.

So `(party, aggregate, version, event_type)` is **not** a unique key here. My first duplicate probe reported 18 "duplicates" — they were distinct events with a constant version, i.e. **the probe was wrong, not the view**. `silver_history` does not project `event_id`, so a caller needing a per-event key must join back to `bronze_events`; counting and time-windowing need none. The file says so, because a caller windowing by version would silently collapse real activity.

`valid_to` is deliberately not projected: it is a `leadInFrame` over the aggregate's own partition and means nothing once rows are re-keyed by party — two accounts owned by one party interleave, so a party-scoped `valid_to` would look like a validity interval while being an artefact of where it came from.

## Gates run, and the parity one falsified

| gate | result |
|---|---|
| `clickhouse-ddl-configmap-parity` | rc=0, 48 objects |
| same, with the ConfigMap entry removed | **rc=1**: *"V16 creates openbank_analytics.silver_party_activity, which the init ConfigMap never creates"* |
| `clickhouse-migration-configmap-sync` | rc=0, 16 migrations |
| `aggregate-type-case-fold` | rc=0, 2920 files |
| `flyway-version-commit-order` | rc=0, 479 migrations |

The `upper()` on `aggregate_type` is redundant (V8 already folds `silver_history`) and restated anyway, for the reason V12 gives in place: a caller that inherits case-folding by accident breaks the day the source view changes, and nothing in the failure says why.

## Changes

- `clickhouse/V16__party_activity_history.sql` — one view, `silver_party_activity`
- `gitops/.../clickhouse-init-configmap.yaml` — the same DDL, so a rebuilt cluster gets it

## Deliberately not included

No gold aggregate, no counts, no cadence, no score. #8792 does not ask for one, and ADR-0220 D5's rule applies: a rewards programme rendered from fabricated profiles is worse than a missing feature. This is one row per historical event per owning party; which fold is wanted is the caller's decision, not this file's.

## Note on what merging does

Per ADR-0022 analytics-sink runs **no migration runner**, so merging this applies nothing to a running warehouse. An operator applies `V16`; the ConfigMap copy is what a rebuilt cluster gets. That is why both had to change together, and why the parity gate exists.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — SQL + ConfigMap only
- [ ] Unit tests added/updated. — no code path; verification is the measured queries above
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — no Kotlin touched
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed). — ClickHouse DDL, not Flyway; rollback is `DROP VIEW openbank_analytics.silver_party_activity`, which strands nothing since no view reads it yet
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). — the rationale, the grain and the version-0 trap are in the migration header

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. — none
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → no.
- [x] PII path changed? → **it projects an existing pseudonymous `party_id` over existing rows.** No new field is read and nothing is unmasked: `payload` is already `PayloadMasker`-masked at the sink, and `silver_party_events` exposes the same two columns from the same sources. Retention and erasure are unchanged — a view holds no rows of its own.
- [x] Cardholder data path changed? → no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR — a view over already-ingested pseudonymous data, adding no field and no retention. Flagged rather than waved through because it re-keys events by data subject, which is worth a reviewer's eye even when the underlying rows do not change.
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
