### PR TITLE
fix(ci): classify test evidence by the lane that ran, not the filename

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -200,9 +200,41 @@ def classify(name: str, classname: str, task: str, component: str, service: Path
     identity = f"{classname} {task}"
     if re.search(r"integration|inttest", identity, re.I) or re.search(r"IT(?:$|[.$\s])", identity):
         return "integration"
-    if re.search(r"pact|contract", identity, re.I):
+
+    # The TASK is the producer's own declaration of which lane ran; the CLASSNAME is a
+    # filename someone chose. When they disagree the task wins, because a Playwright spec
+    # named `*-contract.spec.ts` is still an end-to-end run of the real screen, and counting
+    # it as contract evidence moves it into a dimension whose controls it cannot satisfy.
+    # Measured on a real Admin UI report (#8263): 2 cases from campaign-visual-contract.spec.ts
+    # were reported as contract while their task said e2e.
+    if re.search(r"\be2e\b|playwright", task, re.I):
+        return "e2e"
+
+    # Two ways `pact` legitimately appears, and one way it does not.
+    #
+    #   (?<![A-Za-z])pact   a separated token: `ledger-pact`, `pacts/`, `.pact.json`
+    #   (?<=[a-z0-9])Pact   a CamelCase segment: `LedgerPactTest` — case-SENSITIVE, the
+    #                       capital is what marks the boundary Kotlin class names use
+    #
+    # Neither matches `compact`, which is the second defect here: the previous unbounded
+    # search classified `compact-filters-a11y.guard.test.ts` as CONTRACT because
+    # "com-PACT-filters" contains the substring (#8263).
+    #
+    # A plain `\bpact\b` is NOT enough and looks like it is — it rejects `compact` correctly
+    # and also rejects `LedgerPactTest`, since there is no word boundary inside CamelCase.
+    # That silently reclassifies every Kotlin pact suite in the fleet as `unit`, which is a
+    # worse defect than the one being fixed and passes any test written only from the issue's
+    # three examples.
+    if re.search(r"(?<![A-Za-z])pacts?(?![A-Za-z])", identity, re.I) \
+            or re.search(r"(?<=[a-z0-9])Pacts?(?![a-z])", identity) \
+            or re.search(r"\bcontract\b", identity, re.I):
         return "contract"
-    if re.search(r"e2e|playwright", identity, re.I):
+
+    # Only reachable when the task did not declare a lane — e.g. a Vitest run whose classname
+    # merely mentions Playwright. `\be2e\b` keeps that from promoting a unit test:
+    # `playwright-test-intelligence-evidence.guard.test.ts` is a Vitest guard ABOUT Playwright,
+    # not an end-to-end test, and it was being reported as e2e.
+    if re.search(r"\be2e\b", identity, re.I):
         return "e2e"
     if component == "openbank-simulation":
         return "simulation"
@@ -1179,6 +1211,32 @@ def main() -> None:
                 raise AssertionError("a runtime observation after its run was accepted")
             except ValueError:
                 pass
+        # Classification, in BOTH directions. The three must-move cases come from #8263; the
+        # must-stay ones exist because the obvious fix for them is wrong: a plain `\bpact\b`
+        # rejects `compact` correctly AND rejects `LedgerPactTest`, since CamelCase has no word
+        # boundary — silently reclassifying every Kotlin pact suite in the fleet as `unit`.
+        # That regression passes any test written only from the issue's examples, which is why
+        # the must-stay rows are here.
+        for classname, task, want in [
+            # must MOVE (the reported defects)
+            ("campaign-visual-contract.spec.ts", "e2e", "e2e"),
+            ("playwright-test-intelligence-evidence.guard.test.ts", "test", "unit"),
+            ("compact-filters-a11y.guard.test.ts", "test", "unit"),
+            # must STAY (the regressions a narrower fix would cause)
+            ("opsmessage-api.contract.test.ts", "test", "contract"),
+            ("com.openbank.ledger.LedgerPactTest", "test", "contract"),
+            ("SwiftPactFolderProviderVerificationTest", "test", "contract"),
+            ("ledger-pact.spec.ts", "test", "contract"),
+            ("LedgerOutboxProjectionIT", "integrationTest", "integration"),
+            ("com.openbank.party.PartyServiceTest", "test", "unit"),
+            ("compaction-policy.guard.test.ts", "test", "unit"),
+        ]:
+            got = classify("a case", classname, task, "openbank-admin-ui")
+            if got != want:
+                raise AssertionError(
+                    f"classify({classname!r}, task={task!r}) returned {got!r}, expected {want!r}"
+                )
+
         print("test-run evidence collector self-test: classification and runtime red/green paths proven")
         return
     if not args.service or not args.out:


### PR DESCRIPTION
Closes #8263.

## Reproduced first

All three reported cases, against `origin/main`:

```
campaign-visual-contract.spec.ts        task=e2e   -> contract   (want e2e)
playwright-test-intelligence-…guard.ts  task=test  -> e2e        (want unit)
compact-filters-a11y.guard.test.ts      task=test  -> contract   (want unit)
```

The third is the sharpest: **"com-PACT-filters" contains `pact`**.

## Two changes

**The task decides the e2e lane.** `task` is the producer's own declaration of what ran; `classname`
is a filename someone chose. A Playwright spec named `*-contract.spec.ts` is still an end-to-end run
of the real screen, and counting it as contract evidence moves it into a dimension whose controls it
cannot satisfy.

**`pact` is matched at a real boundary**, not anywhere inside a word.

## The obvious fix is wrong, and my first attempt shipped it

```
\bpact\b   rejects `compact` correctly
           AND rejects `LedgerPactTest` — CamelCase has no word boundary
```

That silently reclassifies **every Kotlin pact suite in the fleet** as `unit`: a worse defect than
the one being fixed, in the same dimension, and it passes any test written from this issue's three
examples alone. I wrote it, and the must-stay control case caught it:

```
[FAIL] real pact: com.openbank.ledger.LedgerPactTest task=test -> unit (want contract)
```

So the match is a separated token `(?<![A-Za-z])pacts?(?![A-Za-z])` **or** a case-sensitive
CamelCase segment `(?<=[a-z0-9])Pacts?(?![a-z])`. The capital is what marks the boundary Kotlin
class names use.

## Verification, both directions

```
[ok] campaign-visual-contract.spec.ts          task=e2e             -> e2e
[ok] playwright-test-intelligence-…guard.ts    task=test            -> unit
[ok] compact-filters-a11y.guard.test.ts        task=test            -> unit
[ok] opsmessage-api.contract.test.ts           task=test            -> contract
[ok] com.openbank.ledger.LedgerPactTest        task=test            -> contract
[ok] SwiftPactFolderProviderVerificationTest   task=test            -> contract
[ok] ledger-pact.spec.ts                       task=test            -> contract
[ok] LedgerOutboxProjectionIT                  task=integrationTest -> integration
[ok] com.openbank.party.PartyServiceTest       task=test            -> unit
[ok] compaction-policy.guard.test.ts           task=test            -> unit
MISCLASSIFIED: 0        (was 3 on origin/main)
```

All ten rows are now in `--self-test`, must-move and must-stay together, and it fails when the
task-precedence line is removed:

```
AssertionError: classify('campaign-visual-contract.spec.ts', task='e2e') returned 'contract', expected 'e2e'
```

`check-test-intelligence-ecosystem.py --self-test` still passes (`red path proven`) — both are the
declared self-tests for the `test-intelligence-ecosystem` gate.

## Scope

Fleet totals do not change; only the per-kind split does. That is the point — the totals were green
throughout, which is why this survived.
