### PR TITLE
fix(copilot): publish the two ActionKind values the spec omits

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -116,8 +116,6 @@ BASELINE: dict[str, str] = {
     "openbank-delegation-service:EXECUTED,PROPOSED,REJECTED":
         "#5962 — lifecycle approval state: deliberate subset of libs ProposalState; decide is "
         "atomic, APPROVED/WITHDRAWN are unpersistable by construction.",
-    "openbank-copilot-service:CARD_FREEZE,DISPUTE,PAYMENT":
-        "#5962 — ActionKind: undeclared FX_CONVERSION",
     # MIS-PAIRINGS, surfaced when the scan began including openbank-libs-* (#7984): three
     # customer-edge spec enums clear the threshold against shared libs enums on 2-3 coincidental
     # values. FAILED/PENDING (a screening verdict vs OutboxStatus), APPROVED/REJECTED (a task

--- a/openbank-copilot-service/src/main/resources/openapi.yaml
+++ b/openbank-copilot-service/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ openapi: "3.1.0"
 
 info:
   title: OpenBank Copilot Service API
-  version: "1.3.0"
+  version: "1.4.0"
   description: |
     Customer-facing AI assistant (mobile copilot), per ADR-0089.
 
@@ -217,7 +217,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [PAYMENT, CARD_FREEZE, DISPUTE]
+          enum: [PAYMENT, CARD_FREEZE, DISPUTE, FX_CONVERSION, CREDIT_APPLICATION]
         summary:
           type: string
           description: Human-readable one-liner of the proposed action.


### PR DESCRIPTION
## The defect

`ActionProposal.kind` is published as `enum: [PAYMENT, CARD_FREEZE, DISPUTE]`. The domain
`ActionKind` has **five** values, and the two missing ones are reachable today —
`FxConversionProposalTool` returns `FX_CONVERSION`, `CreditApplicationDraftTool` returns
`CREDIT_APPLICATION`. A client generated from that document cannot represent a proposal the service
really sends.

The baseline entry owning this said *"undeclared FX_CONVERSION"* — one value. The gate says two:

```
spec omits ['CREDIT_APPLICATION', 'FX_CONVERSION']
```

`CREDIT_APPLICATION` arrived later with ADR-0269 rule 5 and the baseline's reason was never updated.
A note asserting current state, with nothing re-checking it.

## Why this is additive, not breaking in fact

`ActionProposal` appears only inside a **response** (`proposal` on the chat reply), so publishing the
missing values widens what a client must accept and narrows nothing it may send.

The api-contract gate reaches the same conclusion and explains its own reclassification:

```
spec-only PR — reclassifying 2 breaking document change(s) … as a CORRECTION. No other file in
openbank-copilot-service changed, so the served contract is unchanged and a MAJOR bump would
violate the ADR-0048 D2 URL-major invariant. Requiring MINOR instead.
correction change, info.version 1.3.0 -> 1.4.0 — OK
```

That reclassification holds **only while the PR touches nothing else in the service**, which is why
the baseline edit lives in `.github/scripts/` and not beside the spec.

## Verification — falsified in both directions

| | |
|---|---|
| baseline entry dropped, spec **not** fixed | `rc=1` — "spec omits `['CREDIT_APPLICATION','FX_CONVERSION']`" |
| spec fixed, baseline entry **kept** | `rc=1` — "baseline entry … no longer drifts — drop it from BASELINE" |
| both | `rc=0`, drift **14 → 13**, all baselined, no stale declaration |

The two negatives matter together: the first proves the spec fix is real, the second proves the
baseline removal is required rather than cosmetic. Either alone would leave the pair inconsistent.

Refs #5962
