### PR TITLE
fix(ci): use the shared transient vocabulary, not a private regex

### DIFF
--- a/.github/scripts/check-ruleset-bypass-actors.py
+++ b/.github/scripts/check-ruleset-bypass-actors.py
@@ -113,12 +113,49 @@ class Unreadable(RuntimeError):
     """
 
 
-# A rate limit is not a broken call: the subject was never read, exactly as in the
-# missing-admin-scope case. `gh` reports it on stderr; the primary limit says "API rate limit
-# exceeded", the secondary one "secondary rate limit" / "exceeded a secondary rate limit".
-# Matched on the message rather than the status, because `gh api` exits 1 for every HTTP error
-# and does not surface the code separately here.
-_RATE_LIMITED = re.compile(r"rate limit exceeded|exceeded a secondary rate limit", re.IGNORECASE)
+# The vocabulary is NOT defined here. `gh-transient-patterns.txt` next to this file is the one
+# shared list, read by `gh-retry.sh` and `check-ruleset-context-parity.py` as well. Its header
+# carries the measurement that produced it: three hand-written classifiers of this exact question
+# agreed on 23 of 31 real `gh` messages and disagreed on 8, each missing five the others caught.
+# A private regex here would have been the fourth — and this one's first draft was, missing
+# `Too Many Requests (HTTP 429)`, `abuse detection mechanism`, and a bare `HTTP 503`.
+_PATTERNS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gh-transient-patterns.txt")
+_PATTERN_CACHE: list[re.Pattern] | None = None
+
+
+def _transient_patterns() -> list[re.Pattern]:
+    """Compile [rate_limit] + [transient] from the shared vocabulary.
+
+    An unreadable or empty vocabulary raises — it must NOT silently classify everything as final.
+    An empty pattern list matches nothing, so every failure would read as a real finding while
+    each call still returned a plausible boolean.
+    """
+    global _PATTERN_CACHE
+    if _PATTERN_CACHE is not None:
+        return _PATTERN_CACHE
+    section, pats = None, {"rate_limit": [], "transient": []}
+    with open(_PATTERNS_FILE) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1]
+                continue
+            if section in pats:
+                pats[section].append(line)
+    if not pats["rate_limit"] or not pats["transient"]:
+        raise RuntimeError(
+            f"transient-pattern vocabulary at {_PATTERNS_FILE} has an empty [rate_limit] or "
+            f"[transient] section; refusing to classify with no patterns."
+        )
+    _PATTERN_CACHE = [re.compile(x, re.IGNORECASE) for x in pats["rate_limit"] + pats["transient"]]
+    return _PATTERN_CACHE
+
+
+def _is_transient(message: str) -> bool:
+    """True when a `gh` failure is about REACHABILITY, not about the bypass actors."""
+    return any(r.search(message) for r in _transient_patterns())
 
 
 def gh_api(path: str) -> list | dict:
@@ -139,7 +176,7 @@ def gh_api(path: str) -> list | dict:
         raise RuntimeError(f"could not run `gh api {path}`: {exc}") from exc
     if p.returncode != 0:
         stderr = p.stderr.strip()
-        if _RATE_LIMITED.search(stderr):
+        if _is_transient(stderr):
             raise Unreadable(
                 f"gh api {path} was RATE LIMITED (rc={p.returncode}): {stderr}. The subject was "
                 f"never read, so this run says nothing about bypass actors either way — it is "
@@ -314,11 +351,18 @@ def self_test() -> int:
         # matching stderr, so a message that is NOT a rate limit must stay a RuntimeError. Without
         # this, widening the pattern to `.*` would pass every case above.
         _real_gh_api = _real
+        # The last three transient cases are exactly what a PRIVATE regex misses — the first
+        # draft of this gate had one and classified all three as final, which is a PR turned red
+        # for a reason its diff cannot cause. They come from the shared vocabulary's own corpus.
         for msg, want_unreadable in (
             ("API rate limit exceeded for installation", True),
             ("You have exceeded a secondary rate limit", True),
+            ("gh: Too Many Requests (HTTP 429)", True),
+            ("You have triggered an abuse detection mechanism. Please wait and try again.", True),
+            ("HTTP 503", True),
             ("Bad credentials", False),
             ("Not Found", False),
+            ("Resource not accessible by integration", False),
         ):
             class _FakeProc:
                 returncode = 1
@@ -366,7 +410,7 @@ def self_test() -> int:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: ruleset-bypass-actors is falsifiable (17 cases, both directions, exit codes and the rate-limit classifier included)")
+    print("self-test ok: ruleset-bypass-actors is falsifiable (21 cases, both directions, exit codes and the shared transient vocabulary included)")
     return 0
 
 


### PR DESCRIPTION
## Fixing my own regression from #9682

#9682 taught `ruleset-bypass-actors` that a rate limit is UNRESOLVED, not a finding. It did that
with a regex written inline:

```python
re.compile(r"rate limit exceeded|exceeded a secondary rate limit")
```

That was the **fourth** hand-written classifier of this question in the repo, and
`gh-transient-patterns.txt` exists precisely because the first three drifted apart. Its own
header carries the measurement — over a 31-message corpus the three agreed on 23 and disagreed
on 8, each missing five transient messages the others caught.

Mine missed three, now pinned as self-test cases:

```
gh: Too Many Requests (HTTP 429)
You have triggered an abuse detection mechanism. Please wait and try again.
HTTP 503                                   (bare, no parentheses)
```

Each would have been classified as a real finding — a PR turned red for something its diff cannot
cause, the defect #5896 already cost once.

## What changed

The vocabulary is read from the shared file, the same way `check-ruleset-context-parity.py` and
`gh-retry.sh` read it. An unreadable or empty vocabulary **raises** instead of classifying
everything as final: an empty pattern list matches nothing, so every failure would read as a real
answer while every call still returned a plausible boolean.

## Verified by effect

```
self-test (21 cases)                        exit 0
real run, live repo                         exit 0, 1 live / 0 undeclared / 0 stale
SABOTAGE: revert to the private regex       exit 1
  -> 'Too Many Requests (HTTP 429)' must be Unreadable
  -> 'abuse detection mechanism'      must be Unreadable
  -> 'HTTP 503'                       must be Unreadable
SABOTAGE: empty [rate_limit] + [transient]  exit 1
restored                                    exit 0
```

The first sabotage is the point — it names exactly what a private list costs, rather than
asserting that sharing is better.

## Context

Six more **enforced** gates call `gh api` without handling this at all:

```
check-agent-pr-guard.py          check-main-red-watch.py
check-gh-repo-context.py         check-merged-past-red-check.py
check-governance-lineage.py      check-stale-comment-references.py
```

Measured live on #9194 an hour ago: `CodeQL` failing with
`API rate limit exceeded for installation`. Third-party actions cannot be taught the third state,
but every gate this repo owns can be. Tracked in #9681; this PR is the pattern the others should
follow.

Refs #9681, #9682
