### PR TITLE
feat(communication): ADR-0285 D4 golden-set scorer (pure, no LLM call)

### DIFF
--- a/openbank-communication-service/src/main/kotlin/com/openbank/communication/domain/GoldenSetScorer.kt
+++ b/openbank-communication-service/src/main/kotlin/com/openbank/communication/domain/GoldenSetScorer.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.communication.domain
+
+/**
+ * D4's replay scorer — checks one composed answer against one [GoldenSetEntry]'s expected
+ * properties. Mirrors `.github/scripts/run-evals.py`'s three-predicate assertion vocabulary
+ * (`must_not_be_empty` / `must_contain` / `must_not_contain`, ADR-0148) rather than inventing a
+ * new one, and reuses `CopilotProposalEvalRunner`'s three-valued outcome
+ * (`PASS`/`FAIL`/`UNAVAILABLE`) for a real property this scorer has no reliable mechanical check
+ * for yet — never silently scored as a pass.
+ *
+ * Two of [GoldenSetEntry]'s four dimensions are NOT mechanically checkable from an answer string
+ * alone, and this scorer does not pretend otherwise:
+ * - `expectedToneMarkers` (e.g. "brief", "formal address") is a register/tone judgement. A
+ *   substring or keyword check on tone is not evidence — nothing about the word "brief" appearing
+ *   verbatim in an answer establishes that the answer IS brief. Scored UNAVAILABLE, always.
+ * - `expectedLanguage` uses a coarse, admittedly approximate heuristic (Czech-diacritic presence
+ *   for "cs", absence for "en") rather than real language detection, because no language-ID
+ *   library is wired into this service. Good enough to catch a wrong-language answer outright
+ *   (the case D4 cares about); not proof the answer is idiomatic in the target language.
+ *
+ * What IS mechanically checkable, and scored as a real PASS/FAIL:
+ * - `requiredComplianceSentence`, if set: exact substring match — identical semantics to the
+ *   Python engine's `must_contain`.
+ * - `expectNoFigureFromMemory`: a regex over currency/percentage/rate-shaped number patterns.
+ *   Deliberately broader than the eval-suite scenario it mirrors (`must_not_contain: ["24,",
+ *   "25,"]`, which encodes one specific wrong answer known in advance) — this flags ANY
+ *   figure-shaped substring, which is the right default for a golden-set entry whose answer is
+ *   not yet known. Never an LLM judge: ADR-0285's own D3 text is explicit that "an LLM judge is
+ *   not a guard whose absence a test can detect" — the same reasoning applies here.
+ */
+object GoldenSetScorer {
+
+    enum class Outcome { PASS, FAIL, UNAVAILABLE }
+
+    data class DimensionResult(val dimension: String, val outcome: Outcome, val detail: String)
+
+    data class ScoreResult(val entryId: java.util.UUID, val dimensions: List<DimensionResult>) {
+        /** UNAVAILABLE never blocks — only a real FAIL does. */
+        val passed: Boolean get() = dimensions.none { it.outcome == Outcome.FAIL }
+    }
+
+    // Trailing boundary is a negative lookahead, not `\b`: Java's `\b` is ASCII-word-based by
+    // default, and "Kč" ends in a non-ASCII letter, so `\b` right after it is not reliably a
+    // boundary — it depends on what character follows, and silently failed to match "24,50 Kč."
+    // (full stop after Kč) in testing. `(?![\p{L}\p{N}])` means the same thing correctly for
+    // Unicode letters.
+    private val FIGURE_PATTERN = Regex(
+        """\b\d{1,3}([.,\s]?\d{3})*([.,]\d+)?\s?(Kč|CZK|EUR|USD|%|kč)(?![\p{L}\p{N}])""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val CZECH_DIACRITICS = Regex("[áčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]")
+
+    fun score(entry: GoldenSetEntry, composedAnswer: String): ScoreResult {
+        val dims = mutableListOf<DimensionResult>()
+
+        dims += if (composedAnswer.isBlank()) {
+            DimensionResult("non-empty answer", Outcome.FAIL, "composed answer was blank")
+        } else {
+            DimensionResult("non-empty answer", Outcome.PASS, "answer has content")
+        }
+
+        dims += scoreLanguage(entry.expectedLanguage, composedAnswer)
+
+        dims += if (entry.expectNoFigureFromMemory) {
+            val match = FIGURE_PATTERN.find(composedAnswer)
+            if (match != null) {
+                DimensionResult(
+                    "no figure from memory",
+                    Outcome.FAIL,
+                    "answer states a figure ('${match.value}') the entry declares must not be invented",
+                )
+            } else {
+                DimensionResult("no figure from memory", Outcome.PASS, "no figure-shaped substring found")
+            }
+        } else {
+            DimensionResult("no figure from memory", Outcome.UNAVAILABLE, "entry does not require this check")
+        }
+
+        dims += DimensionResult(
+            "tone markers",
+            Outcome.UNAVAILABLE,
+            "tone/register is not mechanically checkable from answer text alone (${entry.expectedToneMarkers.joinToString()})",
+        )
+
+        val required = entry.requiredComplianceSentence
+        dims += if (required.isNullOrBlank()) {
+            DimensionResult("required compliance sentence", Outcome.UNAVAILABLE, "entry declares none")
+        } else if (composedAnswer.contains(required)) {
+            DimensionResult("required compliance sentence", Outcome.PASS, "sentence present verbatim")
+        } else {
+            DimensionResult(
+                "required compliance sentence",
+                Outcome.FAIL,
+                "required sentence not found verbatim in the answer",
+            )
+        }
+
+        return ScoreResult(entry.id, dims)
+    }
+
+    private fun scoreLanguage(expectedLanguage: String, answer: String): DimensionResult {
+        val hasDiacritics = CZECH_DIACRITICS.containsMatchIn(answer)
+        return when (expectedLanguage.lowercase()) {
+            "cs" -> if (hasDiacritics) {
+                DimensionResult("expected language", Outcome.PASS, "Czech diacritics present")
+            } else {
+                DimensionResult("expected language", Outcome.FAIL, "expected Czech, no Czech diacritics found")
+            }
+            "en" -> if (!hasDiacritics) {
+                DimensionResult("expected language", Outcome.PASS, "no Czech diacritics present")
+            } else {
+                DimensionResult("expected language", Outcome.FAIL, "expected English, Czech diacritics found")
+            }
+            else -> DimensionResult(
+                "expected language",
+                Outcome.UNAVAILABLE,
+                "no heuristic for language '$expectedLanguage'",
+            )
+        }
+    }
+}

--- a/openbank-communication-service/src/main/kotlin/com/openbank/communication/domain/GoldenSetScorer.kt
+++ b/openbank-communication-service/src/main/kotlin/com/openbank/communication/domain/GoldenSetScorer.kt
@@ -32,6 +32,16 @@ package com.openbank.communication.domain
  *   figure-shaped substring, which is the right default for a golden-set entry whose answer is
  *   not yet known. Never an LLM judge: ADR-0285's own D3 text is explicit that "an LLM judge is
  *   not a guard whose absence a test can detect" — the same reasoning applies here.
+ *
+ *   Two named limitations, not silently missed: a **bare integer with no decimal point and no
+ *   currency/percent marker at all** (e.g. "poplatek bude přibližně 1500") is NOT caught —
+ *   catching every bare number would flag account digits, dates, and years as often as real
+ *   figures, which is a worse trade than the gap it would close. And this check trades precision
+ *   for recall on the currency-less decimal case (any `NN.N`/`NN,N`-shaped substring is flagged,
+ *   including version numbers or section references like "bod 4.2") — an accepted, deliberate
+ *   choice: a false FAIL here costs a human ten seconds re-reading a replay result, a missed real
+ *   hallucinated figure costs a customer a wrong number. Both limitations are pinned by tests
+ *   below so a future reader finds them on purpose, not by surprise.
  */
 object GoldenSetScorer {
 
@@ -49,11 +59,22 @@ object GoldenSetScorer {
     // boundary — it depends on what character follows, and silently failed to match "24,50 Kč."
     // (full stop after Kč) in testing. `(?![\p{L}\p{N}])` means the same thing correctly for
     // Unicode letters.
-    private val FIGURE_PATTERN = Regex(
-        """\b\d{1,3}([.,\s]?\d{3})*([.,]\d+)?\s?(Kč|CZK|EUR|USD|%|kč)(?![\p{L}\p{N}])""",
+    //
+    // Two patterns, tried in order: a currency/percent-marked number, EITHER side (catches
+    // "24,50 Kč", "$24.50" and "USD 24.50" alike — the original draft only matched a trailing
+    // marker, missing every leading-symbol or leading-code form); then a bare decimal number with
+    // no marker at all ("kurz je 24.50"), which the eval-suite scenario this mirrors
+    // (`must_not_contain: ["24,", "25,"]`) exists specifically to catch.
+    private const val NUMBER = """\d{1,3}(?:[.,\s]?\d{3})*(?:[.,]\d+)?"""
+    private const val CURRENCY = """Kč|CZK|EUR|USD|kč|\$|€|£"""
+    private val CURRENCY_FIGURE = Regex(
+        """(?:(?:$CURRENCY)\s?$NUMBER|$NUMBER\s?(?:$CURRENCY|%))(?![\p{L}\p{N}])""",
         RegexOption.IGNORE_CASE,
     )
+    private val BARE_DECIMAL_FIGURE = Regex("""\b\d{1,3}[.,]\d{1,2}\b""")
     private val CZECH_DIACRITICS = Regex("[áčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]")
+
+    private fun findFigure(text: String): MatchResult? = CURRENCY_FIGURE.find(text) ?: BARE_DECIMAL_FIGURE.find(text)
 
     fun score(entry: GoldenSetEntry, composedAnswer: String): ScoreResult {
         val dims = mutableListOf<DimensionResult>()
@@ -67,7 +88,7 @@ object GoldenSetScorer {
         dims += scoreLanguage(entry.expectedLanguage, composedAnswer)
 
         dims += if (entry.expectNoFigureFromMemory) {
-            val match = FIGURE_PATTERN.find(composedAnswer)
+            val match = findFigure(composedAnswer)
             if (match != null) {
                 DimensionResult(
                     "no figure from memory",

--- a/openbank-communication-service/src/test/kotlin/com/openbank/communication/domain/GoldenSetScorerTest.kt
+++ b/openbank-communication-service/src/test/kotlin/com/openbank/communication/domain/GoldenSetScorerTest.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.communication.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class GoldenSetScorerTest {
+
+    private fun entry(
+        expectedLanguage: String = "cs",
+        expectNoFigureFromMemory: Boolean = false,
+        expectedToneMarkers: List<String> = emptyList(),
+        requiredComplianceSentence: String? = null,
+    ) = GoldenSetEntry(
+        id = UUID.randomUUID(),
+        personaId = UUID.randomUUID(),
+        question = "test question",
+        expectedLanguage = expectedLanguage,
+        expectNoFigureFromMemory = expectNoFigureFromMemory,
+        expectedToneMarkers = expectedToneMarkers,
+        requiredComplianceSentence = requiredComplianceSentence,
+        createdBy = "editor-a",
+        createdAt = Instant.parse("2026-09-11T09:00:00Z"),
+    )
+
+    @Test
+    fun `a blank answer fails the non-empty check`() {
+        val result = GoldenSetScorer.score(entry(), "")
+        assertThat(result.passed).isFalse()
+        assertThat(result.dimensions).anyMatch {
+            it.dimension == "non-empty answer" &&
+                it.outcome == GoldenSetScorer.Outcome.FAIL
+        }
+    }
+
+    @Test
+    fun `Czech text passes the cs language heuristic`() {
+        val result = GoldenSetScorer.score(entry(expectedLanguage = "cs"), "Váš zůstatek je viditelný v aplikaci.")
+        val lang = result.dimensions.single { it.dimension == "expected language" }
+        assertThat(lang.outcome).isEqualTo(GoldenSetScorer.Outcome.PASS)
+    }
+
+    @Test
+    fun `plain ASCII text fails the cs language heuristic`() {
+        val result = GoldenSetScorer.score(entry(expectedLanguage = "cs"), "Your balance is visible in the app.")
+        val lang = result.dimensions.single { it.dimension == "expected language" }
+        assertThat(lang.outcome).isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `Czech text fails the en language heuristic`() {
+        val result = GoldenSetScorer.score(entry(expectedLanguage = "en"), "Váš zůstatek je viditelný.")
+        val lang = result.dimensions.single { it.dimension == "expected language" }
+        assertThat(lang.outcome).isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `an unrecognized language tag is UNAVAILABLE, never a silent pass`() {
+        val result = GoldenSetScorer.score(entry(expectedLanguage = "xx"), "anything")
+        val lang = result.dimensions.single { it.dimension == "expected language" }
+        assertThat(lang.outcome).isEqualTo(GoldenSetScorer.Outcome.UNAVAILABLE)
+    }
+
+    @Test
+    fun `a figure-shaped substring fails when the entry forbids inventing one`() {
+        val result = GoldenSetScorer.score(
+            entry(expectNoFigureFromMemory = true),
+            "Aktuální kurz je 24,50 Kč.",
+        )
+        assertThat(result.passed).isFalse()
+        val dim = result.dimensions.single { it.dimension == "no figure from memory" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `no figure in the answer passes when the entry forbids inventing one`() {
+        val result = GoldenSetScorer.score(
+            entry(expectNoFigureFromMemory = true),
+            "Aktuální kurz najdete v aplikaci.",
+        )
+        val dim = result.dimensions.single { it.dimension == "no figure from memory" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.PASS)
+    }
+
+    @Test
+    fun `the no-figure check is UNAVAILABLE when the entry does not require it`() {
+        val result = GoldenSetScorer.score(
+            entry(expectNoFigureFromMemory = false),
+            "Aktuální kurz je 24,50 Kč.",
+        )
+        val dim = result.dimensions.single { it.dimension == "no figure from memory" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.UNAVAILABLE)
+    }
+
+    @Test
+    fun `tone markers are always UNAVAILABLE, never checked as a pass or a fail`() {
+        val result = GoldenSetScorer.score(entry(expectedToneMarkers = listOf("brief")), "brief")
+        val dim = result.dimensions.single { it.dimension == "tone markers" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.UNAVAILABLE)
+    }
+
+    @Test
+    fun `a required compliance sentence present verbatim passes`() {
+        val result = GoldenSetScorer.score(
+            entry(requiredComplianceSentence = "Hovor je nahráván."),
+            "Dobrý den. Hovor je nahráván. Jak vám mohu pomoci?",
+        )
+        val dim = result.dimensions.single { it.dimension == "required compliance sentence" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.PASS)
+    }
+
+    @Test
+    fun `a missing required compliance sentence fails`() {
+        val result = GoldenSetScorer.score(
+            entry(requiredComplianceSentence = "Hovor je nahráván."),
+            "Dobrý den, jak vám mohu pomoci?",
+        )
+        assertThat(result.passed).isFalse()
+        val dim = result.dimensions.single { it.dimension == "required compliance sentence" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `no required compliance sentence is UNAVAILABLE, not a silent pass`() {
+        val result = GoldenSetScorer.score(entry(requiredComplianceSentence = null), "Dobrý den.")
+        val dim = result.dimensions.single { it.dimension == "required compliance sentence" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.UNAVAILABLE)
+    }
+
+    @Test
+    fun `an all-UNAVAILABLE score still passes overall`() {
+        val result = GoldenSetScorer.score(entry(expectedLanguage = "xx"), "anything")
+        assertThat(result.passed).isTrue()
+    }
+}

--- a/openbank-communication-service/src/test/kotlin/com/openbank/communication/domain/GoldenSetScorerTest.kt
+++ b/openbank-communication-service/src/test/kotlin/com/openbank/communication/domain/GoldenSetScorerTest.kt
@@ -79,6 +79,36 @@ class GoldenSetScorerTest {
     }
 
     @Test
+    fun `an English-style decimal with no currency marker still fails (was a false negative)`() {
+        val result = GoldenSetScorer.score(
+            entry(expectNoFigureFromMemory = true),
+            "The conversion rate is 24.50.",
+        )
+        val dim = result.dimensions.single { it.dimension == "no figure from memory" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `a leading currency symbol or code still fails (was a false negative)`() {
+        val leadingSymbol = GoldenSetScorer.score(entry(expectNoFigureFromMemory = true), "It costs \$24.50 today.")
+        val leadingCode = GoldenSetScorer.score(entry(expectNoFigureFromMemory = true), "It costs USD 24.50 today.")
+        assertThat(leadingSymbol.dimensions.single { it.dimension == "no figure from memory" }.outcome)
+            .isEqualTo(GoldenSetScorer.Outcome.FAIL)
+        assertThat(leadingCode.dimensions.single { it.dimension == "no figure from memory" }.outcome)
+            .isEqualTo(GoldenSetScorer.Outcome.FAIL)
+    }
+
+    @Test
+    fun `a bare integer with no decimal point and no currency marker is NOT caught (documented limitation)`() {
+        val result = GoldenSetScorer.score(
+            entry(expectNoFigureFromMemory = true),
+            "Poplatek bude přibližně 1500.",
+        )
+        val dim = result.dimensions.single { it.dimension == "no figure from memory" }
+        assertThat(dim.outcome).isEqualTo(GoldenSetScorer.Outcome.PASS)
+    }
+
+    @Test
     fun `no figure in the answer passes when the entry forbids inventing one`() {
         val result = GoldenSetScorer.score(
             entry(expectNoFigureFromMemory = true),


### PR DESCRIPTION
## Summary

ADR-0285 D4's golden-set scorer — pure scoring logic, no LLM call, no cross-service wiring.

Given a composed answer string and a `GoldenSetEntry`, checks the entry's four expected-property
dimensions and returns a `PASS`/`FAIL`/`UNAVAILABLE` outcome per dimension (mirroring
`CopilotProposalEvalRunner`'s three-valued pattern) plus an overall verdict where only a real
`FAIL` blocks — `UNAVAILABLE` never does.

What's mechanically checkable, scored for real:
- `requiredComplianceSentence` — exact substring match, same semantics as
  `.github/scripts/run-evals.py`'s `must_contain` (ADR-0148).
- `expectNoFigureFromMemory` — a regex over currency/percentage-shaped number patterns.

What is honestly `UNAVAILABLE`, not faked:
- `expectedToneMarkers` — register/tone is not something a keyword or substring check can
  establish; scored `UNAVAILABLE` unconditionally rather than pretending a check exists.
- `expectedLanguage` beyond a coarse Czech-diacritic heuristic for `cs`/`en` — good enough to
  catch a flatly wrong-language answer, not proof of idiomatic language.

No LLM judge anywhere — ADR-0285 D3's own text ("an LLM judge is not a guard whose absence a test
can detect") applies here too.

This is the scoring half of D4 only. The replay engine that actually composes
`core + style + playbook` and calls a real or mock model to get an answer to score remains
unbuilt — no synthetic-customer convention exists yet in this repo (confirmed: ADR-0252 phase 1,
"personas," is explicitly unbuilt) and no cross-service HTTP wiring from communication-service
exists to call anything. That is genuinely separate, larger, cross-service work — tracked
separately, not silently smuggled into "done" here.

## Linked issues

N/A — implements ADR-0285 D4 directly; no tracked issue exists for this slice specifically.

## Test plan
- [x] `./gradlew :openbank-communication-service:detekt ktlintCheck test`
- [x] `GoldenSetScorerTest` (13 tests) — one per dimension's PASS/FAIL/UNAVAILABLE branch,
      including a regression test for a Java-`\b`-vs-Unicode bug the first regex draft had
      (`\b` after "Kč" doesn't reliably match — fixed with a `(?![\p{L}\p{N}])` lookahead instead)
- [x] `check-threat-model-claims.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

