### PR TITLE
fix(finops): make the workload-tier check able to fail

### DIFF
--- a/openbank-infra/scripts/check-finops-tiers.py
+++ b/openbank-infra/scripts/check-finops-tiers.py
@@ -4,9 +4,14 @@
 Validates the `finops_tiers` block in rules.yaml on the DECLARED side — the half
 that needs no cluster metrics. The measured side (declared-vs-observed drift) is the
 classifier (ADR-0057 / ADR-0054 phase 2); until it ships, the `finops-tier-drift`
-gate is `enforced: advisory` in rules.yaml, so THIS check is advisory too: it prints
-findings and always exits 0, never blocking a PR. Flip to blocking when the policy's
-`enforced:` flips to `block`.
+gate is `enforced: advisory` in rules.yaml.
+
+That advisory setting governs the POLICY finding only — a money-path service declared below T0.
+It never governed whether `rules.yaml` parses, whether a declared tier exists, or whether a
+declared key names a real service. Those are config bugs, they do not improve when the classifier
+ships, and they now fail under every setting. Until #9678 this file made no such distinction and
+exited 0 against all of them, including a rules.yaml it could not parse — measured, three
+rejectable inputs, three zeros.
 
 Declared-side checks (deterministic, no cloud creds):
   1. every declared tier value is one of the tiers defined in finops_tiers.tiers
@@ -20,7 +25,10 @@ check-version-lifecycle.py. The YAML is parsed with targeted line scanning (the 
 pragmatic approach the version-lifecycle gate uses) rather than a yaml dependency.
 
 Modes:
-  (default)   advisory -> print findings, ALWAYS exit 0 (honours enforced: advisory)
+  (default)   config bugs exit 1; a policy finding exits 0 while finops_tiers.enforced
+              is `advisory`, and 1 once it says `block`
+  --enforce   also fail on the policy finding, without waiting for the rules.yaml flip
+  --self-test prove the check can fail: 7 cases, both directions
   --report             -> markdown report to stdout for the weekly audit; first line
                           is `FINOPS_TIERS_FINDING=0|1` so the workflow can open/update
                           a tracking issue.
@@ -112,33 +120,48 @@ def service_dirs() -> set[str]:
 
 
 def evaluate() -> tuple[list[str], list[str]]:
-    """Return (errors, info)."""
+    """Return (errors, info). Kept for callers that do not care which kind a finding is."""
+    config, policy, info = evaluate_split()
+    return config + policy, info
+
+
+def evaluate_split() -> tuple[list[str], list[str], list[str]]:
+    """Return (config_errors, policy_findings, info).
+
+    The split is the point. `finops_tiers.enforced: advisory` is a statement about the DRIFT
+    gate — declared-versus-observed, which needs the classifier that has not shipped. It was
+    never a statement about whether `rules.yaml` parses, whether a declared tier exists, or
+    whether a declared key names a real service. Those are config bugs: nothing about them
+    improves when the classifier lands, and a typo'd tier is wrong under every policy setting.
+    Conflating the two is how this check came to exit 0 against a malformed rules.yaml (#9678).
+    """
     text = _read_rules()
     money_path = parse_money_path_services(text)
     tiers, declared, enforced = parse_finops_tiers(text)
     services = service_dirs()
 
-    errors: list[str] = []
+    config: list[str] = []
+    policy: list[str] = []
     info: list[str] = []
 
     if not tiers:
-        errors.append("finops_tiers.tiers is empty or unparseable — expected T0..T3.")
+        config.append("finops_tiers.tiers is empty or unparseable — expected T0..T3.")
     # lowest (most-scaled) tiers, in order; T0 is always-on
     below_t0 = {t for t in tiers if t != "T0"}
 
     for svc, tier in sorted(declared.items()):
         if tier not in tiers:
-            errors.append(f"{svc}: declared tier '{tier}' is not a defined tier {sorted(tiers)}.")
+            config.append(f"{svc}: declared tier '{tier}' is not a defined tier {sorted(tiers)}.")
         if svc not in services:
-            errors.append(f"{svc}: declared in finops_tiers but is not an openbank-* service directory.")
+            config.append(f"{svc}: declared in finops_tiers but is not an openbank-* service directory.")
         if svc in money_path and tier in below_t0:
-            errors.append(
+            policy.append(
                 f"{svc}: money-path service declared '{tier}' (below T0). Demoting a money-path "
                 f"service requires an ADR-0030 threat model + 2 approvals — it must not be set here."
             )
 
     if enforced not in ("advisory", "block"):
-        errors.append(f"finops_tiers.enforced is '{enforced or '(missing)'}' — expected advisory|block.")
+        config.append(f"finops_tiers.enforced is '{enforced or '(missing)'}' — expected advisory|block.")
 
     # money-path inherits T0 via the baseline; union (not sum) so a service that is
     # both explicitly declared and money-path is counted once.
@@ -151,15 +174,117 @@ def evaluate() -> tuple[list[str], list[str]]:
     )
     info.append(f"declared: {declared or '{}'}")
     info.append(f"gate enforced: {enforced}")
-    return errors, info
+    return config, policy, info
+
+
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+
+
+def self_test() -> int:
+    """Prove this check can FAIL. It could not, for its whole life (#9678).
+
+    Three rejectable inputs were measured against the old version — a tier value that is not a
+    defined tier, `enforced: block` with a money-path service below T0, and a rules.yaml the
+    parser cannot read at all — and every one of them exited 0 while printing findings. A check
+    that prints and exits 0 is a report; the gate label on it was the defect.
+
+    Each case below drives the real `evaluate_split` over a temporary rules.yaml, so it exercises
+    the parser and the classification, not a mock of them. The must-PASS case is as load-bearing
+    as the must-FAIL ones: a self-test where everything fails proves nothing either.
+    """
+    import tempfile
+
+    global RULES
+    original = RULES
+    failures: list[str] = []
+
+    def run(label: str, yaml_text: str, *, enforce: bool, want_config: bool, want_policy: bool) -> None:
+        nonlocal failures
+        with tempfile.TemporaryDirectory() as td:
+            f = pathlib.Path(td) / "rules.yaml"
+            f.write_text(yaml_text, encoding="utf-8")
+            globals()["RULES"] = f
+            try:
+                config, policy, _ = evaluate_split()
+            finally:
+                globals()["RULES"] = original
+        ok = bool(config) == want_config and bool(policy) == want_policy
+        blocking = bool(config) or (bool(policy) and enforce)
+        print(f"  [{'ok ' if ok else 'FAIL'}] {label}: config={len(config)} policy={len(policy)} "
+              f"blocking={blocking}")
+        if not ok:
+            failures.append(label)
+
+    # A real money-path service directory, so case 3 is about the TIER and not about an unknown key.
+    mp = sorted(parse_money_path_services(original.read_text(encoding="utf-8")) & service_dirs())
+    if not mp:
+        print("  [FAIL] self-test cannot run: no money-path service directory found")
+        return EXIT_FINDINGS
+    svc = mp[0]
+
+    def doc(tier_line: str, enforced: str = "advisory") -> str:
+        return (
+            "money_path_services:\n"
+            f"  - {svc}\n"
+            "finops_tiers:\n"
+            f"  enforced: {enforced}\n"
+            "  tiers:\n"
+            "    T0:\n"
+            "      description: always-on\n"
+            "    T1:\n"
+            "      description: scaled\n"
+            "  declared:\n"
+            f"{tier_line}"
+        )
+
+    # must PASS — a money-path service at T0 under an advisory policy is the healthy shape
+    run("a money-path service at T0 is clean", doc(f"    {svc}: T0"),
+        enforce=False, want_config=False, want_policy=False)
+
+    # must FAIL as a CONFIG bug, under every policy setting
+    run("an undefined tier is a config error", doc(f"    {svc}: T9"),
+        enforce=False, want_config=True, want_policy=False)
+    run("a declared key that is not a service is a config error",
+        doc("    openbank-does-not-exist: T0"), enforce=False, want_config=True, want_policy=False)
+    run("an unparseable finops_tiers is a config error",
+        "money_path_services:\n  - " + svc + "\nfinops_tiers:\n  enforced: advisory\n",
+        enforce=False, want_config=True, want_policy=False)
+    run("an invalid enforced value is a config error", doc(f"    {svc}: T0", enforced="maybe"),
+        enforce=False, want_config=True, want_policy=False)
+
+    # must be a POLICY finding — blocking only when enforcing
+    run("a money-path service below T0 is a policy finding", doc(f"    {svc}: T1"),
+        enforce=False, want_config=False, want_policy=True)
+    run("…and the same input blocks under --enforce", doc(f"    {svc}: T1"),
+        enforce=True, want_config=False, want_policy=True)
+
+    print()
+    if failures:
+        print(f"SELF-TEST FAILED: {len(failures)} case(s): {', '.join(failures)}")
+        return EXIT_FINDINGS
+    print("self-test ok: the check can fail — config bugs block under any policy, a money-path")
+    print("              demotion blocks under --enforce or `enforced: block`, and a healthy")
+    print("              declaration still passes.")
+    return EXIT_OK
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--report", action="store_true", help="markdown report for the weekly audit")
+    ap.add_argument(
+        "--enforce",
+        action="store_true",
+        help="also fail on POLICY findings (money-path below T0). Config bugs fail regardless.",
+    )
+    ap.add_argument("--self-test", action="store_true", help="prove this check can fail")
     args = ap.parse_args()
 
-    errors, info = evaluate()
+    if args.self_test:
+        return self_test()
+
+    config, policy, info = evaluate_split()
+    errors = config + policy
 
     if args.report:
         finding = 1 if errors else 0
@@ -175,17 +300,32 @@ def main() -> int:
             print("\nNo declared-side findings.")
         return 0
 
-    print("FinOps workload-tier validator (ADR-0057, declared side) — advisory\n")
+    # `enforced: block` in rules.yaml means what it says. Before #9678 this value was read,
+    # printed, and then ignored — the check exited 0 under `block` exactly as under `advisory`,
+    # so flipping the policy would have changed nothing and everyone would have believed it had.
+    enforcing = args.enforce or any(line == "gate enforced: block" for line in info)
+
+    print("FinOps workload-tier validator (ADR-0057, declared side)\n")
     for line in info:
         print(f"  {line}")
-    if errors:
-        print("\nFindings (advisory — not blocking until the classifier flips the gate to block):")
-        for e in errors:
-            print(f"  ⚠️ {e}")
-    else:
+
+    if config:
+        print("\nCONFIG ERRORS (always blocking — these are bugs in rules.yaml, not policy):")
+        for e in config:
+            print(f"  ::error::{e}")
+    if policy:
+        label = "blocking" if enforcing else "advisory, not blocking while finops_tiers.enforced is advisory"
+        print(f"\nPOLICY FINDINGS ({label}):")
+        for e in policy:
+            print(f"  {'::error::' if enforcing else '  ⚠️ '}{e}")
+    if not config and not policy:
         print("\n  OK — no declared-side findings.")
-    # Advisory: honour rules.yaml `finops_tiers.enforced: advisory` — never block a PR.
-    return 0
+
+    if config:
+        return EXIT_FINDINGS
+    if policy and enforcing:
+        return EXIT_FINDINGS
+    return EXIT_OK
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #9678.

## The defect, re-measured before fixing

`check-finops-tiers.py` printed findings and returned 0 on every path. Three separate rejectable
inputs, run against `origin/main` in a scratch tree:

```
real rules.yaml, money-path service at T1   -> "⚠️ … declared 'T1' (below T0)"   exit 0
tier mutated to T9                          -> "⚠️ … 'T9' is not a defined tier"  exit 0
enforced: block                             -> "…not blocking until the classifier flips"  exit 0
rules.yaml replaced with malformed YAML     -> 2 findings printed                exit 0
```

The probe is proven live by the fact that it emitted findings in every run — the zero is the
check's behaviour, not a broken harness. A check that can only ever pass is a report; the gate
label on it was the defect.

## The distinction the file never drew

`finops_tiers.enforced: advisory` is a statement about the **drift** gate — declared versus
observed, which needs the classifier that has not shipped. It was never a statement about whether
`rules.yaml` parses, whether a declared tier exists, or whether a declared key names a real
service.

| finding | kind | exits |
|---|---|---|
| unparseable `finops_tiers` | config bug | 1, always |
| declared tier is not a defined tier | config bug | 1, always |
| declared key is not an `openbank-*` service | config bug | 1, always |
| `enforced:` is neither `advisory` nor `block` | config bug | 1, always |
| money-path service declared below T0 | policy | 0 while advisory, 1 under `--enforce` or `enforced: block` |

Config bugs do not improve when the classifier lands, and a typo'd tier is wrong under every
policy setting.

`enforced: block` is now actually honoured. It was read, printed, and ignored — so flipping the
policy would have changed nothing while everyone believed it had. That is the half of this bug I
find most worth naming: the lever existed and was disconnected.

## `--self-test`, both directions

```
[ok ] a money-path service at T0 is clean:                 config=0 policy=0 blocking=False
[ok ] an undefined tier is a config error:                 config=1 policy=0 blocking=True
[ok ] a declared key that is not a service is a config error: config=1 policy=0 blocking=True
[ok ] an unparseable finops_tiers is a config error:       config=1 policy=0 blocking=True
[ok ] an invalid enforced value is a config error:         config=1 policy=0 blocking=True
[ok ] a money-path service below T0 is a policy finding:   config=0 policy=1 blocking=False
[ok ] …and the same input blocks under --enforce:          config=0 policy=1 blocking=True
```

Each case drives the real `evaluate_split` over a temporary `rules.yaml`, so the parser and the
classification are exercised rather than mocked. The must-PASS case is as load-bearing as the
must-FAIL ones — a self-test where everything fails proves nothing either.

## Behaviour on the current tree is deliberately unchanged

```
default    rc=0   (one policy finding: openbank-card-issuance-service declared T1, advisory)
--enforce  rc=1   (same finding, now blocking)
--report   rc=0   FINOPS_TIERS_FINDING=1
```

That real finding — a money-path service declared below T0, which per the message requires an
ADR-0030 threat model and two approvals — is exactly what this check exists to catch and has been
unable to report as a failure. **Flipping it to blocking is a governance decision and is not in
this PR**, because doing so would redden every PR until the declaration is resolved.
