### PR TITLE
fix(admin-ui): lift the selected sanctions row's metadata off the AA floor

### DIFF
--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -1004,7 +1004,16 @@ export default function SanctionsPage() {
                                 {isPep && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--accent-text)', background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', padding: '1px 4px', borderRadius: '3px' }}>PEP</span>}
                                 {!lst.enabled && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--text-tertiary)', background: 'var(--surface-4)', padding: '1px 4px', borderRadius: '3px' }}>{t('vyp.', 'off')}</span>}
                               </div>
-                              <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
+                              {/* A checked row paints --accent-bg (#eef2ff) behind this line, and
+                                  --text-tertiary (#64748b) on it measures 4.26:1 — under the 4.5:1
+                                  AA floor this page's own axe assertion enforces. --text-secondary
+                                  is 6.78:1 on the same surface, so a selected row steps up one
+                                  EXISTING token rather than the palette moving fleet-wide (#9749).
+                                  Unchecked rows keep the tertiary tone on --surface-2, where it
+                                  has always cleared AA. Reachable only since #9751 fixed the
+                                  selection — before that no row was ever checked, so the assertion
+                                  never ran against this state. */}
+                              <div style={{ fontSize: '10px', color: checked ? 'var(--text-secondary)' : 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
                                 {lst.lastEntryCount ? `${lst.lastEntryCount.toLocaleString(numberLocale)} ${t('zázn.', 'entries')}` : t('nestaženo', 'not synced')}
                               </div>
                             </div>


### PR DESCRIPTION
Re-opens the contrast half of the closed #9737. Refs #9736, #9749.

## Why this is a separate PR

#9737 was **closed, not merged** — #9751 landed the same two other fixes from a parallel session
(the card e2e fixtures and the impure list-scope updater). Its third commit did not come with them,
so this change is missing from `main`:

```
git show origin/main:…/sanctions/page.tsx | grep -c "checked ? 'var(--text-secondary)'"   ->  0
```

## The defect, measured in the browser on current `main`

With the PEP row checked:

```
color = rgb(100,116,139)  #64748b   (--text-tertiary)
bg    = rgb(238,242,255)  #eef2ff   (--accent-bg)
10px / weight 400  ->  4.25:1   against the 4.5:1 AA floor for normal text
```

A selected row now steps up one **existing** token to `--text-secondary` — 6.78:1 on the same
surface. Unchecked rows keep the tertiary tone on `--surface-2`, where it has always cleared AA.
No colour is invented and no other surface moves; whether `--text-tertiary` should be darkened
fleet-wide stays in #9749 with its own measurement.

This was unreachable until #9751: before it, no row was ever checked on first load, so the accent
background never rendered and the pair did not exist on screen.

## Verification — and it deliberately does not rest on the e2e suite

Running axe directly against that page on current `main` reports it:

```
AXE violations(color-contrast) = [4.25]
AXE total violations = 1
```

But **`sanctions-theme.spec.ts` passes on `main` while rendering the identical pair.** Instrumented
inside the spec itself:

```
SPEC-DBG color=rgb(100,116,139) bg=rgb(238,242,255)
1 passed
```

Same page, same axe tags, same computed colours — the standalone run flags it, the spec's own run
does not. It *did* catch it earlier today on a branch differing only in this file, so the coverage
is **intermittent rather than absent**.

I am flagging that rather than leaning on it. An accessibility assertion that sometimes misses is
worse than a missing one, because it is read as protection — and it means "the test goes red without
this fix" is not a claim I can make here. The justification is the measured ratio and the standalone
axe verdict.

Worth someone deciding whether the spec's axe run needs a scoped selector (or a scroll/visibility
step) so that what it asserts is deterministic.
