### PR TITLE
fix(admin-ui): fix impure sanctions list-scope state updater, port RFC-4122 card fixture fix

### DIFF
--- a/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
@@ -1,11 +1,14 @@
 import { expect, test } from '@playwright/test'
 import { signInAsOperator } from './helpers/auth'
 
-const cardId = '11111111-1111-1111-1111-111111111111'
+// RFC-4122 shape is load-bearing: parseCard (clientContract.ts) validates the version and
+// variant nibbles, so a repeated-digit placeholder is rejected and the page renders its
+// service-unavailable state instead of the card (#9736).
+const cardId = '11111111-1111-4111-8111-111111111111'
 const card = {
   id: cardId,
-  partyId: '22222222-2222-2222-2222-222222222222',
-  accountId: '33333333-3333-3333-3333-333333333333',
+  partyId: '22222222-2222-4222-8222-222222222222',
+  accountId: '33333333-3333-4333-8333-333333333333',
   productCode: 'DEBIT-CLASSIC',
   cardType: 'DEBIT',
   network: 'VISA',

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -294,13 +294,20 @@ export default function SanctionsPage() {
       setLists(nextLists)
       // Reconciliation may reveal that an ambiguous PUT actually disabled a list. Remove only
       // types that are no longer enabled; never add back a list the operator deliberately omitted.
-      setSelectedListTypes(current => {
-        if (!listScopeInitialisedRef.current) {
-          listScopeInitialisedRef.current = true
-          return nextLists.filter(list => list.enabled).map(list => list.listType)
-        }
-        return retainEnabledSelectedListTypes(current, nextLists)
-      })
+      //
+      // The ref flip must happen HERE, not inside the setSelectedListTypes updater: React
+      // StrictMode double-invokes updater functions in dev to catch impure ones, and an updater
+      // that mutates a ref as a side effect is exactly that — the throwaway first invocation
+      // flips the ref, so the real second invocation sees `initialised = true` with a still-empty
+      // `current` and takes the retain branch against nothing, permanently discarding the initial
+      // scope. Since `next dev` (not a prod build) backs the Playwright webServer, this reproduced
+      // on every single run (#9736).
+      if (!listScopeInitialisedRef.current) {
+        listScopeInitialisedRef.current = true
+        setSelectedListTypes(nextLists.filter(list => list.enabled).map(list => list.listType))
+      } else {
+        setSelectedListTypes(current => retainEnabledSelectedListTypes(current, nextLists))
+      }
     } catch (error) {
       setListsError(error instanceof Error ? error.message : 'Spojení se službou selhalo')
     }


### PR DESCRIPTION
## Summary

Fixes all 4 specs behind the deterministic admin-ui e2e failures tracked in #9736 (the required
"Admin UI build" / "Validate manifests" gate that blocks every admin-ui-touching PR, e.g. #9729, #9737).

- **`sanctions-theme.spec.ts` (both light/dark) + the pruning case of `sanctions-list-change-review.spec.ts`**:
  `src/app/sanctions/page.tsx`'s manual-screening list-scope initialisation mutated
  `listScopeInitialisedRef` inside the `setSelectedListTypes` functional updater. React StrictMode
  double-invokes updater functions in dev specifically to catch this kind of impurity: the throwaway
  first invocation flips the ref as a side effect, so the real second invocation sees
  `initialised = true` against a still-empty `current` and takes the "retain" branch against
  nothing — permanently discarding the initial list-scope selection. The Playwright `webServer` runs
  `next dev` (not a prod build), so this reproduced on every single run. Fix: move the ref
  check/flip out of the updater and into the `loadLists` async function body, where it executes once
  per real call instead of twice per dispatch.

- **`card-detail-recovery.spec.ts`**: already correctly diagnosed and fixed on branch
  `fix/e2e-rfc4122-fixtures` (PR #9737) — `parseCard` (added in #9552) validates the UUID version and
  variant nibbles, which the fixture's repeated-digit placeholder IDs (`11111111-1111-1111-...`)
  don't satisfy. Ports that same one-line fixture change here so this PR clears the whole gate on
  its own; #9737 can be closed as superseded once this merges (or merged first — either order
  resolves the same lines).

## How it was diagnosed

Reproduced locally against this branch with `npm ci && npm run pretest && npx playwright test`
(admin-ui e2e conventions per `CLAUDE.md`) — got the exact same 4 failures, 3 passes, confirming the
failure is pre-existing and unrelated to whatever diff a PR happens to carry. The `getaddrinfo
ENOTFOUND sepa-payment.payments.svc` / `domestic-payment.payments.svc` DNS noise in the webServer log
is a red herring: those routes proxy to real in-cluster DNS names when `SEPA_SERVICE_URL`/
`DOMESTIC_SERVICE_URL` aren't set, but none of the 4 failing specs touch payments, and none of that
DNS resolution is on the browser-visible network path the specs mock via `page.route()`.

The sanctions bug was isolated by instrumenting the `setSelectedListTypes` updater with a debug log
and observing it fire twice per single `/api/sanctions/lists` response — `initialised: false` then
`initialised: true`, both with `current: []` — which is the signature of React StrictMode's dev-only
double invocation of state-updater functions landing on an impure one.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx eslint src/app/sanctions/page.tsx` — clean
- [x] `npm test` — 547 files / 2921 passed, 1 pre-existing skip
- [x] `npx playwright test e2e/sanctions-list-change-review.spec.ts e2e/sanctions-theme.spec.ts e2e/card-detail-recovery.spec.ts` — 7/7 passed (previously 4 failed)

Closes #9736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
