### PR TITLE
perf(ci): stop the Dependabot auto-merge firing on every push to every PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,21 @@ name: Dependabot auto-merge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # NOT `synchronize` (#9031). GitHub's native auto-merge is a property of the PR, not of a
+    # commit: the `--auto` merge enabled once at `opened` survives every later push, including
+    # Dependabot's own rebases. So `synchronize` could only ever re-assert a setting already in
+    # place — while firing this workflow on every push to every open PR in the repository.
+    #
+    # Measured 2026-09-12 over a 0.32 h window of 300 workflow runs: this workflow ran 18 times
+    # and SKIPPED 18 of 18, every one of them triggered by a push to one of five non-Dependabot
+    # feature branches. A skipped job still costs a queued Actions run and its API calls, and the
+    # installation quota was exhausted that same morning — hard-failing `dependency-review` and
+    # the `CodeQL` SARIF upload across the open PRs with
+    # `API rate limit exceeded for installation`.
+    #
+    # `labeled` stays: a label is how a human re-opens the question for a PR this job already
+    # declined, and it fires rarely enough not to be part of the cost.
+    types: [opened, reopened, labeled]
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); the auto-merge job below declares its own override for the write access it needs.


### PR DESCRIPTION
## Summary

`Dependabot auto-merge` fires on every push to every open PR and does nothing on almost all of them.
Dropping `synchronize` from its trigger removes a queued Actions run and its API calls per push,
without changing what it does for a Dependabot PR.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9031

## Changes

- `.github/workflows/dependabot-auto-merge.yml`: `types: [opened, synchronize, reopened, labeled]`
  becomes `types: [opened, reopened, labeled]`, with the measurement and the reasoning in place.

## Why `synchronize` cannot be load-bearing

GitHub's native auto-merge is a property of the **pull request**, not of a commit. The setting this
workflow enables when the PR is opened survives every later push, Dependabot's own rebases included.
So a `synchronize` firing could only ever re-assert a setting already in place.

## Measurement

The pinned query from #9031, window **2026-09-12 05:01:47Z .. 05:20:53Z (0.32 h)**, 300 runs:

| workflow | runs/h | skipped |
|---|---:|---:|
| Dependabot auto-merge | 57 | **18 / 18** |

It was the only workflow in the sample with a 100% skip rate, and all 18 runs came from pushes to
five non-Dependabot feature branches — so by elimination they were `synchronize`, not `opened`,
`reopened` or `labeled`.

A skipped job is not free: it is a queued Actions run and its API calls against the installation
quota. That quota was exhausted the same morning, and the failures were not confined to advisory
checks:

- `dependency-review` on #9733 exhausted its entire 0/30/60/120/240/480 s recovery ladder and died
  on `gh: API rate limit exceeded for installation ... (HTTP 403)`.
- The `CodeQL (javascript-typescript)` SARIF upload on #9751 failed with
  `##[error]API rate limit exceeded for installation` **after** the analysis itself had completed.

## Why `labeled` is kept

A label is how a human re-opens the question for a PR this job already declined. It fires rarely
enough not to be part of the cost, and removing it would silently drop that affordance.

## Local verification

`python3 .github/scripts/run-gates.py --all` on this branch, differenced against the same command on
bare `origin/main`: **zero new findings**. `actionlint` on the changed file: clean.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

A trigger-list change to one workflow: no Kotlin, no service boundary, no API, no DB, no event. The
rationale is carried in the file itself so the next reader does not re-add `synchronize` for the
symmetry of it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? → not changed.
- [x] PII path changed? → not changed.
- [x] Cardholder data path changed? → not changed.

No change to the job's permissions, its policy (patch-only, gradle/npm, never `github_actions` or
`docker`), or its actor condition — only to how often it is queued.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
