### PR TITLE
fix(admin-ui): stop a contract error reading as a cold pod, and fix the checked-row contrast

### DIFF
--- a/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
@@ -46,3 +46,35 @@ test('keeps the masked card detail visible after a failed refresh', async ({ pag
   await expect(page.getByRole('heading', { name: '411111******4242' })).toBeVisible()
   await expect(page.getByText('Verified Cardholder', { exact: true })).toBeVisible()
 })
+
+test('a payload the client contract rejects is a data error, not "the service is waking up"', async ({ page }) => {
+  // The card contract is the client-side PCI allow-list boundary, so it throws on a payload the
+  // upstream should not have sent. That throw used to land in useServiceResource's TRANSPORT catch
+  // and was classified as a cold KEDA pod: the screen said the service was waking up, retried
+  // three times, then reported `unreachable` — pointing the operator at a scaling problem that did
+  // not exist while the real fault, a malformed response, was named nowhere.
+  //
+  // `maskedPan` here is a full unmasked PAN, which is exactly the regression the contract exists
+  // to refuse.
+  await page.route(`**/api/svc/card-issuance-service/api/v1/cards/${cardId}`, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    // Assembled from chunks: the repo's `pan-card-number` gitleaks rule matches any Luhn-shaped
+    // 13-19 digit run, and it is right to — so the file carries no literal PAN. Allowlisting a
+    // whole test file to keep one literal would blind that rule on everything else in it.
+    body: JSON.stringify({ ...card, maskedPan: ['4111', '1111', '1111', '4242'].join('') }),
+  }))
+
+  await page.goto(`/cards/${cardId}`)
+
+  // Checked at a FIXED moment, not with a retrying matcher. `expect(...).not.toContainText` would
+  // pass the moment the text goes away — and the broken behaviour shows "waking up" only until the
+  // three wake retries are exhausted (~12s), after which it settles on `unreachable`. A 15-second
+  // retrying assertion therefore passed against both the fix and the defect. Two seconds in is
+  // where the two genuinely differ: the fix already shows a terminal data error, the defect is
+  // mid-retry.
+  await page.waitForTimeout(2000)
+  const main = (await page.locator('main').textContent()) ?? ''
+  expect(main).not.toMatch(/waking up|probouzí/i)
+  expect(main).not.toContain(['4111', '1111', '1111', '4242'].join(''))
+})

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -1004,7 +1004,14 @@ export default function SanctionsPage() {
                                 {isPep && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--accent-text)', background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', padding: '1px 4px', borderRadius: '3px' }}>PEP</span>}
                                 {!lst.enabled && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--text-tertiary)', background: 'var(--surface-4)', padding: '1px 4px', borderRadius: '3px' }}>{t('vyp.', 'off')}</span>}
                               </div>
-                              <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
+                              {/*
+                                --text-tertiary on the CHECKED row's --accent-bg is 4.25:1 at 10px,
+                                and WCAG AA wants 4.5:1. It was unreachable while the scope failed
+                                to seed and nothing was ever checked; fixing the seeding made the
+                                checked background real and the violation with it. --text-secondary
+                                on the same background clears AA.
+                              */}
+                              <div style={{ fontSize: '10px', color: checked ? 'var(--text-secondary)' : 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
                                 {lst.lastEntryCount ? `${lst.lastEntryCount.toLocaleString(numberLocale)} ${t('zázn.', 'entries')}` : t('nestaženo', 'not synced')}
                               </div>
                             </div>

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -1004,14 +1004,7 @@ export default function SanctionsPage() {
                                 {isPep && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--accent-text)', background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', padding: '1px 4px', borderRadius: '3px' }}>PEP</span>}
                                 {!lst.enabled && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--text-tertiary)', background: 'var(--surface-4)', padding: '1px 4px', borderRadius: '3px' }}>{t('vyp.', 'off')}</span>}
                               </div>
-                              {/*
-                                --text-tertiary on the CHECKED row's --accent-bg is 4.25:1 at 10px,
-                                and WCAG AA wants 4.5:1. It was unreachable while the scope failed
-                                to seed and nothing was ever checked; fixing the seeding made the
-                                checked background real and the violation with it. --text-secondary
-                                on the same background clears AA.
-                              */}
-                              <div style={{ fontSize: '10px', color: checked ? 'var(--text-secondary)' : 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
+                              <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
                                 {lst.lastEntryCount ? `${lst.lastEntryCount.toLocaleString(numberLocale)} ${t('zázn.', 'entries')}` : t('nestaženo', 'not synced')}
                               </div>
                             </div>

--- a/openbank-admin-ui/src/lib/services/useServiceResource.ts
+++ b/openbank-admin-ui/src/lib/services/useServiceResource.ts
@@ -129,7 +129,24 @@ export function useServiceResource<T = unknown>(
         }
         const raw = (await res.json()) as unknown
         if (cancelled) return
-        setData((select ? select(raw) : (raw as T)))
+        // `select` runs OUTSIDE the transport catch below, deliberately. These pages parse through
+        // a strict client contract (cards is the PCI allow-list boundary), so `select` throws on a
+        // payload the upstream should not have sent. Letting that land in the transport catch
+        // classified a CONTRACT violation as a cold pod: the screen said "the service is waking
+        // up", retried three times, and then reported `unreachable` — sending the operator after
+        // a scaling problem that does not exist while the real fault, a malformed response, was
+        // never named anywhere. A parse failure is `error`: terminal, not retried.
+        let parsed: T
+        try {
+          parsed = (select ? select(raw) : (raw as T))
+        } catch {
+          if (cancelled) return
+          setUnavailable({ kind: 'error', status: res.status })
+          setWaking(false)
+          setLoading(false)
+          return
+        }
+        setData(parsed)
         setUnavailable(null)
         setWaking(false)
         setLoading(false)


### PR DESCRIPTION
## Summary

**Rewritten after #9751 merged.** That PR landed the sanctions seeding fix and the card-fixture UUID
independently, so this PR was reduced **by subtraction** to the two defects #9751 does not carry —
not closed, because both are real and neither is covered elsewhere.

The conflicting hunks were resolved **hunk by hunk to main's side**, not with `git checkout --ours`:
that is whole-file and would have discarded this PR's own additions in the same files.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9736 (the seeding half is closed by #9751; the suite-wide instability is out of scope — see below)

## 1. A contract failure reported itself as a cold pod

A throw from `select` landed in `useServiceResource`'s **transport** catch and was classified as a
cold KEDA pod: three wake retries, then `unreachable`. So a malformed upstream response presented as
*"the service is waking up"* — sending an operator after a scaling problem that does not exist, while
the real fault was named nowhere. `select` now runs outside that catch, and a parse failure is a
terminal `error`.

## 2. ~~A WCAG AA failure that #9751 made reachable~~ — REMOVED, superseded by #9765

**Subtracted 2026-09-12 (second time this branch has been reduced this way).** #9765
(`fix/sanctions-selected-row-contrast`) makes the **byte-for-byte identical** change to the same line
of `sanctions/page.tsx`. Two agents found the same defect independently and fixed it the same way;
identical code cannot merge twice — whichever landed second would conflict, or leave the file
carrying two comments about one change.

#9765 keeps the fix: it is single-purpose, and documents the measurement more completely (4.26:1 vs
`--text-secondary`'s 6.78:1, and why a selected row steps up one **existing** token rather than
moving the palette fleet-wide, #9749).

`sanctions/page.tsx` is now **byte-identical to `origin/main`** (verified by shasum of the blob on
both sides, not by reading a diff). GitHub still lists it among this PR's files — that list is
computed against the merge base, not against `main` — so read the content, not the file list. This
PR's real delta is now two files: the contract/cold-pod fix and its test.

## Falsification, reported honestly

**(1) is falsifiable and now falsified.** It needed a purpose-built test, because with a valid
fixture `select` never throws and the new branch never runs. The test feeds a payload carrying a full
unmasked PAN — the exact regression the client contract exists to refuse. Reverting the hook reddens
it (`1 failed, 1 passed`).

My first version of that test **passed against the defect too**: `not.toContainText` succeeds the
moment the text disappears, and "waking up" is shown only until the retries exhaust (~12s), so a
15-second retrying assertion was satisfied either way. It asserts at a **fixed 2s moment** instead.

**(2) is gone from this PR** — see above; its falsifiability is now #9765's to state.

## The PAN literal, and why this branch was rewritten

The `pan-card-number` gitleaks rule flagged the fixture's unmasked PAN and was **right to** — public
repo, and the contract is the client-side PCI allow-list boundary. It is assembled from chunks now.
Allowlisting the file would have been the cheap fix and the wrong one: it blinds that rule on
everything else in the file, for one test literal.

Worth recording for the next person: **gitleaks scans the branch's commits, not the worktree**
(`3 commits scanned`). Fixing the file in a later commit returned the *same fingerprint* naming the
earlier commit, so the branch was rewritten to a single clean commit —
`gitleaks detect --log-opts "origin/main..HEAD"` now reports `no leaks found`.

## Verification

- The four target specs: **4 passed** on the rebased branch (`card-detail-recovery`, `sanctions-theme`).
- Unit suite (before the rebase, via `npm test` so `pretest` bakes the artifacts): 547 files,
  2921 passed, 1 skipped. `tsc --noEmit` clean.

## What this does NOT claim

The admin-ui e2e suite is broadly unstable locally beyond these specs — a full serial run shows 61
failures, and the `core-workflow-*-accessibility` WCAG specs fail a *different subset each run*.
Measured against an unmodified checkout of the same commit, nothing fails that does not also fail
there. So this change is not the cause, and it does not make the suite green; that part of #9736
stays open.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert. The card screen returns to misreporting contract failures as cold starts,
  and the checked sanctions row to 4.25:1.
- Data migration reversible: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

