### PR TITLE
test(admin-ui): scan the settled dark theme, not the crossfade

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -232,6 +232,15 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
   })
 
   test('the dark token theme changes shared surfaces without collapsing status distinction', async ({ page }) => {
+    // `.stat-card` carries `transition: all 0.2s ease`, so flipping the theme starts a 200ms
+    // animation and an axe scan issued straight after samples a colour pair that exists in
+    // NEITHER palette — an interpolated background such as #5a5f69, which is simply white on its
+    // way to #111827. That reads as a contrast violation on the shared surfaces while the settled
+    // theme is fine, and it is non-deterministic: the sampled instant, and therefore the reported
+    // ratio, moves with machine speed and with any change to the LIGHT token the animation starts
+    // from. Emulating reduced motion collapses every transition to .01ms via the media query
+    // globals.css already carries, so the scan measures the theme rather than the crossfade.
+    await page.emulateMedia({ reducedMotion: 'reduce' })
     await page.route('**/api/prod-readiness', route =>
       route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),
     )
@@ -240,6 +249,14 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     const body = page.locator('body')
     const lightBackground = await body.evaluate(el => getComputedStyle(el).backgroundColor)
     await page.locator('html').evaluate(el => el.classList.add('dark'))
+    // The class lands on a later frame, so reading straight away returns the LIGHT colour and
+    // every assertion below compares the old theme with itself. Wait for the repaint instead of
+    // guessing a frame count: if the theme never applies, this times out and the test fails —
+    // the same guarantee the not-equal assertion was there to give.
+    await page.waitForFunction(
+      light => getComputedStyle(document.body).backgroundColor !== light,
+      lightBackground,
+    )
     const darkBackground = await body.evaluate(el => getComputedStyle(el).backgroundColor)
     expect(darkBackground).not.toBe(lightBackground)
 


### PR DESCRIPTION
## What is broken

`e2e/ui-primitives.spec.ts` → *the dark token theme…* fails on unmodified `origin/main`
**4 runs out of 5**. It sits in `Admin UI build`, which feeds the required `Validate manifests`
context, so it intermittently blocks every admin-ui PR — #9788 and #9791 are both red on it right
now.

## Why

The test flips the theme and scans immediately. `.stat-card` has `transition: all 0.2s ease`, so
axe measures the crossfade:

```
insufficient color contrast of 3.48 (foreground #b6c0cc, background #5a5f69)
```

`#5a5f69` is in neither palette — it is light `--bg` `#fafafa` about 72% of the way to dark `--bg`
`#0b1220`. The ratio moved every run I measured (3.38, 3.48, 3.55, 3.56, 4.49).

Two things follow, and they matter beyond this test:

- **The settled dark theme is fine.** No dark token fails AA here.
- **The number also moves with the LIGHT palette**, because that is where the animation starts.
  That is why #9788 — which darkens a *light-theme* token for #9749 — looked like it had broken
  dark-theme contrast. It had not: the same test fails on `main` without it.

A second defect in the same test, found while fixing the first: `expect(darkBackground).not.toBe(lightBackground)`
was passing **only because the transition had already started moving the colour**. With
transitions off, the read lands before the class applies and returns the light value — so that
assertion had never tested what it claims.

## The change

- `page.emulateMedia({ reducedMotion: 'reduce' })` — globals.css already carries
  `transition-duration: .01ms !important` under `prefers-reduced-motion`, so the scan measures the
  theme rather than the crossfade. No production code changes.
- `waitForFunction` on the body repaint instead of an immediate read. If the theme never applies
  it times out and the test fails — the same guarantee the not-equal assertion was meant to give.

## Verification

| | dark-theme test |
|---|---|
| `origin/main`, unchanged spec | **1 passed / 4 failed** in 5 runs |
| same commit + this fix | **8 passed / 0 failed** in 8 runs |

Falsified in the other direction too: removing only the `emulateMedia` line brings the
interpolated-background violations straight back, so the reduced-motion emulation is the
load-bearing part and not the added wait.

Full admin-ui Playwright suite: **137 passed**.

Closes #9808
