### PR TITLE
feat(kyb): find a company by name and town, not only by IČO

### DIFF
--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/port/in/KybUseCases.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/port/in/KybUseCases.kt
@@ -8,6 +8,8 @@ import com.openbank.kyb.domain.model.BusinessOnboardingCase
 import com.openbank.kyb.domain.model.CaseStatus
 import com.openbank.kyb.domain.model.IdentifierScheme
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
 import java.time.LocalDate
 import java.util.UUID
 
@@ -47,6 +49,26 @@ data class SignCommand(val caseId: UUID, val signerPartyId: UUID, val signatureR
 data class ResolveReviewCommand(val caseId: UUID, val requiredSignatures: Int, val operator: String)
 
 data class RejectCaseCommand(val caseId: UUID, val reason: String, val operator: String)
+
+/**
+ * Find a company by name instead of by identifier (issue #9707). [country] selects the register
+ * through the country pack; the scheme follows from it.
+ */
+data class SearchRegistryCommand(
+    val country: String,
+    val name: String,
+    val city: String? = null,
+    val limit: Int = RegistrySearchQuery.DEFAULT_LIMIT,
+)
+
+interface RegistrySearchUseCase {
+    /**
+     * Null when the register for [SearchRegistryCommand.country] cannot search — distinct from an
+     * empty result, so the caller can hide the search box rather than show one that never finds
+     * anything.
+     */
+    suspend fun search(cmd: SearchRegistryCommand): RegistrySearchResult?
+}
 
 interface RegistryLookupUseCase {
     /**

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/port/out/KybPorts.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/port/out/KybPorts.kt
@@ -12,6 +12,8 @@ import com.openbank.kyb.domain.model.IdentifierScheme
 import com.openbank.kyb.domain.model.KybEvent
 import com.openbank.kyb.domain.model.LegalEntityIdentifier
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
 import com.openbank.kyb.domain.model.UboFinding
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.libs.persistence.outbox.OutboxRepository
@@ -32,11 +34,22 @@ interface RegistryAdapter {
     val source: String
     fun supports(scheme: IdentifierScheme): Boolean
     suspend fun lookup(identifier: LegalEntityIdentifier, declared: DeclaredEntity?): RegistryExtract?
+
+    /**
+     * Find candidates by name (issue #9707). **Null means this register cannot search**, which is a
+     * different answer from an empty result and has to stay that way: the UI offers the search box
+     * only where a register backs it, and silently showing a box that always finds nothing is worse
+     * than not offering one. Default so a register without the capability needs no code.
+     */
+    suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? = null
 }
 
 /** The router over every [RegistryAdapter]; what the use cases depend on. */
 interface BusinessRegistryPort {
     suspend fun lookup(identifier: LegalEntityIdentifier, declared: DeclaredEntity?): RegistryExtract?
+
+    /** Null when no adapter for [scheme] supports search; see [RegistryAdapter.search]. */
+    suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? = null
 }
 
 /** Short-lived cache of extracts so a lookup on the entry screen and the case start share one register call. */

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/usecase/RegistrySearchService.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/application/usecase/RegistrySearchService.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.application.usecase
+
+import com.openbank.kyb.application.port.`in`.RegistrySearchUseCase
+import com.openbank.kyb.application.port.`in`.SearchRegistryCommand
+import com.openbank.kyb.application.port.out.BusinessRegistryPort
+import com.openbank.kyb.domain.model.IdentifierScheme
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
+import com.openbank.kyb.infrastructure.registry.CountryPackRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.LocalDate
+
+/**
+ * Name search over a country's public register (issue #9707).
+ *
+ * Deliberately NOT cached, unlike [RegistryLookupService]: an extract is keyed by an identifier and
+ * is worth reusing, while a search is keyed by free text the customer is still typing, so a cache
+ * would hold mostly one-hit entries for prefixes nobody repeats. It is also read-only and returns
+ * only what the register already publishes, so there is nothing here to keep consistent.
+ */
+@ApplicationScoped
+class RegistrySearchService : RegistrySearchUseCase {
+
+    @Inject lateinit var registry: BusinessRegistryPort
+
+    @Inject lateinit var packs: CountryPackRegistry
+
+    @Inject lateinit var clock: Clock
+
+    override suspend fun search(cmd: SearchRegistryCommand): RegistrySearchResult? {
+        val name = cmd.name.trim()
+        // Short of the floor we answer EMPTY rather than calling the register: a two-letter query
+        // matches tens of thousands of names, which ARES rejects outright, so the round trip buys
+        // nothing but load on a public service.
+        if (name.length < RegistrySearchQuery.MIN_NAME_LENGTH) return RegistrySearchResult.EMPTY
+
+        val pack = packs.packFor(cmd.country, LocalDate.now(clock)) ?: return null
+        // The pack's own scheme list is the routing key, not a hardcoded country->scheme map: a
+        // jurisdiction can carry more than one (PL has NIP and KRS) and the pack decides the order.
+        val scheme = pack.schemes.firstOrNull { it.country == pack.country } ?: return null
+
+        return registry.search(
+            scheme,
+            RegistrySearchQuery(
+                name = name,
+                city = cmd.city?.trim()?.ifBlank {
+                    null
+                },
+                limit = cmd.limit,
+            ),
+        )
+    }
+
+    /** Visible for tests that need the scheme resolution without a register call. */
+    internal fun schemeFor(country: String): IdentifierScheme? =
+        packs.packFor(country, LocalDate.now(clock))?.let { p -> p.schemes.firstOrNull { it.country == p.country } }
+}

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/domain/model/CountryPack.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/domain/model/CountryPack.kt
@@ -45,6 +45,13 @@ data class RegistryDescriptor(
     val free: Boolean,
     val listsRepresentatives: Boolean,
     val listsRepresentationRule: Boolean,
+    /**
+     * The register can be searched by company name (issue #9707). Declared per jurisdiction, and
+     * false by default, because the UI must only offer a search box where one exists — a box that
+     * always finds nothing reads as "the bank does not know my company". CZ (ARES) has it; other
+     * packs stay false until their adapter implements [RegistryAdapter.search].
+     */
+    val supportsNameSearch: Boolean = false,
 )
 
 /** How ultimate beneficial owners are established in this jurisdiction. */

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/domain/model/RegistrySearch.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/domain/model/RegistrySearch.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.domain.model
+
+/**
+ * Finding a company by NAME rather than by identifier (ADR-0284 D1, issue #9707).
+ *
+ * Onboarding opens on an identifier field, and a founder typically does not know their own IČO —
+ * it lives on an invoice, not in anyone's head. Search closes that gap, and in doing so moves the
+ * choice of legal entity from "the customer typed a number we then verified" to "the customer
+ * picked a row". That is the whole risk of this feature: picking the wrong `STAVBY s.r.o.` out of
+ * several hundred identically-named ones is silent, and the mistake only surfaces at signing or,
+ * worse, at the first payment. Nothing here is allowed to bind a case on its own — a hit carries
+ * an identifier, and the identifier still goes through the ordinary lookup + extract confirmation.
+ */
+data class RegistrySearchQuery(
+    /** Free text matched against the registered company name. */
+    val name: String,
+    /**
+     * Municipality, matched against the registered SEAT. Deliberately a narrowing hint rather than
+     * a filter the caller must get right: for a large share of small companies the registered seat
+     * is an accountant's office or a virtual address, so the town the founder associates with the
+     * business is often not the town in the register.
+     */
+    val city: String? = null,
+    val limit: Int = DEFAULT_LIMIT,
+) {
+    init {
+        require(name.isNotBlank()) { "name must not be blank" }
+        require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT" }
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT = 20
+        const val MAX_LIMIT = 50
+
+        /**
+         * Shortest query accepted. Not cosmetic: a one- or two-letter query matches tens of
+         * thousands of names, which the register answers with an error rather than a page (see
+         * [RegistrySearchResult.tooManyMatches]), so it costs a round trip to learn nothing.
+         */
+        const val MIN_NAME_LENGTH = 3
+    }
+}
+
+/**
+ * One row a customer can pick. Carries what is needed to TELL TWO COMPANIES APART and nothing
+ * else — the full extract (statutory body, representation rule, status) is fetched by identifier
+ * once a row is chosen, so a search result can never be mistaken for a verified entity.
+ */
+data class RegistrySearchHit(
+    val identifier: LegalEntityIdentifier,
+    val name: String,
+    /** Register legal-form code; the country pack turns it into a label and a [LegalFormClass]. */
+    val legalFormCode: String?,
+    /** The registered seat as the register renders it, town included. */
+    val registeredAddress: String?,
+)
+
+/**
+ * [totalMatches] is the register's own count, which can exceed `hits.size` — the customer needs to
+ * know a narrower query exists, not just see the first twenty rows.
+ *
+ * [tooManyMatches] is a THIRD outcome next to hits and no-hits, and it is the common one for a
+ * short query: measured against ARES on 2026-09-11, `obchodniJmeno=stavby` matches 2 818 subjects
+ * and the register answers `VYSTUP_PRILIS_MNOHO_VYSLEDKU` — an error document, not a truncated
+ * list, and paging does not help because the cap is on the match count rather than the page. It is
+ * not an outage, so it must not be reported as one: the customer is told to add a town or more of
+ * the name.
+ */
+data class RegistrySearchResult(
+    val hits: List<RegistrySearchHit>,
+    val totalMatches: Int,
+    val tooManyMatches: Boolean = false,
+) {
+    companion object {
+        fun tooMany(total: Int) = RegistrySearchResult(emptyList(), total, tooManyMatches = true)
+        val EMPTY = RegistrySearchResult(emptyList(), 0)
+    }
+}

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/AresRegistryAdapter.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/AresRegistryAdapter.kt
@@ -5,6 +5,7 @@
 package com.openbank.kyb.infrastructure.registry
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.openbank.kyb.application.port.`in`.DeclaredEntity
 import com.openbank.kyb.application.port.out.RegistryAdapter
 import com.openbank.kyb.application.port.out.RegistryUnavailableException
@@ -17,12 +18,17 @@ import com.openbank.kyb.domain.model.LegalEntityIdentifier
 import com.openbank.kyb.domain.model.LegalFormClass
 import com.openbank.kyb.domain.model.RegisteredAddress
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchHit
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
 import com.openbank.kyb.domain.model.RepresentationRule
 import com.openbank.kyb.domain.model.Representative
 import com.openbank.libs.web.SyntheticTaintExternalBoundary
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
@@ -56,6 +62,16 @@ interface AresRestClient {
     @GET
     @Path("/ekonomicke-subjekty-vr/{ico}")
     suspend fun publicRegister(@PathParam("ico") ico: String): JsonNode
+
+    /**
+     * Name search (issue #9707). POST, and the body shape is not guessable — see
+     * [AresRegistryAdapter.search] for the two fields that were measured against the live service
+     * and the one that silently does nothing.
+     */
+    @POST
+    @Path("/ekonomicke-subjekty/vyhledat")
+    @Consumes(MediaType.APPLICATION_JSON)
+    suspend fun searchSubjects(body: JsonNode): JsonNode
 }
 
 @ApplicationScoped
@@ -256,8 +272,78 @@ class AresRegistryAdapter : RegistryAdapter {
         runCatching { LocalDate.parse(it.take(DATE_LENGTH)) }.getOrNull()
     }
 
+    /**
+     * Find companies by name, optionally narrowed by town.
+     *
+     * **The town filter is `sidlo.textovaAdresa`, NOT `sidlo.nazevObce`.** Measured against the
+     * live service on 2026-09-11 with `obchodniJmeno=Asseco` (6 matches in total):
+     *
+     * ```
+     * sidlo.textovaAdresa = Praha -> 4   Brno -> 0   Ostrava -> 0   Bratislava -> 2      (4+2 = 6)
+     * sidlo.nazevObce     = Praha -> 6   Brno -> 6                  Bratislava -> 6
+     * ```
+     *
+     * `nazevObce` is the field name that appears in every RESPONSE and is the obvious one to reach
+     * for; the search endpoint ignores it, returning the unfiltered set for any town including one
+     * in another country. A town box wired to it would look like it worked — results still come
+     * back, they are simply not filtered — so this is a comment that has to stay next to the code.
+     *
+     * The over-limit answer is an error document rather than a truncated page: above 1 000 matches
+     * ARES returns `VYSTUP_PRILIS_MNOHO_VYSLEDKU` and `pocet` does not help, because the cap is on
+     * the match count, not the page size. That is a refine-the-query outcome, not an outage, and
+     * [RegistrySearchResult.tooManyMatches] carries it as such.
+     */
+    override suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? {
+        if (!supports(scheme)) return null
+        val response = try {
+            ares.searchSubjects(searchBody(query))
+        } catch (e: WebApplicationException) {
+            // A 400 here is ARES rejecting the QUERY, not the service being down. The only one we
+            // translate is the over-limit case; anything else is a genuine bad request we surface
+            // as unavailable rather than as "no such company".
+            val doc = runCatching { e.response.readEntity(JsonNode::class.java) }.getOrNull()
+            if (doc?.text("subKod") == TOO_MANY) {
+                return RegistrySearchResult.tooMany(parseMatchCount(doc.text("popis")))
+            }
+            log.warnf(e, "ARES search failed: %s", doc?.text("popis") ?: e.message)
+            throw RegistryUnavailableException("ares search: ${e.message}", e)
+        }
+        return toResult(response)
+    }
+
+    /**
+     * Visible for tests, and the single place the field names live. `sidlo.textovaAdresa` is
+     * load-bearing — see the measurement in [search].
+     */
+    internal fun searchBody(query: RegistrySearchQuery): JsonNode = JsonNodeFactory.instance.objectNode().apply {
+        put("obchodniJmeno", query.name)
+        put("pocet", query.limit)
+        query.city?.let { putObject("sidlo").put("textovaAdresa", it) }
+    }
+
+    /** Visible for tests: ARES search payload → hits. A row with no IČO or no name is dropped. */
+    internal fun toResult(response: JsonNode): RegistrySearchResult {
+        val hits = response.path("ekonomickeSubjekty").mapNotNull { toHit(it) }
+        return RegistrySearchResult(hits = hits, totalMatches = response.path("pocetCelkem").asInt(hits.size))
+    }
+
+    private fun toHit(node: JsonNode) = node.text("ico")?.let { ico ->
+        RegistrySearchHit(
+            identifier = LegalEntityIdentifier.of(IdentifierScheme.CZ_ICO, ico),
+            name = node.text("obchodniJmeno") ?: return@let null,
+            legalFormCode = node.text("pravniForma"),
+            registeredAddress = node.path("sidlo").text("textovaAdresa"),
+        )
+    }
+
+    /** The count lives only in the message text (`"... vrací příliš mnoho výsledků (2 818)."`). */
+    private fun parseMatchCount(popis: String?): Int =
+        popis?.let { Regex("\\(([\\d\\s\u00a0]+)\\)").find(it)?.groupValues?.get(1) }
+            ?.replace(Regex("[\\s\u00a0]"), "")?.toIntOrNull() ?: 0
+
     companion object {
         const val SOURCE = "ares"
+        private const val TOO_MANY = "VYSTUP_PRILIS_MNOHO_VYSLEDKU"
         private const val NOT_FOUND = 404
         private const val ARES_TIMEOUT_MS = 4000L
         private const val DATE_LENGTH = 10

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/CountryPackRegistry.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/CountryPackRegistry.kt
@@ -68,6 +68,7 @@ class CountryPackRegistry(private val mapper: ObjectMapper) {
                 free = it.path("free").asBoolean(false),
                 listsRepresentatives = it.path("listsRepresentatives").asBoolean(false),
                 listsRepresentationRule = it.path("listsRepresentationRule").asBoolean(false),
+                supportsNameSearch = it.path("supportsNameSearch").asBoolean(false),
             )
         },
         uboRegister = n.path("uboRegister").let {

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/RegistryRouter.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/registry/RegistryRouter.kt
@@ -9,8 +9,11 @@ import com.openbank.kyb.application.port.out.BusinessRegistryPort
 import com.openbank.kyb.application.port.out.KybMetricsPort
 import com.openbank.kyb.application.port.out.RegistryAdapter
 import com.openbank.kyb.application.port.out.RegistryUnavailableException
+import com.openbank.kyb.domain.model.IdentifierScheme
 import com.openbank.kyb.domain.model.LegalEntityIdentifier
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Instance
 import jakarta.inject.Inject
@@ -28,6 +31,26 @@ class RegistryRouter : BusinessRegistryPort {
     @Inject lateinit var adapters: Instance<RegistryAdapter>
 
     @Inject lateinit var metrics: KybMetricsPort
+
+    /**
+     * Routed like [lookup] except for the fallback: the manual-attestation adapter cannot search,
+     * so a scheme whose only adapter is that one answers **null** — "this register has no search" —
+     * rather than an empty list. The caller hides the search box on null; an empty list would tell
+     * the customer their company does not exist.
+     */
+    override suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? {
+        val adapter = adapters
+            .sortedBy { if (it is ManualAttestationRegistryAdapter) 1 else 0 }
+            .firstOrNull { it.supports(scheme) } ?: return null
+        return try {
+            adapter.search(scheme, query)?.also { metrics.registryLookup(adapter.source, "search") }
+        } catch (e: RegistryUnavailableException) {
+            // A search outage must not read as "no such company": the customer would go on to type
+            // an identifier that is also about to fail, or conclude the bank does not know them.
+            metrics.registryLookup(adapter.source, "search_unavailable")
+            throw e
+        }
+    }
 
     override suspend fun lookup(identifier: LegalEntityIdentifier, declared: DeclaredEntity?): RegistryExtract? {
         val ordered = adapters.sortedBy { if (it is ManualAttestationRegistryAdapter) 1 else 0 }

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/KybResource.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/KybResource.kt
@@ -10,8 +10,10 @@ import com.openbank.kyb.application.port.`in`.InviteCosignersCommand
 import com.openbank.kyb.application.port.`in`.LookupCommand
 import com.openbank.kyb.application.port.`in`.MatchInitiatorCommand
 import com.openbank.kyb.application.port.`in`.RegistryLookupUseCase
+import com.openbank.kyb.application.port.`in`.RegistrySearchUseCase
 import com.openbank.kyb.application.port.`in`.RejectCaseCommand
 import com.openbank.kyb.application.port.`in`.ResolveReviewCommand
+import com.openbank.kyb.application.port.`in`.SearchRegistryCommand
 import com.openbank.kyb.application.port.`in`.SignCommand
 import com.openbank.kyb.application.port.`in`.StartCaseCommand
 import com.openbank.kyb.application.port.out.BeneficialOwnershipPort
@@ -19,6 +21,7 @@ import com.openbank.kyb.application.usecase.CaseCallerMismatchException
 import com.openbank.kyb.domain.model.CaseStatus
 import com.openbank.kyb.domain.model.IdentifierScheme
 import com.openbank.kyb.domain.model.LegalEntityIdentifier
+import com.openbank.kyb.domain.model.RegistrySearchQuery
 import com.openbank.kyb.infrastructure.rest.dto.CaseResponse
 import com.openbank.kyb.infrastructure.rest.dto.ClaimInvitationRequest
 import com.openbank.kyb.infrastructure.rest.dto.ExtractResponse
@@ -28,6 +31,8 @@ import com.openbank.kyb.infrastructure.rest.dto.MatchInitiatorRequest
 import com.openbank.kyb.infrastructure.rest.dto.RejectRequest
 import com.openbank.kyb.infrastructure.rest.dto.ResolveReviewRequest
 import com.openbank.kyb.infrastructure.rest.dto.SchemeResponse
+import com.openbank.kyb.infrastructure.rest.dto.SearchHitResponse
+import com.openbank.kyb.infrastructure.rest.dto.SearchResponse
 import com.openbank.kyb.infrastructure.rest.dto.SignRequest
 import com.openbank.kyb.infrastructure.rest.dto.StartCaseRequest
 import com.openbank.kyb.infrastructure.rest.dto.UboResponse
@@ -50,6 +55,7 @@ import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import java.net.URI
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -67,6 +73,8 @@ import java.util.UUID
 class KybResource {
 
     @Inject lateinit var lookup: RegistryLookupUseCase
+
+    @Inject lateinit var search: RegistrySearchUseCase
 
     @Inject lateinit var onboarding: BusinessOnboardingUseCase
 
@@ -100,11 +108,52 @@ class KybResource {
                             "version" to it.version,
                             "registry" to it.registry.name,
                             "uboFallback" to it.uboRegister.fallback,
+                            "supportsNameSearch" to it.registry.supportsNameSearch,
                         )
                     },
                 "schemes" to list.map { SchemeResponse(it.name, it.country, it.displayName, it.checksum, example(it)) },
             ),
         ).build()
+    }
+
+    /**
+     * Find a company by name and town (issue #9707). Reuses the `kyb.lookup` action on purpose:
+     * it returns a strict subset of what `/lookup` returns (public-register data, less of it), and
+     * a new action would need a `role_action_matrix` line, a `shared_m2m_matrix_write_grants`
+     * entry and a ~79-bundle OPA restamp — a governance change for no extra exposure.
+     *
+     * Parameters are nullable and checked in the body: a non-null `String` query param is a 500
+     * for the absent case, never a 400 (root CLAUDE.md, `nonnull-jaxrs-param-ratchet`).
+     */
+    @GET
+    @Path("/registry/search")
+    @Authorize(action = "kyb.lookup")
+    @Operation(
+        summary = "Find a company by name, optionally narrowed by town (404 when this register cannot search)",
+    )
+    suspend fun searchRegistry(
+        @QueryParam("country") country: String?,
+        @QueryParam("name") name: String?,
+        @QueryParam("city") city: String?,
+        @QueryParam("limit") limit: Int?,
+    ): Response {
+        val c = requireNotNull(country?.takeIf { it.isNotBlank() }) { "query parameter 'country' is required" }
+        val n = requireNotNull(name?.takeIf { it.isNotBlank() }) { "query parameter 'name' is required" }
+        val result = search.search(
+            SearchRegistryCommand(
+                country = c.uppercase(),
+                name = n,
+                city = city,
+                limit = limit ?: RegistrySearchQuery.DEFAULT_LIMIT,
+            ),
+        ) ?: return Response.status(Response.Status.NOT_FOUND).entity(
+            mapOf("error" to "the register for country '$c' does not support name search"),
+        ).build()
+        val pack = packs.packFor(c.uppercase(), LocalDate.now(clock))
+        val hits = result.hits.map { h ->
+            SearchHitResponse.from(h, h.legalFormCode?.let { code -> pack?.legalFormLabels?.get(code)?.get("cs") })
+        }
+        return Response.ok(SearchResponse(hits, result.totalMatches, result.tooManyMatches)).build()
     }
 
     @POST

--- a/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/dto/KybDtos.kt
+++ b/openbank-kyb-service/src/main/kotlin/com/openbank/kyb/infrastructure/rest/dto/KybDtos.kt
@@ -8,6 +8,7 @@ import com.openbank.kyb.application.port.`in`.DeclaredEntity
 import com.openbank.kyb.domain.model.BusinessOnboardingCase
 import com.openbank.kyb.domain.model.IdentifierScheme
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchHit
 import com.openbank.kyb.domain.model.Signer
 import com.openbank.kyb.domain.model.UboFinding
 import java.time.Instant
@@ -62,6 +63,38 @@ data class SignRequest(val signatureRef: String?)
 data class ResolveReviewRequest(val requiredSignatures: Int?)
 
 data class RejectRequest(val reason: String?)
+
+/**
+ * One row of a name search (issue #9707). Carries what tells two companies apart and nothing that
+ * could pass for a verified extract — no representatives, no rule, no status — so a client cannot
+ * bind a case from a search hit without going through `/lookup`.
+ */
+data class SearchHitResponse(
+    val scheme: String,
+    val identifier: String,
+    val name: String,
+    val legalFormCode: String?,
+    val legalForm: String?,
+    val registeredAddress: String?,
+) {
+    companion object {
+        fun from(h: RegistrySearchHit, legalForm: String?) = SearchHitResponse(
+            scheme = h.identifier.scheme.name,
+            identifier = h.identifier.value,
+            name = h.name,
+            legalFormCode = h.legalFormCode,
+            legalForm = legalForm,
+            registeredAddress = h.registeredAddress,
+        )
+    }
+}
+
+/**
+ * [totalMatches] can exceed `hits.size`; [tooManyMatches] means the register refused to answer at
+ * all (ARES caps at 1 000 matches and returns an error, not a page) and the customer should add a
+ * town or more of the name. Both are for the UI to say, not to hide.
+ */
+data class SearchResponse(val hits: List<SearchHitResponse>, val totalMatches: Int, val tooManyMatches: Boolean)
 
 data class SchemeResponse(
     val scheme: String,

--- a/openbank-kyb-service/src/main/resources/country-packs/cz-v1.json
+++ b/openbank-kyb-service/src/main/resources/country-packs/cz-v1.json
@@ -10,7 +10,8 @@
     "publicSource": "https://ares.gov.cz",
     "free": true,
     "listsRepresentatives": true,
-    "listsRepresentationRule": true
+    "listsRepresentationRule": true,
+    "supportsNameSearch": true
   },
   "uboRegister": {
     "name": "Evidence skutečných majitelů",

--- a/openbank-kyb-service/src/main/resources/openapi.yaml
+++ b/openbank-kyb-service/src/main/resources/openapi.yaml
@@ -1,7 +1,8 @@
 openapi: 3.1.0
 info:
   title: OpenBank KYB Service API
-  version: 1.1.0
+  # 1.1.0 -> 1.2.0 (#9707): additive — GET /registry/search, name search where the pack declares it.
+  version: 1.2.0
   description: |
     Legal-entity verification and business onboarding (ADR-0284). Business identifiers are
     verified against public registers (ARES for CZ, GLEIF for LEI, manual attestation elsewhere);
@@ -69,6 +70,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RegistryExtract'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/RegistryUnavailable'
+  /api/v1/kyb/registry/search:
+    get:
+      tags: [KYB]
+      summary: Find a company by name, optionally narrowed by town
+      description: >-
+        For the customer who does not know their identifier. Returns only what tells two companies
+        apart; a chosen row still goes through /lookup, so a search hit can never bind a case by
+        itself. `tooManyMatches` is a distinct outcome, not an error: the register refuses to
+        answer a query above its match cap (ARES: 1 000) and the customer should narrow it.
+        404 when the register for `country` declares no name search (see `supportsNameSearch`
+        on /schemes).
+      operationId: searchRegistry
+      parameters:
+        - name: country
+          in: query
+          required: true
+          schema: { type: string, example: CZ }
+        - name: name
+          in: query
+          required: true
+          description: Free text matched against the registered company name (min 3 characters)
+          schema: { type: string, minLength: 3 }
+        - name: city
+          in: query
+          required: false
+          description: Narrowing hint matched against the registered seat; the seat is often an accountant's address, so absence of a match is not absence of the company
+          schema: { type: string }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 50, default: 20 }
+      responses:
+        '200':
+          description: Candidate rows
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -416,6 +461,25 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
   schemas:
+    SearchHit:
+      type: object
+      required: [scheme, identifier, name]
+      properties:
+        scheme: { type: string, example: CZ_ICO }
+        identifier: { type: string, example: "27074358" }
+        name: { type: string }
+        legalFormCode: { type: string, nullable: true }
+        legalForm: { type: string, nullable: true, description: Label from the country pack, when the code is known }
+        registeredAddress: { type: string, nullable: true }
+    SearchResponse:
+      type: object
+      required: [hits, totalMatches, tooManyMatches]
+      properties:
+        hits:
+          type: array
+          items: { $ref: '#/components/schemas/SearchHit' }
+        totalMatches: { type: integer, description: The register's own count; may exceed hits.length }
+        tooManyMatches: { type: boolean, description: The register refused the query as too broad; narrow it }
     UboFinding:
       type: object
       properties:

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/application/usecase/RegistrySearchServiceTest.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/application/usecase/RegistrySearchServiceTest.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.kyb.application.port.`in`.DeclaredEntity
+import com.openbank.kyb.application.port.`in`.SearchRegistryCommand
+import com.openbank.kyb.application.port.out.BusinessRegistryPort
+import com.openbank.kyb.domain.model.IdentifierScheme
+import com.openbank.kyb.domain.model.LegalEntityIdentifier
+import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchHit
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
+import com.openbank.kyb.infrastructure.registry.CountryPackRegistry
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/** Country → register routing and the query floor for name search (issue #9707). */
+class RegistrySearchServiceTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-09-11T10:00:00Z"), ZoneOffset.UTC)
+
+    private class RecordingRegistry(private val answer: RegistrySearchResult?) : BusinessRegistryPort {
+        var seen: Pair<IdentifierScheme, RegistrySearchQuery>? = null
+        var calls = 0
+        override suspend fun lookup(identifier: LegalEntityIdentifier, declared: DeclaredEntity?): RegistryExtract? =
+            null
+        override suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? {
+            calls++
+            seen = scheme to query
+            return answer
+        }
+    }
+
+    private fun service(registry: BusinessRegistryPort) = RegistrySearchService().apply {
+        this.registry = registry
+        this.packs = CountryPackRegistry(ObjectMapper())
+        this.clock = this@RegistrySearchServiceTest.clock
+    }
+
+    @Test
+    fun `a CZ search routes to the CZ_ICO scheme with the trimmed terms`() {
+        val registry = RecordingRegistry(
+            RegistrySearchResult(
+                listOf(
+                    RegistrySearchHit(
+                        LegalEntityIdentifier.of(IdentifierScheme.CZ_ICO, "27074358"),
+                        "Asseco Central Europe, a.s.",
+                        "121",
+                        "Praha 4",
+                    ),
+                ),
+                totalMatches = 1,
+            ),
+        )
+
+        val result = runBlocking {
+            service(registry).search(SearchRegistryCommand(country = "CZ", name = "  Asseco  ", city = " Praha "))
+        }
+
+        assertThat(result?.hits).hasSize(1)
+        assertThat(registry.seen?.first).isEqualTo(IdentifierScheme.CZ_ICO)
+        assertThat(registry.seen?.second?.name).isEqualTo("Asseco")
+        assertThat(registry.seen?.second?.city).isEqualTo("Praha")
+    }
+
+    @Test
+    fun `a blank town is dropped rather than sent as an empty filter`() {
+        val registry = RecordingRegistry(RegistrySearchResult.EMPTY)
+
+        runBlocking { service(registry).search(SearchRegistryCommand(country = "CZ", name = "Kofola", city = "   ")) }
+
+        assertThat(registry.seen?.second?.city).isNull()
+    }
+
+    @Test
+    fun `a query below the floor answers empty WITHOUT calling the register`() {
+        val registry = RecordingRegistry(RegistrySearchResult.EMPTY)
+
+        val result = runBlocking { service(registry).search(SearchRegistryCommand(country = "CZ", name = "ab")) }
+
+        assertThat(result).isEqualTo(RegistrySearchResult.EMPTY)
+        assertThat(registry.calls)
+            .describedAs(
+                "a two-letter query matches tens of thousands of names; ARES rejects it, so the call buys nothing",
+            )
+            .isZero()
+    }
+
+    @Test
+    fun `an unknown country answers null — no register, so no search box`() {
+        val registry = RecordingRegistry(RegistrySearchResult.EMPTY)
+
+        val result = runBlocking { service(registry).search(SearchRegistryCommand(country = "ZZ", name = "Anything")) }
+
+        assertThat(result)
+            .describedAs("null is 'cannot search'; an empty list would read as 'your company does not exist'")
+            .isNull()
+        assertThat(registry.calls).isZero()
+    }
+
+    @Test
+    fun `the too-many outcome is passed through, not flattened into an empty result`() {
+        val registry = RecordingRegistry(RegistrySearchResult.tooMany(2818))
+
+        val result = runBlocking { service(registry).search(SearchRegistryCommand(country = "CZ", name = "stavby")) }
+
+        assertThat(result?.tooManyMatches).isTrue()
+        assertThat(result?.totalMatches).isEqualTo(2818)
+        assertThat(result?.hits).isEmpty()
+    }
+}

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/infrastructure/registry/AresRegistrySearchTest.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/infrastructure/registry/AresRegistrySearchTest.kt
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.infrastructure.registry
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.kyb.domain.model.IdentifierScheme
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The ARES name search (issue #9707). The request-body test is the point of this file.
+ *
+ * `sidlo.nazevObce` is the field name ARES puts in every search RESPONSE, so it is the one a
+ * reader reaches for — and the search endpoint ignores it. Measured against the live service on
+ * 2026-09-11 with `obchodniJmeno=Asseco`, six matches in total:
+ *
+ * ```
+ * sidlo.textovaAdresa  Praha 4   Brno 0   Ostrava 0   Bratislava 2     (4 + 2 = 6, discriminates)
+ * sidlo.nazevObce      Praha 6   Brno 6                Bratislava 6     (ignored — every town, 6)
+ * ```
+ *
+ * A town box wired to `nazevObce` still returns results, so nothing downstream would notice: the
+ * customer would be shown companies from the wrong end of the country while believing they had
+ * filtered. This test fails the moment the key changes, which is the only cheap defence against a
+ * "fix" that makes the field name look more correct.
+ */
+class AresRegistrySearchTest {
+
+    private val json = ObjectMapper()
+    private val adapter = AresRegistryAdapter()
+
+    @Test
+    fun `the town filter is sidlo_textovaAdresa, the field that actually narrows`() {
+        val body = adapter.searchBody(RegistrySearchQuery(name = "Asseco", city = "Praha", limit = 20))
+
+        assertThat(body.path("sidlo").path("textovaAdresa").asText()).isEqualTo("Praha")
+        assertThat(body.path("sidlo").has("nazevObce"))
+            .describedAs("nazevObce is silently ignored by the ARES search endpoint; see the class KDoc")
+            .isFalse()
+        assertThat(body.path("obchodniJmeno").asText()).isEqualTo("Asseco")
+        assertThat(body.path("pocet").asInt()).isEqualTo(20)
+    }
+
+    @Test
+    fun `no town means no sidlo filter at all, not an empty one`() {
+        val body = adapter.searchBody(RegistrySearchQuery(name = "Kofola"))
+
+        assertThat(body.has("sidlo"))
+            .describedAs("an empty sidlo object would narrow to nothing on some registers")
+            .isFalse()
+    }
+
+    @Test
+    fun `a search payload maps to hits carrying only what tells two companies apart`() {
+        val response = json.readTree(
+            """
+            {"pocetCelkem":2,"ekonomickeSubjekty":[
+              {"ico":"27074358","obchodniJmeno":"Asseco Central Europe, a.s.","pravniForma":"121",
+               "sidlo":{"textovaAdresa":"Budějovická 778/3, 14000 Praha 4"}},
+              {"ico":"45274649","obchodniJmeno":"Příklad s.r.o.","pravniForma":"112",
+               "sidlo":{"textovaAdresa":"Náměstí 1, 60200 Brno"}}
+            ]}
+            """.trimIndent(),
+        )
+
+        val result = adapter.toResult(response)
+
+        assertThat(result.totalMatches).isEqualTo(2)
+        assertThat(result.tooManyMatches).isFalse()
+        assertThat(result.hits).hasSize(2)
+        val first = result.hits.first()
+        assertThat(first.identifier.scheme).isEqualTo(IdentifierScheme.CZ_ICO)
+        assertThat(first.identifier.value).isEqualTo("27074358")
+        assertThat(first.name).isEqualTo("Asseco Central Europe, a.s.")
+        assertThat(first.legalFormCode).isEqualTo("121")
+        assertThat(first.registeredAddress).contains("Praha")
+    }
+
+    @Test
+    fun `totalMatches keeps the register's own count when it exceeds the returned page`() {
+        val response = json.readTree(
+            """
+            {"pocetCelkem":412,"ekonomickeSubjekty":[
+              {"ico":"27074358","obchodniJmeno":"Jedna s.r.o.","pravniForma":"112","sidlo":{"textovaAdresa":"Praha"}}
+            ]}
+            """.trimIndent(),
+        )
+
+        val result = adapter.toResult(response)
+
+        assertThat(result.hits).hasSize(1)
+        assertThat(result.totalMatches)
+            .describedAs("the customer needs to know a narrower query exists, not just see one row")
+            .isEqualTo(412)
+    }
+
+    @Test
+    fun `a row without an identifier or a name is dropped rather than shown unpickable`() {
+        val response = json.readTree(
+            """
+            {"pocetCelkem":3,"ekonomickeSubjekty":[
+              {"obchodniJmeno":"Bez IČO s.r.o.","pravniForma":"112"},
+              {"ico":"27074358","pravniForma":"112"},
+              {"ico":"45274649","obchodniJmeno":"Dobrá s.r.o.","pravniForma":"112"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val result = adapter.toResult(response)
+
+        assertThat(result.hits).hasSize(1)
+        assertThat(result.hits.single().name).isEqualTo("Dobrá s.r.o.")
+    }
+
+    @Test
+    fun `search returns null for a scheme this register does not serve`() {
+        // Null is "this register cannot search", which the router turns into a hidden search box —
+        // distinct from an empty result, which would read as "your company does not exist".
+        val result = kotlinx.coroutines.runBlocking {
+            adapter.search(IdentifierScheme.GB_CRN, RegistrySearchQuery(name = "Anything"))
+        }
+
+        assertThat(result).isNull()
+    }
+}

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/integration/RegistrySearchApiIT.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/integration/RegistrySearchApiIT.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyb.integration
+
+import com.openbank.kyb.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+
+/**
+ * `GET /api/v1/kyb/registry/search` over real HTTP (issue #9707).
+ *
+ * A unit test cannot tell a served route from an unserved one, and it cannot tell a 400 from a
+ * 500 — both matter here. The parameters are declared nullable precisely so an absent one is a
+ * 400 from `requireNotNull`; declared non-null, JAX-RS injects null and Kotlin's
+ * `checkNotNullParameter` throws at offset 0, which `GenericExceptionMapper` renders as a 500
+ * (root CLAUDE.md, gate `nonnull-jaxrs-param-ratchet`). The missing-parameter cases below are
+ * that guard.
+ */
+@QuarkusTest
+@QuarkusTestResource(KybBootSmokeIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresTestResource::class)
+class RegistrySearchApiIT {
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `a name search returns pickable rows carrying the identifier the customer did not know`() {
+        Given {
+            queryParam("country", "CZ")
+            queryParam("name", "Příklad")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(200)
+            body("hits", hasSize<Any>(2))
+            body("hits[0].scheme", equalTo("CZ_ICO"))
+            body("hits[0].identifier", equalTo("45274649"))
+            body("tooManyMatches", equalTo(false))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `the town narrows the result set`() {
+        Given {
+            queryParam("country", "CZ")
+            queryParam("name", "Příklad")
+            queryParam("city", "Praha")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(200)
+            body("hits", hasSize<Any>(1))
+            body("hits[0].identifier", equalTo("26185610"))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `too many matches is a 200 telling the customer to narrow, not an error`() {
+        Given {
+            queryParam("country", "CZ")
+            queryParam("name", "stavby")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            // A 4xx/5xx here would read as "the bank is broken" or "no such company"; the register
+            // simply refuses a query above its match cap, and the customer can act on that.
+            statusCode(200)
+            body("tooManyMatches", equalTo(true))
+            body("totalMatches", equalTo(2818))
+            body("hits", hasSize<Any>(0))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `a register without name search is a 404, so the UI can hide the box`() {
+        Given {
+            queryParam("country", "ZZ")
+            queryParam("name", "Anything")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(404)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `a missing name is 400, never the 500 a non-null parameter would give`() {
+        Given {
+            queryParam("country", "CZ")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `a missing country is 400`() {
+        Given {
+            queryParam("name", "Příklad")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    @Test
+    fun `the search surface is not anonymous`() {
+        Given {
+            queryParam("country", "CZ")
+            queryParam("name", "Příklad")
+        } When {
+            get("/api/v1/kyb/registry/search")
+        } Then {
+            statusCode(401)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `schemes advertises which registers can be searched at all`() {
+        Given {
+            queryParam("country", "CZ")
+        } When {
+            get("/api/v1/kyb/schemes")
+        } Then {
+            statusCode(200)
+            body("pack.supportsNameSearch", equalTo(true))
+        }
+    }
+}

--- a/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/it/StubCollaborators.kt
+++ b/openbank-kyb-service/src/test/kotlin/com/openbank/kyb/it/StubCollaborators.kt
@@ -16,6 +16,9 @@ import com.openbank.kyb.domain.model.LegalEntityIdentifier
 import com.openbank.kyb.domain.model.LegalFormClass
 import com.openbank.kyb.domain.model.RegisteredAddress
 import com.openbank.kyb.domain.model.RegistryExtract
+import com.openbank.kyb.domain.model.RegistrySearchHit
+import com.openbank.kyb.domain.model.RegistrySearchQuery
+import com.openbank.kyb.domain.model.RegistrySearchResult
 import com.openbank.kyb.domain.model.RepresentationMode
 import com.openbank.kyb.domain.model.RepresentationRule
 import com.openbank.kyb.domain.model.Representative
@@ -51,6 +54,33 @@ class StubAresAdapter : RegistryAdapter {
             "26185610" -> extract(identifier, LegalFormClass.SOLE_TRADER, RepresentationRule.SOLE, listOf("Jan Novák"))
             else -> null
         }
+
+    /**
+     * Name search for the REST-surface ITs. "stavby" stands in for the over-cap case ARES answers
+     * with an error rather than a page, so the endpoint's third outcome is exercised without a
+     * live register.
+     */
+    override suspend fun search(scheme: IdentifierScheme, query: RegistrySearchQuery): RegistrySearchResult? {
+        if (!supports(scheme)) return null
+        if (query.name.lowercase().startsWith("stavby")) return RegistrySearchResult.tooMany(2818)
+        val all = listOf(
+            RegistrySearchHit(
+                LegalEntityIdentifier.of(IdentifierScheme.CZ_ICO, "45274649"),
+                "Příklad s.r.o.",
+                "112",
+                "Náměstí 1, 60200 Brno",
+            ),
+            RegistrySearchHit(
+                LegalEntityIdentifier.of(IdentifierScheme.CZ_ICO, "26185610"),
+                "Příklad Praha s.r.o.",
+                "112",
+                "Budějovická 778/3, 14000 Praha 4",
+            ),
+        ).filter { it.name.lowercase().contains(query.name.lowercase()) }
+        val hits =
+            query.city?.let { c -> all.filter { it.registeredAddress?.contains(c, ignoreCase = true) == true } } ?: all
+        return RegistrySearchResult(hits = hits, totalMatches = hits.size)
+    }
 
     private fun extract(id: LegalEntityIdentifier, form: LegalFormClass, rule: RepresentationRule, reps: List<String>) =
         RegistryExtract(


### PR DESCRIPTION
## Summary

Business onboarding opens on an identifier field, and a founder typically does not know their own
IČO — it lives on an invoice, not in anyone's head. This adds name (+ optional town) search over the
country register so the customer can pick their company from the listed rows instead.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #9707, Refs ADR-0284

## Changes

- `GET /api/v1/kyb/registry/search?country&name&city&limit` — 200 with pickable rows, 404 where the
  register cannot be searched, 400 for a missing parameter.
- `RegistrySearchQuery` / `RegistrySearchHit` / `RegistrySearchResult` in the domain; a hit carries
  only what tells two companies apart.
- `RegistrySearchService`, deliberately uncached (a search is keyed by text the customer is still
  typing) and short-circuiting below a three-character floor without a round trip.
- `AresRegistryAdapter.search` over `POST /ekonomicke-subjekty/vyhledat`.
- `supportsNameSearch` on the country pack (CZ only today), also surfaced on `/api/v1/kyb/schemes`
  so the UI can hide the box where no register serves it.
- openapi.yaml `1.1.0 -> 1.2.0` (additive).

## Reviewer notes — the two things worth checking

**A search hit binds nothing.** The feature moves the choice of legal entity from "the customer
typed a number we then verified" to "the customer picked a row", and picking the wrong
`STAVBY s.r.o.` out of several hundred identically-named ones is silent — it surfaces at signing or
at the first payment. So a hit carries an identifier and that identifier still goes through the
ordinary lookup + extract confirmation; nothing in this PR creates or advances a case.

**The town filter must be `sidlo.textovaAdresa`.** `sidlo.nazevObce` is what ARES returns in every
search response, so it is the field a reader reaches for, and the search endpoint ignores it.
Measured against the live service on 2026-09-11, `obchodniJmeno=Asseco`, six matches in total:

```
sidlo.textovaAdresa  Praha 4   Brno 0   Ostrava 0   Bratislava 2    (4 + 2 = 6, discriminates)
sidlo.nazevObce      Praha 6   Brno 6                Bratislava 6    (ignored — every town, 6)
```

A town box wired to `nazevObce` still returns results, so nothing downstream notices; the customer
sees companies from the wrong end of the country while believing they filtered. `AresRegistrySearchTest`
asserts the key and was falsified by flipping it (6 tests, 1 failure).

Third point: too-many-matches is an outcome, not an error. `obchodniJmeno=stavby` matches 2 818
subjects and ARES answers `VYSTUP_PRILIS_MNOHO_VYSLEDKU` — an error document, not a truncated list,
and paging does not help because the cap is on the match count. Rendered as a 200 with
`tooManyMatches: true`, so the customer is told to narrow rather than that the bank is broken.

The endpoint reuses the existing `kyb.lookup` authz action on purpose: it reads the same public
register and exposes nothing `lookup` does not, while a new action would need a `role_action_matrix`
line plus a fleet-wide OPA bundle restamp.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [ ] Docs updated (README, ADR if architectural).

19 new tests (6 ARES body/mapping, 5 routing, 8 over real HTTP); module runs 72 tests, 0 skipped,
0 failures. No DB change, no event change, no new dependency.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

The query parameters are declared nullable with `requireNotNull` in the body, per the
`nonnull-jaxrs-param-ratchet` rule — a non-null JAX-RS parameter makes an absent one a 500, and the
integration tests assert 400. The surface is not anonymous (asserted).

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [x] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

KYB is an AML control surface, but this is read-only over a public register and changes no
verification step: the extract confirmation that decides a case is untouched.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the PR; the endpoint is additive and nothing calls it yet.
- Data migration reversible: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
