### PR TITLE
ci(gates): name the missing runner variable instead of dying on unbound

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -28,13 +28,30 @@
   supplychain` both passed and `gates (lint)` failed on two of the three. Both meta-gates had landed
   on `main` while the branch was open, which is the normal case, not bad luck. The full run is ~340 s
   CPU / ~50 s wall on 8 jobs; that is cheaper than one CI round trip.
-  **Six failures are environmental — know them or you will read them as your regression.** Five
-  diff-scoped gates (`api-contract`, `release-scope-mismatch`, `db-migration`, `schema-compat`,
-  `threat-model-updated-on-trust-boundary-change`) print `PR_DIFF_BASE is empty but this gate
-  requires it — refusing to run vacuously`, and `loki-rule-load-test` reports UNFALSIFIED on
-  `BASE_REF: unbound variable`. Both are variables only CI sets. Confirm rather than assume: run the
-  same ids in a throwaway `git worktree add --detach <tmp> origin/main` and check they fail
-  identically there. Anything that fails on your branch and passes on that control IS yours.
+  **A dozen-ish failures are environmental — and the count is not the thing to remember, because it
+  grows every time a diff-scoped gate is added.** Each one now SAYS SO in its own output: `<VAR> is
+  empty but this gate requires it — refusing to run vacuously` (`PR_DIFF_BASE` for the diff-scoped
+  gates; `BASE_REF`, `GITHUB_REPOSITORY`, `PR_BODY`, `PR_NUMBER` for the few that read the runner's
+  own context). Read the output, never the count — this bullet said **six** on 2026-09-12 when the
+  true number was eleven, and the five it did not name were read as "pre-existing red on `main`" and
+  published as such in a PR body. They were not; `main` was fine.
+  To run the whole manifest locally as CI sees it, supply what they ask for. Measured 2026-09-12
+  against `origin/main`: the bare `--all` gave **11 FAIL**, and this gave **0** — `220 gates
+  PASS=217 WARN=2 UNFALSIFIED=1`, the remaining three being a genuine advisory warning and a
+  network-bound gate, not environment.
+  ```
+  PR_DIFF_BASE=$(git rev-parse HEAD~1) BASE_REF=$(git rev-parse HEAD~1) \
+    GITHUB_REPOSITORY=JiRaska/open-bank-oss PR_NUMBER=<n> \
+    PR_BODY="$(gh pr view <n> --json body -q .body)" \
+    python3 .github/scripts/run-gates.py --all
+  ```
+  Leave one out and the gate needing it says which — that is the point; do not memorise the list.
+  **A control run answers "is this mine?", never "is this real?".** Running the same ids in a
+  throwaway `git worktree add --detach <tmp> origin/main` tells you only about authorship —
+  anything that fails on your branch and passes there IS yours, and anything that fails on BOTH is
+  merely *unclassified*. To classify it, make it PASS: give it the missing variable, credential or
+  input and watch it go green. Confirming a shared failure is a defect takes that second step, and
+  skipping it is how a false "main is red" gets published.
 - **A gate that has only ever passed is unfalsified.** Its failure path is code nobody has run, and
   it fails in ways a green/red signal cannot express. Three independent instances in one week: the
   ADR-0071 governance reporter crashed with a `TypeError` on *every* failure, so it had never once

--- a/.github/scripts/run-gates.py
+++ b/.github/scripts/run-gates.py
@@ -83,6 +83,38 @@ VALID_MODES = {"enforced", "advisory"}
 VALID_WHEN = {"always", "pull_request"}
 VALID_EXPECT = {"pass", "fail"}
 
+# Variables the Actions runner sets and a laptop does not. A gate reading one of these BARE dies
+# under `bash -euo pipefail` with `unbound variable`, which is the same failure the PR_DIFF_BASE
+# guard below already exists to dress properly — see its comment: "refusing to run vacuously" says
+# what went wrong, `unbound variable` does not. Measured 2026-09-12: 3 of 220 gates read one bare,
+# and locally they produced a red that reads exactly like a finding. `security-checklist-money-path`
+# walked GITHUB_REPOSITORY -> PR_NUMBER one crash at a time, and the 5 gates that looked like
+# "pre-existing red on main" in a local `--all` were all this.
+#
+# A hand-kept list of EXTERNAL FACTS (what the runner provides), not of coverage: a name missing
+# here leaves the old `unbound variable` crash, i.e. failing towards today's behaviour, never
+# towards a gate that silently passes. PR_DIFF_BASE is deliberately absent — it has its own
+# richer required/optional derivation below.
+CI_ONLY_ENV = (
+    "BASE_REF",
+    "GH_TOKEN",
+    "GITHUB_ACTOR",
+    "GITHUB_BASE_REF",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_EVENT_PATH",
+    "GITHUB_HEAD_REF",
+    "GITHUB_OUTPUT",
+    "GITHUB_REF",
+    "GITHUB_REPOSITORY",
+    "GITHUB_RUN_ID",
+    "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_TOKEN",
+    "GITHUB_WORKSPACE",
+    "PR_BODY",
+    "PR_NUMBER",
+)
+
 
 # ---------------------------------------------------------------------------
 # Manifest
@@ -305,6 +337,14 @@ def load(root: pathlib.Path, path: str = MANIFEST):
             )
             sys.exit(2)
         g["needs_base"] = derived
+        # Same treatment for the other runner-only variables, DERIVED the same way so there is
+        # nothing to declare and nothing to drift: a bare `$NAME` is required, `${NAME:-}` supplies
+        # its own default and is not. No `when` restriction — unlike PR_DIFF_BASE these are set on
+        # push as well as on pull_request, so a required one is satisfiable under either event.
+        g["needs_env"] = sorted(
+            v for v in CI_ONLY_ENV
+            if re.search(r"\$\{?" + v + r"\b", run) and not re.search(r"\$\{" + v + r":[-=]", run)
+        )
         if derived == "required" and g["when"] != "pull_request":
             sys.stderr.write(
                 f"::error::gate {g['id']}: needs_base `required` with when `{g['when']}` can "
@@ -511,6 +551,19 @@ def execute(gate, root: pathlib.Path, is_pr: bool, timeout: int, index=None, cha
         # supply their own default and are written to work without a base.
         r.status = "failed"
         r.output = "PR_DIFF_BASE is empty but this gate requires it — refusing to run vacuously\n"
+        return r
+    missing_env = [v for v in gate.get("needs_env", ()) if not os.environ.get(v)]
+    if missing_env:
+        # Say which variable and that the runner provides it. Without this the gate dies on
+        # `unbound variable` — same red, but it names a shell symptom instead of the cause, and
+        # reads like a finding to anyone running the manifest locally.
+        r.status = "failed"
+        r.output = (
+            f"{', '.join(missing_env)} {'is' if len(missing_env) == 1 else 'are'} empty but this "
+            f"gate requires {'it' if len(missing_env) == 1 else 'them'} — refusing to run "
+            f"vacuously. The Actions runner sets {'this' if len(missing_env) == 1 else 'these'}; "
+            f"locally, export {'it' if len(missing_env) == 1 else 'them'} to run this gate.\n"
+        )
         return r
 
     t0 = time.monotonic()
@@ -1245,6 +1298,36 @@ def self_test():
                 bad.append(
                     f"empty PR_DIFF_BASE + {decl}: failed for the wrong reason — expected "
                     f"the guard's message, got: {r.output.strip()[:120]}"
+                )
+
+        # The same guard for the other runner-only variables. Asserting the MESSAGE is the whole
+        # point here too: `bash -euo pipefail` already fails on a bare unset variable, so a status
+        # check alone passes against no guard at all. Known-positive (bare read, variable unset),
+        # known-negative in BOTH directions — the variable present, and the `${NAME:-}` form that
+        # supplies its own default and must run even when unset.
+        for body, env, want, want_text in (
+            ('run: "echo $GITHUB_REPOSITORY"', None, "failed", "GITHUB_REPOSITORY is empty"),
+            ('run: "echo $GITHUB_REPOSITORY"', "o/r", "ok", None),
+            ('run: "echo ${GITHUB_REPOSITORY:-}"', None, "ok", None),
+            ('run: "echo $PR_NUMBER $GITHUB_REPOSITORY"', None, "failed",
+             "GITHUB_REPOSITORY, PR_NUMBER are empty"),
+        ):
+            (tmp / ".github" / "gates" / "gates.yaml").write_text(
+                f"gates:\n  - id: x\n    name: x\n    group: t\n    {body}\n"
+            )
+            os.environ.pop("GITHUB_REPOSITORY", None)
+            os.environ.pop("PR_NUMBER", None)
+            if env:
+                os.environ["GITHUB_REPOSITORY"] = env
+            g = load(tmp)[0]
+            r = execute(g, tmp, is_pr=True, timeout=5)
+            os.environ.pop("GITHUB_REPOSITORY", None)
+            if r.status != want:
+                bad.append(f"CI-only env {body} (env={env}): want {want}, got {r.status}")
+            if want_text and want_text not in r.output:
+                bad.append(
+                    f"CI-only env {body}: failed for the wrong reason — expected the guard's "
+                    f"message naming the variable, got: {r.output.strip()[:120]}"
                 )
 
         # --json end to end: a real file gets written and round-trips through json.load, and


### PR DESCRIPTION
## Summary

`run-gates.py` already dresses one missing environment variable properly: a gate reading a bare
`$PR_DIFF_BASE` is refused with *"refusing to run vacuously"* rather than being allowed to die under
`set -u`. Its own self-test says why the wording matters — *"`refusing to run vacuously` says what
went wrong, `unbound variable` does not."*

Three gates read the runner's **other** variables the same way and got no such treatment. This
extends the existing mechanism to them, and corrects the `.github/CLAUDE.md` bullet that told you how
many such failures to expect.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9736 — surfaced while checking that issue's gate failures. No issue of its own.

## Changes

- `run-gates.py`: `needs_env` is **derived from the command** exactly as `needs_base` already is — a
  bare `$NAME` is required, `${NAME:-}` supplies its own default and is not. So there is nothing to
  declare in `gates.yaml` and nothing that can drift out of sync. A missing one is refused with a
  message that names the variable and says the runner provides it.
- `CI_ONLY_ENV`: the runner-set variables. A hand-kept list of **external facts** (what Actions
  provides), not of coverage — a name missing from it leaves today's `unbound variable` crash, i.e.
  it fails towards current behaviour, never towards a gate that passes silently.
- `.github/CLAUDE.md`: the environmental-failure bullet, below.

**CI is unaffected.** The runner sets all of these, so no gate changes behaviour there. This is
purely about what a local `--all` tells you.

## The defect, measured

3 of 220 gates read a runner-only variable bare. Locally they die naming a shell symptom:

```
bash: line 6: GITHUB_REPOSITORY: unbound variable
```

`security-checklist-money-path` walked `GITHUB_REPOSITORY` → `PR_NUMBER` → `PR_BODY`, one crash per
run. `loki-rule-load-test` spent **98 s** before dying on `BASE_REF`; it now refuses in 0.0 s.

After:

```
GITHUB_REPOSITORY, PR_BODY, PR_NUMBER are empty but this gate requires them — refusing to run
vacuously. The Actions runner sets these; locally, export them to run this gate.
```

Full local manifest on `origin/main`, before and after supplying what each gate asks for:

| run | result |
|---|---|
| bare `--all` | **11 FAIL** |
| with the variables supplied | **0 FAIL** — `220 gates PASS=217 WARN=2 UNFALSIFIED=1` |

The remaining three are a genuine advisory warning and a network-bound gate — not environment.

## Why this is worth a gate change rather than a doc line

On 2026-09-12 those 11 local failures were triaged with the documented control (a throwaway
`git worktree add --detach <tmp> origin/main`). Six were the documented set; the other five failed
identically on the control, and I published in a PR body that they were *"pre-existing red on `main`,
worth a separate look"*. They were not — all five were environmental too, and `main` was fine. That
claim is now corrected on #9766.

So `.github/CLAUDE.md` picks up two things:

- **The count is not the durable fact.** It said six when the truth was eleven, and it grows with
  every diff-scoped gate added. It now gives the verified command and says to read each gate's own
  output, which after this change states exactly what is missing.
- **A control run answers "is this mine?", never "is this real?"** The existing text states only the
  first direction ("anything that fails on your branch and passes on that control IS yours") and is
  silent on what a *shared* failure means — which is exactly where the stronger claim got filled in.
  A shared failure is *unclassified*; classifying it means making it PASS.

## Falsification

Four self-test assertions in `run-gates.py --self-test`, both directions: variable unset (refused,
and the message must NAME it), present (runs), the `${NAME:-}` form (runs), and two missing at once.

Sabotage — stub the guard so it never finds a missing variable:

```
- CI-only env run: "echo $GITHUB_REPOSITORY": failed for the wrong reason — expected the guard's
  message naming the variable, got: --- gate ---
```

Note **which** assertion reddens: the status stays `failed` either way, because `set -u` fails the
gate anyway. Only the message assertion moves. A status-only test would have passed against no guard
at all — which is the same trap the existing `PR_DIFF_BASE` case documents, reproduced here rather
than assumed.

## Definition of Done

- [x] Hexagonal layering preserved — N/A, CI tooling only.
- [x] Unit tests added/updated — 4 self-test assertions, both directions.
- [x] Integration tests added/updated — N/A.
- [x] Contract tests updated — N/A.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, no JVM source touched.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated — N/A.
- [x] Flyway migration added + rollback note — N/A.
- [x] Avro schema versioned backward-compatibly — N/A.
- [x] Docs updated — `.github/CLAUDE.md`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII — the list names variables, holds no values; `GH_TOKEN`
      and `GITHUB_TOKEN` are only ever tested for emptiness, never printed.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification — none.
- [x] No new third-party dependency — none.
- [x] Auth / crypto / payment code changed? → No.
- [x] PII path changed? → No.
- [x] Cardholder data path changed? → No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — CI tooling, takes effect on merge.
- Rollback plan: revert; gates return to crashing on `unbound variable`.
- Data migration reversible: N/A

## Reviewer notes

The one judgement call is `CI_ONLY_ENV` being a literal list. It is deliberate and the failure
direction is the argument: a forgotten name yields today's behaviour, so the list can only ever fail
to help, never mislead. Deriving it instead (e.g. from what `ci.yml` exports) would couple the runner
to the workflow that invokes it, and would still be a list — just one further away.

`PR_DIFF_BASE` stays out of `CI_ONLY_ENV`: it keeps its own richer required/optional derivation,
including the `required` + `when: always` contradiction check that this simpler treatment has no need
for (the runner sets these on push as well as on pull_request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
