### PR TITLE
fix(governance): card-issuance inherits T0, its T1 declaration rests on an expired premise

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2493,12 +2493,17 @@ finops_tiers:
   # t0_baseline and need no explicit entry.
   declared:
     openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
-    # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
-    # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
-    # is declarable on the evidence of the live scaled object + classifier-measured idle —
-    # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
-    # the same hold product-catalog carries below.
-    openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+    # card-issuance was declared T1 here on 2026-07-29 (ADR-0173 D3) on the stated premise
+    # "Not money-path". That premise expired: ADR-0283 phase 0 (#8808) added
+    # openbank-card-issuance-service to money_path_services, because it ships the card
+    # AUTHORISATION decision. A money-path service inherits T0 from t0_baseline and needs no
+    # entry, so the declaration is removed rather than rewritten to T0.
+    #
+    # Nothing about the running workload changes, and that is the point: the live
+    # HTTPScaledObject payments/card-issuance-http is min:1 / max:3 and the Deployment is 1/1,
+    # i.e. it already never scales to zero — the T0 mechanism, not T1's. All three sources
+    # agreed on always-on; only this line said otherwise, and it was the one producing
+    # `check-finops-tiers` POLICY FINDING "money-path service declared 'T1' (below T0)".
     # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
     # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
     # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:


### PR DESCRIPTION
## Summary

`openbank-card-issuance-service` is declared `T1` in `rules.yaml` on a premise that has since
expired, and that one line is the live `check-finops-tiers` policy finding. Removing it lets the
service inherit `T0` from `t0_baseline`, which is what both the money-path list and the running
workload already say.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #8799

## The stale premise

The declaration carries its own reasoning, and it is explicit about why it was allowed:

> ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject with an
> `openbank.io/finops-tier: T1` label and was missing here. **Not money-path**, so T1 is declarable…

That was true when written. **ADR-0283 phase 0 (#8808) then added `openbank-card-issuance-service`
to `money_path_services`** — it ships the card authorisation decision. Nothing re-checked the
declaration against the list it depends on, so the two have contradicted each other since.

`check-finops-tiers` says so on every run:

```
⚠️ openbank-card-issuance-service: money-path service declared 'T1' (below T0). Demoting a
   money-path service requires an ADR-0030 threat model + 2 approvals — it must not be set here.
```

## Nothing about the running workload changes

Measured against the sandbox cluster before choosing the direction:

```
NAME                 SCALETARGETREF                          MIN  MAX
card-issuance-http   apps/v1/Deployment/card-issuance-service  1    3
deployment.apps/card-issuance-service                        1/1
```

`min:1` — it already never scales to zero. That is `T0`'s mechanism (*"minReplicas >= 1 … never
scales to zero"*), not `T1`'s (*"scale from/to zero on inbound HTTP"*). So all three sources agreed
on always-on behaviour and only the `declared:` line said otherwise.

Removed rather than rewritten to `T0`, because `rules.yaml` says so in the block above it:

> Money-path services inherit T0 via `t0_baseline` and need no explicit entry.

## Why this matters beyond the warning

It is the blocker behind #8799. That PR registers `finops-tier-drift` as an enforced gate, and the
`advisory-gate-registration` gate then asks for `finops_tiers.enforced: enforce`. Flipping it today
would make this finding **blocking** and red-gate `main` — over a contradiction, not a real
demotion. With the contradiction gone, the flip is a decision about policy rather than a way to
break the build.

I am not making that flip here; this PR only removes the false declaration.

## Verification

- `check-finops-tiers.py` before: one POLICY FINDING. After: `OK — no declared-side findings`,
  exit 0.
- `run-gates.py --all`, differenced against the same command on bare `origin/main`: **zero new
  findings**.
- `regen-derived.sh` leaves the tree clean — `finops_tiers` is not in the OPA read set, so no bundle
  restamps.

**One consequence worth stating:** the declared count drops 3 → 2, which is exactly #8799's proposed
`min_subjects: 2`. That floor was sized as *"3 declared observed 2026-09-05; 2 lets one service be
demoted, a wipe cannot pass"* — so this is precisely the one removal it was built to tolerate, and
the next one would breach it. That is the floor working, but whoever lands #8799 should know the
slack is now spent.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

One governance declaration removed; no code, no API, no DB, no event. The reasoning and the cluster
measurement are recorded in `rules.yaml` in place of the removed comment, so the next reader sees why
the entry is absent rather than wondering whether it was lost.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? → not changed.
- [x] PII path changed? → not changed.
- [x] Cardholder data path changed? → not changed.

This *raises* a money-path service's availability floor on paper to match what it already runs; it
weakens nothing. `openbank-card-issuance-service` stays in `money_path_services` and keeps every
control that list carries.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
