### PR TITLE
fix(infra): pin the runner image that carries all three attestations

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -87,7 +87,19 @@ locals {
   # the FIRST runner-image.yml run to complete after PR #963 — its "Verify
   # signature + attestation actually landed" step (no continue-on-error)
   # passed for this exact digest, confirmed live before this bump.
-  runner_image   = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/openbank-ci-runner@sha256:45c0408d8992a900d7a539463b9210686d988513b39b06beaa35643b4a03e972"
+  #
+  # 2026-09-12: re-pinned to sha256:9f227805… — the first build from the FIXED
+  # runner-image.yml (#9793, run 34693338577), whose log carries the line this workflow
+  # had never produced before: "attested + verified SLSA provenance". The 45c0408d… pin
+  # above was signed and SBOM-attested and still denied at admission, because #8847 made
+  # SLSA provenance an admission input on 2026-09-05 and this image had none.
+  #
+  # Verified against the PUBLIC KEY THE POLICIES PIN, not the KMS alias — the 2026-09-04
+  # build verified fine against the alias and was rejected anyway, so the alias is not the
+  # thing that answers the question:
+  #   signature OK · cyclonedx OK · slsaprovenance OK
+  #
+  runner_image   = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/openbank-ci-runner@sha256:9f227805610d42bb0f3ace66248c7aba271c78fe6f0e8c5e26fc5d9ca53a32f9"
   runner_command = ["/home/runner/run.sh"]
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
## Linked issues

Refs #9793 — the workflow fix that produced this image.
Refs #9803 — the temporary PolicyException this is a precondition for removing.
Refs #9805 — the governance follow-up for the class.

## What

Pin `openbank-ci-runner@sha256:9f227805…` — the first build from the fixed `runner-image.yml`.

## Why this digest and not the last one

The previous pin (`45c0408d…`) was signed and SBOM-attested and **still denied at admission**. #8847 made SLSA provenance an admission input on 2026-09-05 and that image had none, so every runner Pod in all four pools has been denied since. An earlier version of #9793 tried to fix this by bumping to the 2026-09-04 digest; that one is denied too, for the same reason.

Run [34693338577](https://github.com/JiRaska/open-bank-oss/actions/runs/34693338577) is the first to emit the line this workflow had never produced:

```
signed (key=awskms:///alias/openbank-cosign-signing)
attested + verified SBOM (serialNumber=urn:uuid:9fbf1bcc-55d8-4ff6-aedc-a21dd186e3e8)
build SLSA provenance predicate
attested + verified SLSA provenance (run=.../runs/34693338577/attempts/1)
✅ signature + CycloneDX SBOM + SLSA provenance all verified present
```

## Verified against the key that decides, not the one that signs

Checked with the public key extracted from `verify-sbom-attestation-policy.yaml` on `origin/main` — **not** the KMS alias. That distinction is the whole lesson of this incident: the 2026-09-04 build verified fine against `awskms:///alias/openbank-cosign-signing` and admission rejected it anyway, so the alias cannot answer the question.

```
== does sha256:9f227805610d… satisfy all three policies? ==
   signature        OK
   cyclonedx        OK
   slsaprovenance   OK
```

The same check, run against the old digest, refuses and names the miss — so it can fail, and is not decoration:

```
== does sha256:45c0408d8992… satisfy all three policies? ==
   signature        OK
   cyclonedx        OK
   slsaprovenance   MISSING
REFUSING to bump: this digest would be denied exactly like the old one.
```

## Merging this does not apply it

The tofu apply for `sandbox-platform` is `workflow_dispatch`-only. Until it runs, the pools keep the old digest and it is #9803's PolicyException that admits runner Pods.

## After apply

```bash
kubectl -n arc-runners get autoscalingrunnerset \
  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.spec.template.spec.containers[0].image}{"\n"}{end}'
```

Then prove admission at the new digest **without** relying on the exception — the honest test is to re-probe once #9803's entries are removed, which is the next PR. Note that admission is currently nondeterministic for unverifiable images (~12–25 % admitted via `failurePolicy: Ignore`, measured and filed as item 4 on #9805), so any such probe must be repeated and unanimous rather than run once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
