### PR TITLE
fix(iam): declare the ADR-0285 comms + DPO role grants in the realm template

### DIFF
--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -458,7 +458,8 @@
       ],
       "realmRoles": [
         "ROLE_COMPLIANCE",
-        "ROLE_VIEWER"
+        "ROLE_VIEWER",
+        "ROLE_COMMS_EDITOR"
       ]
     },
     {
@@ -477,7 +478,8 @@
       ],
       "realmRoles": [
         "ROLE_COMPLIANCE",
-        "ROLE_VIEWER"
+        "ROLE_VIEWER",
+        "ROLE_COMMS_APPROVER"
       ]
     },
     {

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -459,7 +459,8 @@
       "realmRoles": [
         "ROLE_COMPLIANCE",
         "ROLE_VIEWER",
-        "ROLE_COMMS_EDITOR"
+        "ROLE_COMMS_EDITOR",
+        "ROLE_DPO"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Declares in the realm template the three role grants applied to the live sandbox realm:
`ROLE_COMMS_EDITOR` and `ROLE_DPO` to `compliance@openbank.local`, `ROLE_COMMS_APPROVER` to
`compliance2@openbank.local`. Without this the grants exist only in the running realm, where
`--import-realm` (cold start only) can never reproduce them.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9783 (the publish deadlock these grants resolve), Refs #9703 (ADR-0285 D6 follow-up)

## Changes

Two commits, same shape:

- `ROLE_COMMS_EDITOR` added to `compliance@openbank.local`'s `realmRoles`, `ROLE_COMMS_APPROVER` to
  `compliance2@openbank.local`'s.
- `ROLE_DPO` added to `compliance@openbank.local`'s.

Only `openbank-infra/gitops/components/keycloak/realm-template.json`, purely additive, no
reformatting, no other user or role touched.

## Why this exists

#9783 measured that ADR-0285's publish path was **unreachable** in the sandbox: neither comms role
existed in the live realm, so every `@RolesAllowed("ROLE_COMMS_*", "ROLE_ADMIN")` degraded to
`ROLE_ADMIN` — held by exactly one enabled human — while `CommunicationStyleService.publish:124`
refuses `maker == checker`. The only identity that could draft was the only one that could approve.

The roles were created live earlier today (by another session acting on #9783), which closed the
role-existence half: `check-realm-role-parity.py` now reports `namedByCodeButNotLive: []`, down from
three roles. But creating them granted them to nobody, so the deadlock survived untouched — the gate
went green while reachability did not change at all.

These grants close it, and they are deliberately **two different identities**: one account holding
both roles hits the same application-layer `maker != checker` refusal and the deadlock returns in a
new form.

## How it was verified

The live grants were applied first (HTTP 204 each), then read back both directions — per-user
mappings and the role-holder listing agree, one holder each, no overlap:

```
compliance@  -> [ROLE_COMMS_EDITOR, ROLE_COMPLIANCE, ROLE_DPO, ROLE_VIEWER, default-roles-openbank]
compliance2@ -> [ROLE_COMMS_APPROVER, ROLE_COMPLIANCE, ROLE_VIEWER, default-roles-openbank]
ROLE_COMMS_EDITOR   holders: [compliance@openbank.local]
ROLE_COMMS_APPROVER holders: [compliance2@openbank.local]
ROLE_DPO            holders: [compliance@openbank.local]
```

**That live-only state is itself a defect, which is what this PR fixes.** Against a snapshot of the
live realm, `check-realm-user-role-parity.py` before this commit:

```
overGranted:
  compliance@openbank.local:  [ROLE_COMMS_EDITOR]
  compliance2@openbank.local: [ROLE_COMMS_APPROVER]
```

and after it, same script, same snapshot:

```
overGranted:  NONE
underGranted: NONE
```

That is the script's own "silent by construction" direction: every role involved exists on both
sides, nothing 403s, the accounts simply do more than the repo says they may — and ArgoCD reports
Synced/Healthy throughout, because the resource it manages does match git.

Gates run locally on this branch:

```
PASS  realm-template-importable     [security]
PASS  rolesallowed-realm-parity     [security]
PASS  realm-devci-artifact-parity   [security]
PASS  duplicate-yaml-key-guard      [data]
```

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — no code touched
- [x] Unit tests added/updated. — N/A; the invariant is covered by `check-realm-user-role-parity.py`, verified above against the live realm
- [x] Integration tests added/updated (if service boundary involved). — N/A
- [x] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no JVM sources
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — N/A
- [x] Flyway migration added + rollback note (if DB changed). — N/A
- [x] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — ADR-0285 D6 already specifies these roles; no decision changed

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — the template's password
      fields remain `__PLACEHOLDER__` substitutions, untouched
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → **yes, this is an IAM role grant; tagged
      `security-review-required`**
- [x] PII path changed? → no
- [x] Cardholder data path changed? → no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None
- [x] GDPR

No regulated control *changes state* — Art. 17 erasure and Art. 20 export were always reachable by
`ROLE_ADMIN` or the data subject, and still are. What changes is who may reach them at
least privilege: `compliance@` is now a designated `ROLE_DPO` identity rather than every DPO action
having to be taken as full admin. Flagged rather than waved through because designating who may
erase a data subject's record is a data-protection decision, not a config tidy-up. Separation of
duties for the Communication Studio also improves — two distinct roles on two distinct identities
instead of both duties collapsing onto the single `ROLE_ADMIN` holder.

## Rollout / Rollback

- Deployment strategy: none needed — the live realm already holds these grants; this commit makes
  git describe reality so a cold start reproduces it.
- Rollback plan: revert the commits, and remove the three live grants
  (`DELETE /admin/realms/openbank/users/<id>/role-mappings/realm`) if the grant itself is being
  withdrawn rather than just its declaration.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

N/A

## Reviewer notes

- **Who holds the approver role is a business decision, and it was the repo owner's.** I proposed
  `compliance@` / `compliance2@` and they chose it; I did not pick the identities.
- **Still open from #9783**: nothing here proves an end-to-end publish. The roles and grants make it
  *possible* (two distinct subjects, so `maker != checker` can be satisfied); an actual
  draft → submit → publish against a running communication-service has not been exercised. Worth
  doing before calling #9783 closed.
- **`ROLE_DPO` is in the second commit.** It gates GDPR Art. 17 erasure and Art. 20 export
  (`PartyResource.kt:369,404`). Nothing was broken without it — those handlers test
  `isAdmin || isDpo || isSelf` — but no identity could hold least-privilege access to them. No
  account anywhere in the tree was designated DPO, so the identity was not derivable from the repo;
  the owner chose `compliance@`. Note that account now carries `ROLE_COMMS_EDITOR` **and**
  `ROLE_DPO`, which are unrelated duties: fine for a sandbox demo realm, but in a real deployment
  the DPO is a distinct statutory function that would want its own identity. `demo@` was explicitly
  not considered — its credentials are published on purpose, and the parity gate raises severity for
  exactly that reason.
- The `openbank-customers` realm remains `unchecked` by both parity scripts — no live snapshot is
  captured for it. Pre-existing, unrelated to this diff, and worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
