### PR TITLE
feat(infra): register the infra-vuln-scanner Application

### DIFF
--- a/openbank-infra/gitops/apps/infra-vuln-scanner.yaml
+++ b/openbank-infra/gitops/apps/infra-vuln-scanner.yaml
@@ -1,0 +1,37 @@
+# Daily Grype CVE scan of the running infra images (ADR-0077 evolution).
+# See gitops/components/infra-vuln-scanner/ for design rationale.
+#
+# Shape and destination copied from sbom-drift-scanner, the sibling that already
+# runs this way: a CronJob in namespace `admin-ui` that writes a ConfigMap admin-ui
+# mounts with optional: true. The component declares no Namespace of its own and its
+# RoleBindings target existing namespaces (admin-ui, messaging, iam, vault,
+# observability, accounts), so CreateNamespace stays false.
+#
+# Registered because the consumer has been waiting since the component landed: admin-ui
+# mounts ConfigMap `infra-vulns` (optional: true, "BFF degrades to 'not yet scanned'
+# gracefully") and openbank-admin-ui/infra-vulns.json is still the placeholder whose own
+# note says to "wire the infra-vuln-scanner CronJob". Nothing ever synced the component,
+# so that ConfigMap has never existed and the panel has never shown a scan.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: infra-vuln-scanner
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/infra-vuln-scanner
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: admin-ui
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true


### PR DESCRIPTION
## What

Add `openbank-infra/gitops/apps/infra-vuln-scanner.yaml` — the ArgoCD Application for the daily Grype CVE scan of running infra images.

## Why

`gitops/components/infra-vuln-scanner` has existed since #2388, and no Application ever pointed at it. `root-app` recurses `gitops/apps`; that file has never existed in this repo's history. So the CronJob has never run.

The consumer has been waiting the whole time. admin-ui mounts the ConfigMap the scan writes:

```yaml
- name: infra-vulns
  configMap:
    name: infra-vulns
    optional: true   # "BFF degrades to 'not yet scanned' gracefully"
```

Live: `kubectl -n admin-ui get cm | grep vuln` → **absent**, and the ServiceAccount/Role/CronJob are absent too. `openbank-admin-ui/infra-vulns.json` is still the committed placeholder, whose own note reads *"Run build-push-admin-ui.sh --scan-infra … or wire the infra-vuln-scanner CronJob (ADR-0077 evolution). Until then the UI honestly shows 'not yet scanned'."*

That honesty is why this never surfaced as a defect: the panel renders a truthful empty state rather than an error, so nothing alerts and nothing looks wrong.

## Shape

Copied from `sbom-drift-scanner` — the sibling already registered this exact way: a CronJob in namespace `admin-ui` writing a ConfigMap that admin-ui mounts optionally.

| | infra-vuln-scanner | sbom-drift-scanner |
|---|---|---|
| destination namespace | `admin-ui` | `admin-ui` |
| `CreateNamespace` | false | false |
| `ServerSideApply` | true | true |
| automated prune + selfHeal | yes | yes |

The component declares no `Namespace` of its own. Its `RoleBinding`s target six existing namespaces — checked rather than assumed, all `Active`:

```
admin-ui Active  messaging Active  iam Active  vault Active  observability Active  accounts Active
```

Image is `docker.io/anchore/grype:v0.94.0`, which reaches ECR through the node-level containerd `hosts.toml` mirror like every other `docker.io/*` image already running here (`grafana/k6`, `valkey/valkey`), so no Kyverno rewrite rule is involved.

## Gates

`gitops-duplicate-resources`, `gitops-secret-refs`, `netpol-coverage`, `opa-bundle-apply-size` — all pass with the Application in place. `check-netpol-coverage.py` already lists `infra-vuln-scanner` in `KNOWN_UNCOVERED` as *"scanner job, no inbound traffic"*, so registering it does not arm that gate.

## After the first sync

The CronJob is `15 2 * * *`, so nothing appears until the next window — force one to verify rather than waiting:

```bash
kubectl -n admin-ui create job --from=cronjob/infra-vuln-scanner infra-vuln-scanner-verify
kubectl -n admin-ui get cm infra-vulns -o jsonpath='{.data}' | head -c 200
```

The volume has no `subPath`, so kubelet projects the new ConfigMap into running admin-ui pods on its next sync; if the panel still reads "not yet scanned" after a couple of minutes, restart the Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
