### PR TITLE
fix(admin-ui): paginate the full merchant catalogue (re-land #9425)

### DIFF
--- a/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/merchant-pagination-recovery.spec.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const merchant = (descriptorKey: string, cleanName: string) => ({
+  descriptorKey,
+  cleanName,
+  logoUrl: null,
+  logoContentHash: null,
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+})
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the current merchant page visible when its refresh is malformed', async ({ page }) => {
+  let malformed = false
+  await page.route('**/api/svc/transaction-service/api/v1/merchants/unmatched**', route => route.fulfill({ json: [] }))
+  await page.route('**/api/svc/transaction-service/api/v1/merchants?**', route => {
+    const requestedPage = new URL(route.request().url()).searchParams.get('page')
+    const row = requestedPage === '1' ? merchant('SECOND', 'Second merchant') : merchant('FIRST', 'First merchant')
+    if (malformed && requestedPage === '1') row.updatedAt = 'not-a-date'
+    return route.fulfill({ json: { data: [row], total: 51 } })
+  })
+
+  await page.goto('/merchants')
+  await expect(page.getByText('First merchant')).toBeVisible()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await expect(page.getByText('Second merchant')).toBeVisible()
+  await expect(page.getByText('Showing 51–51 of 51')).toBeVisible()
+
+  malformed = true
+  await page.getByRole('button', { name: 'Refresh the merchant catalogue' }).click()
+  await expect(page.getByText('Second merchant')).toBeVisible()
+  await expect(page.getByText(/Načtení selhalo|Failed to load/)).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/merchants/page.tsx
+++ b/openbank-admin-ui/src/app/merchants/page.tsx
@@ -22,28 +22,13 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui'
+import { parseMerchantCataloguePage, parseUnmatchedMerchantDescriptors, type MerchantCatalogueRow, type UnmatchedMerchantDescriptor } from '@/lib/merchants/merchantCatalogueContract'
 
 const SERVICE = 'transaction-service'
 const CATALOGUE = '/api/v1/merchants'
 
-type Merchant = {
-  descriptorKey: string
-  cleanName: string
-  /** Provenance — where the stored bitmap came from. NOT the URL a customer app is given. */
-  logoUrl?: string | null
-  /** Null exactly when no logo has been ingested, which is what "Upload" vs "Replace" turns on. */
-  logoContentHash?: string | null
-  /** What the coordinates on the CATALOGUE row can answer. CITY for every chain. */
-  geoPrecision?: string | null
-  category?: string | null
-  lat?: number | null
-  lon?: number | null
-  city?: string | null
-  country?: string | null
-  updatedAt?: string
-}
-
-type Unmatched = { descriptorKey: string; occurrences: number }
+type Merchant = MerchantCatalogueRow
+type Unmatched = UnmatchedMerchantDescriptor
 
 type MerchantLocation = {
   descriptorKey: string
@@ -87,12 +72,15 @@ type Draft = {
 type PendingRemoval = { kind: 'entry' | 'logo'; merchant: Merchant }
 
 const EMPTY_DRAFT: Draft = { descriptorKey: '', cleanName: '', category: '', city: '', country: '', lat: '', lon: '' }
+const PAGE_SIZE = 50
 
 export default function MerchantsPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [rows, setRows] = useState<Merchant[]>([])
   const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(0)
+  const loadedPage = useRef<number | null>(null)
   const [unmatched, setUnmatched] = useState<Unmatched[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
@@ -115,11 +103,15 @@ export default function MerchantsPage() {
   const removalTriggerRef = useRef<HTMLButtonElement | null>(null)
   const newEntryRef = useRef<HTMLButtonElement>(null)
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (requestedPage: number) => {
+    const canRetainSnapshot = loadedPage.current === requestedPage
     setLoading(true)
+    if (!canRetainSnapshot) { setRows([]); setTotal(0); loadedPage.current = null }
     try {
+      // Three requests, not the two this change was originally written against: `sourcesRes`
+      // arrived on main afterwards and is kept. Only the catalogue URL gains the page window.
       const [listRes, unmatchedRes, sourcesRes] = await Promise.all([
-        fetch(svcUrl(SERVICE, CATALOGUE, { size: '100' }), { cache: 'no-store' }),
+        fetch(svcUrl(SERVICE, CATALOGUE, { page: String(requestedPage), size: String(PAGE_SIZE) }), { cache: 'no-store' }),
         fetch(svcUrl(SERVICE, `${CATALOGUE}/unmatched`, { limit: '25' }), { cache: 'no-store' }),
         fetch(svcUrl(SERVICE, `${CATALOGUE}/logo-sources`), { cache: 'no-store' }),
       ])
@@ -127,12 +119,16 @@ export default function MerchantsPage() {
         setUnavailable({ kind: await classifyBffFailure(listRes) })
         return
       }
-      const page = await listRes.json() as { data?: Merchant[]; total?: number }
-      setRows(Array.isArray(page.data) ? page.data : [])
-      setTotal(typeof page.total === 'number' ? page.total : 0)
+      let nextPage
+      try { nextPage = parseMerchantCataloguePage(await listRes.json() as unknown, PAGE_SIZE) } catch { setUnavailable({ kind: 'error' }); return }
+      const lastPage = nextPage.total === 0 ? 0 : Math.floor((nextPage.total - 1) / PAGE_SIZE)
+      if (requestedPage > lastPage) { setPage(lastPage); return }
+      setRows(nextPage.data); setTotal(nextPage.total); loadedPage.current = requestedPage
       // The worklist failing must not blank the catalogue: they are separate reads, and a stale
       // or empty worklist is a smaller loss than losing the rows an operator is editing.
-      setUnmatched(unmatchedRes.ok ? (await unmatchedRes.json() as Unmatched[]) : [])
+      if (unmatchedRes.ok) {
+        try { setUnmatched(parseUnmatchedMerchantDescriptors(await unmatchedRes.json() as unknown)) } catch { /* independent worklist drift must not blank the catalogue */ }
+      }
       // A failed read is treated as "off", not as "unknown": offering an action that will certainly
       // be refused wastes the operator's time and teaches them to ignore errors.
       setLogoSources(sourcesRes.ok ? (await sourcesRes.json() as LogoSources) : { enabled: false, allowedHosts: [] })
@@ -144,7 +140,7 @@ export default function MerchantsPage() {
     }
   }, [])
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => { void load(page) }, [load, page])
 
   const save = async () => {
     if (!draft) return
@@ -171,7 +167,7 @@ export default function MerchantsPage() {
         return
       }
       setDraft(null)
-      await load()
+      await load(page)
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
     } finally {
@@ -189,7 +185,7 @@ export default function MerchantsPage() {
         setActionError(t('Smazání selhalo', 'Delete failed'))
         return false
       }
-      await load()
+      await load(page)
       return true
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
@@ -227,7 +223,7 @@ export default function MerchantsPage() {
         setActionError(body?.message ?? t('Nahrání loga selhalo', 'The logo upload failed'))
         return
       }
-      await load()
+      await load(page)
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
     } finally {
@@ -246,7 +242,7 @@ export default function MerchantsPage() {
         setActionError(t('Smazání loga selhalo', 'Deleting the logo failed'))
         return false
       }
-      await load()
+      await load(page)
       return true
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
@@ -362,7 +358,9 @@ export default function MerchantsPage() {
       }
       setFetchFor(null)
       setFetchUrl('')
-      await load()
+      // `load` takes the page to read since #9425; this call site arrived on main afterwards and
+      // reloads the page the operator is standing on, not page 0.
+      await load(page)
     } catch {
       setActionError(t('Služba je nedostupná', 'The service is unreachable'))
     } finally {
@@ -383,7 +381,7 @@ export default function MerchantsPage() {
         )}
         icon={<Store size={20} style={{ color: 'var(--accent)' }} />}
         actions={<button
-          onClick={load}
+          onClick={() => void load(page)}
           disabled={loading}
           type="button"
           aria-busy={loading}
@@ -406,7 +404,7 @@ export default function MerchantsPage() {
         dense={rows.length > 0}
       />}
 
-      {!unavailable && <>
+      {(!unavailable || rows.length > 0) && <>
         <section className="card" style={{ marginBottom: 18 }}>
           <h2 style={{ fontSize: 14, margin: '0 0 4px' }}>{t('Nespárované descriptory', 'Unmatched descriptors')}</h2>
           <p style={{ fontSize: 12, color: 'var(--text-tertiary)', margin: '0 0 10px' }}>
@@ -620,6 +618,15 @@ export default function MerchantsPage() {
               )}
             </tbody>
           </table>
+          <nav aria-label={t('Stránkování katalogu obchodníků', 'Merchant catalogue pagination')} style={{ padding: '12px 14px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+            <span aria-live="polite" style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>
+              {total === 0 ? t('Žádné záznamy', 'No entries') : t(`Zobrazeno ${page * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE + rows.length, total)} z ${total}`, `Showing ${page * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE + rows.length, total)} of ${total}`)}
+            </span>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" className="btn btn-secondary btn-sm" disabled={loading || unavailable !== null || page === 0} onClick={() => setPage(current => Math.max(0, current - 1))}>{t('Předchozí', 'Previous')}</button>
+              <button type="button" className="btn btn-secondary btn-sm" disabled={loading || unavailable !== null || (page + 1) * PAGE_SIZE >= total} onClick={() => setPage(current => current + 1)}>{t('Další', 'Next')}</button>
+            </div>
+          </nav>
         </div>
       </>}
       {pendingRemoval && <MerchantRemovalDialog

--- a/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
+++ b/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
@@ -15,7 +15,7 @@ export interface MerchantCatalogueRow {
   lon: number | null
   city: string | null
   country: string | null
-  updatedAt: string
+  updatedAt: string | null
 }
 
 export interface MerchantCataloguePage { data: MerchantCatalogueRow[]; total: number }
@@ -31,15 +31,22 @@ function requiredString(record: Record<string, unknown>, field: string): string 
   return value
 }
 
+/** Absent and explicitly null mean the same thing to this UI: render an em dash.
+ *
+ *  Treating `undefined` as invalid would reject rows a backend may legitimately send — the page
+ *  already writes `m.category ?? '—'` and guards `m.updatedAt ? … : '—'` — and a parser throw is
+ *  indistinguishable from an outage here, because `useServiceResource` catches it in the same
+ *  branch as a network failure (#9738). The fields this parser genuinely cannot do without are
+ *  `descriptorKey` and `cleanName`; everything else is validated only when present. */
 function nullableString(record: Record<string, unknown>, field: string): string | null {
   const value = record[field]
-  if (value === null) return null
+  if (value === null || value === undefined) return null
   return requiredString(record, field)
 }
 
 function nullableNumber(record: Record<string, unknown>, field: string): number | null {
   const value = record[field]
-  if (value === null) return null
+  if (value === null || value === undefined) return null
   if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid merchant ${field}`)
   return value
 }
@@ -48,13 +55,13 @@ function parseMerchant(value: unknown): MerchantCatalogueRow {
   if (!isRecord(value)) throw new Error('Invalid merchant row')
   const lat = nullableNumber(value, 'lat')
   const lon = nullableNumber(value, 'lon')
-  const updatedAt = requiredString(value, 'updatedAt')
+  const updatedAt = nullableString(value, 'updatedAt')
   if ((lat === null) !== (lon === null) || (lat !== null && (lat < -90 || lat > 90)) || (lon !== null && (lon < -180 || lon > 180))) throw new Error('Invalid merchant location')
-  if (Number.isNaN(Date.parse(updatedAt))) throw new Error('Invalid merchant updatedAt')
+  if (updatedAt !== null && Number.isNaN(Date.parse(updatedAt))) throw new Error('Invalid merchant updatedAt')
   return {
     descriptorKey: requiredString(value, 'descriptorKey'), cleanName: requiredString(value, 'cleanName'),
     logoUrl: nullableString(value, 'logoUrl'), logoContentHash: nullableString(value, 'logoContentHash'),
-    geoPrecision: value.geoPrecision === undefined ? null : nullableString(value, 'geoPrecision'),
+    geoPrecision: nullableString(value, 'geoPrecision'),
     category: nullableString(value, 'category'), lat, lon, city: nullableString(value, 'city'),
     country: nullableString(value, 'country'), updatedAt,
   }

--- a/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
+++ b/openbank-admin-ui/src/lib/merchants/merchantCatalogueContract.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface MerchantCatalogueRow {
+  descriptorKey: string
+  cleanName: string
+  logoUrl: string | null
+  logoContentHash: string | null
+  /** What the coordinates on this row can answer. Optional on the wire: a backend that does not
+   *  send it yet must not be rejected — the page already defaults it to CITY at the render site.
+   *  Demanding a field the server may legitimately omit is how a parser turns a working response
+   *  into a "service unavailable" screen. */
+  geoPrecision: string | null
+  category: string | null
+  lat: number | null
+  lon: number | null
+  city: string | null
+  country: string | null
+  updatedAt: string
+}
+
+export interface MerchantCataloguePage { data: MerchantCatalogueRow[]; total: number }
+export interface UnmatchedMerchantDescriptor { descriptorKey: string; occurrences: number }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, field: string): string {
+  const value = record[field]
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`Invalid merchant ${field}`)
+  return value
+}
+
+function nullableString(record: Record<string, unknown>, field: string): string | null {
+  const value = record[field]
+  if (value === null) return null
+  return requiredString(record, field)
+}
+
+function nullableNumber(record: Record<string, unknown>, field: string): number | null {
+  const value = record[field]
+  if (value === null) return null
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`Invalid merchant ${field}`)
+  return value
+}
+
+function parseMerchant(value: unknown): MerchantCatalogueRow {
+  if (!isRecord(value)) throw new Error('Invalid merchant row')
+  const lat = nullableNumber(value, 'lat')
+  const lon = nullableNumber(value, 'lon')
+  const updatedAt = requiredString(value, 'updatedAt')
+  if ((lat === null) !== (lon === null) || (lat !== null && (lat < -90 || lat > 90)) || (lon !== null && (lon < -180 || lon > 180))) throw new Error('Invalid merchant location')
+  if (Number.isNaN(Date.parse(updatedAt))) throw new Error('Invalid merchant updatedAt')
+  return {
+    descriptorKey: requiredString(value, 'descriptorKey'), cleanName: requiredString(value, 'cleanName'),
+    logoUrl: nullableString(value, 'logoUrl'), logoContentHash: nullableString(value, 'logoContentHash'),
+    geoPrecision: value.geoPrecision === undefined ? null : nullableString(value, 'geoPrecision'),
+    category: nullableString(value, 'category'), lat, lon, city: nullableString(value, 'city'),
+    country: nullableString(value, 'country'), updatedAt,
+  }
+}
+
+export function parseMerchantCataloguePage(raw: unknown, pageSize: number): MerchantCataloguePage {
+  if (!isRecord(raw) || !Array.isArray(raw.data) || typeof raw.total !== 'number' || !Number.isInteger(raw.total) || raw.total < 0) throw new Error('Invalid merchant page')
+  if (raw.data.length > pageSize || raw.data.length > raw.total) throw new Error('Invalid merchant page window')
+  return { data: raw.data.map(parseMerchant), total: raw.total }
+}
+
+export function parseUnmatchedMerchantDescriptors(raw: unknown): UnmatchedMerchantDescriptor[] {
+  if (!Array.isArray(raw)) throw new Error('Invalid unmatched merchant list')
+  return raw.map(value => {
+    if (!isRecord(value)) throw new Error('Invalid unmatched merchant')
+    const occurrences = value.occurrences
+    if (typeof occurrences !== 'number' || !Number.isInteger(occurrences) || occurrences <= 0) throw new Error('Invalid merchant occurrences')
+    return { descriptorKey: requiredString(value, 'descriptorKey'), occurrences }
+  })
+}

--- a/openbank-admin-ui/src/test/merchant-catalogue-contract.test.ts
+++ b/openbank-admin-ui/src/test/merchant-catalogue-contract.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { parseMerchantCataloguePage, parseUnmatchedMerchantDescriptors } from '@/lib/merchants/merchantCatalogueContract'
+
+const row = { descriptorKey: 'BILLA', cleanName: 'Billa', logoUrl: null, logoContentHash: null, category: 'GROCERIES', lat: 50.0755, lon: 14.4378, city: 'Praha', country: 'CZ', updatedAt: '2026-09-09T08:00:00Z' }
+
+describe('merchant catalogue response contract', () => {
+  it('preserves the complete catalogue page and worklist evidence', () => {
+    expect(parseMerchantCataloguePage({ data: [row], total: 51 }, 50)).toMatchObject({ total: 51, data: [{ descriptorKey: 'BILLA' }] })
+    expect(parseUnmatchedMerchantDescriptors([{ descriptorKey: 'ALZACZ', occurrences: 42 }])).toEqual([{ descriptorKey: 'ALZACZ', occurrences: 42 }])
+  })
+  it.each([[{ ...row, cleanName: '' }, 'cleanName'], [{ ...row, lon: null }, 'location'], [{ ...row, lat: 91 }, 'location'], [{ ...row, updatedAt: 'not-a-date' }, 'updatedAt']])('rejects malformed catalogue rows', (candidate, message) => {
+    expect(() => parseMerchantCataloguePage({ data: [candidate], total: 1 }, 50)).toThrow(message)
+  })
+  it('rejects impossible page windows and unmatched counts', () => {
+    expect(() => parseMerchantCataloguePage({ data: [row], total: 0 }, 50)).toThrow('window')
+    expect(() => parseUnmatchedMerchantDescriptors([{ descriptorKey: 'ALZACZ', occurrences: 0 }])).toThrow('occurrences')
+  })
+})

--- a/openbank-admin-ui/src/test/merchants-logo.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-logo.test.tsx
@@ -11,8 +11,20 @@ vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: 
 
 const HASH = 'a'.repeat(64)
 
-const withLogo = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: HASH }
-const withoutLogo = { descriptorKey: 'ALZACZ', cleanName: 'Alza.cz', logoContentHash: null }
+const merchant = (descriptorKey: string, cleanName: string, logoContentHash: string | null) => ({
+  descriptorKey,
+  cleanName,
+  logoUrl: null,
+  logoContentHash,
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+})
+const withLogo = merchant('BILLA', 'Billa', HASH)
+const withoutLogo = merchant('ALZACZ', 'Alza.cz', null)
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })

--- a/openbank-admin-ui/src/test/merchants-removal-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-removal-dialog.test.tsx
@@ -7,7 +7,18 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import MerchantsPage from '@/app/merchants/page'
 
-const merchant = { descriptorKey: 'BILLA', cleanName: 'Billa', logoContentHash: 'a'.repeat(64) }
+const merchant = {
+  descriptorKey: 'BILLA',
+  cleanName: 'Billa',
+  logoUrl: null,
+  logoContentHash: 'a'.repeat(64),
+  category: null,
+  lat: null,
+  lon: null,
+  city: null,
+  country: null,
+  updatedAt: '2026-09-09T08:00:00Z',
+}
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
 
 function renderPage(write: () => Response = () => json({}, 204)) {

--- a/openbank-admin-ui/src/test/merchants-worklist.test.tsx
+++ b/openbank-admin-ui/src/test/merchants-worklist.test.tsx
@@ -3,14 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import React from 'react'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import MerchantsPage from '@/app/merchants/page'
 
 vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
 
 const catalogue = {
-  data: [{ descriptorKey: 'BILLA', cleanName: 'Billa', category: 'GROCERIES', city: 'Praha', country: 'CZ' }],
+  data: [{ descriptorKey: 'BILLA', cleanName: 'Billa', logoUrl: null, logoContentHash: null, category: 'GROCERIES', lat: null, lon: null, city: 'Praha', country: 'CZ', updatedAt: '2026-09-09T08:00:00Z' }],
   total: 1,
 }
 const worklist = [
@@ -63,5 +63,24 @@ describe('merchant catalogue worklist', () => {
     render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
 
     await waitFor(() => expect(screen.queryByText('Billa')).not.toBeInTheDocument())
+  })
+
+  it('makes every backend page reachable and reports the visible range', async () => {
+    const first = { ...catalogue.data[0], descriptorKey: 'FIRST', cleanName: 'First merchant' }
+    const second = { ...catalogue.data[0], descriptorKey: 'SECOND', cleanName: 'Second merchant' }
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (String(url).includes('/unmatched')) return Promise.resolve(json([]))
+      const isSecondPage = String(url).includes('page=1')
+      return Promise.resolve(json({ data: [isSecondPage ? second : first], total: 51 }))
+    }))
+
+    render(React.createElement(LanguageProvider, null, React.createElement(MerchantsPage)))
+
+    await screen.findByText('First merchant')
+    expect(screen.getByText('Showing 1–1 of 51')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await screen.findByText('Second merchant')
+    expect(screen.getByText('Showing 51–51 of 51')).toBeInTheDocument()
+    expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).includes('page=1&size=50'))).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #9416. Refs #9713.

## Why it was still missing

#9425 reads `MERGED` and its content never reached `main` — it merged into
`security/admin-ui-sharp-0.35.4`, a branch that was squash-merged away. Three of its four siblings
were later redone by hand; **this one nobody redid**, so `main` still has:

```
merchants/page.tsx:122   fetch(svcUrl(SERVICE, CATALOGUE, { size: '100' }))
merchants/page.tsx:497   renders "Katalog … ({total})"
grep -cE "setPage|hasMore|page="   ->  0
```

First 100 rows, the backend's full `total` printed beside them, and no way to reach the rest. The UI
states a number it is not showing.

## This is authored, not replayed

`f7a088ac1` does **not** cherry-pick clean — three conflicting hunks. `main` gained three things
after it, and all three are kept:

| gained on main | kept how |
|---|---|
| #9115's `geoPrecision` + its `PrecisionBadge` render site | moved into the contract type |
| a **third** request (`logoSources`) and its *"a failed read is off, not unknown"* semantics | `Promise.all` keeps all three; only the catalogue URL gains the page window |
| #9477's focus restore | untouched |

The unmatched worklist is now parsed rather than cast, while `logoSources` keeps main's behaviour
verbatim.

**`geoPrecision` is parsed as optional — absent becomes `null`.** The page renders
`m.geoPrecision ?? 'CITY'`, so a backend that does not send it yet is legitimate. A parser that
demanded it would turn a working response into a service-unavailable screen, which is exactly the
failure shape filed as #9738.

One call site needed adapting rather than merging: `load()` takes a page since #9425, and main's
later logo-fetch flow calls it bare. It now reloads the page the operator is standing on, not page 0.

## Verification

```
tsc --noEmit          finding set IDENTICAL to origin/main (20 pre-existing on both sides)
vitest                4 files, 20 tests passed
playwright            e2e/merchant-pagination-recovery.spec.ts  1 passed
```

And falsified rather than trusted — replacing `parseMerchantCataloguePage` with a raw cast:

```
1 failed
```

so the spec detects the absence of what it tests.

## Note on how this class of loss is found

Not by `state: MERGED`, which was true throughout. Only by content —
`git cat-file -e origin/main:<file>` for a file the PR adds, and `git log -1 -- <file>` to see which
commit actually put it there. That second command is what separates "landed" from "someone quietly
did it again".
