### PR TITLE
test(authz): assert commstyle.publish is denied to service accounts

### DIFF
--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -1194,7 +1194,6 @@ test_four_eyes_exemptions_key_absent_is_backward_compatible if {
 		with data.rules as {"four_eyes": {"verbs": [], "actions": ["opsmessage.compose"]}}
 }
 
-
 # ---------------------------------------------------------------------------------------
 # The shared M2M identity may never reach a WRITE through a role-only operator reason
 # (GHSA-58jq-9hq3-66jr). `service-account-openbank-services` carries ROLE_OPERATOR in the
@@ -1400,4 +1399,45 @@ test_matrix_inheritance_does_not_grant_unlisted if {
 			"ROLE_OPERATOR": {"grant": ["account.freeze"]},
 			"ROLE_ADMIN": {"grant": [], "inherits": "ROLE_OPERATOR"},
 		}}
+}
+
+# ---------------------------------------------------------------------------------------
+# commstyle-publish (ADR-0285 D3/D6): a human ROLE_COMMS_APPROVER may publish; a Keycloak
+# service account may not, whatever roles it holds. The rule had no test until #9705 — the
+# "never granted to a service account" claim was prose, and #3765 is what an untested
+# "never" looks like on a live bundle. Real rules data, so a future role_action_matrix
+# grant of commstyle.publish (which matrix-allows would hand to any HUMAN, service
+# accounts included) turns the deny case red instead of silently widening the grant.
+# ---------------------------------------------------------------------------------------
+test_commstyle_publish_allows_human_approver if {
+	decision := rest.allow with input as {
+		"principal": {"id": "user-9", "type": "HUMAN", "roles": ["ROLE_COMMS_APPROVER"]},
+		"action": "commstyle.publish",
+		"resource": {"type": "commstyle", "id": "v-1"},
+	}
+		with data.rules as rules_real
+	decision.allow
+	decision.reason == "commstyle-publish"
+}
+
+test_commstyle_publish_denies_service_account_with_every_role if {
+	not rest.allow with input as {
+		"principal": {
+			"id": "service-account-openbank-services",
+			"type": "HUMAN",
+			"roles": ["ROLE_COMMS_APPROVER", "ROLE_OPERATOR", "ROLE_ADMIN"],
+		},
+		"action": "commstyle.publish",
+		"resource": {"type": "commstyle", "id": "v-1"},
+	}
+		with data.rules as rules_real
+}
+
+test_commstyle_publish_denies_human_without_approver_role if {
+	not rest.allow with input as {
+		"principal": {"id": "user-9", "type": "HUMAN", "roles": ["ROLE_OPERATOR", "ROLE_COMMS_EDITOR"]},
+		"action": "commstyle.publish",
+		"resource": {"type": "commstyle", "id": "v-1"},
+	}
+		with data.rules as rules_real
 }


### PR DESCRIPTION
## Summary

ADR-0285 D6 says a service account is never granted `commstyle.publish`. `rest.rego` enforces it and nothing tested it — `rest_test.rego` had zero `commstyle` cases. Three cases added; the deny case goes red the day the guard is dropped.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [x] test (commit type `test`; no template box)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9705 (closes its "done when" first bullet), Refs #3765 (the precedent).

## Changes

- `openbank-libs/governance/policies/rest_test.rego`: three tests against `rules_real` —
  - `test_commstyle_publish_allows_human_approver` — must-ALLOW, reason `commstyle-publish`
  - `test_commstyle_publish_denies_service_account_with_every_role` — must-DENY for `service-account-openbank-services` holding `ROLE_COMMS_APPROVER` + `ROLE_OPERATOR` + `ROLE_ADMIN`
  - `test_commstyle_publish_denies_human_without_approver_role` — must-DENY for a human with `ROLE_OPERATOR` + `ROLE_COMMS_EDITOR`

Verified by effect, not appearance:
- `opa test openbank-libs/governance/policies openbank-infra/opa/policies` → 188/188
- with the `not startswith(input.principal.id, "service-account-")` line removed from `rest.rego` → exactly the service-account deny test fails (187/188); restored → 188/188
- `opa eval` against `rest.rego` + the real `rules-opa-data.yaml` as `data.rules`, before writing the test: service account `false`, human approver `{"allow":true,"reason":"commstyle-publish","attributes":{"four_eyes_required":true}}`

`regen-derived.sh` reports no changes — a `_test.rego` edit restamps no bundle.

Not in this PR: the optional #9705 item asserting the communication-service `openapi.yaml` declares no core path.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [x] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [x] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
