### PR TITLE
ci(admin-ui): make the Playwright report upload reachable on E2E failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,15 @@ jobs:
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: steps.browser_e2e.outcome == 'failure'
+        # `always() &&` is load-bearing. A step `if:` that names no status-check function is
+        # implicitly ANDed with success(), so `browser_e2e.outcome == 'failure'` could never hold:
+        # the E2E step has no continue-on-error, so its failure puts the job in a failed state and
+        # every later plain-`if:` step is skipped. Measured on five main runs (21590f0e8, bebbfc4fd,
+        # 8713dc4ba, 8db73dbbd, d57a02b6f): e2e=failure, the always() envelope step beside this one
+        # ran, and this upload was skipped — so the report existed for exactly the runs that did not
+        # need it. The three sibling `outcome == 'failure'` guards in dependency-review.yml and
+        # security.yml are correct as written because those steps DO set continue-on-error.
+        if: always() && steps.browser_e2e.outcome == 'failure'
         with:
           name: playwright-report-${{ github.run_id }}-a${{ github.run_attempt }}
           path: openbank-admin-ui/playwright-report/


### PR DESCRIPTION
## Summary

`Upload Playwright report` in `ci.yml` is guarded by `if: steps.browser_e2e.outcome == 'failure'`.
That guard **can never hold**. A step `if:` naming no status-check function is implicitly ANDed with
`success()`, and the E2E step sets no `continue-on-error` — so its failure puts the job in a failed
state and every later plain-`if:` step is skipped. The report was therefore uploaded for exactly the
runs that did not need it, and never once for a run that did.

Found while trying to work out why E2E failed on `70962abf6` and `3fdcaa2ae` this morning, and
having no report to read.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9787 — the interrupted-job half this deliberately does not fix (see below). No issue of its
own; the defect and its fix are one line.

## Changes

- `.github/workflows/ci.yml`: `if: always() && steps.browser_e2e.outcome == 'failure'`, plus a
  comment recording why `always() &&` is load-bearing and why the sibling guards do not need it.

## Measured, not reasoned from the docs

Five `main` runs where E2E genuinely failed:

| head | E2E step | `always()` envelope step beside it | this upload |
|---|---|---|---|
| `21590f0e8` | failure | **success** | skipped |
| `bebbfc4fd` | failure | **success** | skipped |
| `8713dc4ba` | failure | **success** | skipped |
| `8db73dbbd` | failure | **success** | skipped |
| `d57a02b6f` | failure | **success** | skipped |

The middle column is what makes this a guard defect rather than a lost runner: the `always()` step
immediately above the upload ran to success in all five, so the runner was healthy and the job walked
its whole step list. Only the plain-`if:` step was skipped.

## Control group — why this is one defect, not a sweep

Every step-level `if:` in `.github/workflows/**` that reads a `steps.*.outcome`:

| file | guard | verdict |
|---|---|---|
| `ci.yml:190` | `browser_e2e.outcome == 'failure'` | **broken** — no `continue-on-error` on the step |
| `dependency-review.yml:142` | `review.outcome == 'failure'` | correct — step sets `continue-on-error` |
| `dependency-review.yml:163` | `review.outcome == 'failure'` | correct — same |
| `security.yml:319` | `install-trivy.outcome == 'failure'` | correct — step sets `continue-on-error` |
| `_service-ci.yml:559` | `ecr_auth.outcome == 'success'` | unaffected by construction |

`continue-on-error: true` keeps the job out of a failed state, which is what leaves a later
`outcome == 'failure'` guard reachable. That is the whole difference, and `browser_e2e` is the only
one missing it. Adding `continue-on-error` to the E2E step would be the wrong fix — it would stop an
E2E failure from failing the job, i.e. retire a merge-blocking gate.

Consistency note: `ci.yml` holds seven step-level `if:`s and the other six are all `if: always()`.

## What this does NOT fix — stated rather than implied

A run whose job is interrupted hard enough that even the `always()` steps are skipped. Five such runs
the same morning (`588a50609`, `3ce926c41`, `e80ca1f26`, `a1d6bad91`, `c33fd14b9` — `envelope=skipped`).
No `if:` reaches those; that is the spot-reclaim shape in #9787. So this makes the report available
for a *normal* E2E failure, not for every red E2E job.

## Falsification — honest about its limit

The defect is falsified: the five runs above are the known-positive, and the `always()` neighbour is
the control that rules out the competing explanation.

**The fix is not falsified on this PR, and I can't make it so honestly.** It only proves itself when
E2E actually fails, and E2E currently passes (#9751 fixed the four failing specs — five consecutive
green main runs since). Deliberately breaking a spec to force an upload would mean shipping a red
test. What confirms it instead: the next genuine E2E failure on any branch produces a
`playwright-report-*` artifact where today it produces none. Recording that here so the claim is
checkable rather than assumed.

Validated as far as it can be locally: `actionlint` exit 0, YAML parses, `workflow-run-step-size`
within budget (the prose is a YAML comment, not a `run:` block), and
`run-gates.py --all` 220 gates / PASS=218 / **FAIL=0**.

## Definition of Done

- [x] Hexagonal layering preserved — N/A, CI workflow only.
- [x] Unit tests added/updated — N/A; falsification is the five measured runs, see above.
- [x] Integration tests added/updated — N/A.
- [x] Contract tests updated — N/A.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, no JVM source touched.
- [x] No new lint warnings — `actionlint` exit 0.
- [x] OpenAPI spec regenerated — N/A.
- [x] Flyway migration added + rollback note — N/A.
- [x] Avro schema versioned backward-compatibly — N/A.
- [x] Docs updated — the reasoning is a comment at the change site.

## Security checklist

- [x] No secrets, tokens, passwords, or PII — one `if:` expression and a comment.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification — none.
- [x] No new third-party dependency — none; the action SHA is unchanged.
- [x] Auth / crypto / payment code changed? → No.
- [x] PII path changed? → No.
- [x] Cardholder data path changed? → No.

Note the artifact is a Playwright report from a suite that mocks every BFF endpoint via
`page.route()` — no live services, no real data. Retention stays 7 days.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — CI workflow, takes effect on merge.
- Rollback plan: revert; the upload returns to being unreachable.
- Data migration reversible: N/A

## Reviewer notes

The one judgement call is `always() &&` versus `failure()`. `failure()` alone would also upload when
an *earlier* step failed and `playwright-report/` does not exist, which makes an empty-artifact
warning rather than a report. Keeping the explicit `browser_e2e.outcome` test keeps the guard aimed at
the step whose output it collects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
