### PR TITLE
feat(admin-ui): add the financial and managerial reporting packs

### DIFF
--- a/openbank-admin-ui/src/lib/reporting/clientContract.ts
+++ b/openbank-admin-ui/src/lib/reporting/clientContract.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export type CatalogueParam = { name: string; labelCs: string; labelEn: string; type: 'date' | 'number' | 'enum'; required: boolean; defaultValue?: string; options?: readonly string[] }
+export type CatalogueParam = { name: string; labelCs: string; labelEn: string; type: 'date' | 'month' | 'number' | 'enum'; required: boolean; defaultValue?: string; options?: readonly string[] }
 export type CatalogueColumn = { key: string; labelCs: string; labelEn: string; format: 'text' | 'number' | 'money' | 'datetime' }
 export type CatalogueReport = { id: string; titleCs: string; titleEn: string; descriptionCs: string; descriptionEn: string; permission: string; params: readonly CatalogueParam[]; columns: readonly CatalogueColumn[] }
 export type ReportResult = { available: boolean; reportId: string; columns: readonly CatalogueColumn[]; rows: Record<string, unknown>[]; generatedAt: string | null; rowCount: number; truncated: boolean; error?: string }
@@ -8,7 +8,7 @@ export type ReportResult = { available: boolean; reportId: string; columns: read
 const IDENTIFIER = /^[a-z][A-Za-z0-9_-]{0,127}$/
 const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
 const FORMATS = ['text', 'number', 'money', 'datetime'] as const
-const PARAM_TYPES = ['date', 'number', 'enum'] as const
+const PARAM_TYPES = ['date', 'month', 'number', 'enum'] as const
 
 function object(value: unknown): Record<string, unknown> { if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Expected object'); return value as Record<string, unknown> }
 function text(value: unknown, max = 2_000): string { if (typeof value !== 'string' || value.trim() === '' || value.length > max) throw new Error('Invalid text'); return value }

--- a/openbank-admin-ui/src/lib/reporting/registry.ts
+++ b/openbank-admin-ui/src/lib/reporting/registry.ts
@@ -38,13 +38,31 @@ function isIsoDate(value: string): boolean {
   return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value
 }
 
+const MONTH_RE = /^(\d{4})-(\d{2})$/
+
+/**
+ * An accounting PERIOD, `YYYY-MM`. Shape and calendar month, for the same reason as [isIsoDate]:
+ * '2026-13' carries no quote and is injection-safe, but reaches ClickHouse as a comparison that
+ * silently matches nothing, turning a typo into an empty report rather than a named error.
+ *
+ * The format is not a guess. `LoanProvisioningEntity.period` is `@Column(name = "period",
+ * length = 7)` and lending-service's own tests pin the values — `runProvisioningCycle("2026-06",
+ * LocalDate.parse("2026-06-01"), ...)` and `period = "2026-08"`.
+ */
+function isIsoMonth(value: string): boolean {
+  const m = MONTH_RE.exec(value)
+  if (!m) return false
+  const month = Number(m[2])
+  return month >= 1 && month <= 12
+}
+
 export type ParamValue = string
 
 export interface ReportParam {
   name: string
   labelCs: string
   labelEn: string
-  type: 'date' | 'number' | 'enum'
+  type: 'date' | 'month' | 'number' | 'enum'
   required: boolean
   /** Fallback applied when a non-required parameter is absent. Must itself validate. */
   defaultValue?: string
@@ -65,6 +83,8 @@ export function validateParam(param: ReportParam, raw: string | null): string | 
   switch (param.type) {
     case 'date':
       return isIsoDate(value) ? value : null
+    case 'month':
+      return isIsoMonth(value) ? value : null
     case 'number': {
       if (!/^\d+(\.\d+)?$/.test(value)) return null
       const n = Number(value)
@@ -107,6 +127,21 @@ const TO: ReportParam = { name: 'to', labelCs: 'Do', labelEn: 'To', type: 'date'
 
 const dayRange = (p: Record<string, string>, column = 'day') =>
   `${column} BETWEEN toDate('${p.from}') AND toDate('${p.to}')`
+
+const FROM_MONTH: ReportParam = {
+  name: 'fromMonth', labelCs: 'Od období', labelEn: 'From period', type: 'month', required: true,
+}
+const TO_MONTH: ReportParam = {
+  name: 'toMonth', labelCs: 'Do období', labelEn: 'To period', type: 'month', required: true,
+}
+
+/**
+ * `period` is a `YYYY-MM` String column, not a date, so the range is a lexicographic BETWEEN.
+ * That is exact for this format — zero-padded, fixed width, most-significant first — and it is
+ * the reason the validator insists on both halves rather than accepting `2026-9`.
+ */
+const monthRange = (p: Record<string, string>, column = 'period') =>
+  `${column} BETWEEN '${p.fromMonth}' AND '${p.toMonth}'`
 
 export const REPORT_REGISTRY: readonly ReportEntry[] = [
   {
@@ -227,6 +262,153 @@ export const REPORT_REGISTRY: readonly ReportEntry[] = [
       FROM ${DB}.gold_risk_event_volume_daily
       WHERE ${dayRange(p)}
       ORDER BY day DESC, events DESC`,
+  },
+  // ── Financial pack (ADR-0286, #8976) ───────────────────────────────────────
+  //
+  // These three reuse the V14 credit-lifecycle gold views rather than re-deriving their figures in
+  // a new migration. That is deliberate and is the rule this registry is built on: one definition
+  // of each business figure lives with the schema. `gold_loan_provisioning_by_stage` already sums
+  // expected credit loss per period and stage; a second definition here would be a second answer
+  // to the same question, free to drift from the first.
+  //
+  // They tolerate an empty source by construction. The V14 marts were written ahead of their data
+  // (the lending subscription lands separately), so an empty result is the normal early state —
+  // the BFF's `available: false` path covers the warehouse being absent, and zero rows are simply
+  // zero rows.
+  {
+    id: 'finance-ifrs9-provisioning',
+    titleCs: 'IFRS 9 — opravné položky podle stupně',
+    titleEn: 'IFRS 9 — provisioning by stage',
+    descriptionCs: 'Očekávaná úvěrová ztráta a její pohyb podle období a stupně znehodnocení.',
+    descriptionEn: 'Expected credit loss and its movement per accounting period and impairment stage.',
+    permission: 'compliance:view',
+    params: [FROM_MONTH, TO_MONTH],
+    columns: [
+      { key: 'period', labelCs: 'Období', labelEn: 'Period', format: 'text' },
+      { key: 'stage', labelCs: 'Stupeň', labelEn: 'Stage', format: 'text' },
+      { key: 'loans', labelCs: 'Úvěrů', labelEn: 'Loans', format: 'number' },
+      { key: 'expected_credit_loss', labelCs: 'ECL', labelEn: 'ECL', format: 'money' },
+      { key: 'ecl_movement', labelCs: 'Pohyb ECL', labelEn: 'ECL movement', format: 'money' },
+    ],
+    sql: (p) => `
+      SELECT period, stage, loans, expected_credit_loss, ecl_movement
+      FROM ${DB}.gold_loan_provisioning_by_stage
+      WHERE ${monthRange(p)}
+      ORDER BY period DESC, stage`,
+  },
+  {
+    id: 'finance-stage-migration',
+    titleCs: 'Migrace mezi stupni IFRS 9',
+    titleEn: 'IFRS 9 stage migration',
+    descriptionCs: 'Přechody mezi stupni za období. Vyléčení se sleduje stejně jako zhoršení.',
+    descriptionEn: 'Stage transitions per period. Cures are tracked alongside deteriorations — a matrix that counts only one direction reads as a book that never recovers.',
+    permission: 'compliance:view',
+    params: [FROM_MONTH, TO_MONTH],
+    columns: [
+      { key: 'period', labelCs: 'Období', labelEn: 'Period', format: 'text' },
+      { key: 'previous_stage', labelCs: 'Z', labelEn: 'From', format: 'text' },
+      { key: 'new_stage', labelCs: 'Do', labelEn: 'To', format: 'text' },
+      { key: 'loans', labelCs: 'Úvěrů', labelEn: 'Loans', format: 'number' },
+      { key: 'deteriorations', labelCs: 'Zhoršení', labelEn: 'Deteriorations', format: 'number' },
+      { key: 'cures', labelCs: 'Vyléčení', labelEn: 'Cures', format: 'number' },
+    ],
+    sql: (p) => `
+      SELECT period, previous_stage, new_stage, loans, deteriorations, cures
+      FROM ${DB}.gold_loan_stage_migration
+      WHERE ${monthRange(p)}
+      ORDER BY period DESC, previous_stage, new_stage`,
+  },
+  {
+    id: 'finance-loan-vintage',
+    titleCs: 'Vintage křivka úvěrů',
+    titleEn: 'Loan vintage curve',
+    descriptionCs: 'Úvěry podle měsíce čerpání proti nejhoršímu dosaženému stupni.',
+    descriptionEn: 'Loans grouped by disbursement month against the worst stage each has reached. `never_migrated` is reported as its own fact, not asserted as Stage 1 — "no event" and "an event saying Stage 1" are different measurements.',
+    permission: 'compliance:view',
+    params: [FROM_MONTH, TO_MONTH],
+    columns: [
+      { key: 'vintage_month', labelCs: 'Měsíc čerpání', labelEn: 'Vintage month', format: 'text' },
+      { key: 'loans', labelCs: 'Úvěrů', labelEn: 'Loans', format: 'number' },
+      { key: 'never_migrated', labelCs: 'Bez migrace', labelEn: 'Never migrated', format: 'number' },
+      { key: 'reached_stage_2', labelCs: 'Dosáhlo st. 2', labelEn: 'Reached stage 2', format: 'number' },
+      { key: 'reached_stage_3', labelCs: 'Dosáhlo st. 3', labelEn: 'Reached stage 3', format: 'number' },
+      { key: 'ever_90_plus_dpd', labelCs: '90+ dpd', labelEn: 'Ever 90+ dpd', format: 'number' },
+    ],
+    sql: (p) => `
+      SELECT vintage_month, loans, never_migrated, reached_stage_2, reached_stage_3, ever_90_plus_dpd
+      FROM ${DB}.gold_loan_vintage
+      WHERE ${monthRange(p, 'vintage_month')}
+      ORDER BY vintage_month DESC`,
+  },
+
+  // ── Managerial pack (ADR-0286, #8976) ──────────────────────────────────────
+  //
+  // Day-keyed KPIs over gold views that already exist. No new DDL for the same reason as above.
+  {
+    id: 'mgmt-credit-decisions-daily',
+    titleCs: 'Denní rozhodnutí o úvěrech',
+    titleEn: 'Daily credit decisions',
+    descriptionCs: 'Schváleno / postoupeno / zamítnuto za den, včetně cenového pásma u schválených.',
+    descriptionEn: 'Approved / referred / declined per day, with the price band of approvals.',
+    permission: 'compliance:view',
+    params: [FROM, TO],
+    columns: [
+      { key: 'day', labelCs: 'Den', labelEn: 'Day', format: 'text' },
+      { key: 'evaluated', labelCs: 'Posouzeno', labelEn: 'Evaluated', format: 'number' },
+      { key: 'approved', labelCs: 'Schváleno', labelEn: 'Approved', format: 'number' },
+      { key: 'referred', labelCs: 'Postoupeno', labelEn: 'Referred', format: 'number' },
+      { key: 'declined', labelCs: 'Zamítnuto', labelEn: 'Declined', format: 'number' },
+      { key: 'approved_prime', labelCs: 'Schváleno PRIME', labelEn: 'Approved PRIME', format: 'number' },
+      { key: 'parties_evaluated', labelCs: 'Klientů', labelEn: 'Parties', format: 'number' },
+    ],
+    sql: (p) => `
+      SELECT day, evaluated, approved, referred, declined, approved_prime, parties_evaluated
+      FROM ${DB}.gold_credit_decision_outcomes
+      WHERE ${dayRange(p)}
+      ORDER BY day DESC`,
+  },
+  {
+    id: 'mgmt-platform-event-volume',
+    titleCs: 'Objem událostí platformy',
+    titleEn: 'Platform event volume',
+    descriptionCs: 'Události podle dne a služby. Syntetický provoz je z pohledu vyloučen.',
+    descriptionEn: 'Events per day and producing service. Synthetic traffic is excluded by the view (ADR-0252), so this is a management number and not a test-traffic number.',
+    permission: 'compliance:view',
+    params: [FROM, TO],
+    columns: [
+      { key: 'day', labelCs: 'Den', labelEn: 'Day', format: 'text' },
+      { key: 'source_service', labelCs: 'Služba', labelEn: 'Service', format: 'text' },
+      { key: 'aggregate_type', labelCs: 'Typ agregátu', labelEn: 'Aggregate type', format: 'text' },
+      { key: 'events', labelCs: 'Událostí', labelEn: 'Events', format: 'number' },
+    ],
+    sql: (p) => `
+      SELECT day, source_service, aggregate_type, sum(events) AS events
+      FROM ${DB}.gold_daily_event_volume
+      WHERE ${dayRange(p)}
+      GROUP BY day, source_service, aggregate_type
+      ORDER BY day DESC, events DESC`,
+  },
+  {
+    id: 'mgmt-onboarding-funnel-daily',
+    titleCs: 'Denní onboarding funnel',
+    titleEn: 'Daily onboarding funnel',
+    descriptionCs: 'Kroky onboardingu za den podle akce a metody KYC.',
+    descriptionEn: 'Onboarding steps per day by action and KYC method.',
+    permission: 'compliance:view',
+    params: [FROM, TO],
+    columns: [
+      { key: 'day', labelCs: 'Den', labelEn: 'Day', format: 'text' },
+      { key: 'step', labelCs: 'Krok', labelEn: 'Step', format: 'text' },
+      { key: 'action', labelCs: 'Akce', labelEn: 'Action', format: 'text' },
+      { key: 'kyc_method', labelCs: 'Metoda KYC', labelEn: 'KYC method', format: 'text' },
+      { key: 'sessions', labelCs: 'Relací', labelEn: 'Sessions', format: 'number' },
+    ],
+    sql: (p) => `
+      SELECT day, step, action, kyc_method, uniqExact(session_id) AS sessions
+      FROM ${DB}.gold_onboarding_funnel_events
+      WHERE ${dayRange(p)}
+      GROUP BY day, step, action, kyc_method
+      ORDER BY day DESC, sessions DESC`,
   },
 ]
 

--- a/openbank-admin-ui/src/test/reporting-financial-managerial-packs.test.ts
+++ b/openbank-admin-ui/src/test/reporting-financial-managerial-packs.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// ADR-0286 / #8976. Two things are asserted here and they are different in kind:
+//
+//  1. the `month` parameter type is an INJECTION BOUNDARY like every other validator, so the
+//     tests are rejection tests — a month that reaches the SQL builder is a month that passed;
+//  2. each new entry reads a GOLD view and only gold, which is the registry's own rule. A report
+//     that reached into silver or bronze would be a second definition of a business figure.
+
+import { describe, expect, it } from 'vitest'
+import { REPORT_REGISTRY, getReport, validateParam, validateParams, type ReportParam } from '@/lib/reporting/registry'
+
+const MONTH: ReportParam = {
+  name: 'fromMonth', labelCs: 'Od', labelEn: 'From', type: 'month', required: true,
+}
+
+const FINANCIAL = ['finance-ifrs9-provisioning', 'finance-stage-migration', 'finance-loan-vintage']
+const MANAGERIAL = ['mgmt-credit-decisions-daily', 'mgmt-platform-event-volume', 'mgmt-onboarding-funnel-daily']
+
+describe('month parameter — the injection boundary', () => {
+  it('accepts a well-formed accounting period', () => {
+    expect(validateParam(MONTH, '2026-09')).toBe('2026-09')
+    expect(validateParam(MONTH, '2026-01')).toBe('2026-01')
+    expect(validateParam(MONTH, '2026-12')).toBe('2026-12')
+  })
+
+  it('rejects every malformed or injecting value', () => {
+    for (const bad of [
+      '2026-9',            // not zero-padded: lexicographic BETWEEN would order it wrongly
+      '2026-13',           // not a calendar month
+      '2026-00',
+      '2026-09-01',        // a date, not a period
+      '2026',
+      "2026-09' OR '1'='1",
+      "2026-09'; DROP TABLE silver_loans; --",
+      'toStartOfMonth(now())',
+      ' 2026-09',
+      '2026-09 ',
+      '',
+    ]) {
+      expect(validateParam(MONTH, bad), `should reject ${JSON.stringify(bad)}`).toBeNull()
+    }
+  })
+})
+
+describe('financial and managerial packs', () => {
+  it('registers all six reports with unique ids', () => {
+    for (const id of [...FINANCIAL, ...MANAGERIAL]) {
+      expect(getReport(id), `${id} is registered`).toBeTruthy()
+    }
+    const ids = REPORT_REGISTRY.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('reads gold views only — never silver, never bronze', () => {
+    for (const id of [...FINANCIAL, ...MANAGERIAL]) {
+      const entry = getReport(id)!
+      const params = Object.fromEntries(entry.params.map((p) => [
+        p.name, p.type === 'month' ? '2026-09' : '2026-09-01',
+      ]))
+      const sql = entry.sql(params)
+      expect(sql, `${id} reads gold`).toMatch(/FROM openbank_analytics\.gold_/)
+      expect(sql, `${id} does not read silver`).not.toMatch(/openbank_analytics\.silver_/)
+      expect(sql, `${id} does not read bronze`).not.toMatch(/openbank_analytics\.bronze_/)
+    }
+  })
+
+  it('interpolates only values that passed validation', () => {
+    const entry = getReport('finance-ifrs9-provisioning')!
+    const rejected = validateParams(entry, { fromMonth: "2026-09' OR '1'='1", toMonth: '2026-09' })
+    expect(rejected.ok).toBe(false)
+
+    const accepted = validateParams(entry, { fromMonth: '2026-01', toMonth: '2026-09' })
+    expect(accepted.ok).toBe(true)
+    if (accepted.ok) {
+      const sql = entry.sql(accepted.params)
+      expect(sql).toContain("period BETWEEN '2026-01' AND '2026-09'")
+    }
+  })
+
+  it('declares every column its SQL selects, and no others', () => {
+    // A column the UI renders but the query never returns is an empty cell the operator reads as
+    // a zero; the reverse is a figure nobody sees. Both are silent, so both are asserted.
+    for (const id of [...FINANCIAL, ...MANAGERIAL]) {
+      const entry = getReport(id)!
+      for (const column of entry.columns) {
+        const params = Object.fromEntries(entry.params.map((p) => [
+          p.name, p.type === 'month' ? '2026-09' : '2026-09-01',
+        ]))
+        expect(entry.sql(params), `${id} selects ${column.key}`).toContain(column.key)
+      }
+    }
+  })
+
+  it('keeps the whole registry behind a declared permission', () => {
+    for (const entry of REPORT_REGISTRY) {
+      expect(entry.permission, `${entry.id} declares a permission`).toBeTruthy()
+    }
+  })
+})

--- a/openbank-admin-ui/src/test/reporting-presentation.test.tsx
+++ b/openbank-admin-ui/src/test/reporting-presentation.test.tsx
@@ -23,9 +23,14 @@ it('does not present a truncated result as a period total', () => {
   expect(screen.queryByLabelText('Daily report trend')).not.toBeInTheDocument()
 })
 it('rejects impossible dates and inverted date ranges before querying', () => {
-  expect(validateParams(REPORT_REGISTRY[0], { from: '2026-02-30', to: '2026-03-01' }).ok).toBe(false)
-  expect(validateParams(REPORT_REGISTRY[0], { from: '2026-09-08', to: '2026-09-01' }).ok).toBe(false)
-  expect(validateParams(REPORT_REGISTRY[0], { from: '2024-02-29', to: '2024-03-01' }).ok).toBe(true)
+  // By id, not by position: REPORT_REGISTRY[0] silently becomes a DIFFERENT report the moment an
+  // entry is added above it, and a date-parameter assertion aimed at a month-parameter report
+  // fails for a reason that has nothing to do with dates. That is what happened when the
+  // financial pack landed (#8976).
+  const dateReport = REPORT_REGISTRY.find((entry) => entry.id === 'risk-settlement-daily')!
+  expect(validateParams(dateReport, { from: '2026-02-30', to: '2026-03-01' }).ok).toBe(false)
+  expect(validateParams(dateReport, { from: '2026-09-08', to: '2026-09-01' }).ok).toBe(false)
+  expect(validateParams(dateReport, { from: '2024-02-29', to: '2024-03-01' }).ok).toBe(true)
 })
 
 describe('report ownership', () => {


### PR DESCRIPTION
Closes #8976 — the financial and managerial packs, six entries in the governed query registry.

## No new DDL, deliberately

The issue allowed either a V16+ migration or reuse *"with a header note why re-derivation is
avoided"*. Reuse is the right half here, and the note is in the file: `gold_loan_provisioning_by_stage`
already sums expected credit loss per period and stage, so a second definition in the registry would
be a second answer to the same question, free to drift from the first. That is the rule this
registry is built on — **one definition of each business figure, living with the schema**.

It also disposes of the acceptance criterion that needed a sandbox ClickHouse apply (#7645's gap):
there is nothing to apply.

| pack | entries | gold source |
|---|---|---|
| financial | `finance-ifrs9-provisioning`, `finance-stage-migration`, `finance-loan-vintage` | V14 credit-lifecycle marts |
| managerial | `mgmt-credit-decisions-daily`, `mgmt-platform-event-volume`, `mgmt-onboarding-funnel-daily` | V14, V9, V7 |

All six tolerate an empty source by construction — the V14 marts were written ahead of their data,
so zero rows is the normal early state and is simply zero rows, distinct from the BFF's
`available: false` warehouse-absent path.

## The `month` parameter

The accounting period is `YYYY-MM`, so it needed a type — added **at the boundary**, which is where
the file's header says a new type must land, "never ad-hoc in an entry".

The format is established, not assumed: `LoanProvisioningEntity.period` is
`@Column(name = "period", length = 7)` and lending-service's own tests pin the values —
`runProvisioningCycle("2026-06", LocalDate.parse("2026-06-01"), 500)` and `period = "2026-08"`.

It rejects `2026-9` as firmly as `2026-13`: the range is a lexicographic `BETWEEN` over a String
column, which is exact **only** while the value is zero-padded and fixed width.

## Two things the existing code caught

Worth naming, because in both cases the existing control was right and my change was incomplete:

1. **`clientContract.ts` carries its own closed `PARAM_TYPES`.** Adding the type to the registry
   alone left the browser rejecting the entire catalogue with `Invalid enum`. The parser was doing
   exactly its job.
2. **`reporting-presentation.test.ts` asserted date validation against `REPORT_REGISTRY[0]`.**
   Appending entries at the front made `[0]` a month-parameter report, and the test failed for a
   reason with nothing to do with dates. Fixed to look the report up by id, with a note: a
   positional index into a registry is a dependency on ordering that nobody declared.

## Permission

Reuses `compliance:view` rather than introducing `finance:view`. The issue left this to the PR:
these read the same warehouse for the same audience, and a new permission is a new authz surface to
justify rather than a free label. `roles.ts` is untouched.

## Verification — falsified in both directions

| | |
|---|---|
| remove `month` from `clientContract` `PARAM_TYPES` | catalogue parse fails, `Invalid enum` |
| point one entry at `silver_` instead of `gold_` | "reads gold views only" fails |
| restored | 7 passed |
| full admin-ui suite | **557 files, 2984 passed, 1 skipped** |
| `tsc --noEmit` / `npm run lint` | clean / 0 errors |

The injection tests are rejection tests, matching the file's own posture that the validator *is* the
SQL-injection boundary: `2026-09' OR '1'='1`, `2026-09'; DROP TABLE silver_loans; --`,
`toStartOfMonth(now())` and whitespace-padded values all fail before any SQL is built.

Closes #8976
