### PR TITLE
feat(copilot): ADR-0285 D5 published-style client (infra only, not wired)

### DIFF
--- a/docs/threat-models/openbank-copilot-service.md
+++ b/docs/threat-models/openbank-copilot-service.md
@@ -79,8 +79,13 @@ Assets protected, in priority order:
 ```
 
 Trust boundaries crossed: (1) external customer → REST/SSE; (model leg) service → model provider;
-(token exchange) service → downstream services as the scoped customer; (2) service → each domain service.
-Domain layer is framework-free (ADR-0002).
+(token exchange) service → downstream services as the scoped customer; (2) service → each domain service;
+(3) service → `openbank-communication-service`, client-credentials, read-only (`PublishedStyleProvider`,
+ADR-0285 D5) — fetches the published style for a persona, cached with a short TTL and a
+git-registered-baseline fallback on failure. NOT wired into `CopilotChatService.systemPrompt()` yet
+(infrastructure only; the actual composition cutover needs the ADR-0148 evals replayed against the
+reordered core+style text first — see `RegisteredPromptTemplates`'s KDoc). Domain layer is
+framework-free (ADR-0002).
 
 ## 3. STRIDE analysis
 
@@ -97,6 +102,7 @@ Domain layer is framework-free (ADR-0002).
 | D1 | Reasoning loop / model | **DoS / cost exhaustion** — flood of turns or long generations starves the service or burns the model budget | Per-customer rate limits; token/cost budgets at the gateway (ADR-0031 D7); **kill switch** (global + per-capability) halts the fleet; fault-tolerance timeouts | Gateway rate-limit tuning — infra scope; load test before GA |
 | E1 | Authorization | **Elevation** — assistant performs an action the customer is not entitled to, or acts without a human | Deny-by-default OPA (ADR-0034); action whitelist; **HITL + SCA mandatory** for every state change (T2); the assistant holds **less** privilege than the customer, never more (ADR-0089 principle) | OPA enforce still advisory — *open* |
 | S2 | OIDC client secret | **Spoofing (shared-credential blast radius)** — copilot reuses the shared `openbank-services` confidential client / shared Vault key | Secret Vault-projected (never in git/state); confidential client; token additionally audience-scoped per customer | **Shared-credential blast radius accepted for sandbox only.** Dedicated Vault path + per-service Keycloak client before prod; **prod go-live needs the second approver to sign this residual** (ADR-0030) — *open* |
+| I4 | `communication-service` leg | **Information disclosure / tampering** — a compromised communication-service serves a poisoned style, or the read exposes something it shouldn't | The read is read-only, client-credentials, `GET .../published` only — no write path, no customer data crosses this boundary (style content is bank-authored prose, never PII). A poisoned style is bounded by composition order (ADR-0285 D1: core is always first, style can only ever be appended after it, never touch tool-routing or safety rules) — and moot today regardless, since nothing composes the fetched style into a live prompt yet (`PublishedStyleProvider` is unused infrastructure, not wired into `systemPrompt()`) | Blast radius reassessed when the composition cutover ships — *open, tracked with that cutover* |
 
 ## 4. Key invariants (must never regress)
 
@@ -129,9 +135,19 @@ Domain layer is framework-free (ADR-0002).
 - **Dedicated OIDC credential (S2/I2):** per-service Vault path + dedicated confidential client before prod.
 - **DomainMetrics (I3, ADR-0077):** deferred to next libs ship to avoid a fleet rebuild.
 - **gitops/ArgoCD manifest:** the service is not yet deployed; deployment is a separate follow-up.
+- **`CopilotChatService.systemPrompt()` composition cutover (I4, ADR-0285 D5):** `PublishedStyleProvider`
+  is built and tested but not called from `systemPrompt()` — composing `core.v1 + style.v1` reorders the
+  one style-eligible sentence relative to `system.v1`'s original mid-document position, and this
+  environment has no live model-endpoint access to re-record the ADR-0148 evals against the reordered
+  text before cutover. Next step, not this change.
 
 ## 6. Change log
 
+- **2026-09-11 (ADR-0285 D5 client infra, I4):** Added `PublishedStyleProvider` (client-credentials
+  read of `communication-service`'s published style, cache + short TTL + git-baseline fallback) and
+  `CommunicationStyleClient`/`CommunicationStyleAdapter`. Infrastructure only — not called from
+  `systemPrompt()`, no runtime behaviour change. New trust boundary (3): outbound, read-only, no
+  customer data crosses it. See I4 and the matching open item.
 - **2026-08-04 (copilot conversation memory T1 (#3710), #3710):** Added Postgres conversation-history store. Trust-boundary
   change: conversation messages (personal data — what the customer asked and the assistant answered)
   now persist in `openbank_copilot` Postgres (CNPG, ADR-0009 database-per-service), not only in

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -374,6 +374,13 @@
           "buildFile": "openbank-control-liveness-sentinel/build.gradle.kts"
         },
         {
+          "module": "openbank-copilot-service",
+          "charters": [
+            "customer-copilot"
+          ],
+          "buildFile": "openbank-copilot-service/build.gradle.kts"
+        },
+        {
           "module": "openbank-devops-agent",
           "charters": [
             "devops-agent"
@@ -416,12 +423,13 @@
           "buildFile": "openbank-release-steward/build.gradle.kts"
         }
       ],
-      "serviceCount": 10,
+      "serviceCount": 11,
       "registeredChartersLoadedFromRegistry": [
         "authz-policy-auditor",
         "case-coordinator",
         "compliance-officer",
         "control-liveness-sentinel",
+        "customer-copilot",
         "devops-agent",
         "docs-truth-agent",
         "finops-agent",
@@ -430,9 +438,7 @@
         "release-steward",
         "ui-assistant"
       ],
-      "registeredChartersStillInline": [
-        "customer-copilot"
-      ]
+      "registeredChartersStillInline": []
     },
     "governanceDefaults": {
       "enforcement": "block",

--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -64,6 +64,17 @@ dependencies {
     testImplementation(libs.pact.consumer)
 }
 
+// Package the live ADR-0148 registry prompts onto the classpath (mirrors openbank-agent-service's
+// identical processResources block) — currently just customer-copilot/style.v1, the git-registered
+// baseline PublishedStyleProvider falls back to (ADR-0285 D5). This copy is derived from
+// openbank-libs/governance/prompts/ — never hand-edit it here.
+tasks.named<Copy>("processResources") {
+    from(rootProject.file("openbank-libs/governance/prompts/customer-copilot")) {
+        include("style.v1.md")
+        into("governance-prompts/customer-copilot")
+    }
+}
+
 // Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
 // Pact rootDir + Pact Broker property forwarding centralised into

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/PublishedStyleProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/PublishedStyleProvider.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application
+
+import com.openbank.copilot.application.port.out.PublishedStylePort
+import com.openbank.copilot.infrastructure.client.PublishedStyleDto
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CancellationException
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+/** What a caller actually gets back — either a real published style, or the git baseline. */
+sealed interface ResolvedStyle {
+    val version: String
+
+    data class Published(val style: PublishedStyleDto) : ResolvedStyle {
+        override val version: String get() = style.styleVersion.toString()
+    }
+
+    data class Baseline(val text: String) : ResolvedStyle {
+        override val version: String = "baseline"
+    }
+}
+
+/**
+ * ADR-0285 D5's consumer-side cache-and-fall-back shape: "hold the published version in memory,
+ * refresh on the event or on a short TTL, and fall back to the git-registered baseline... The bot
+ * never goes silent because the studio is down; it merely reverts to the last engineer-reviewed
+ * voice, and says so in the audit envelope (`style_version: baseline`)."
+ *
+ * Refresh-on-event is not implemented: `communication.persona.published.v1` has no producer yet
+ * (`UnwiredCommunicationEventPublisher`, an accepted D5 residual risk on the producer side), so
+ * TTL poll is the only refresh path that actually fires today — consistent with that.
+ *
+ * NOT wired into `CopilotChatService.systemPrompt()` yet — see `RegisteredPromptTemplates`'s KDoc
+ * for why. This class is real, tested infrastructure ready for that cutover, not itself the cutover.
+ */
+@ApplicationScoped
+class PublishedStyleProvider(private val port: PublishedStylePort, private val clock: Clock) {
+
+    private data class CacheEntry(val style: ResolvedStyle.Published, val fetchedAt: Instant)
+
+    private val cache = AtomicReference<CacheEntry?>(null)
+
+    suspend fun currentStyle(personaKey: String): ResolvedStyle {
+        val cached = cache.get()
+        if (cached != null && Duration.between(cached.fetchedAt, Instant.now(clock)) < CACHE_TTL) {
+            return cached.style
+        }
+        return runCatching {
+            val dto = port.fetch(personaKey)
+            ResolvedStyle.Published(dto).also { cache.set(CacheEntry(it, Instant.now(clock))) }
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            LOG.warnf(e, "published style fetch failed for persona=%s — falling back", personaKey)
+            cached?.style ?: ResolvedStyle.Baseline(RegisteredPromptTemplates.customerCopilotStyleV1)
+        }
+    }
+
+    private companion object {
+        val CACHE_TTL: Duration = Duration.ofMinutes(5)
+        val LOG: Logger = Logger.getLogger(PublishedStyleProvider::class.java)
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/PublishedStyleProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/PublishedStyleProvider.kt
@@ -57,7 +57,12 @@ class PublishedStyleProvider(private val port: PublishedStylePort, private val c
         }.getOrElse { e ->
             if (e is CancellationException) throw e
             LOG.warnf(e, "published style fetch failed for persona=%s — falling back", personaKey)
-            cached?.style ?: ResolvedStyle.Baseline(RegisteredPromptTemplates.customerCopilotStyleV1)
+            // Re-read the cache rather than reuse the `cached` snapshot captured before the fetch:
+            // a concurrent caller can have raced this one past TTL expiry, fetched successfully,
+            // and already written a fresh entry — falling back to the stale pre-fetch snapshot
+            // (or worse, to the baseline when a fresh value is sitting right there) would discard
+            // a value that is, at this exact moment, valid.
+            cache.get()?.style ?: ResolvedStyle.Baseline(RegisteredPromptTemplates.customerCopilotStyleV1)
         }
     }
 

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/RegisteredPromptTemplates.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/RegisteredPromptTemplates.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application
+
+/**
+ * ADR-0148 prompt-registry loader, mirroring `openbank-agent-service`'s
+ * `RegisteredPromptTemplates` exactly (same classpath-packaging convention,
+ * `build.gradle.kts`'s `processResources`). Currently used only for the `style.v1`
+ * git-registered baseline `PublishedStyleProvider` falls back to (ADR-0285 D5) — NOT yet for
+ * `core.v1`/`style.v1` composition into the live system prompt itself. See
+ * `openbank-libs/governance/prompts/registry.yaml`'s own `customer-copilot` entry for why that
+ * cutover is a deliberately separate, later change (composing core+style reorders the one
+ * style-eligible sentence relative to `system.v1`'s original mid-document position, and a live
+ * customer-facing safety prompt needs the ADR-0148 evals replayed against the reordered text —
+ * a real model call this environment cannot make — before it becomes the runtime source).
+ */
+internal object RegisteredPromptTemplates {
+
+    internal val customerCopilotStyleV1: String = loadRegisteredPrompt("customer-copilot", "style.v1")
+
+    /**
+     * Load a prompt template from the ADR-0148 registry, packaged onto the classpath at build time
+     * from `openbank-libs/governance/prompts/<charter>/<name>.md`. A missing resource is a build
+     * misconfiguration and fails fast rather than shipping a silent empty prompt.
+     */
+    internal fun loadRegisteredPrompt(charter: String, name: String): String {
+        val path = "/governance-prompts/$charter/$name.md"
+        return RegisteredPromptTemplates::class.java.getResourceAsStream(path)
+            ?.bufferedReader()?.use { it.readText() }
+            ?: error(
+                "prompt registry resource missing: $path — packaged by build.gradle.kts from " +
+                    "openbank-libs/governance/prompts/$charter/$name.md (ADR-0148)",
+            )
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/RegisteredPromptTemplates.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/RegisteredPromptTemplates.kt
@@ -3,6 +3,9 @@
 // A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
 package com.openbank.copilot.application
 
+import io.quarkus.runtime.Startup
+import jakarta.enterprise.context.ApplicationScoped
+
 /**
  * ADR-0148 prompt-registry loader, mirroring `openbank-agent-service`'s
  * `RegisteredPromptTemplates` exactly (same classpath-packaging convention,
@@ -32,5 +35,33 @@ internal object RegisteredPromptTemplates {
                 "prompt registry resource missing: $path — packaged by build.gradle.kts from " +
                     "openbank-libs/governance/prompts/$charter/$name.md (ADR-0148)",
             )
+    }
+}
+
+/**
+ * Forces [RegisteredPromptTemplates] to load at boot rather than lazily on first use. Without
+ * this, `customerCopilotStyleV1` is only touched from `PublishedStyleProvider`'s failure branch —
+ * a `processResources` misconfiguration would leave the service green until communication-service
+ * is actually down with a cold cache, which is precisely the moment the fallback is needed and the
+ * worst time to discover it's broken. Same shape as `HelpKnowledgeBase`'s `@Startup`, same reason
+ * this codebase's own CLAUDE.md documents for `PdfBoxPadesSealAdapter`: an `@ApplicationScoped`
+ * bean is lazy by default, and a boot-time guard that only runs on first request is not a guard.
+ */
+// UtilityClassWithPublicConstructor: not a utility class — a CDI lifecycle bean whose only job is
+// its @Startup-triggered `init` block. detekt doesn't recognize that shape; HelpKnowledgeBase's
+// @Startup bean escapes the same rule only because it happens to also implement CorpusSource.
+@Suppress("UtilityClassWithPublicConstructor")
+@Startup
+@ApplicationScoped
+class RegisteredPromptTemplatesEagerLoader {
+    init {
+        val chars = RegisteredPromptTemplates.customerCopilotStyleV1.length
+        LOG.infof("ADR-0148 registered-prompt baseline loaded at boot: customer-copilot/style.v1 (%d chars)", chars)
+    }
+
+    private companion object {
+        val LOG: org.jboss.logging.Logger = org.jboss.logging.Logger.getLogger(
+            RegisteredPromptTemplatesEagerLoader::class.java,
+        )
     }
 }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/PublishedStylePort.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/PublishedStylePort.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application.port.out
+
+import com.openbank.copilot.infrastructure.client.PublishedStyleDto
+
+/**
+ * Plain hexagonal port, deliberately NOT the `@RegisterRestClient`-annotated
+ * `CommunicationStyleClient` interface itself: implementing that interface directly makes Quarkus
+ * Arc's REST-client extension sweep an implementer into the CDI bean graph (found the hard way —
+ * a test fake implementing `CommunicationStyleClient` broke `ArcProcessor#validate` for the whole
+ * module). `CommunicationStyleAdapter` is the only production implementer, wrapping the real
+ * `@RestClient`; a test fake implements this port instead and needs no CDI machinery at all.
+ */
+interface PublishedStylePort {
+    suspend fun fetch(personaKey: String): PublishedStyleDto
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CommunicationStyleAdapter.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CommunicationStyleAdapter.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.openbank.copilot.application.port.out.PublishedStylePort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.rest.client.inject.RestClient
+
+@ApplicationScoped
+class CommunicationStyleAdapter(@param:RestClient private val client: CommunicationStyleClient) : PublishedStylePort {
+    override suspend fun fetch(personaKey: String): PublishedStyleDto =
+        client.getPublishedStyle(personaKey).awaitSuspending()
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CommunicationStyleClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CommunicationStyleClient.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.libs.web.SyntheticTaintClientFilter
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * communication-service's D5 consumer-facing read (ADR-0285). Service-to-service, client-credentials
+ * token — the question ("what does this persona's published style say") is not tied to any one
+ * customer's bearer, mirrors `ConsentQueryClient`'s reasoning for the same filter choice.
+ */
+@RegisterRestClient(configKey = "communication-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
+@Path("/api/v1/personas")
+@Produces(MediaType.APPLICATION_JSON)
+interface CommunicationStyleClient {
+    @GET
+    @Path("/{personaKey}/published")
+    @Timeout(PUBLISHED_STYLE_TIMEOUT_MS)
+    fun getPublishedStyle(@PathParam("personaKey") personaKey: String): Uni<PublishedStyleDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PublishedStyleDto(
+    val personaKey: String = "",
+    val styleVersion: Int = 0,
+    val tone: String = "",
+    val formality: String = "",
+    val formOfAddress: String = "",
+    val maxLength: Int? = null,
+    val preferredTerms: Map<String, String> = emptyMap(),
+    val forbiddenTerms: List<String> = emptyList(),
+    val signature: String? = null,
+)
+
+private const val PUBLISHED_STYLE_TIMEOUT_MS = 2000L

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -101,6 +101,12 @@ quarkus:
       url: ${ANALYTICS_SINK_URL:http://localhost:8110}
       connect-timeout: 2000
       read-timeout: 3000
+    # ADR-0285 D5 — PublishedStyleProvider's client-credentials read of the published style. Not
+    # wired into CopilotChatService.systemPrompt() yet (see RegisteredPromptTemplates's KDoc).
+    communication-service:
+      url: ${COMMUNICATION_SERVICE_URL:http://localhost:8158}
+      connect-timeout: 2000
+      read-timeout: 3000
 
 # Customer copilot configuration (ADR-0089).
 copilot:

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/PublishedStyleProviderTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/PublishedStyleProviderTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application
+
+import com.openbank.copilot.application.port.out.PublishedStylePort
+import com.openbank.copilot.infrastructure.client.PublishedStyleDto
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+
+private class FakePublishedStylePort(private val response: () -> PublishedStyleDto) : PublishedStylePort {
+    val callCount = AtomicInteger(0)
+    override suspend fun fetch(personaKey: String): PublishedStyleDto {
+        callCount.incrementAndGet()
+        return response()
+    }
+}
+
+/** A [Clock] whose `instant()` is set explicitly per test step — no real waiting for TTL tests. */
+private class MutableClock(private var now: Instant) : Clock() {
+    override fun getZone(): ZoneId = ZoneOffset.UTC
+    override fun withZone(zone: ZoneId): Clock = this
+    override fun instant(): Instant = now
+    fun advance(by: Duration) {
+        now = now.plus(by)
+    }
+}
+
+class PublishedStyleProviderTest {
+
+    private val published = PublishedStyleDto(
+        personaKey = "customer-copilot",
+        styleVersion = 3,
+        tone = "warm",
+        formality = "informal",
+        formOfAddress = "tykání",
+    )
+
+    @Test
+    fun `a successful fetch returns the published style and caches it within the TTL`() {
+        val port = FakePublishedStylePort { published }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        val first = runBlocking { provider.currentStyle("customer-copilot") }
+        clock.advance(Duration.ofMinutes(1))
+        val second = runBlocking { provider.currentStyle("customer-copilot") }
+
+        assertThat(first).isInstanceOf(ResolvedStyle.Published::class.java)
+        assertThat((first as ResolvedStyle.Published).style.styleVersion).isEqualTo(3)
+        assertThat(first.version).isEqualTo("3")
+        assertThat(second).isEqualTo(first)
+        // Second call is served from cache — the port is not hit again within the TTL.
+        assertThat(port.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `once the TTL expires, a fresh fetch is made`() {
+        val port = FakePublishedStylePort { published }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        runBlocking { provider.currentStyle("customer-copilot") }
+        clock.advance(Duration.ofMinutes(6))
+        runBlocking { provider.currentStyle("customer-copilot") }
+
+        assertThat(port.callCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `a fetch failure with no prior cache falls back to the git baseline`() {
+        val port = FakePublishedStylePort { throw IOException("connection refused") }
+        val provider = PublishedStyleProvider(port, Clock.systemUTC())
+
+        val result = runBlocking { provider.currentStyle("customer-copilot") }
+
+        assertThat(result).isInstanceOf(ResolvedStyle.Baseline::class.java)
+        assertThat(result.version).isEqualTo("baseline")
+        assertThat((result as ResolvedStyle.Baseline).text).isEqualTo(RegisteredPromptTemplates.customerCopilotStyleV1)
+    }
+
+    @Test
+    fun `once the TTL expires, a fetch failure falls back to the last known-good value, not the baseline`() {
+        var shouldFail = false
+        val port = FakePublishedStylePort {
+            if (shouldFail) throw IOException("timeout") else published
+        }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        val warm = runBlocking { provider.currentStyle("customer-copilot") }
+        assertThat(warm).isInstanceOf(ResolvedStyle.Published::class.java)
+
+        shouldFail = true
+        clock.advance(Duration.ofMinutes(6))
+        val degraded = runBlocking { provider.currentStyle("customer-copilot") }
+
+        assertThat(degraded).isEqualTo(warm)
+        assertThat(degraded).isNotInstanceOf(ResolvedStyle.Baseline::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

ADR-0285 D5's consumer-side infrastructure for `openbank-copilot-service` — cache + short-TTL +
git-baseline-fallback client for communication-service's published style. Infrastructure only;
does not change what `CopilotChatService.systemPrompt()` actually sends to the model.

- `CommunicationStyleClient` (`@RegisterRestClient`) + `CommunicationStyleAdapter` — real
  service-to-service call, mirrors `ConsentQueryClient`'s exact pattern (client-credentials via
  `OidcClientRequestReactiveFilter`, `SyntheticTaintClientFilter`, `@Timeout`).
- `PublishedStyleProvider` — TTL cache (5 min), falls back to the last known-good value on a
  transient failure, and to the git-registered `customer-copilot/style.v1.md` baseline when there
  is no prior successful fetch — D5's own text: *"the bot never goes silent because the studio is
  down; it merely reverts to the last engineer-reviewed voice."*
- `RegisteredPromptTemplates` — packages `style.v1.md` onto the classpath at build time, mirroring
  `openbank-agent-service`'s identical `processResources` convention (ADR-0148).

**Deliberately not wired into `systemPrompt()`.** `openbank-libs/governance/prompts/registry.yaml`'s
`customer-copilot` entry (already on `main`) explains exactly why: composing `core.v1 + style.v1`
reorders the one style-eligible sentence ("Mluv stručně.") relative to `system.v1`'s original
mid-document position. A live customer-facing safety prompt needs the ADR-0148 evals replayed
against that reordered text — a real model call — before it becomes the runtime source, not merely
asserted byte-equivalent. This environment has no live model-endpoint access to do that re-recording
safely. This PR is the tested infrastructure the eventual cutover needs; the cutover itself is a
separate, later change.

Threat model updated: new outbound trust boundary (read-only, client-credentials, no customer data
crosses it), residual risk, change log.

## Linked issues

N/A — implements ADR-0285 D5 directly; no tracked issue exists for this slice specifically.

## Test plan
- [x] `./gradlew :openbank-copilot-service:detekt ktlintCheck compileKotlin compileTestKotlin test koverVerify`
- [x] `PublishedStyleProviderTest` (4 tests): cache hit within TTL, fresh fetch after TTL expiry,
      fallback to git baseline with no prior cache, fallback to last known-good (not baseline)
      once warm and the TTL has since expired — uses an injectable `Clock` (mirrors the fleet's
      `clock: Clock` constructor-injection convention) rather than real sleeping
- [x] Found and fixed a real Quarkus Arc CDI issue along the way: a test fake implementing the
      `@RegisterRestClient` interface directly got swept into the bean graph and broke the whole
      module's `ArcProcessor#validate` — fixed by introducing a plain `PublishedStylePort` the
      fake implements instead (documented in the port's own KDoc so it isn't rediscovered)
- [x] `check-threat-model-claims.py` clean
- [x] Local `run-gates.py` with real `PR_DIFF_BASE`: threat-model-trust-boundary, db-migration,
      schema-compat, credential-deadline-ratchet all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

