### PR TITLE
fix(incentive): answer 404 for an offer that does not exist, before any conflict check

### DIFF
--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -320,6 +320,23 @@ class PanacheIncentiveStore(
 
     override suspend fun reserve(command: ReserveIncentive): PromoReservation = Panache.withTransaction {
         lockedOffer(command.offerId).flatMap { offerEntity ->
+            // EXISTENCE before CONFLICT. An offer this service does not hold is a 404 whatever else
+            // is true of the request, and until this line the only null-check on `offerEntity` was
+            // inside `redeemableOffer` below — three steps and one conflict check later. So a POST
+            // naming a nonexistent offer whose `attributionRef` had already been reserved answered
+            // **409** from `existingAttribution`, and the 404 branch was unreachable for it.
+            //
+            // Measured on the live broker: customer-edge's *POST an attributed customer reservation
+            // for an offer the bank does not hold* expects 404 and got
+            // `{"attribute":"status","description":"expected status of 404 but was 409"}`, which
+            // classified customer-edge as a contract REGRESSION and failed every auto-deploy run —
+            // fail-closed on one service, so the whole fleet's deploy stopped (issue #9794).
+            //
+            // Deliberately NOT hoisting all of `redeemableOffer`: it also raises IncentiveConflict
+            // for an offer that exists but is not currently redeemable, and that check must stay
+            // AFTER the idempotency replay below, or replaying a reservation made while the offer
+            // was open would start answering 409 once the offer closed.
+            if (offerEntity == null) throw IncentiveNotFound("offer not found")
             reservations.find("offerId = ?1 and idempotencyKey = ?2", command.offerId, command.idempotencyKey)
                 .firstResult<ReservationEntity>().flatMap { replay ->
                     if (replay != null) {

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -218,6 +218,32 @@ class IncentiveRestContractIT {
             body("$", not(hasKey("idempotencyKey")))
             body("$", not(hasKey("codeDigest")))
         } Extract { path<String>("id") }
+        // An offer this service does not hold is a 404, even when the request's attributionRef has
+        // already been reserved (it has, one call above). The conflict check used to run first, so
+        // this answered 409 and the 404 branch was unreachable — which broke customer-edge's
+        // *POST an attributed customer reservation for an offer the bank does not hold* pact and,
+        // because can-i-deploy fails closed on one contract regression, every auto-deploy run
+        // (issue #9794). Asserted HERE rather than as its own @Test so the already-reserved
+        // attribution is real state rather than a fixture: with the fix reverted this line is the
+        // one that goes red.
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            header("Idempotency-Key", "customer-claim-missing-offer")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef"
+                }
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/customer-incentives/offers/${java.util.UUID.randomUUID()}/reservations")
+        } Then {
+            statusCode(404)
+        }
+
         assertThat(string("select party_ref from promo_reservation where id = '$attributedId'"))
             .isEqualTo(customerParty.toString())
         assertThat(string("select attribution_ref::text from promo_reservation where id = '$attributedId'"))


### PR DESCRIPTION
## Summary

`IncentivePersistence.reserve` resolved the offer but never null-checked it — the only check was
inside `redeemableOffer`, three steps and one conflict throw later:

```kotlin
lockedOffer(command.offerId).flatMap { offerEntity ->      // may be null — not checked
  reservations.find(...idempotencyKey...).flatMap { replay ->
    ...
    existingAttribution(command.attributionRef).flatMap { attributed ->
      if (attributed != null) throw IncentiveConflict("attribution was already reserved")  // 409 here
      val offer = redeemableOffer(offerEntity, command)     // 404 only here
```

So a POST naming a nonexistent offer answers **409** whenever its `attributionRef` has already been
reserved, and the 404 branch is unreachable for exactly that request.

## Why it mattered beyond this service

It broke customer-edge's pact interaction *POST an attributed customer reservation for an offer the
bank does not hold*. Measured on the live broker (customer-edge `7e92be54b`, verified
2026-09-12T07:05:31Z against incentive `0e2e534a1`):

```
{"attribute": "status", "description": "expected status of 404 but was 409"}
```

`can-i-deploy` fails closed on a single contract REGRESSION, so this failed **every** `auto-deploy`
run — one service's ordering bug stopped the whole fleet's deploys, and nothing had reached sandbox
since. That in turn kept four money-path services blocked, because their stale verification records
can only clear once a fixed provider version is actually deployed.

## Why the ordering, not the missing state

The interaction declares **no provider state**, which is what let it depend on the sibling
interaction's reserved attribution at all — the shape `TransactionPactStateCoverageTest` exists for
in transaction-service. Fixing the ordering is the better answer: an offer this service does not hold
is a 404 whatever else is true of the request, so the result no longer depends on sibling state.

`redeemableOffer` is deliberately **not** hoisted wholesale. It also raises `IncentiveConflict` for an
offer that exists but is not currently redeemable, and that check must stay after the idempotency
replay — otherwise replaying a reservation made while the offer was open would start answering 409
once the offer closed.

## Falsified, not just green

- [x] With the one-line check removed: `IncentiveRestContractIT.published inventory reserves once
      under concurrency then releases commits and expires` **FAILS** (`BUILD FAILED`).
- [x] With it restored: **BUILD SUCCESSFUL**.
- [x] `ktlintCheck` + `detekt` for the service: green.

The assertion lives inside that scenario rather than as its own `@Test` on purpose — there the
already-reserved attribution is real state produced by the preceding call, not a fixture, so the test
exercises the exact condition that made 409 win.

## Follow-up, not bundled

Nothing flags a pact interaction that declares no provider state. transaction-service grew a
service-local test after its own incident; the blind spot is fleet-wide, and it is what turns an
ordering bug into a cross-service deploy outage. It needs a baseline pass over the committed pacts,
so it belongs in its own change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — one null-check and a test.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`. — none added.
- [x] No new third-party dependency. — no build files touched.
- [x] Auth / crypto / payment code changed? — no. This is a resource-existence check; it makes a
      *nonexistent* offer answer 404 instead of 409 and changes no authorization decision. Note it
      does not leak existence either way round — both responses are errors to the same caller, and
      the endpoint already requires `ROLE_API` plus a trusted party header.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

Closes #9794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
