### PR TITLE
fix(infra): one owning component per gitops resource

### DIFF
--- a/.github/scripts/check-gitops-duplicate-resources.py
+++ b/.github/scripts/check-gitops-duplicate-resources.py
@@ -32,6 +32,19 @@ Two rules, both within a single file:
      `OPENBANK_NAMESPACES` is the live instance; the rule is general because the
      next such list will not be called that.
 
+  3. No (kind, name, namespace) declared by two different directories under
+     `gitops/components/`. Rules 1 and 2 are deliberately one file at a time —
+     across files a redefinition is usually an overlay, and legitimate. Under
+     `components/` it is not: one directory is one ArgoCD Application, so two
+     directories claiming one resource put it in two desired states. ArgoCD
+     tracks it for whichever got there first and answers SharedResourceWarning
+     on the other, which then reports OutOfSync forever. That was live for
+     `ExternalSecret platform/kafka-cluster-ca-truststore`, declared identically
+     by `agent` (#696) and `case-coordinator` (#4236): case-coordinator had been
+     permanently OutOfSync, so its drift signal said nothing about drift. The
+     copies were identical, which is the quiet half — nothing is wrong until the
+     day they differ, and then the sync order decides which one the cluster gets.
+
 Usage:
     check-gitops-duplicate-resources.py             # warn
     check-gitops-duplicate-resources.py --enforce   # fail
@@ -120,6 +133,61 @@ def check_file(path: pathlib.Path) -> list[str]:
     return problems
 
 
+
+COMPONENTS_ROOT = "openbank-infra/gitops/components"
+
+
+def _component_identities(components_root: pathlib.Path) -> dict:
+    """Map (kind, name, namespace) -> set of component directory names that declare it."""
+    owners: dict = collections.defaultdict(set)
+    if not components_root.is_dir():
+        return owners
+    for component in sorted(p for p in components_root.iterdir() if p.is_dir()):
+        for path in sorted(component.rglob("*.yaml")):
+            try:
+                docs = gatelib.load_yaml_all(path)
+            except yaml.YAMLError:
+                continue  # rule 1 reports an unparseable file; do not report it twice
+            for doc in docs:
+                if not isinstance(doc, dict):
+                    continue
+                meta = doc.get("metadata") or {}
+                if not isinstance(meta, dict):
+                    continue
+                kind, name = doc.get("kind"), meta.get("name")
+                if not kind or not name:
+                    continue
+                owners[(kind, name, meta.get("namespace"))].add(component.name)
+    return owners
+
+
+def check_components(components_root: pathlib.Path) -> list[str]:
+    """One resource, one owning component — see rule 3 in the module docstring."""
+    problems: list[str] = []
+    for identity, components in sorted(_component_identities(components_root).items()):
+        if len(components) < 2:
+            continue
+        kind, name, ns = identity
+        where = f" in namespace {ns}" if ns else " (cluster-scoped)"
+        listed = ", ".join(sorted(components))
+        problems.append(
+            f"{components_root}: {kind}/{name}{where} is declared by {len(components)} "
+            f"components ({listed}). Each is its own ArgoCD Application, so the resource "
+            f"is in two desired states: ArgoCD tracks it for one and reports "
+            f"SharedResourceWarning + a permanent OutOfSync on the other. Declare it in "
+            f"one component; the others consume it by name."
+        )
+    return problems
+
+
+SELF_TEST_SHARED_RESOURCE = """\
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: probe-truststore
+  namespace: probe-ns
+"""
+
 SELF_TEST_DUPLICATE_DOC = """\
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -175,11 +243,56 @@ spec:
 """
 
 
+SELF_TEST_COMPONENT_TREES = {
+    # Two components declaring one resource into one namespace: the live shape of
+    # ExternalSecret platform/kafka-cluster-ca-truststore before #9799.
+    "shared across components": (
+        {
+            "alpha/secret.yaml": SELF_TEST_SHARED_RESOURCE,
+            "beta/secret.yaml": SELF_TEST_SHARED_RESOURCE,
+        },
+        True,
+    ),
+    # One component declaring it once: the shape this gate must leave alone.
+    "single owner": ({"alpha/secret.yaml": SELF_TEST_SHARED_RESOURCE}, False),
+    # Same kind and name, different namespace, different components: legitimate —
+    # every service declares its own `ExternalSecret/oidc` in its own namespace.
+    "same name, different namespaces": (
+        {
+            "alpha/secret.yaml": SELF_TEST_SHARED_RESOURCE,
+            "beta/secret.yaml": SELF_TEST_SHARED_RESOURCE.replace(
+                "namespace: probe-ns", "namespace: other-ns"
+            ),
+        },
+        False,
+    ),
+}
+
+
+def _self_test_components() -> int:
+    failures = 0
+    for label, (tree, must_flag) in SELF_TEST_COMPONENT_TREES.items():
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            for rel, content in tree.items():
+                target = root / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content, encoding="utf-8")
+            flagged = bool(check_components(root))
+            ok = flagged == must_flag
+            print(f"  [{'ok' if ok else 'FAIL'}] cross-component {label}: "
+                  f"flagged={flagged}, expected={must_flag}")
+            if not ok:
+                failures += 1
+    return failures
+
+
 def self_test() -> int:
     """Each case is one the check MUST get right, including the ones it must NOT flag.
 
-    The clean case matters as much as the dirty ones: the same (kind, name) in two
-    DIFFERENT namespaces is normal, and so is a non-repeating list.
+    The clean cases matter as much as the dirty ones: the same (kind, name) in two
+    DIFFERENT namespaces is normal, so is a non-repeating list, and so is a resource
+    declared exactly once by one component.
     """
     cases = [
         ("duplicate document", SELF_TEST_DUPLICATE_DOC, True),
@@ -196,6 +309,7 @@ def self_test() -> int:
             print(f"  [{'ok' if ok else 'FAIL'}] {label}: flagged={flagged}, expected={must_flag}")
             if not ok:
                 failures += 1
+    failures += _self_test_components()
     if failures:
         print(f"\nself-test: {failures} case(s) wrong — the check does not measure what it claims.")
         return 1
@@ -219,10 +333,15 @@ def main() -> int:
             checked += 1
             problems.extend(check_file(path))
 
+    problems.extend(check_components(pathlib.Path(COMPONENTS_ROOT)))
+
     gatelib.subjects(checked, "gitops manifests")
 
     if not problems:
-        print(f"check-gitops-duplicate-resources: OK — {checked} manifests, no duplicate resource or list entry")
+        print(
+            f"check-gitops-duplicate-resources: OK — {checked} manifests, no duplicate resource "
+            f"or list entry, and no resource declared by two components"
+        )
         return 0
 
     level = "error" if args.enforce else "warning"

--- a/openbank-infra/gitops/components/case-coordinator/kafka-case-coordinator-mtls.yaml
+++ b/openbank-infra/gitops/components/case-coordinator/kafka-case-coordinator-mtls.yaml
@@ -57,23 +57,14 @@ spec:
     - extract:
         key: case-coordinator
 ---
-# ── ExternalSecret: cluster CA truststore ───────────────────────────────────
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-  name: kafka-cluster-ca-truststore
-  namespace: platform
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: kafka-messaging-certs
-  target:
-    name: kafka-cluster-ca-truststore
-    creationPolicy: Owner
-    deletionPolicy: Retain
-  dataFrom:
-    - extract:
-        key: openbank-cluster-cluster-ca-cert
+# The cluster CA truststore Secret lives in namespace `platform` and is declared ONCE,
+# by the `agent` component (agent/kafka-agent-mtls.yaml, #696). It is not repeated here.
+#
+# It used to be: this file carried a byte-identical copy (#4236), so ExternalSecret
+# platform/kafka-cluster-ca-truststore was in the desired state of TWO Applications.
+# ArgoCD tracked it for `agent` and answered `SharedResourceWarning` on
+# `case-coordinator`, which therefore reported OutOfSync permanently — a real drift
+# signal spent on a copy that was never going to differ. Both Applications sync into
+# `platform`, so whichever ran last would have won silently had they ever diverged.
+#
+# case-coordinator-service consumes the Secret by name; it does not need to declare it.


### PR DESCRIPTION
## What

`ExternalSecret platform/kafka-cluster-ca-truststore` was declared **twice**, byte-identically, by two different components:

- `agent/kafka-agent-mtls.yaml` — #696, 2026-07-09
- `case-coordinator/kafka-case-coordinator-mtls.yaml` — #4236

Each `gitops/components/<dir>` is its own ArgoCD Application, so one resource sat in two desired states. Live:

```
$ kubectl -n argocd get applications -o json | … conditions
case-coordinator SharedResourceWarning ExternalSecret/kafka-cluster-ca-truststore
                 is part of applications argocd/case-coordinator and agent

$ kubectl -n platform get externalsecret kafka-cluster-ca-truststore \
    -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/tracking-id}'
agent:external-secrets.io/ExternalSecret:platform/kafka-cluster-ca-truststore
```

ArgoCD tracks it for `agent`, so `case-coordinator` has been **permanently OutOfSync** — one of three non-green Applications in the sandbox, and the one whose drift signal could never mean anything.

Dropped the copy. `agent` keeps the single declaration; `case-coordinator-service` consumes the Secret by name and never needed to declare it. A comment in its place says where the declaration lives, so the next person does not re-add it.

## Why it also gets a gate

The copies were identical, which is the quiet half of this: nothing is wrong until the day they differ, and then whichever Application syncs last wins, silently.

`check-gitops-duplicate-resources` already existed but is scoped to one file at a time, on purpose — across files a redefinition is usually a legitimate overlay. That reasoning does not hold under `components/`, where one directory is one Application. Rule 3 adds exactly that case.

Scanning the whole tree finds **one** collision — this one — so the rule enforces immediately, with no baseline to erode.

## Verified by effect, both polarities

Self-test (the negatives matter as much: a gate that flags the legitimate shape would fire on every service's own `ExternalSecret/oidc`):

```
  [ok] cross-component shared across components: flagged=True, expected=True
  [ok] cross-component single owner: flagged=False, expected=False
  [ok] cross-component same name, different namespaces: flagged=False, expected=False
```

And against the real tree rather than fixtures — duplicate restored, then removed:

```
::error::… ExternalSecret/kafka-cluster-ca-truststore in namespace platform is declared
by 2 components (agent, case-coordinator). …
1 problem(s) across 733 manifests.          exit=1

check-gitops-duplicate-resources: OK — 733 manifests, no duplicate resource or list
entry, and no resource declared by two components      exit=0
```

## After merge

`case-coordinator` should go Synced. The Secret itself is untouched — `agent` already owns it, so nothing is pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
