### PR TITLE
perf(ci): drop `labeled` from the Dependabot auto-merge trigger

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,9 +40,33 @@ on:
     # the `CodeQL` SARIF upload across the open PRs with
     # `API rate limit exceeded for installation`.
     #
-    # `labeled` stays: a label is how a human re-opens the question for a PR this job already
-    # declined, and it fires rarely enough not to be part of the cost.
-    types: [opened, reopened, labeled]
+    # NOT `labeled` either, and the reason it was kept did not survive measurement. The comment
+    # here used to read "a label is how a human re-opens the question for a PR this job already
+    # declined, and it fires rarely enough not to be part of the cost." Both halves were wrong.
+    #
+    # Measured 2026-09-12 over 600 completed `pull_request` runs (07:25:42Z..10:10:22Z, 2.74 h):
+    # this workflow ran 38 times on 20 branches, 34 skipped and the other 4 cancelled — zero
+    # useful executions, and not one of those branches was a Dependabot branch. Eight branches
+    # fired it more than once; the worst fired FIVE times.
+    #
+    # Those repeats are not rare human labelling. `openbank-gitops-bot` applies the PR's labels
+    # when it opens a deploy PR, and applies each one twice:
+    #
+    #     08:15:10  labeled  chore   by openbank-gitops-bot[bot]
+    #     08:15:11  labeled  gitops  by openbank-gitops-bot[bot]
+    #     08:15:11  labeled  chore   by openbank-gitops-bot[bot]
+    #     08:15:11  labeled  gitops  by openbank-gitops-bot[bot]
+    #
+    # One `opened` plus four `labeled` is exactly the five runs measured — so `labeled` costs four
+    # queued runs per bot deploy PR and buys nothing. Dependabot's own labels (`dependencies`,
+    # plus the ecosystem) are applied at creation too, so `labeled` there is redundant with
+    # `opened` rather than additional to it.
+    #
+    # What the removal costs: re-labelling a PR this job declined no longer re-asks it. `reopened`
+    # still does, and a maintainer can re-run the workflow. That is a smaller affordance than four
+    # wasted runs per deploy PR, and unlike the claim it replaces it is not asserted — nothing in
+    # the window shows `labeled` ever doing work.
+    types: [opened, reopened]
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); the auto-merge job below declares its own override for the write access it needs.


### PR DESCRIPTION
## Summary

`Dependabot auto-merge` still fires four extra times per bot deploy PR, on `labeled`. Measured over
600 runs it did **zero** useful work in 2.74 hours. This drops `labeled`; `opened` and `reopened`
stay.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9031

## This corrects a comment I wrote in #9757

#9757 dropped `synchronize` and kept `labeled` with this justification:

> `labeled` stays: a label is how a human re-opens the question for a PR this job already declined,
> and it fires rarely enough not to be part of the cost.

Both halves are false, and measuring was the only way to find that out.

## Measurement

600 completed `pull_request` runs, window **2026-09-12 07:25:42Z .. 10:10:22Z (2.74 h)**:

```bash
for p in 1 2 3 4 5 6; do
  gh api "repos/JiRaska/open-bank-oss/actions/runs?event=pull_request&status=completed&per_page=100&page=$p" \
    --jq '.workflow_runs[]|"\(.created_at)\t\(.name)\t\(.conclusion)\t\(.head_branch)"'
done
```

| workflow | runs | skipped |
|---|---:|---:|
| Dependabot auto-merge | 38 | 34 |

The other four are `cancelled`, so **nothing in the window executed**. None of the 20 branches was a
Dependabot branch. Eight branches fired it more than once; the worst fired five times.

Those repeats are not human labelling. `openbank-gitops-bot` labels its own deploy PR at creation,
and applies each label twice:

```
08:15:10  labeled  chore   by openbank-gitops-bot[bot]
08:15:11  labeled  gitops  by openbank-gitops-bot[bot]
08:15:11  labeled  chore   by openbank-gitops-bot[bot]
08:15:11  labeled  gitops  by openbank-gitops-bot[bot]
```

One `opened` + four `labeled` = the five runs measured. Dependabot's own labels (`dependencies` plus
the ecosystem) are likewise applied at creation, so `labeled` there is redundant with `opened` rather
than additional to it.

## What it costs, stated rather than dismissed

Re-labelling a PR this job already declined will no longer re-ask it. `reopened` still does, and a
maintainer can re-run the workflow. That is the affordance being traded for four queued runs per
deploy PR — and unlike the claim it replaces, this one is not asserted: nothing in the window shows
`labeled` ever doing work.

## Effect of #9757 so far, for calibration

Before it, this workflow ran ~57/h with a 100% skip rate. Over this window it is ~14/h — about a
fourfold cut, all of it from `synchronize`. The residue measured here is the `labeled` fan-out, which
is most of what is left.

## Verification

- `actionlint` on the changed file: clean. YAML parses; `types` is `['opened', 'reopened']`.
- `run-gates.py --all` differenced against the same command on bare `origin/main`: **zero new
  findings**.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

A trigger-list change to one workflow. The measurement and the label-event trace are recorded in the
file, so the next person to consider re-adding `labeled` sees what it cost rather than re-deriving
the guess I made in #9757.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? → not changed.
- [x] PII path changed? → not changed.
- [x] Cardholder data path changed? → not changed.

No change to the job's permissions, its actor condition, or its policy (patch-only, gradle/npm, never
`github_actions` or `docker`) — only to how often it is queued.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
