### PR TITLE
feat(agent-service): ADR-0285 D5 ui-assistant published-style client (infra only, not wired)

### DIFF
--- a/docs/threat-models/openbank-agent-service.md
+++ b/docs/threat-models/openbank-agent-service.md
@@ -54,7 +54,11 @@ Trust boundaries: (a) browser→BFF (NextAuth session), (b) BFF→agent-service 
 (c) agent-service→downstream services (service bearer), (d) agent-service→OPA (localhost sidecar),
 (e) agent-service→Kafka (mTLS, KafkaUser `agent-service`, `Write, Describe` on
 `openbank.agent.audit.events` and deliberately no `Read` — a component may append to the trail
-about itself and may not read it back; `openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml`).
+about itself and may not read it back; `openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml`);
+(f) agent-service→`openbank-communication-service`, client-credentials, read-only
+(`PublishedStyleProvider`, ADR-0285 D5) — fetches the published style for the `ui-assistant`
+persona, cached with a short TTL, no baseline fallback (see T-I3). NOT wired into
+`AgentChatService.systemPrompt()` or `CatalogReviewService` yet (infrastructure only).
 
 ## 2. STRIDE
 
@@ -136,6 +140,17 @@ about itself and may not read it back; `openbank-infra/gitops/components/agent/k
 - **T-I2 — prompt-injection exfiltration (FIND-S4-05).** Untrusted tool results are wrapped in
   data markers; the system prompt forbids following embedded instructions; the charter allow-list +
   gate bound what any missed phrasing could reach. PII is masked on every agent data scope.
+- **T-I3 — `communication-service` leg (ADR-0285 D5).** **Information disclosure / tampering** — a
+  compromised communication-service serves a poisoned style, or the read exposes something it
+  shouldn't. The read is read-only, client-credentials, `GET .../published` only — no write path,
+  no customer or operator data crosses this boundary (style content is bank-authored prose, never
+  PII). Moot today regardless: nothing composes the fetched style into a live prompt yet
+  (`PublishedStyleProvider` is unused infrastructure, not wired into `AgentChatService.systemPrompt()`
+  or `CatalogReviewService`), and unlike `openbank-copilot-service`'s equivalent provider it has no
+  git-registered-baseline fallback to poison in the first place — `ui-assistant`'s ADR-0148 registry
+  entry has never been split into `core.v1`/`style.v1`, so a total failure returns `null`, not a
+  substitute prompt. Blast radius reassessed when a composition cutover is actually proposed —
+  *open, tracked with that follow-up*.
 
 ### Denial of service
 
@@ -161,3 +176,16 @@ about itself and may not read it back; `openbank-infra/gitops/components/agent/k
   operator's roles) is a follow-up. Requires admin-ui pod compromise to exploit; deny tier untouched.
 - **D3b:** author≠approver codified in agent policy (not only GitHub branch protection).
 - Explicit per-run OTel trace already live (D7, #2385); LLM-level Langfuse observability planned.
+- **`AgentChatService`/`CatalogReviewService` composition cutover (T-I3, ADR-0285 D5):**
+  `PublishedStyleProvider` is built and tested but not called from either service. Unlike
+  copilot-service, there is no `core.v1`/`style.v1` registry split for `ui-assistant` to compose
+  yet — that is a separate, later decision (registry entry + ADR-0148 evals), not this change.
+
+## 4. Change log
+
+- **2026-09-11 (ADR-0285 D5 client infra, T-I3):** Added `PublishedStyleProvider` (client-credentials
+  read of `communication-service`'s published style for the `ui-assistant` persona, cache + short
+  TTL, no baseline fallback) and `CommunicationStyleClient`/`CommunicationStyleAdapter`.
+  Infrastructure only — not called from `AgentChatService.systemPrompt()` or `CatalogReviewService`,
+  no runtime behaviour change. New trust boundary (f): outbound, read-only, no customer or operator
+  data crosses it. See T-I3 and the matching open item.

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/PublishedStyleProvider.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/PublishedStyleProvider.kt
@@ -65,7 +65,11 @@ class PublishedStyleProvider(private val port: PublishedStylePort, private val c
         }.getOrElse { e ->
             if (e is CancellationException) throw e
             LOG.warnf(e, "published style fetch failed for persona=%s — falling back", personaKey)
-            cached?.style
+            // Re-read the cache rather than reuse the `cached` snapshot captured before the fetch:
+            // a concurrent caller can have raced this one past TTL expiry, fetched successfully,
+            // and already written a fresh entry — falling back to the stale pre-fetch snapshot
+            // would discard a value that is, at this exact moment, valid.
+            cache.get()?.style
         }
     }
 

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/PublishedStyleProvider.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/PublishedStyleProvider.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.agent.application
+
+import com.openbank.agent.application.port.out.PublishedStylePort
+import com.openbank.agent.infrastructure.client.PublishedStyleDto
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CancellationException
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+/** What a caller actually gets back for a successful (cached-or-fresh) published-style read. */
+sealed interface ResolvedStyle {
+    val version: String
+
+    data class Published(val style: PublishedStyleDto) : ResolvedStyle {
+        override val version: String get() = style.styleVersion.toString()
+    }
+}
+
+/**
+ * ADR-0285 D5's consumer-side cache-and-fall-back shape for `ui-assistant`, mirroring
+ * `openbank-copilot-service`'s `PublishedStyleProvider` — hold the published version in memory,
+ * refresh on a short TTL, serve the last known-good value on a transient failure.
+ *
+ * **Unlike copilot-service's provider, this one has NO git-registered-baseline fallback.**
+ * `openbank-libs/governance/prompts/registry.yaml`'s `ui-assistant` entry has not been split into
+ * a `core.v1`/`style.v1` pair the way `customer-copilot` has (it registers only
+ * `system.v1`/`system.v2`/`system.v3`/`catalog-review.v1` — the whole, unsplit prompts actually
+ * served by `AgentChatService`/`CatalogReviewService`). Inventing a style baseline here would mean
+ * fabricating prompt content that has never been registered or reviewed under ADR-0148 — that is a
+ * decision for whoever authors the `ui-assistant` core/style split, not something to guess in this
+ * infrastructure-only change. So on total failure (no warm cache AND the fetch itself failed),
+ * [currentStyle] returns `null` rather than a synthesized baseline: callers must treat a `null`
+ * result as "no style layer available for this persona today", not as an empty-but-valid style.
+ *
+ * Refresh-on-event is not implemented: `communication.persona.published.v1` has no producer yet
+ * (same accepted D5 residual risk noted in copilot-service's provider), so TTL poll is the only
+ * refresh path that actually fires today.
+ *
+ * NOT wired into `AgentChatService.systemPrompt()` or `CatalogReviewService` — this class is real,
+ * tested infrastructure, not itself a runtime-behaviour change. See the threat model's matching
+ * open item for what a future cutover would still need.
+ */
+@ApplicationScoped
+class PublishedStyleProvider(private val port: PublishedStylePort, private val clock: Clock) {
+
+    private data class CacheEntry(val style: ResolvedStyle.Published, val fetchedAt: Instant)
+
+    private val cache = AtomicReference<CacheEntry?>(null)
+
+    suspend fun currentStyle(personaKey: String): ResolvedStyle? {
+        val cached = cache.get()
+        if (cached != null && Duration.between(cached.fetchedAt, Instant.now(clock)) < CACHE_TTL) {
+            return cached.style
+        }
+        return runCatching {
+            val dto = port.fetch(personaKey)
+            ResolvedStyle.Published(dto).also { cache.set(CacheEntry(it, Instant.now(clock))) }
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            LOG.warnf(e, "published style fetch failed for persona=%s — falling back", personaKey)
+            cached?.style
+        }
+    }
+
+    private companion object {
+        val CACHE_TTL: Duration = Duration.ofMinutes(5)
+        val LOG: Logger = Logger.getLogger(PublishedStyleProvider::class.java)
+    }
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/port/out/PublishedStylePort.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/port/out/PublishedStylePort.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.agent.application.port.out
+
+import com.openbank.agent.infrastructure.client.PublishedStyleDto
+
+/**
+ * Plain hexagonal port, deliberately NOT the `@RegisterRestClient`-annotated
+ * `CommunicationStyleClient` interface itself: implementing that interface directly makes Quarkus
+ * Arc's REST-client extension sweep an implementer into the CDI bean graph (found the hard way in
+ * `openbank-copilot-service` — a test fake implementing `CommunicationStyleClient` broke
+ * `ArcProcessor#validate` for the whole module). `CommunicationStyleAdapter` is the only production
+ * implementer, wrapping the real `@RestClient`; a test fake implements this port instead and needs
+ * no CDI machinery at all.
+ */
+interface PublishedStylePort {
+    suspend fun fetch(personaKey: String): PublishedStyleDto
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/CommunicationStyleAdapter.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/CommunicationStyleAdapter.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.agent.infrastructure.client
+
+import com.openbank.agent.application.port.out.PublishedStylePort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.rest.client.inject.RestClient
+
+@ApplicationScoped
+class CommunicationStyleAdapter(@param:RestClient private val client: CommunicationStyleClient) : PublishedStylePort {
+    override suspend fun fetch(personaKey: String): PublishedStyleDto =
+        client.getPublishedStyle(personaKey).awaitSuspending()
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/CommunicationStyleClient.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/CommunicationStyleClient.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.agent.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.libs.web.SyntheticTaintClientFilter
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * communication-service's D5 consumer-facing read (ADR-0285). Service-to-service, client-credentials
+ * token — the question ("what does this persona's published style say") is not tied to any one
+ * operator's bearer, mirrors the reasoning `openbank-copilot-service`'s identical client uses for
+ * the same filter choice (and `ConsentQueryClient` before it).
+ */
+@RegisterRestClient(configKey = "communication-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
+@Path("/api/v1/personas")
+@Produces(MediaType.APPLICATION_JSON)
+interface CommunicationStyleClient {
+    @GET
+    @Path("/{personaKey}/published")
+    @Timeout(PUBLISHED_STYLE_TIMEOUT_MS)
+    fun getPublishedStyle(@PathParam("personaKey") personaKey: String): Uni<PublishedStyleDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PublishedStyleDto(
+    val personaKey: String = "",
+    val styleVersion: Int = 0,
+    val tone: String = "",
+    val formality: String = "",
+    val formOfAddress: String = "",
+    val maxLength: Int? = null,
+    val preferredTerms: Map<String, String> = emptyMap(),
+    val forbiddenTerms: List<String> = emptyList(),
+    val signature: String? = null,
+)
+
+private const val PUBLISHED_STYLE_TIMEOUT_MS = 2000L

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -113,6 +113,13 @@ quarkus:
       url: http://localhost:8135
     sepa-instant-service:
       url: http://localhost:8127
+    # ADR-0285 D5 — PublishedStyleProvider's client-credentials read of the published style for
+    # the ui-assistant persona. Not wired into AgentChatService.systemPrompt() yet (see
+    # PublishedStyleProvider's KDoc).
+    communication-service:
+      url: ${COMMUNICATION_SERVICE_URL:http://localhost:8158}
+      connect-timeout: 2000
+      read-timeout: 3000
     # Observability stack (anonymous in-cluster read; no OIDC filter on these clients).
     prometheus:
       url: http://localhost:9090

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/PublishedStyleProviderTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/PublishedStyleProviderTest.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.agent.application
+
+import com.openbank.agent.application.port.out.PublishedStylePort
+import com.openbank.agent.infrastructure.client.PublishedStyleDto
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+
+private class FakePublishedStylePort(private val response: () -> PublishedStyleDto) : PublishedStylePort {
+    val callCount = AtomicInteger(0)
+    override suspend fun fetch(personaKey: String): PublishedStyleDto {
+        callCount.incrementAndGet()
+        return response()
+    }
+}
+
+/** A [Clock] whose `instant()` is set explicitly per test step — no real waiting for TTL tests. */
+private class MutableClock(private var now: Instant) : Clock() {
+    override fun getZone(): ZoneId = ZoneOffset.UTC
+    override fun withZone(zone: ZoneId): Clock = this
+    override fun instant(): Instant = now
+    fun advance(by: Duration) {
+        now = now.plus(by)
+    }
+}
+
+class PublishedStyleProviderTest {
+
+    private val published = PublishedStyleDto(
+        personaKey = "ui-assistant",
+        styleVersion = 3,
+        tone = "neutral",
+        formality = "formal",
+        formOfAddress = "vykání",
+    )
+
+    @Test
+    fun `a successful fetch returns the published style and caches it within the TTL`() {
+        val port = FakePublishedStylePort { published }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        val first = runBlocking { provider.currentStyle("ui-assistant") }
+        clock.advance(Duration.ofMinutes(1))
+        val second = runBlocking { provider.currentStyle("ui-assistant") }
+
+        assertThat(first).isInstanceOf(ResolvedStyle.Published::class.java)
+        assertThat((first as ResolvedStyle.Published).style.styleVersion).isEqualTo(3)
+        assertThat(first.version).isEqualTo("3")
+        assertThat(second).isEqualTo(first)
+        // Second call is served from cache — the port is not hit again within the TTL.
+        assertThat(port.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `once the TTL expires, a fresh fetch is made`() {
+        val port = FakePublishedStylePort { published }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        runBlocking { provider.currentStyle("ui-assistant") }
+        clock.advance(Duration.ofMinutes(6))
+        runBlocking { provider.currentStyle("ui-assistant") }
+
+        assertThat(port.callCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `a fetch failure with no prior cache returns null — there is no baseline to fall back to`() {
+        val port = FakePublishedStylePort { throw IOException("connection refused") }
+        val provider = PublishedStyleProvider(port, Clock.systemUTC())
+
+        val result = runBlocking { provider.currentStyle("ui-assistant") }
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `once the TTL expires, a fetch failure falls back to the last known-good value, not null`() {
+        var shouldFail = false
+        val port = FakePublishedStylePort {
+            if (shouldFail) throw IOException("timeout") else published
+        }
+        val clock = MutableClock(Instant.parse("2026-09-11T09:00:00Z"))
+        val provider = PublishedStyleProvider(port, clock)
+
+        val warm = runBlocking { provider.currentStyle("ui-assistant") }
+        assertThat(warm).isInstanceOf(ResolvedStyle.Published::class.java)
+
+        shouldFail = true
+        clock.advance(Duration.ofMinutes(6))
+        val degraded = runBlocking { provider.currentStyle("ui-assistant") }
+
+        assertThat(degraded).isEqualTo(warm)
+        assertThat(degraded).isNotNull()
+    }
+}


### PR DESCRIPTION
## Linked issues

N/A — implements ADR-0285 D5 directly; no tracked issue exists for this slice specifically.

## What

ADR-0285 ("Communication Studio") Phase 4 calls for adoption by `ui-assistant`
(openbank-agent-service). This PR builds the same consumer-side infrastructure
just shipped for `openbank-copilot-service` in #9729 — a client, a hexagonal
port, and a cache+TTL provider for the published style — **infrastructure
only, not wired into any live prompt.**

- `CommunicationStyleClient` — `@RegisterRestClient(configKey = "communication-service")`,
  `GET /api/v1/personas/{personaKey}/published`, same `PublishedStyleDto` shape and
  2s timeout as the copilot-service client.
- `PublishedStylePort` (plain interface) + `CommunicationStyleAdapter` — kept
  deliberately separate from the `@RegisterRestClient` interface itself: a test
  fake implementing that interface directly gets swept into Quarkus Arc's CDI
  bean graph and breaks the whole module's build (the exact failure copilot-service
  hit and documents in its port's KDoc).
- `PublishedStyleProvider` — cache + 5 min TTL + fallback-to-last-known-good on a
  transient failure, constructor-injected `Clock`. agent-service already has a
  `ClockProducer` (`@ApplicationScoped fun clock(): Clock = Clock.systemUTC()`),
  so no new producer was needed.
- `application.yaml` — `communication-service` rest-client block,
  `${COMMUNICATION_SERVICE_URL:http://localhost:8158}`, same pattern as
  copilot-service's.
- `docs/threat-models/openbank-agent-service.md` — new trust boundary (f), a new
  `T-I3` STRIDE entry, an open item, and (since this file had no `## N. Change log`
  section yet, unlike most other threat models in the repo) a new `## 4. Change log`
  section with a dated entry, following the same convention every other threat
  model in `docs/threat-models/` already uses.
- Unit tests mirroring `PublishedStyleProviderTest` — cache hit within TTL, TTL
  expiry triggers refetch, failure-after-warm-cache falls back to last known-good,
  and the no-baseline case below.

## Registry situation: no core/style split for `ui-assistant` (case B)

`openbank-libs/governance/prompts/registry.yaml`'s `customer-copilot` entry
already lists `[system.v1, core.v1, style.v1]` — `core.v1`/`style.v1` are the
ADR-0285 D1 split of the shipped `system.v1` text, registered and immutable.
**`ui-assistant`'s entry has no such split** — it lists only
`[system.v1, system.v2, system.v3, catalog-review.v1]`, the whole unsplit
prompts `AgentChatService`/`CatalogReviewService` actually serve. Deciding what
`ui-assistant`'s core/style split should look like is a job for whoever authors
that ADR-0148 registry entry, not something to invent in an infra PR — so unlike
copilot-service's provider, **this one has no git-registered-baseline fallback**.

Design consequence: `ResolvedStyle` here has only one variant (`Published`), and
`PublishedStyleProvider.currentStyle()` returns `ResolvedStyle?` — `null` on a
total failure (no warm cache and the fetch itself failed), rather than a
synthesized `Baseline` carrying placeholder text. A caller must treat `null` as
"no style layer available today," never as an empty-but-valid style. This is
documented in the provider's KDoc and exercised by
`a fetch failure with no prior cache returns null — there is no baseline to fall back to`.

## Explicitly NOT done

- `AgentChatService.systemPrompt()` and `CatalogReviewService` are untouched —
  `PublishedStyleProvider` is not called from anywhere live. No runtime
  behaviour change.
- No `core.v1`/`style.v1` prompt content was invented for `ui-assistant`.
- rm-copilot (ADR-0222) is out of scope — it has no code yet.

## Verification

All run against a worktree at `/private/tmp/ob-agent-style-1789163717` on
`feat/agent-service-published-style-client`, branched from fresh `origin/main`.

- `./gradlew :openbank-agent-service:detekt :openbank-agent-service:ktlintFormat`
  → `BUILD SUCCESSFUL in 11s`, no format changes needed beyond what was already
  ktlint-clean.
- `./gradlew :openbank-agent-service:ktlintCheck :openbank-agent-service:compileKotlin :openbank-agent-service:compileTestKotlin :openbank-agent-service:test :openbank-agent-service:koverVerify`
  → `BUILD SUCCESSFUL in 1m 40s`, 46 actionable tasks. Aggregated JUnit XML across
  the whole module: **178 tests, 0 skipped, 0 failures, 0 errors** (checked the
  skip count explicitly, not just the failure count — a module that fails to boot
  reports its tests as SKIPPED here, which a naive read of "0 failures" would miss).
  `PublishedStyleProviderTest` itself: 4/4 passing.
- `python3 .github/scripts/check-threat-model-claims.py` run from the worktree
  root (so it actually sees the new claims) → `OK: every mechanically checkable
  mitigation claim resolves to real, non-stub code` (exit 0).
- `PR_DIFF_BASE=$(git merge-base HEAD origin/main) python3 .github/scripts/run-gates.py --root . --only threat-model-updated-on-trust-boundary-change --only credential-deadline-ratchet`
  → both `PASS`:
  ```
  1/2 PASS         threat-model-updated-on-trust-boundary-change (0.1s)
  2/2 PASS         credential-deadline-ratchet (0.1s)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

