### PR TITLE
feat(infra): register the communication Application

### DIFF
--- a/openbank-infra/gitops/apps/communication.yaml
+++ b/openbank-infra/gitops/apps/communication.yaml
@@ -1,0 +1,53 @@
+# Communication Studio (ADR-0285). communication-service serves the business-editable
+# style/playbook layer that sits on top of the immutable git prompt core, and admin-ui
+# edits it under four-eyes with evals-on-publish.
+#
+# Registered at the SAME stage referral was: the component declares the namespace, its
+# single-owner CNPG Postgres + daily ScheduledBackup, the OIDC ExternalSecret, the
+# internal TLS Certificate, the valkey cache, the OPA bundle and the workload — with the
+# Deployment at `replicas: 0`. Syncing this Application therefore provisions the domain
+# and starts NO pod; activation is a separate reviewed change that records live health
+# evidence, exactly as communication-service.yaml's own header states.
+#
+# Why it is registered now rather than at activation: admin-ui already ships a
+# RoleBinding for admin-ui-discovery into namespace `communication` (#9173) and lists
+# `communication` in OPENBANK_NAMESPACES. With no Application, that namespace did not
+# exist, and admin-ui's sync failed on every attempt —
+#   error running kubectl auth reconcile: error getting namespace communication:
+#   namespaces "communication" not found
+# — so admin-ui itself had been OutOfSync since 2026-09-10T21:10Z, and communication-db
+# fired PostgresClusterDeclaredNotDeployed. A component that nothing syncs is not a
+# staged rollout, it is a manifest no one applies; the staging lives in `replicas: 0`.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: communication
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
+  finalizers: [resources-finalizer.argocd.argoproj.io]
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/communication
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: communication
+  syncPolicy:
+    syncOptions:
+      # The component carries an OPA bundle ConfigMap; client-side apply would store the
+      # whole object in the last-applied-configuration annotation and the API server
+      # rejects one over 256 KB, which ArgoCD retries forever while serving the previous
+      # policy. Gate: opa-bundle-apply-size.
+      - ServerSideApply=true
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m


### PR DESCRIPTION
## What

Add `openbank-infra/gitops/apps/communication.yaml`, the ArgoCD Application for the `communication` component.

## Why

`gitops/components/communication` has existed since #9173 (ADR-0285 D6/D7) and **nothing ever synced it**. `root-app` recurses `gitops/apps`, and there was no file there — `apps/communication.yaml` has never existed in this repo's history.

Three live consequences, all one cause:

1. Namespace `communication` did not exist.
2. `communication-db` fired `PostgresClusterDeclaredNotDeployed` (warning, since 02:07Z).
3. **admin-ui had been OutOfSync since 2026-09-10T21:10Z.** It already ships a `RoleBinding` for `admin-ui-discovery` into that namespace and lists `communication` in `OPENBANK_NAMESPACES` (both from #9173), so every sync attempt died on:

```
error running rbacReconcile: error running kubectl auth reconcile:
error getting namespace communication: namespaces "communication" not found.
Retrying attempt #4
```

A component that nothing syncs is not a staged rollout — it is a manifest no one applies. Only `communication`, `loyalty` and `infra-vuln-scanner` are in that state; this PR handles the one that was breaking another Application.

## This does not start the service

`communication-service.yaml` declares `replicas: 0` and states that activation is a separate reviewed step. Syncing provisions the domain and starts no pod:

| resource | effect |
|---|---|
| Namespace (PSA `restricted`) | created |
| CNPG `communication-db`, 1 instance + daily ScheduledBackup | created |
| OIDC ExternalSecret, internal TLS Certificate, valkey, OPA bundle, 2 NetworkPolicies | created |
| Deployment `communication-service` | **0 replicas** |

`apps/referral.yaml` is the precedent and the shape copied here — `referral-service` is live at `0/0` today under exactly this arrangement. `ServerSideApply=true` is carried for the OPA bundle ConfigMap (gate `opa-bundle-apply-size`).

## Prerequisites checked, not assumed

- `ClusterIssuer/openbank-ca` exists (`kubectl get clusterissuer` → Ready 104d).
- The Vault key the OIDC ExternalSecret extracts is the one 20+ components already use.
- `db-backups.tf:207` already declares the `communication` pod-identity association; `check-db-backup-associations` reports every cluster targeting the managed bucket has one.
- `communication-service` is not in `rules.yaml: money_path_services`.

Gates run locally with the Application in place: `gitops-duplicate-resources`, `gitops-secret-refs`, `opa-bundle-apply-size`, `cnpg-backup-declared`, `cnpg-scrape-coverage`, `untrusted-pg-extension` — all pass.

## After the first sync

```bash
kubectl -n argocd get application communication admin-ui \
  -o custom-columns='N:.metadata.name,S:.status.sync.status,H:.status.health.status'
kubectl -n communication get deploy communication-service   # expect 0/0
```

Then confirm the base backup **by listing objects**, not by reading a condition — a CNPG archiver reports `ContinuousArchivingSuccess` with no bucket behind it:

```bash
aws s3 ls s3://openbank-sandbox-db-backups/communication-db/
kubectl -n communication get cluster communication-db \
  -o jsonpath='{.status.firstRecoverabilityPoint}'
```

If `firstRecoverabilityPoint` is empty after the ScheduledBackup window, force one unmanaged `kind: Backup` — WAL archiving alone is not a recovery point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
