### PR TITLE
fix(ci): stop the money-path security checklist blocking release-only PRs

### DIFF
--- a/.github/scripts/check-security-checklist.py
+++ b/.github/scripts/check-security-checklist.py
@@ -21,6 +21,22 @@ Deliberately NOT checked: the checkboxes' truthfulness (CI cannot know whether t
 author really ran a secrets sweep — the control is the pause, not the proof) and
 non-money-path PRs (the pause is priced; spend it where a mistake moves money).
 
+RELEASE-DERIVED FILES ARE NOT MONEY-PATH CODE (#9230). A release-please PR touches
+`CHANGELOG.md`, `version.txt` and `.release-please-manifest.json` under every service
+that released, and nothing else — no Kotlin, no config, no migration, no spec. Counted
+as money-path files those tripped this gate on a PR with no code in it at all, and the
+remedy the error names is unanswerable: there is no secrets sweep to run and no
+suppression to justify over a generated changelog, and the PR is authored by a bot that
+cannot tick a box. Measured on #9230: 42 "money-path files" across 21 services, 88 files
+in the diff, and ZERO of them outside the four derived names below — the release train
+sat blocked from 2026-09-08.
+
+This is the `gate whose remedy cannot be performed` shape, so the fix is the SCOPE, not
+the severity: strip the derived names before deciding whether the PR is money-path. A
+release PR that also carried real code still trips the gate, because the strip is
+per-file and the code file survives it. That case is the self-test's must-FAIL control —
+without it this exclusion would be indistinguishable from switching the gate off.
+
 Usage:  check-security-checklist.py --body-file <file> [--base origin/main]
         check-security-checklist.py --self-test
 """
@@ -37,6 +53,23 @@ RULES = Path("openbank-libs/governance/rules.yaml")
 SECTION = re.compile(r"^##\s+Security checklist\s*$", re.M | re.I)
 NEXT_HEADING = re.compile(r"^##\s+", re.M)
 BOX = re.compile(r"^\s*-\s*\[(?P<mark>[ xX])\]\s*(?P<text>.*)$", re.M)
+
+# Files release-please writes, and the only files a release-only PR contains. Matched on the
+# BASENAME, because each lives under its own service directory (and the manifest at the root).
+# Deliberately a closed list of four exact names, not a glob: `*.md` would swallow a threat model
+# and `*.json` an OPA bundle, and both of those are exactly the money-path evidence this gate must
+# keep seeing.
+RELEASE_DERIVED = frozenset({
+    "CHANGELOG.md",
+    "version.txt",
+    ".release-please-manifest.json",
+})
+
+
+def is_release_derived(path: str) -> bool:
+    """True for a file release-please generates, which carries no code and no attack surface."""
+    return path.rsplit("/", 1)[-1] in RELEASE_DERIVED
+
 
 
 def money_path_dirs(root: Path) -> list[str]:
@@ -83,10 +116,21 @@ def unticked(body: str) -> tuple[str, list[str]] | None:
 def run(root: Path, body: str, base: str, enforce: bool) -> int:
     dirs = money_path_dirs(root)
     files = changed_files(base)
-    touched = [f for f in files if any(f == d or f.startswith(d + "/") for d in dirs)]
+    in_money_path = [f for f in files if any(f == d or f.startswith(d + "/") for d in dirs)]
+    touched = [f for f in in_money_path if not is_release_derived(f)]
+    derived = len(in_money_path) - len(touched)
     if not touched:
-        print(f"security-checklist: PR touches no money-path directory ({len(files)} files) — not applicable")
+        if derived:
+            # Say it out loud. A gate that narrows its own scope silently is how a control becomes
+            # a no-op nobody notices, so the release-only case reports what it skipped and why.
+            print(f"security-checklist: {derived} money-path file(s) are release-derived "
+                  f"(CHANGELOG.md / version.txt / .release-please-manifest.json) and carry no code; "
+                  f"no other money-path file in this PR — not applicable")
+        else:
+            print(f"security-checklist: PR touches no money-path directory ({len(files)} files) — not applicable")
         return 0
+    if derived:
+        print(f"security-checklist: ignoring {derived} release-derived money-path file(s)")
     print(f"security-checklist: {len(touched)} money-path file(s) touched "
           f"({', '.join(sorted({t.split('/')[0] for t in touched}))})")
 
@@ -125,6 +169,65 @@ def self_test() -> int:
     r3 = unticked(other)
     if r3 is None or r3[1]:
         print("self-test FAIL: box in the next section leaked into the check"); bad += 1
+    # ── the release-derived exclusion, both directions (#9230) ───────────────────────────────
+    #
+    # The must-FAIL half is the load-bearing one: an exclusion that also let a real money-path
+    # source file through would be indistinguishable from switching the gate off, and every case
+    # above would still pass. So drive the real `run()` over a throwaway git repo — the parser,
+    # the diff and the decision, not a mock of them.
+    import subprocess as _sp
+    import tempfile as _tf
+
+    money = money_path_dirs(Path("."))
+    if not money:
+        print("self-test FAIL: no money-path service to build a fixture from"); bad += 1
+        money = ["openbank-ledger-service"]
+    svc = sorted(money)[0]
+
+    def fixture(paths: list[str], body: str) -> int:
+        with _tf.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "openbank-libs" / "governance").mkdir(parents=True)
+            (root / "openbank-libs" / "governance" / "rules.yaml").write_text(
+                "money_path_services:\n  - " + svc + "\n", encoding="utf-8")
+            env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t",
+                   "GIT_COMMITTER_EMAIL": "t@t", "PATH": __import__("os").environ.get("PATH", "")}
+            def git(*a):
+                _sp.run(["git", "-C", str(root), *a], check=True, capture_output=True, env=env)
+            git("init", "-q", "-b", "base")
+            git("add", "-A"); git("commit", "-q", "-m", "base")
+            for rel in paths:
+                f = root / rel
+                f.parent.mkdir(parents=True, exist_ok=True)
+                f.write_text("x\n", encoding="utf-8")
+            git("checkout", "-q", "-b", "head")
+            git("add", "-A"); git("commit", "-q", "-m", "head")
+            cwd = __import__("os").getcwd()
+            try:
+                __import__("os").chdir(root)
+                return run(root, body, "base", enforce=True)
+            finally:
+                __import__("os").chdir(cwd)
+
+    no_checklist = "## Summary\nrelease\n"
+    release_only = [f"{svc}/CHANGELOG.md", f"{svc}/version.txt", ".release-please-manifest.json"]
+
+    rc = fixture(release_only, no_checklist)
+    if rc != 0:
+        print("self-test FAIL: a release-only PR (CHANGELOG/version.txt/manifest) still trips the gate")
+        bad += 1
+
+    rc = fixture(release_only + [f"{svc}/src/main/kotlin/Money.kt"], no_checklist)
+    if rc == 0:
+        print("self-test FAIL: a release PR that ALSO changes money-path source passed — the "
+              "exclusion is swallowing real code, which is the gate switched off")
+        bad += 1
+
+    # A name that merely resembles a derived one must not be excluded: the strip is exact-basename.
+    rc = fixture([f"{svc}/docs/CHANGELOG.md.bak", f"{svc}/src/main/kotlin/Money.kt"], no_checklist)
+    if rc == 0:
+        print("self-test FAIL: a near-miss filename was treated as release-derived"); bad += 1
+
     print("security-checklist self-test: " + ("clean" if not bad else f"{bad} failure(s)"))
     return 1 if bad else 0
 


### PR DESCRIPTION
## Summary

The money-path security checklist gate blocks release-only PRs, where the remedy it names cannot be
performed. This narrows its scope to files that carry code, and proves the narrowing does not turn
the gate off.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9230

## Changes

- `.github/scripts/check-security-checklist.py`: strip `CHANGELOG.md`, `version.txt` and
  `.release-please-manifest.json` from the money-path file set before deciding whether the gate
  applies, report the narrowing in the output, and add three self-test cases.

## The defect

A release-please PR touches those three files under every service that released, and nothing else —
no Kotlin, no config, no migration, no spec. Counted as money-path files they trip this gate on a PR
with no code in it.

Measured on #9230 (`chore(main): release main`):

```
security-checklist: 42 money-path file(s) touched (openbank-account-service, ... 21 services)
::error::PR touches money-path code but the body has no '## Security checklist' section
```

88 files in the diff, 42 counted as money-path, and **zero** of them outside those three derived
names. The remedy the error names is unanswerable — there is no secrets sweep to run and no
suppression to justify over a generated changelog — and the PR is authored by a bot that cannot tick
a box. The release train has sat blocked on it since **2026-09-08**.

This is the shape where a gate's stated remedy is wrong for the case it fires on, so the fix is the
**scope**, not the severity.

## Why this does not switch the gate off

The strip is per-file, so a release PR that also carries real money-path source still trips the gate.
That is the load-bearing half of the self-test: an exclusion that let real source through would be
indistinguishable from a disabled gate, and every pre-existing case would still pass.

Three new cases, each driving the real `run()` over a throwaway git repo so the parser, the diff and
the decision are exercised rather than mocked:

| case | must |
|---|---|
| release-only PR (CHANGELOG + version.txt + manifest) | PASS |
| release PR that also changes `src/main/kotlin` | FAIL |
| near-miss name `CHANGELOG.md.bak` alongside source | FAIL |

The exclusion is a closed list of exact basenames rather than a glob, deliberately: `*.md` would
swallow a threat model and `*.json` an OPA bundle, and those are exactly the money-path evidence this
gate must keep seeing.

The narrowing is printed, not silent — a gate that quietly reduces its own scope is how a control
becomes a no-op nobody notices.

## Verification

- `python3 .github/scripts/check-security-checklist.py --self-test` — clean, all cases.
- The patched checker run against the **real** #9230 head and diff base:
  ```
  security-checklist: 42 money-path file(s) are release-derived (CHANGELOG.md / version.txt /
  .release-please-manifest.json) and carry no code; no other money-path file in this PR — not applicable
  EXIT=0
  ```
- `python3 .github/scripts/run-gates.py --all` on this branch, differenced against the same command
  on bare `origin/main`: **zero new findings**.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. (The gate's own `--self-test`, which `gates.yaml` runs as
      `selftest_expect: pass`, gains the three cases above.)
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). (The module docstring carries the measurement and
      the reason the exclusion is a closed list.)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? → not changed.
- [x] PII path changed? → not changed.
- [x] Cardholder data path changed? → not changed.

This *narrows a security control*, which is why the must-FAIL cases above are stated before the
must-PASS one. The three excluded names are generated artefacts with no executable content; every
Kotlin, YAML, SQL, `.rego` and OpenAPI file under a money-path service is still in scope, unchanged.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
