### PR TITLE
fix(admin-ui): accept UUIDv7 in the ICT incident parser — main is red

### DIFF
--- a/openbank-admin-ui/src/lib/security/ictIncidentContract.ts
+++ b/openbank-admin-ui/src/lib/security/ictIncidentContract.ts
@@ -22,7 +22,7 @@ export type IctIncidentEnvelope =
   | { available: true; incidents: IctIncident[] }
   | { available: false; reason: string }
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
 const SERVICE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
 


### PR DESCRIPTION
## main is red

`npm test` on clean `origin/main`:

```
FAIL  src/test/uuid-version-class.guard.test.ts
  > no parser restricts the UUID version class to 1-5 — that rejects UUIDv7
AssertionError: expected [ "src/lib/security/ictIncidentContract.ts" ] to deeply equal []
```

## How it got there — two PRs that crossed

| PR | landed | what it did |
|---|---|---|
| #9538 | `4f7aa2f46` | added `ictIncidentContract.ts` with `[1-5]` |
| #9782 | `6b6742388` | added the guard forbidding `[1-5]`, because `Ids.newId()` returns a v7 |

Each was green on its own. The guard scans `src/lib/**` for the pattern, and the file it now
rejects did not exist when the guard's own run happened — so neither PR could have seen it. This is
the semantic-merge-conflict shape: nothing conflicts textually, both are green, `main` breaks.

## It is not only a red test

`ictIncidentContract` is the UI boundary for **DORA ICT incident evidence**. A `[1-5]` version class
rejects every identifier this fleet actually mints, so the page would have refused real incidents as
malformed — the failure a strict parser is supposed to prevent, pointed at valid data.

## Change

One character class, `[1-5]` → `[1-8]` (RFC 9562 defines versions 1–8). That matches the six sibling
parsers which already spell it that way: `cards/clientContract`, `closings/evidence`,
`payments/detailEvidence`, `sdd/sddMandateContract`, `security/summary`,
`swift/swiftMessageContract`.

## Verification, both directions on this commit

| | result |
|---|---|
| reverted to `[1-5]` | guard suite **1 failed / 2 passed**, exit 1 |
| fixed to `[1-8]` | guard suite **3 passed**, exit 0 |
| full admin-ui suite | **555 files, 2975 passed, 1 skipped**, exit 0 |
| `tsc --noEmit` | clean |

The negative case was run first, deliberately: a guard fix that cannot be shown to fail against the
unfixed file is indistinguishable from one that does nothing.

Refs #9782
