### PR TITLE
fix(ci): a rate-limited pact dispatch is a debt, not a failure

### DIFF
--- a/.github/scripts/pact-reconcile-verifications.py
+++ b/.github/scripts/pact-reconcile-verifications.py
@@ -86,6 +86,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gatelib  # noqa: E402  — the shared gh-transient vocabulary lives here
+
 PACTS = "pacts/*.json"
 DEFAULT_BRANCH = "main"
 # A cap exists so a broker outage answering `unknown` for everything cannot dispatch
@@ -180,6 +183,33 @@ def dispatch(repo, workflow, ref, service, token):
     req.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(req, timeout=30) as r:
         return r.status
+
+
+def _defer(provider: str, message: str, deferred: list) -> bool:
+    """Is this dispatch failure a TRANSIENT GitHub answer rather than a real one?
+
+    A rate-limited or transport-failed dispatch is a **debt**, not a defect: the
+    provider still owes the verification, the next scheduled run re-derives the same
+    `todo` set from the broker, and nothing about the repo needs changing. Failing the
+    run for it turns a quota window into a red reconcile — measured 2026-09-11/12,
+    **11 of the last 60 scheduled runs** failed and EVERY one was
+    `API rate limit exceeded for installation ... (HTTP 403)` on the dispatch POST,
+    while the reconcile logic itself was correct in all 11. That red is worse than
+    noise: this workflow is one of the few things watching for a stranded pact, so a
+    failure nobody can act on is how a real strand stops being visible.
+
+    The distinction is NOT re-derived here. `gatelib.is_gh_transient` compiles the
+    shared vocabulary in `gh-transient-patterns.txt`, whose whole point is that four
+    independent copies of this question drifted apart; its measured property is zero
+    over-retries across 11 terminal messages (404/422/401/`Resource not accessible by
+    integration`), so a genuinely broken dispatch — missing workflow, bad ref, token
+    without `actions: write` — still fails this run, loudly.
+    """
+    if gatelib.is_gh_transient(message):
+        sys.stderr.write(f"::warning::dispatch for {provider} deferred (transient): {message}\n")
+        deferred.append(provider)
+        return True
+    return False
 
 
 def main() -> int:
@@ -294,16 +324,30 @@ def main() -> int:
         return 2
 
     bad = 0
+    deferred = []
     for p in todo:
         try:
             status = dispatch(args.repo, args.workflow, args.branch, p, token)
             print(f"  dispatched {args.workflow} for {p} (HTTP {status})")
         except urllib.error.HTTPError as e:
-            sys.stderr.write(f"::error::dispatch for {p} failed: HTTP {e.code} {e.read()[:200]!r}\n")
+            msg = f"HTTP {e.code} {e.read()[:200]!r}"
+            if _defer(p, msg, deferred):
+                continue
+            sys.stderr.write(f"::error::dispatch for {p} failed: {msg}\n")
             bad += 1
         except (urllib.error.URLError, TimeoutError) as e:
+            if _defer(p, str(e), deferred):
+                continue
             sys.stderr.write(f"::error::dispatch for {p} failed: {e}\n")
             bad += 1
+    if deferred:
+        # Named, never silent: an unnamed deferral reads as "nothing else needed doing",
+        # the same mistake the --max-dispatch cap is written to avoid.
+        print(
+            f"::warning::dispatch deferred for {len(deferred)} provider(s) on a transient "
+            f"GitHub answer; still owed and picked up next run (~30 min): "
+            f"{', '.join(deferred)}"
+        )
     return 1 if bad else 0
 
 
@@ -381,6 +425,36 @@ def self_test() -> int:
     print(f"  {'ok ' if pub else 'BAD'} providers in this repo that can publish: {len(pub)}/{len(providers)}")
     if not pub:
         bad.append("no provider in the repo can publish — the check answers False for everything")
+
+    # ---- The dispatch-failure classification (#9750).
+    # The load-bearing asymmetry: a quota answer must DEFER (the debt survives to the next
+    # run), a real answer must FAIL THIS RUN. Both directions are asserted, because a
+    # classifier that defers everything makes this workflow green about a dispatch that can
+    # never succeed — a token without `actions: write` would then strand pacts silently,
+    # which is the exact failure this reconciler exists to make visible.
+    print("\nself-test: dispatch-failure classification")
+    dispatch_cases = [
+        ("HTTP 403 b'{\"message\": \"API rate limit exceeded for installation ID 1.\"}'", True,
+         "installation rate limit DEFERS — this was 11 of the last 60 scheduled runs"),
+        ("You have exceeded a secondary rate limit. Please wait a few minutes.", True,
+         "secondary rate limit DEFERS"),
+        ("HTTP 502 b'Bad gateway'", True, "a 5xx DEFERS"),
+        ("<urlopen error [Errno 104] Connection reset by peer>", True, "a transport failure DEFERS"),
+        ("HTTP 404 b'{\"message\": \"Not Found\"}'", False,
+         "a missing workflow FAILS — retrying cannot create verify-provider.yml"),
+        ("HTTP 422 b'{\"message\": \"Reference does not exist\"}'", False,
+         "a bad ref FAILS"),
+        ("HTTP 403 b'{\"message\": \"Resource not accessible by integration\"}'", False,
+         "a permission denial FAILS — the one message that must not read as quota"),
+        ("HTTP 401 b'{\"message\": \"Bad credentials\"}'", False, "bad credentials FAIL"),
+    ]
+    for msg, want_defer, why in dispatch_cases:
+        seen = []
+        got = _defer("prov", msg, seen)
+        okmark = "ok " if (got == want_defer and bool(seen) == want_defer) else "BAD"
+        print(f"  {okmark} {why}")
+        if okmark == "BAD":
+            bad.append(why)
 
     if bad:
         print("\n::error::self-test FAILED: " + "; ".join(bad))


### PR DESCRIPTION
## What

A transient GitHub answer on the verification dispatch no longer fails the reconcile run. It
defers: warned, named, and left owed for the next run.

## Why — measured, not assumed

```
gh run list --workflow=pact-verification-reconcile.yml --limit 60
  failures: 11
```

Every one of the 11 is the same thing, on the dispatch POST:

```
::error::dispatch for openbank-account-service failed: HTTP 403
  b'{"message": "API rate limit exceeded for installation. ...'
```

The reconcile logic was **correct in all 11** — it derived the owed set, then could not POST. The
provider still owes the verification, the next scheduled run (~30 min) re-derives the same set from
the broker, and nothing in this repo needs changing. So the red was unactionable, and that is worse
here than ordinary noise: this workflow is one of the few things watching for a **stranded pact**
(the 5-hour, 33-of-40-auto-deploy-failures strand it was built for), so a failure nobody can act on
is how a real strand stops being visible.

This is the same treatment `--max-dispatch` already gives what it caps: *"NOT dispatched and still
owed: … they will be picked up next run"*.

## How

`gatelib.is_gh_transient(message)` — the **shared** vocabulary in `gh-transient-patterns.txt`, not a
fourth local copy of "is this transient". That file exists precisely because four copies of this
question drifted apart, and its load-bearing measured property is **zero over-retries** across 11
terminal messages, so a genuinely broken dispatch still reddens this run:

- missing `verify-provider.yml` (404), bad ref (422), `Resource not accessible by integration`
  (403 — the one message that must not read as quota), bad credentials (401).

## Verification — falsified in both directions

`--self-test` gained eight cases. Neither direction passes by accident:

| sabotage | result |
|---|---|
| classifier always `True` (defer everything) | rc=1, **4 BAD** — all four must-fail cases |
| classifier always `False` (defer nothing) | rc=1, **4 BAD** — all four must-defer cases |
| unmodified | rc=0, every branch ok |

That asymmetry is the test: a classifier that defers everything would make this workflow green
about a dispatch that can never succeed — a token without `actions: write` would then strand pacts
silently.

## Measured and deliberately NOT fixed here

Two other things appear in those logs and are **not** this change:

1. `openbank-admin-ui -> openbank-case-coordinator-agent: broker query failed: HTTP Error 400` —
   persistent, and it means that edge is never evaluated, so a strand on it would be invisible. It
   needs a broker-side measurement (which pacticipant/version the matrix is rejecting) that I cannot
   make from the repo; guessing at it would be the "comment asserting current remote state" trap.
   Worth its own issue.
2. `FAILED verification, not dispatching (a retry cannot fix a real break)` for seven edges,
   including `openbank-customer-edge -> openbank-incentive-service`. These are **correct** output:
   the script deliberately does not re-dispatch a verification that failed on its merits (#2549).
   They are real contract breaks and a separate matter from this workflow's exit code.

Refs #6853

🤖 Generated with [Claude Code](https://claude.com/claude-code)
