### PR TITLE
fix(infra): give seven CNPG clusters a replica to break a node-drain deadlock

### DIFF
--- a/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
@@ -16,7 +16,14 @@ metadata:
 spec:
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3

--- a/openbank-infra/gitops/components/apicurio/postgres.yaml
+++ b/openbank-infra/gitops/components/apicurio/postgres.yaml
@@ -17,7 +17,14 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
   # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
   # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against

--- a/openbank-infra/gitops/components/campaign/postgres.yaml
+++ b/openbank-infra/gitops/components/campaign/postgres.yaml
@@ -2,7 +2,8 @@
 # operator. CNPG generates the `campaign-db-app` secret (username/password for the
 # `openbank` owner) and a `campaign-db-rw` Service — both consumed by the
 # campaign-service Deployment for the reactive datasource and Flyway migrations.
-# One instance for sandbox FinOps; prod should raise to 3 for HA.
+# Two instances even in sandbox: one is not a FinOps saving, it is a drain deadlock
+# (see `instances` below, #9691). Prod should raise to 3 for HA.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -14,7 +15,14 @@ spec:
   # app changes (same as every other single-owner cluster).
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3

--- a/openbank-infra/gitops/components/devops-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/devops-agent/postgres.yaml
@@ -13,7 +13,14 @@ spec:
   # owns (selected cluster-wide), lighting up cnpg_* metrics with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
   # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
   # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against

--- a/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
@@ -13,7 +13,14 @@ spec:
   # owns (selected cluster-wide), lighting up cnpg_* metrics with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
   # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
   # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against

--- a/openbank-infra/gitops/components/notifications/postgres.yaml
+++ b/openbank-infra/gitops/components/notifications/postgres.yaml
@@ -2,7 +2,8 @@
 # CNPG operator. CNPG generates the `notifications-db-app` secret (username/
 # password for the `openbank` owner) and a `notifications-db-rw` Service — both
 # consumed by the notification-service Deployment for the reactive datasource and
-# Flyway migrations. One instance for sandbox FinOps; prod should raise to 3 for HA.
+# Flyway migrations. Two instances even in sandbox: one is not a FinOps saving, it is a
+# drain deadlock (see `instances` below, #9691). Prod should raise to 3 for HA.
 #
 # NB: the DB stays resident even while notification-service is scaled to zero
 # (T2, ADR-0057). The compute saving is the *app* replica, not the DB; a future
@@ -20,7 +21,14 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3

--- a/openbank-infra/gitops/components/pid/namespace.yaml
+++ b/openbank-infra/gitops/components/pid/namespace.yaml
@@ -25,7 +25,14 @@ spec:
   # healthy by being unobservable (#7220).
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # Two instances, not one (#9691). CNPG puts a `minAvailable: 1` PDB on the
+  # primary; in a single-instance cluster the sole pod IS the primary, so
+  # `disruptionsAllowed` is pinned at 0 permanently and no eviction can ever be
+  # permitted. That is not a tuning choice, it is arithmetic — and it deadlocked
+  # three node drains for 9-15 days while the cluster paid for both those nodes
+  # and the idle replacements Karpenter had already provisioned. The replica is
+  # also the switchover target a single-instance cluster never had.
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3


### PR DESCRIPTION
## Summary
Three Karpenter nodes have been terminating for **9 to 15 days** (#9691). All three are blocked by the same thing, and it is not Karpenter.

```
notifications/notifications-db-primary   minAvailable 1   ALLOWED DISRUPTIONS 0
notifications-db                         instances=1      currentPrimary=notifications-db-1
```

CNPG puts a `minAvailable: 1` PDB on the primary, selected by `cnpg.io/instanceRole: primary`. In a single-instance cluster **the sole pod IS the primary**, so `expectedPods=1 currentHealthy=1 disruptionsAllowed=0` — permanently, by arithmetic, not by transient state. Karpenter has not given up and is still retrying:

```
Normal  Nominated  pod/notifications-db-1  Pod should schedule on: nodeclaim/default-dnfbj, node/ip-10-80-54-193
```

No finalizers, stuck volumes, uncontrolled pods or expiring grace periods are involved — each was checked. Only the PDB.

## Which clusters and why these seven
The only non-DaemonSet workloads on the three nodes are CNPG `-db-1` pods, every one `instances: 1`:

| node | age | blocked by |
|---|---|---|
| `ip-10-80-55-133` | 45d | `anacredit-db`, `apicurio-db`, `pid-db` |
| `ip-10-80-35-82` | 43d | `notifications-db` |
| `ip-10-80-104-161` | 39d | `campaign-db`, `devops-db`, `docstruth-db` |

A second instance gives the PDB something it can allow and gives CNPG a switchover target. Note that a *supervised switchover was never available* here — with one instance there is nowhere to switch to, which is why the deadlock could not be resolved operationally.

## FinOps — measured before changing anything

**Cost**

| | measured |
|---|---|
| compute | +700m CPU, +1.75 GiB requests — absorbed: **9 of 24 nodes carry ≤1 non-DaemonSet pod, 4 carry none** |
| storage | +16 GiB gp3 ≈ **$1.34/mo** |
| cross-AZ replication | **≈ $0** — 6 of the 7 databases show *exactly* 0 rows inserted/s over 6h, the 7th 0.006/s, and none appears among the top-5 WAL producers. One-time base backup ≈ 16 GB ≈ $0.16 |

**Releases**

| node | type | price |
|---|---|---|
| ip-10-80-55-133 | c8gn.large spot | $0.031/hr (live spot history) = $22.63/mo |
| ip-10-80-35-82 | c8gn.large spot | $0.031/hr = $22.63/mo |
| ip-10-80-104-161 | c6gd.xlarge on-demand | $0.1664/hr (Pricing API) = **$121.47/mo** |

**≈ $166.73/mo**, and it is currently being paid **twice** — Karpenter has already provisioned the replacements (22 nodeclaims: 3 terminating, 19 active), so the cluster carries both.

Roughly **$1.5/mo spent to release ~$167/mo**, plus seven databases stop being a single point of failure with no failover target.

Two header comments asserting *"one instance for sandbox FinOps"* are corrected in the same change — on this evidence, one instance was not a saving.

## Rollout expectations
CNPG builds each replica with `pg_basebackup` and then permits the eviction; the drains should complete on their own without operator action. Per-cluster write volume is ~0, so replica build is bounded by the 1–5 GiB volume sizes rather than by WAL catch-up.

## Test plan
- [x] `yamllint` clean under the CI gate's own config
- [x] All seven parse with `instances: 2` and retain their `backup:` blocks
- [x] `check-cnpg-backup-declared.py --enforce` → OK (63 subjects)
- [x] `check-cnpg-scrape-coverage.py` → OK (64 clusters)
- [x] No gate constrains CNPG instance count (grepped `gates.yaml`)
- [ ] After sync: each cluster reports 2/2 ready, then confirm the three NodeClaims actually finish terminating and node count drops
- [ ] Confirm `notifications-db` switches over cleanly rather than being evicted hard — it is the one with a 43-day-old primary

Refs #9691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
