### PR TITLE
fix(infra): except arc-runners from the SBOM and SLSA image policies, temporarily

### DIFF
--- a/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
+++ b/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
@@ -14,6 +14,33 @@
 # fix and PR #963 — re-bumped to the first post-#963 build). Confirmed live before removal:
 # `cosign verify-attestation --key <the policy's public key> --type cyclonedx
 # <the new pinned digest>` succeeds against openbank-ci-runner's actual current image.
+#
+# ── TEMPORARY, 2026-09-12 (#9793) — REMOVE once the rebuilt runner image is pinned ──────
+# This is the July incident again, one predicate over. #8847 (2026-09-05 18:57) added
+# verify-openbank-image-slsa-provenance scoped to `openbank-*`, which matches
+# openbank-ci-runner, and runner-image.yml never attested SLSA at all — it hand-rolled
+# cosign instead of sourcing cosign-attest.sh, so it only ever produced a CycloneDX SBOM.
+# Kyverno then reports `unverified image` on verify-openbank-image-sbom-attestation
+# (Enforce) as well, while logging the missing SLSA predicate as the only error — so the
+# blocking policy is not the failing one. Measured 2026-09-12: the CycloneDX attestation
+# on the pinned digest verifies fine on its own
+# (`cosign verify-attestation --key <policy PEM> --type cyclonedx` passes), and the control
+# image openbank-ledger-service carries cyclonedx AND slsaprovenance while
+# openbank-ci-runner carried cyclonedx only.
+#
+# Same deadlock as July: runner-image.yml has `runs-on: openbank-deploy`, so the only
+# workflow that can produce a fixed image needs a runner the policy denies. 865 denials
+# in 24 h; the pools ran at all only because these policies set failurePolicy: Ignore, so
+# a webhook timeout admitted the occasional Pod.
+#
+# REMOVAL CRITERIA — all three, then delete both entries below in one PR:
+#   1. #9793 merged (runner-image.yml calls cosign_sign_and_attest; no continue-on-error).
+#   2. runner-image.yml re-run, and its "Verify signature + both attestations actually
+#      landed" step green for the NEW digest — that step now checks all three predicates.
+#   3. The new digest pinned in arc-runners.tf and platform-tofu.yml applied, confirmed by
+#      a server-side dry-run Pod create in arc-runners being ADMITTED for the new digest
+#      while the OLD digest is still denied in the same session (control).
+# July's equivalent removal was #1053. Do not let this one outlive its cause.
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
@@ -32,3 +59,15 @@ spec:
       ruleNames:
         - verify-cosign-signature
         - autogen-verify-cosign-signature
+    # TEMPORARY (see the 2026-09-12 block above) — remove with the digest bump.
+    - policyName: verify-openbank-image-sbom-attestation
+      ruleNames:
+        - verify-cyclonedx-sbom-attestation
+        - autogen-verify-cyclonedx-sbom-attestation
+    # TEMPORARY (see the 2026-09-12 block above) — remove with the digest bump.
+    # Audit-only, but its failure is what makes the Enforce policy above report
+    # `unverified image`, so excepting only the Enforce one would not admit the Pod.
+    - policyName: verify-openbank-image-slsa-provenance
+      ruleNames:
+        - verify-slsa-provenance
+        - autogen-verify-slsa-provenance


### PR DESCRIPTION
## Linked issues

Refs #9793 — the durable fix this exception makes buildable.
Refs #9805 — the governance follow-up for the recurrence.

## What

Extend the existing `arc-runner-image-exception` PolicyException to also cover `verify-openbank-image-sbom-attestation` and `verify-openbank-image-slsa-provenance`, for Pods in `arc-runners` only. **Temporary** — removal criteria are written next to the entries.

## Why now

Every runner Pod in all four ARC pools has been denied at admission since **2026-09-05 18:57**. Root cause and the durable fix are in #9793; this PR only breaks the deadlock so that fix can be built.

`runner-image.yml` has `runs-on: openbank-deploy` — the only workflow that can produce a corrected image needs a runner the policy denies. Merging #9793 alone changes nothing.

## Why both entries, not just the Enforce one

The failing verification and the blocking policy are different policies:

```
kubectl apply --dry-run=server   (Pod in arc-runners, pinned runner digest)
  verify-openbank-image-sbom-attestation:  verify-cyclonedx-sbom-attestation: unverified image   <- Enforce, BLOCKS
  verify-openbank-image-slsa-provenance:   verify-slsa-provenance:            unverified image   <- Audit

kyverno logs, same window:
  "error": "...attestions not found for predicate type https://slsa.dev/provenance/v0.2"   x37 / 3 min
  (no cyclonedx error at all)
```

The CycloneDX attestation on that digest is genuinely fine — `cosign verify-attestation --key <policy PEM> --type cyclonedx` passes against it. The SBOM policy reports `unverified image` because the SLSA verification failed for the same image. So excepting only the Enforce policy would leave the Pod denied; excepting only the Audit one would leave the Enforce policy reporting a failure it did not compute. Both, or it does not work.

`verify-openbank-image-signatures` was **already** excepted here and is untouched — that entry is pre-existing and not an incident exception, which is why the dry-run above lists two policies and not three.

## This is the July incident, one predicate over

The file's own header records it: #887 graduated the SBOM policy to Enforce while `runner-image.yml`'s attestation step was `continue-on-error` and silently failing; #908 added this same kind of exception; #963 + #1051 fixed the cause; #1053 removed it.

Same shape, same deadlock, different missing predicate. #9793 is the part that should stop it recurring — it removes `continue-on-error` and makes the verify step check all three predicates instead of the two the producer happens to write.

## Removal criteria (in the file, next to the entries)

1. #9793 merged.
2. `runner-image.yml` re-run, its `Verify signature + both attestations actually landed` step green for the **new** digest.
3. New digest pinned in `arc-runners.tf`, `platform-tofu.yml` applied, and a dry-run Pod create in `arc-runners` **admitted** for the new digest while the **old** digest is still **denied** in the same session.

That third one is the control. Without it, "the probe returned admitted" is not evidence of anything.

## Scope and risk

Unchanged match: `kinds: [Pod]`, `namespaces: [arc-runners]`. No other namespace, no other workload. For the duration, runner Pods are admitted without SBOM/SLSA attestation checks — which is the state they are already in intermittently, since these policies set `failurePolicy: Ignore` and a webhook timeout admits a Pod anyway. The exception makes that behaviour deliberate and bounded instead of accidental.

## Validation

```
kubectl apply --dry-run=server   ->  policyexception.kyverno.io/arc-runner-image-exception configured
yamllint -c <the gates.yaml CI config>  ->  exit 0
check-gitops-duplicate-resources --enforce  ->  OK, 733 manifests
check-gitops-secret-refs --enforce          ->  OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

