### PR TITLE
fix(admin-ui): accept UUIDv7 in the six strict evidence parsers

### DIFF
--- a/openbank-admin-ui/src/lib/cards/clientContract.ts
+++ b/openbank-admin-ui/src/lib/cards/clientContract.ts
@@ -3,7 +3,7 @@
 import { CARD_NETWORKS, CARD_TYPES, type AccountRef, type Card, type CardEntitlements, type PartyRef } from './types'
 import { CARD_STATUSES } from './lifecycle'
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const CURRENCY = /^[A-Z]{3}$/
 const LOCAL_DATE = /^\d{4}-\d{2}-\d{2}$/
 const DISPLAY_EXPIRY = /^(0[1-9]|1[0-2])\/\d{2}$/

--- a/openbank-admin-ui/src/lib/closings/evidence.ts
+++ b/openbank-admin-ui/src/lib/closings/evidence.ts
@@ -57,7 +57,7 @@ const MAX_ROWS = 1_000
 const isText = (value: unknown, maxLength = 5_000): value is string =>
   typeof value === 'string' && value.trim().length > 0 && value.length <= maxLength
 const isUuid = (value: unknown): value is string => isText(value)
-  && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
 const isCurrency = (value: unknown): value is string => isText(value) && /^[A-Z]{3}$/.test(value)
 const isDate = (value: unknown): value is string => isText(value) && ISO_DATE.test(value)
   && new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value

--- a/openbank-admin-ui/src/lib/payments/detailEvidence.ts
+++ b/openbank-admin-ui/src/lib/payments/detailEvidence.ts
@@ -36,7 +36,7 @@ export interface PaymentDetailEvidence {
   updatedAt?: string
 }
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const CURRENCY = /^[A-Z]{3}$/
 const SEPA_STATUSES = new Set(['RECEIVED', 'VALIDATED', 'PROCESSING', 'COMPLETED', 'REJECTED', 'RETURNED', 'CANCELLED'])
 const DOMESTIC_STATUSES = new Set(['RECEIVED', 'VALIDATED', 'SENT_TO_CLEARING', 'SETTLED', 'REJECTED', 'RETURNED', 'CANCELLED'])

--- a/openbank-admin-ui/src/lib/sdd/sddMandateContract.ts
+++ b/openbank-admin-ui/src/lib/sdd/sddMandateContract.ts
@@ -30,7 +30,7 @@ export interface SddMandate {
 const SCHEMES = new Set<string>(SDD_SCHEMES)
 const SEQUENCES = new Set<string>(SDD_SEQUENCE_TYPES)
 const STATUSES = new Set<string>(SDD_MANDATE_STATUSES)
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const IBAN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$/
 const CREDITOR_ID = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,31}$/
 const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/

--- a/openbank-admin-ui/src/lib/security/summary.ts
+++ b/openbank-admin-ui/src/lib/security/summary.ts
@@ -66,7 +66,7 @@ export type SecurityEnvelope =
   | { available: true; report: PlatformSecurityReport }
   | { available: false; reason: 'not_deployed' | 'unreachable' | 'error' | 'unauthorized'; detail?: string }
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
 const SERVICE_NAME = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
 

--- a/openbank-admin-ui/src/lib/swift/swiftMessageContract.ts
+++ b/openbank-admin-ui/src/lib/swift/swiftMessageContract.ts
@@ -24,7 +24,7 @@ export type SwiftLifecycleGroup = 'in_flight' | 'confirmed' | 'exception'
 
 const MESSAGE_TYPES = new Set<string>(SWIFT_MESSAGE_TYPES)
 const STATUSES = new Set<string>(SWIFT_STATUSES)
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const BIC = /^[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?$/
 const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
 

--- a/openbank-admin-ui/src/test/uuid-version-class.guard.test.ts
+++ b/openbank-admin-ui/src/test/uuid-version-class.guard.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { globSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `Ids.newId()` in openbank-libs-domain returns a **UUIDv7** and is documented as "the default for
+ * durable, indexed identifiers" (ADR-0106 also prefers Postgres 18's `uuidv7()` server-side). A
+ * parser whose version class stops at 5 therefore rejects the fleet's own primary keys.
+ *
+ * That failure is invisible in the worst way: `useServiceResource` catches a parser throw in the
+ * same `catch` as a network error, retries, and renders "the service is not responding". An
+ * operator opens an incident against a healthy service (#9738).
+ *
+ * This guard reads the SOURCE rather than calling each parser, on purpose — the point is to catch
+ * the SEVENTH copy of the regex someone adds next, which no per-parser test would cover.
+ */
+const SOURCES = globSync('src/lib/**/*.ts', { cwd: process.cwd() })
+
+describe('UUID version class across evidence parsers', () => {
+  it('finds the parsers it is meant to guard (a zero-file glob would pass vacuously)', () => {
+    expect(SOURCES.length).toBeGreaterThan(20)
+  })
+
+  it('no parser restricts the UUID version class to 1-5 — that rejects UUIDv7', () => {
+    const offenders = SOURCES.filter(f => /\[1-5\]\[0-9a-f\]\{3\}-\[89ab\]/.test(readFileSync(f, 'utf8')))
+    expect(offenders).toEqual([])
+  })
+
+  it('the version-class regex that IS used accepts v1, v4, v7 and v8 and still rejects placeholders', () => {
+    const re = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    expect(re.test('3f2504e0-4f89-11d3-9a0c-0305e82c3301')).toBe(true)   // v1
+    expect(re.test('24977cca-20b2-4877-80d1-403b40181a89')).toBe(true)   // v4
+    expect(re.test('019fb944-6c3a-7bd2-814d-7c946371f1ae')).toBe(true)   // v7 — Ids.newId()
+    expect(re.test('019fb944-6c3a-8bd2-814d-7c946371f1ae')).toBe(true)   // v8 — RFC 9562
+    expect(re.test('11111111-1111-1111-1111-111111111111')).toBe(false)  // placeholder: bad variant
+    expect(re.test('00000000-0000-0000-0000-000000000000')).toBe(false)  // nil
+    expect(re.test('019fb944-6c3a-7bd2-014d-7c946371f1ae')).toBe(false)  // variant nibble 0
+  })
+})


### PR DESCRIPTION
Closes #9738.

## The defect

Six parsers under `src/lib` validated identifiers with a version class of `[1-5]`:

```
cards/clientContract   closings/evidence   payments/detailEvidence
sdd/sddMandateContract security/summary    swift/swiftMessageContract
```

UUIDv7 has version nibble **7**, so all six reject it — and v7 is what this fleet mints:

> `Ids.kt:46  /** A fresh time-ordered UUIDv7 — the default for durable, indexed identifiers. */`
> `Ids.kt:24  "server-side, prefer PostgreSQL 18's built-in DEFAULT uuidv7() (ADR-0106 Tier 1)"`

The class is now `[1-8]` — every version RFC 9562 defines. **The variant class `[89ab]` is
untouched**: that is the half doing the real work, and it is what rejects a repeated-digit
placeholder.

| input | `[1-5]` | `[1-8]` | want |
|---|---|---|---|
| v1 `3f2504e0-4f89-11d3-…` | ✓ | ✓ | ✓ |
| v4 `24977cca-20b2-4877-…` | ✓ | ✓ | ✓ |
| **v7 `019fb944-6c3a-7bd2-…`** | **✗** | ✓ | ✓ |
| v8 `019fb944-6c3a-8bd2-…` | ✗ | ✓ | ✓ |
| `11111111-1111-1111-…` | ✗ | ✗ | ✗ |
| nil uuid | ✗ | ✗ | ✗ |
| variant nibble `0` | ✗ | ✗ | ✗ |

## Why this is worse than a validation bug

`useServiceResource` catches a parser throw in the **same `catch` as a network failure**, retries
three times, then renders *"the service is deployed but did not answer"*. Nothing says an identifier
was rejected, so a healthy service reads as an outage. Measured on the card page earlier today: a
mocked `200` answered three times while the screen reported the service unreachable.

Four of the six are compliance or money surfaces — payments detail, SDD mandates, SWIFT messages,
security summary.

## The guard reads the source, deliberately

The failure worth preventing is **the seventh copy of the regex** someone adds next, which no
per-parser test would cover. So `uuid-version-class.guard.test.ts` scans `src/lib/**/*.ts` for the
`[1-5]` shape — and asserts its own glob is non-empty first, because a zero-file scan would pass
vacuously.

## Verification, both directions

```
guard on the fixed tree                          3 assertions pass
revert ONE file to [1-5]                         guard fails and NAMES it:
                                                 + "src/lib/swift/swiftMessageContract.ts"
the six parsers' own suites                      4 files, 39 tests pass
full admin-ui suite (npm test, pretest baked)    548 files, 2924 passed, 1 skipped
```

## What this does NOT establish

Whether any of those six screens is failing in a live environment **today**. That depends on whether
the entities they read were minted through `Ids.newId()` (v7) or `randomId()` (v4, which always
passed) — a per-entity-type database read, which I cannot do from here. The fix removes the trap
either way; it does not prove the trap had been sprung.
