### PR TITLE
fix(infra): remove the temporary arc-runners SBOM and SLSA exceptions

### DIFF
--- a/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
+++ b/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
@@ -14,33 +14,19 @@
 # fix and PR #963 — re-bumped to the first post-#963 build). Confirmed live before removal:
 # `cosign verify-attestation --key <the policy's public key> --type cyclonedx
 # <the new pinned digest>` succeeds against openbank-ci-runner's actual current image.
+# The 2026-09-12 entries (sbom-attestation + slsa-provenance) added by #9803 are REMOVED:
+# their cause is gone. #9793 made runner-image.yml attest SLSA provenance through the shared
+# cosign-attest.sh, run 34693338577 produced sha256:9f227805... carrying all three
+# predicates, and #9815 pinned it.
 #
-# ── TEMPORARY, 2026-09-12 (#9793) — REMOVE once the rebuilt runner image is pinned ──────
-# This is the July incident again, one predicate over. #8847 (2026-09-05 18:57) added
-# verify-openbank-image-slsa-provenance scoped to `openbank-*`, which matches
-# openbank-ci-runner, and runner-image.yml never attested SLSA at all — it hand-rolled
-# cosign instead of sourcing cosign-attest.sh, so it only ever produced a CycloneDX SBOM.
-# Kyverno then reports `unverified image` on verify-openbank-image-sbom-attestation
-# (Enforce) as well, while logging the missing SLSA predicate as the only error — so the
-# blocking policy is not the failing one. Measured 2026-09-12: the CycloneDX attestation
-# on the pinned digest verifies fine on its own
-# (`cosign verify-attestation --key <policy PEM> --type cyclonedx` passes), and the control
-# image openbank-ledger-service carries cyclonedx AND slsaprovenance while
-# openbank-ci-runner carried cyclonedx only.
+# Confirmed before removal in ns/default, where this exception does NOT apply, so the answer
+# is about the IMAGE and not about the exception. Eight probes each, because admission is
+# nondeterministic for an unverifiable image (#9805 item 4) and one ADMITTED proves nothing:
+#   NEW sha256:9f227805...  ADMITTED 8/8   <- passes all three policies on its own merits
+#   OLD sha256:45c0408d...  ADMITTED 4/8   <- still not passing; the 4 are the fail-open
 #
-# Same deadlock as July: runner-image.yml has `runs-on: openbank-deploy`, so the only
-# workflow that can produce a fixed image needs a runner the policy denies. 865 denials
-# in 24 h; the pools ran at all only because these policies set failurePolicy: Ignore, so
-# a webhook timeout admitted the occasional Pod.
-#
-# REMOVAL CRITERIA — all three, then delete both entries below in one PR:
-#   1. #9793 merged (runner-image.yml calls cosign_sign_and_attest; no continue-on-error).
-#   2. runner-image.yml re-run, and its "Verify signature + both attestations actually
-#      landed" step green for the NEW digest — that step now checks all three predicates.
-#   3. The new digest pinned in arc-runners.tf and platform-tofu.yml applied, confirmed by
-#      a server-side dry-run Pod create in arc-runners being ADMITTED for the new digest
-#      while the OLD digest is still denied in the same session (control).
-# July's equivalent removal was #1053. Do not let this one outlive its cause.
+# July's equivalent removal was #1053. Same dance, one predicate over; #9805 is the
+# follow-up meant to prevent a third round.
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
@@ -49,25 +35,13 @@ metadata:
 spec:
   match:
     any:
-      - resources:
-          kinds:
-            - Pod
-          namespaces:
-            - arc-runners
+    - resources:
+        kinds:
+        - Pod
+        namespaces:
+        - arc-runners
   exceptions:
-    - policyName: verify-openbank-image-signatures
-      ruleNames:
-        - verify-cosign-signature
-        - autogen-verify-cosign-signature
-    # TEMPORARY (see the 2026-09-12 block above) — remove with the digest bump.
-    - policyName: verify-openbank-image-sbom-attestation
-      ruleNames:
-        - verify-cyclonedx-sbom-attestation
-        - autogen-verify-cyclonedx-sbom-attestation
-    # TEMPORARY (see the 2026-09-12 block above) — remove with the digest bump.
-    # Audit-only, but its failure is what makes the Enforce policy above report
-    # `unverified image`, so excepting only the Enforce one would not admit the Pod.
-    - policyName: verify-openbank-image-slsa-provenance
-      ruleNames:
-        - verify-slsa-provenance
-        - autogen-verify-slsa-provenance
+  - policyName: verify-openbank-image-signatures
+    ruleNames:
+    - verify-cosign-signature
+    - autogen-verify-cosign-signature


### PR DESCRIPTION
## Linked issues

Refs #9793 — the workflow fix that made the runner image attestable.
Refs #9803 — the temporary exception this removes.
Refs #9815 — the digest pin this depends on.
Refs #9805 — the governance follow-up for the class.

## ⚠️ Draft on purpose — do not merge until the apply has landed

`platform-tofu.yml` is `workflow_dispatch`-only and its apply for `sha256:9f227805…` is still queued. **Until it completes the scale sets still run the old digest**, and removing these entries would deny every runner Pod again — the exact outage this PR exists to close out.

Merge condition, checkable in one command:

```bash
kubectl -n arc-runners get autoscalingrunnerset \
  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.spec.template.spec.containers[0].image}{"\n"}{end}'
```

All four must read `…@sha256:9f227805…`.

## What

Drop the two entries #9803 added — `verify-openbank-image-sbom-attestation` and `verify-openbank-image-slsa-provenance` — from `arc-runner-image-exception`. The pre-existing `verify-openbank-image-signatures` entry stays: it is not an incident exception and its own header says not to remove it without first establishing why it was originally needed.

## Evidence the cause is gone

Probed in **`ns/default`**, which this exception does not match. That is the point: inside `arc-runners` the exception admits everything, so a probe there would be measuring the exception rather than the image, and would pass no matter how broken the image was.

```
NEW sha256:9f227805…   ADMITTED 8/8    passes all three policies on its own merits
OLD sha256:45c0408d…   ADMITTED 4/8    still not passing; the 4 are the fail-open
```

Eight probes each, not one: admission is nondeterministic for an unverifiable image (measured 3/12, filed as item 4 on #9805), so a single `ADMITTED` is roughly one-in-five a false pass. The old digest's 4/8 is that effect, visible — and it doubles as the control, because a probe that cannot come back denied is not measuring anything.

The build that produced the new image ([run 34693338577](https://github.com/JiRaska/open-bank-oss/actions/runs/34693338577)) is the first from this workflow ever to emit:

```
attested + verified SLSA provenance (run=.../runs/34693338577/attempts/1)
✅ signature + CycloneDX SBOM + SLSA provenance all verified present
```

## After merge

Argo syncs `kyverno-policies`, then re-run the verifier — this time **inside** `arc-runners`, with the control in `default`:

```
openbank-build / -deploy / -batch / -dr   must be ADMITTED 8/8
control (old digest, ns default)          must NOT be admitted
```

That is the real proof. Everything green while the exception is live is green because of the exception.

## Checks

`yamllint` (with the `gates.yaml` CI config) exit 0 · `gitops-duplicate-resources` OK, 733 manifests · `gitops-secret-refs` OK · `kubectl apply --dry-run=server` accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
