### PR TITLE
governance(rules): move two graduation dates that cannot be met on 2026-09-15

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -400,7 +400,13 @@ change_requirements:
       - "breaking event change ships as a NEW versioned event (-vN topic, ADR-0006), never an in-place edit"
     gate: schema-compat
     enforced: advisory
-    target_enforce_date: "2026-09-15"   # ADR-0144
+    # MOVED 2026-09-12, 2026-09-15 -> 2026-10-31. The date could not be met and this file already
+    # said so: the GRADUATION EVIDENCE block below records 40 findings across 5 commits that would
+    # have been RED under --enforce, and states "a ruling is needed first" on whether an added
+    # non-nullable field is a real replay break. A ruling plus a 40-finding burn-down is not three
+    # days of work, and leaving the date would have failed EVERY PR in the repo via
+    # gate-graduation-guard rather than failing this rule.
+    target_enforce_date: "2026-10-31"   # ADR-0144
     # GRADUATION EVIDENCE, CORRECTED 2026-09-05 by a second-agent replay. The first pass
     # recorded "0 findings on 20 commits"; both numbers were wrong and the verdict inverted.
     # Replaying TODAY'S checker as an imported module over the REAL population — the 22 commits
@@ -768,7 +774,13 @@ change_requirements:
       - "compliance scorecard reflects current live/partial/planned status"
     gate: docs-currency
     enforced: advisory
-    target_enforce_date: "2026-09-15"   # ADR-0144
+    # MOVED 2026-09-12, 2026-09-15 -> 2026-11-30. Longer than the sibling move above because the
+    # blocker is different in kind: this rule has NO producer and, per the measurement below, the
+    # rule as written cannot have one that is worth running — a docs-touched-when-page-touched
+    # gate fails 95% of admin-ui page commits. What is missing is a decidable DEFINITION of
+    # currency scoped to changed controls, which is design work, not a checker. The `blocked_on`
+    # field below already said this; the date did not reflect it.
+    target_enforce_date: "2026-11-30"   # ADR-0144
     # MEASURED 2026-09-04, and the number is the argument: 451 commits in 30 days touch an
     # admin-ui `page.tsx`, and of a 60-commit sample only 3 (5%) also touch docs/, a .mmd
     # diagram or process.yaml. So the rule as written — "the section's documentation updated


### PR DESCRIPTION
## Why this is urgent rather than tidy

`gate-graduation-guard` is **enforced** (`gates.yaml:1638`, `mode: enforced`, group `supplychain`)
and it walks the whole of `rules.yaml`, **not the PR diff**. So a `target_enforce_date` that passes
fails *every open PR in the repository*, whatever it contains.

Verified on this branch rather than assumed — one date set into the past on the real file:

```
::error file=openbank-libs/governance/rules.yaml,line=402::target_enforce_date 2026-09-01 has passed
  and this rule is still advisory/planned (ADR-0144). Either ship the producer and flip to
  enforce/block, or move the date forward with a one-line reason in the commit body.
                                                                              -> exit 1
restored                                                                      -> exit 0
```

Two rules are dated **2026-09-15 — three days away** — and neither can graduate. Both say so in
their own comment blocks; I am not adding a judgement, only acting on the one already recorded.

## The two

**`event_change` / `schema-compat` → 2026-10-31.** Its GRADUATION EVIDENCE block:

> Replaying TODAY'S checker … over the REAL population … gives 60 property-set deltas and **40
> findings** across 5 commits … Under `--enforce` those five commits would have been RED. So this
> rule is NOT ready to graduate on 2026-09-15 on evidence; **a ruling is needed first**

The ruling is whether an added non-nullable field with no default is a real replay break. A ruling
plus a 40-finding burn-down is not three days of work.

**`admin_ui_docs_currency` / `docs-currency` → 2026-11-30.** Longer on purpose, because the blocker
is different in kind: there is no producer, and per the measurement in the file there cannot be one
worth running as the rule is written — a docs-touched-when-page-touched gate **fails 95 % of
admin-ui page commits** (451 `page.tsx` commits in 30 days; 3 of a 60-commit sample also touched
docs). Its `blocked_on` already says the missing piece is a decidable *definition* of currency
scoped to changed controls. That is design work, not a checker.

## What this does not do

No rule graduates, none is retired, no threshold moves, no `enforced:` value changes. The only edit
is two dates and the reason for each.

The precedent is in the same file: `ci_runners` was moved from 2026-08-31, which *"passed with the
blocker unresolved and turned an enforced gate red on every PR regardless of its diff"*. This is that
situation, caught three days early instead of afterwards.

Both decisions remain owed — the replay-break ruling, and the definition of currency. A moved date
is a paper trail, not a resolution.

Refs #9020, #8797
