### PR TITLE
ci(probe): separate "no diff" from "no such path" in a commit pathspec probe

### DIFF
--- a/.github/scripts/lib/probe.sh
+++ b/.github/scripts/lib/probe.sh
@@ -198,6 +198,66 @@ probe_commit_before_utc() {
   echo "$sha"
 }
 
+# ---------------------------------------------------------------------------------------------
+# probe_commit_touches_path <sha> <repo-root-relative-path> [-C <dir>]
+#   -> the changed path(s) on stdout; exit 0 = touched, 1 = looked and it does not, 2 = COULD NOT LOOK
+#
+# `git show <sha> -- <path>` exits 0 and prints nothing in THREE different situations, and neither
+# the status nor the output separates them: the commit genuinely does not touch that file; the path
+# is misspelled; or the path is written relative to the repo root while the command runs from a
+# subdirectory. Measured on this repo — `git show --stat <sha> -- 'openbank-admin-ui/src/app/...'`
+# from inside `openbank-admin-ui/` and the same command against a path that has never existed both
+# answered `exit=0, 0 bytes`, byte for byte identical to each other and structurally identical to a
+# true "unchanged". Pathspec arguments resolve against the CWD, while `git status`/`git diff`
+# --name-only PRINT repo-root-relative paths — so copying a path out of one command's output into
+# another's argument is wrong exactly when you are not at the root, which in a monorepo is most of
+# the time. Under a subdirectory it reads as "this commit did not change that file", and a whole
+# investigation proceeds from a negative the probe was never able to establish.
+#
+# Two things this does that the bare command cannot:
+#   * anchors the pathspec at the repo root with the `:/` magic prefix, so the answer does not
+#     depend on where it was run from;
+#   * FAILS CLOSED (exit 2, loud on stderr) when the path names no file in either the commit's tree
+#     or its parent's — i.e. separates "no diff" from "no such path", which is the distinction the
+#     bare command does not have.
+probe_commit_touches_path() {
+  local sha="$1" path="$2" dir="."
+  if [ "${3:-}" = "-C" ]; then dir="${4:-.}"; fi
+
+  [ -n "$sha" ] && [ -n "$path" ] || {
+    echo "probe_commit_touches_path: usage: <sha> <repo-root-relative-path> [-C <dir>]" >&2; return 2; }
+
+  # A pathspec the caller pre-decorated defeats the anchoring below, and an absolute path is
+  # meaningless to `<rev>:<path>`. Reject both rather than silently answering about something else.
+  case "$path" in
+    :*) echo "probe_commit_touches_path: pass a plain repo-root-relative path, not a pathspec" \
+             "('$path') — this probe adds the ':/' anchor itself" >&2; return 2 ;;
+    /*) echo "probe_commit_touches_path: '$path' is absolute; pass it relative to the repo root" >&2
+        return 2 ;;
+    ./*|../*) echo "probe_commit_touches_path: '$path' is CWD-relative, which is the bug this probe" \
+                   "exists to prevent; pass it relative to the repo root" >&2; return 2 ;;
+  esac
+
+  # `<rev>:<path>` is itself repo-root-relative for a path with no leading `./`, so this existence
+  # check is already CWD-independent. A file the commit ADDS is absent from the parent and a file it
+  # DELETES is absent from the commit, so either tree containing it is enough to prove the pathspec
+  # names something real. A root commit has no parent; `cat-file -e` just fails, which is handled.
+  local in_commit=0 in_parent=0
+  git -C "$dir" cat-file -e "${sha}:${path}" 2>/dev/null && in_commit=1
+  git -C "$dir" cat-file -e "${sha}^:${path}" 2>/dev/null && in_parent=1
+  if [ "$in_commit" = "0" ] && [ "$in_parent" = "0" ]; then
+    echo "probe_commit_touches_path: '$path' exists in neither $sha nor its parent — the pathspec" \
+         "names no file, so an empty diff would carry no information. Check the spelling, and note" \
+         "the path must be relative to the REPO ROOT, not to \$PWD." >&2
+    return 2
+  fi
+
+  local out
+  out="$(git -C "$dir" show --format= --name-only "$sha" -- ":/$path" 2>/dev/null)"
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out"
+}
+
 probe_zombie_runs() {
   local repo="${1:-JiRaska/open-bank-oss}"
   local min_age_hours="${2:-24}"
@@ -638,6 +698,88 @@ _probe_selftest() {
   _check "probe_commit_before_utc fails closed when nothing precedes the cutoff" \
     "$([ "$none_status" = "1" ] && [ -z "$none_out" ] && echo 1 || echo 0)"
   rm -rf "$crepo"
+
+  # --- probe_commit_touches_path ----------------------------------------------------------
+  # The fixture mirrors the real shape: a monorepo with a nested module, so the trap (a pathspec
+  # written relative to the repo root, evaluated from inside a subdirectory) is reproducible rather
+  # than assumed. `sub/src/a.txt` is the one the commit under test changes; `sub/src/b.txt` it does
+  # not; `sub/src/added.txt` it creates, which is the case an existence check against the commit's
+  # PARENT alone would get wrong.
+  local prepo tsha
+  prepo="$(mktemp -d)"
+  (
+    cd "$prepo" || exit 1
+    git init -q -b main .
+    git config user.email probe@example.invalid
+    git config user.name "probe selftest"
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+    mkdir -p sub/src
+    printf 'one\n' > sub/src/a.txt
+    printf 'keep\n' > sub/src/b.txt
+    git add sub/src/a.txt sub/src/b.txt
+    git commit -q -m base
+    printf 'two\n' > sub/src/a.txt
+    printf 'new\n' > sub/src/added.txt
+    git add sub/src/a.txt sub/src/added.txt
+    git commit -q -m change
+  ) >/dev/null 2>&1
+  tsha="$(git -C "$prepo" rev-parse HEAD 2>/dev/null)"
+
+  # Known-positive, from the repo ROOT.
+  local touched
+  touched="$(probe_commit_touches_path "$tsha" "sub/src/a.txt" -C "$prepo" 2>/dev/null)"
+  _check "probe_commit_touches_path finds a path the commit changes (got '$touched')" \
+    "$([ "$touched" = "sub/src/a.txt" ] && echo 1 || echo 0)"
+
+  # Known-negative: a file that exists and the commit leaves alone must be exit 1 with NO output —
+  # distinct from the exit 2 below. A probe that always said "touched" would pass the case above.
+  local untouched_out untouched_status=0
+  untouched_out="$(probe_commit_touches_path "$tsha" "sub/src/b.txt" -C "$prepo" 2>/dev/null)" \
+    || untouched_status=$?
+  _check "probe_commit_touches_path reports exit 1 for a file the commit leaves alone" \
+    "$([ "$untouched_status" = "1" ] && [ -z "$untouched_out" ] && echo 1 || echo 0)"
+
+  # THE case this probe exists for: run from the SUBDIRECTORY with the same repo-root-relative path.
+  # The answer must be identical to the one from the root — that is the CWD-invariance the bare
+  # command does not have.
+  local touched_from_sub
+  touched_from_sub="$(cd "$prepo/sub" && probe_commit_touches_path "$tsha" "sub/src/a.txt" 2>/dev/null)"
+  _check "probe_commit_touches_path is CWD-invariant (root='$touched' sub='$touched_from_sub')" \
+    "$([ -n "$touched_from_sub" ] && [ "$touched_from_sub" = "$touched" ] && echo 1 || echo 0)"
+
+  # VACUITY CONTROL: the naive form must DISAGREE with the probe on this fixture. Without this the
+  # case above could pass against a probe that merely reimplements the bug — and it is the exact
+  # command measured on the real repo: exit 0, zero bytes, indistinguishable from "unchanged".
+  local naive_out naive_status=0
+  naive_out="$(cd "$prepo/sub" && git show --format= --name-only "$tsha" -- 'sub/src/a.txt' 2>/dev/null)" \
+    || naive_status=$?
+  _check "the naive CWD-relative form answers exit 0 with empty output (the trap is reproduced)" \
+    "$([ "$naive_status" = "0" ] && [ -z "$naive_out" ] && echo 1 || echo 0)"
+
+  # And the discrimination the bare command structurally lacks: a path that names no file at all is
+  # exit 2 ("could not look"), never exit 0/1 ("looked, found nothing"). Same fixture, same commit,
+  # so the only difference from the known-negative above is that the path is not real.
+  local missing_out missing_status=0
+  missing_out="$(probe_commit_touches_path "$tsha" "sub/src/NENI.txt" -C "$prepo" 2>/dev/null)" \
+    || missing_status=$?
+  _check "probe_commit_touches_path fails CLOSED (exit 2) on a pathspec that names no file" \
+    "$([ "$missing_status" = "2" ] && [ -z "$missing_out" ] && echo 1 || echo 0)"
+
+  # A file the commit ADDS exists only in the commit's tree, not its parent's. An existence check
+  # written against the parent alone would call this "no such path" and refuse a real answer.
+  local added
+  added="$(probe_commit_touches_path "$tsha" "sub/src/added.txt" -C "$prepo" 2>/dev/null)"
+  _check "probe_commit_touches_path handles a file the commit ADDS (got '$added')" \
+    "$([ "$added" = "sub/src/added.txt" ] && echo 1 || echo 0)"
+
+  # A CWD-relative path is refused outright rather than answered about, because from `sub/` the
+  # path `src/a.txt` would resolve against the root and name nothing — the silent-negative shape.
+  local rel_status=0
+  (cd "$prepo/sub" && probe_commit_touches_path "$tsha" "./src/a.txt" >/dev/null 2>&1) || rel_status=$?
+  _check "probe_commit_touches_path REJECTS a CWD-relative path instead of answering about it" \
+    "$([ "$rel_status" = "2" ] && echo 1 || echo 0)"
+  rm -rf "$prepo"
 
   echo "SUBJECTS=$executed  # self-test assertions executed"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,9 +749,24 @@ touch `.github/`. What stays here is what fires from OUTSIDE that tree: editing
   (`git rev-parse origin/<b>` reads the LOCAL tracking ref and a plain fetch never prunes),
   `probe_pr_failing_checks` (job names contain spaces, so an `awk` column is a word of the NAME),
   `probe_lint_findings` (a newline-joined file list arrives as ONE argument; post-filtering a
-  linter's output hides the failures that are not findings), and `probe_zombie_runs`.
+  linter's output hides the failures that are not findings), `probe_commit_touches_path` (below),
+  and `probe_zombie_runs`.
   Each is held to a known-positive **and** a known-negative by the enforced
   `probe-lib-known-positive` gate — `bash .github/scripts/lib/probe.sh --selftest`.
+- **`git show <sha> -- <path>` exits 0 and prints NOTHING in three different situations, and in a
+  monorepo the likeliest one is that you were standing in the wrong directory.** Pathspec arguments
+  resolve against `$PWD`, while `git status` / `--name-only` PRINT repo-root-relative paths — so
+  copying a path out of one command's output into another's argument is wrong exactly when you are
+  not at the root. Measured from inside `openbank-admin-ui/`: the root-relative path answered
+  `exit=0, 0 bytes`, the same as a path that has never existed, and the same as a genuine
+  "unchanged" — three states, one indistinguishable answer, and the two failures read as the
+  negative finding you were testing for. Use `probe_commit_touches_path <sha> <repo-root-path>`,
+  which anchors the pathspec with git's `:/` magic prefix (CWD-independent) and separates exit 1
+  ("looked; it does not") from exit 2 ("that path names no file — could not look"). The `:/` prefix
+  alone is NOT the whole fix: it cures the CWD dependence and still answers `exit 0`, empty, for a
+  misspelled path. Same family as the `--before=<bare date>` and `date -j -f` traps above; caught
+  twice within one session on #9736, the second time by `git add` erroring loudly where `git show`
+  had not.
 - **`status=in_progress` is not a measure of CI load: 189 of those runs are wedged** — the run
   record never transitioned while every one of its jobs is `completed`, the oldest from
   2026-08-09. They are **not reapable**: both `POST /actions/runs/{id}/cancel` and `.../force-cancel`


### PR DESCRIPTION
## Summary

A probe from the class this repo already tracks: one that fails by reporting clean. `git show <sha>
-- <path>` exits 0 and prints nothing in three different situations — the commit does not touch that
file, the path is misspelled, or the path is repo-root-relative while the command runs from a
subdirectory — and neither the exit status nor the output separates them. Hit twice inside one
session while diagnosing #9736, so it goes into `probe.sh` behind the enforced falsifiability gate
rather than into prose.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9736 — the session that surfaced the trap twice. No issue of its own; this is the preventive
half, the defect half merged as #9751.

## Changes

- `probe_commit_touches_path <sha> <repo-root-relative-path> [-C <dir>]` in
  `.github/scripts/lib/probe.sh`: anchors the pathspec with git's `:/` magic prefix so the answer
  cannot depend on `$PWD`, and **fails closed** (exit 2, loud on stderr) when the path names no file
  in either the commit's tree or its parent's. That separates exit 1 ("looked; it does not touch it")
  from exit 2 ("could not look") — the distinction the bare command structurally lacks. A
  pre-decorated pathspec, an absolute path and a `./`-relative path are rejected rather than answered
  about.
- Seven self-test assertions covering both halves, run by the existing enforced
  `probe-lib-known-positive` gate. `SUBJECTS` 29 → 36; gate 2.1 s → 2.6 s.
- `CLAUDE.md`: one bullet in the existing **Shell probes** section, with the measurement and the note
  that the `:/` prefix alone is not the whole fix.

### Why `:/` alone is not sufficient

It cures the CWD dependence and still answers exit 0, empty, for a misspelled path — which is why
the fail-closed existence check is the other half rather than a nicety.

## Measured, not assumed

From inside `openbank-admin-ui/`, against a real commit that *does* change that file:

| invocation | exit | output |
|---|---|---|
| `git show --stat <sha> -- 'openbank-admin-ui/src/app/cards/[id]/page.tsx'` | 0 | **0 bytes** |
| same, with the `:/` anchor | 0 | 372 bytes |
| `-- ':/openbank-admin-ui/src/app/cards/NENI.tsx'` (never existed) | 0 | **0 bytes** |

Rows 1 and 3 are byte-for-byte identical to each other and structurally identical to a genuine
"unchanged". In the session that prompted this, row 1 was read as "that commit does not touch the
cards page". The same mistake recurred minutes later with `git add`, which — unlike `git show` —
errors loudly on an unmatched pathspec; that loud failure is the only reason the quiet one was
noticed at all.

## Falsification

Each sabotage was applied to a copy, verified to have actually landed in the file, and reddens only
its own case:

| sabotage | result |
|---|---|
| drop the `:/` anchor (restore the naive form) | `[FAIL] … is CWD-invariant (root='sub/src/a.txt' sub='')` — exit 1 |
| fail-closed branch `return 2` → `return 1` | `[FAIL] … fails CLOSED (exit 2) on a pathspec that names no file` — exit 1 |

The `sub=''` in the first is precisely the empty answer measured above. A **vacuity control** asserts
the naive form still answers exit 0 with empty output on the fixture, so the invariance case cannot
pass against a probe that merely reimplements the bug; the fixture is a monorepo with a nested module
specifically so the trap is reproduced rather than stipulated.

My first sabotage attempt did not apply (a bad `perl` regex, 0 occurrences replaced). Per the house
rule that indicted the sabotage, not the function: it was fixed and re-verified to land before any
conclusion was drawn from it.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — N/A, CI tooling only.
- [x] Unit tests added/updated — 7 self-test assertions, both directions each.
- [x] Integration tests added/updated (if service boundary involved) — N/A.
- [x] Contract tests updated (if public API changed) — N/A.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, no JVM source touched.
- [x] No new lint warnings — `shellcheck -S warning` exit 0.
- [x] OpenAPI spec regenerated (if REST API changed) — N/A.
- [x] Flyway migration added + rollback note (if DB changed) — N/A.
- [x] Avro schema versioned backward-compatibly (if event changed) — N/A.
- [x] Docs updated — `CLAUDE.md` **Shell probes** bullet.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — hermetic temp-dir
      fixtures, no network, no credentials.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification — none.
- [x] No new third-party dependency — none; plain `git` and `bash`.
- [x] Auth / crypto / payment code changed? → No.
- [x] PII path changed? → No.
- [x] Cardholder data path changed? → No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — CI tooling, takes effect on merge.
- Rollback plan: revert the commit; the gate returns to its previous 29 assertions.
- Data migration reversible: N/A

## Reviewer notes

`run-gates.py --all` (the meta-gates are blind to `--only`) reports 220 gates, 11 failing. None comes
from this change: 6 are the documented `PR_DIFF_BASE`/`BASE_REF` set, and the other 5 —
`litellm-config-revision`, `credential-deadline-ratchet`, `openapi-version-not-taken`,
`adversarial-contract-test`, `security-checklist-money-path` — fail identically in a throwaway
`git worktree add --detach <tmp> origin/main` control.

**Correcting my own first reading of that control**, which said those 5 were "pre-existing red on
`main`, worth a separate look". They are not: all 5 are environmental too, i.e. the documented set is
simply out of date at 6. Verified by supplying what each one asks for rather than by restating its
message — 4 of the 5 pass the moment `PR_DIFF_BASE` is set, and
`security-checklist-money-path` then walks a chain of `GITHUB_REPOSITORY` → `PR_NUMBER` before
passing. `main` is fine.

The control run answers "is this mine?" and I read an answer to "is this a defect?" off it. Those are
different questions; a control that fails identically on `origin/main` rules out authorship and says
nothing about whether the failure is real.

One small genuine finding while checking: the other four refuse cleanly
(`PR_DIFF_BASE is empty but this gate requires it — refusing to run vacuously`), whereas
`security-checklist-money-path` crashes on `set -u` with `GITHUB_REPOSITORY: unbound variable`. Same
outcome, much worse diagnosis — filing separately rather than folding it in here.

The self-test fixture follows the file's existing hermetic convention, including
`commit.gpgsign false` (a developer machine sets it globally and the fixture would otherwise block on
pinentry locally while passing in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
