### PR TITLE
fix(infra): except namespace pricing from the image policies, temporarily

### DIFF
--- a/openbank-infra/gitops/components/kyverno/pricing-image-exception.yaml
+++ b/openbank-infra/gitops/components/kyverno/pricing-image-exception.yaml
@@ -1,0 +1,68 @@
+# TEMPORARY, 2026-09-12 — namespace `pricing` only, and it should not outlive the
+# pipeline that makes it unnecessary.
+#
+# WHAT IS ACTUALLY MISSING, AND WHAT IS NOT
+# The openbank-pricing images carry a valid cosign signature and a CycloneDX SBOM
+# attestation — verified against the public key THESE policies pin, not the KMS alias:
+#   signature OK · cyclonedx OK · slsaprovenance MISSING
+# Only SLSA build provenance is absent, and it is absent for a structural reason rather
+# than an oversight: openbank-pricing has no image-building CI at all (pricing-ci.yml is
+# a single `verify` job; the repository contains zero references to cosign). Its images
+# were built and signed by hand, and SLSA provenance cannot honestly be minted by hand —
+# cosign_attest_slsa_provenance SKIPS outside GitHub Actions on purpose, because there is
+# no trustworthy invocation record to attest to.
+#
+# WHY THE EXCEPTION COVERS ALL THREE POLICIES ANYWAY
+# Not because the other two artifacts are missing. Measured 2026-09-12: a Deployment of
+# openbank-pricing-console is denied with all three policies named, five attempts out of
+# five, while openbank-pricing-service — identical attestation state — was admitted with
+# SLSA as a mere warning. Kyverno reports `unverified image` on the two Enforce policies
+# while logging only the SLSA error, so an exception naming only the failing policy would
+# leave two live denials. The asymmetry between those two images is unexplained and is
+# tracked as item 4 of #9805; this exception does not depend on explaining it.
+#
+# BLAST RADIUS
+# Namespace `pricing` only. That namespace holds one private, non-public console and its
+# API; it is not money-path, carries no customer data, and its ingress exposes only the
+# console. Nothing in the monorepo deploys there.
+#
+# REMOVAL CRITERIA — all three, then delete this file:
+#   1. openbank-pricing gains a build pipeline that signs and attests through the shared
+#      openbank-infra/scripts/lib/cosign-attest.sh (see #9793 for the same fix applied to
+#      runner-image.yml, which is the worked example).
+#   2. A rebuilt console image verifies all three predicates against the key these
+#      policies pin — signature, cyclonedx AND slsaprovenance.
+#   3. deploy/sandbox pinned to that image, and a dry-run Pod create in `pricing` admitted
+#      with this file removed. Admission is nondeterministic for unverifiable images
+#      (#9805 item 4), so repeat the probe and require unanimity; a single ADMITTED is
+#      roughly one-in-five a false pass.
+#
+# The July precedent for letting an exception outlive its cause is #908 -> #1053, and the
+# one from this morning is #9803 -> #9822, removed the same day. Match the second.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: pricing-image-exception
+  namespace: pricing
+spec:
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - Deployment
+          namespaces:
+            - pricing
+  exceptions:
+    - policyName: verify-openbank-image-signatures
+      ruleNames:
+        - verify-cosign-signature
+        - autogen-verify-cosign-signature
+    - policyName: verify-openbank-image-sbom-attestation
+      ruleNames:
+        - verify-cyclonedx-sbom-attestation
+        - autogen-verify-cyclonedx-sbom-attestation
+    - policyName: verify-openbank-image-slsa-provenance
+      ruleNames:
+        - verify-slsa-provenance
+        - autogen-verify-slsa-provenance


### PR DESCRIPTION
## Linked issues

Refs #9805 — the unexplained admission asymmetry this works around rather than solves.

## What

A `PolicyException` scoped to namespace `pricing`, so the `openbank-pricing` console can be deployed. **Temporary**, with removal criteria written next to the entries.

## Why the console is blocked

Its images are signed and SBOM-attested. Verified against the public key these policies pin — not the KMS alias, which is the distinction that mattered in #9793:

```
signature      OK
cyclonedx      OK
slsaprovenance MISSING
```

The gap is structural, not an oversight. `openbank-pricing` has **no image-building CI**:

```
pricing-ci.yml   one job, `verify`   — checkout, Java, OPA, wrapper checksum, YAML contracts
grep -c cosign across the repo: 0
```

Those images were built and signed by hand. SLSA provenance cannot honestly be minted that way: `cosign_attest_slsa_provenance` skips outside GitHub Actions on purpose, because the predicate's whole claim is *which CI run built this from which commit*. Producing one by hand would be a fabricated attestation, which is worse than a missing one.

## Why it names all three policies

Not because the other two artifacts are missing — they are present. Measured today:

```
openbank-pricing-service   signature OK  cyclonedx OK  slsa MISSING  ->  ADMITTED (slsa warning only)
openbank-pricing-console   signature OK  cyclonedx OK  slsa MISSING  ->  DENIED, 5 attempts of 5
```

Identical attestation state, opposite and *consistent* outcomes. Kyverno names all three policies in the console's denial while logging only the SLSA error, so an exception naming the failing policy alone would leave two live denials.

That asymmetry is unexplained. It is the same family as #9805 item 4 and is stronger evidence than the probes filed there, because these are real Deployments rather than dry-runs. **It also falsifies the mechanism I claimed in #9803** — "a SLSA failure poisons the Enforce policies" does not hold, because here it poisoned one image and not the other. Correction posted to #9805.

## Scope

Namespace `pricing` only — one private, non-public console and its API. Not money-path, no customer data, its ingress exposes only the console, and nothing in this repository deploys there. The `arc-runners` precedent shows the pattern works: the same `kyverno-policies` Application already syncs a PolicyException into a different namespace.

## Removal criteria, in the file

1. `openbank-pricing` gains a build pipeline that signs and attests through the shared `cosign-attest.sh` — #9793 is the worked example.
2. A rebuilt console image verifies **all three** predicates against the key these policies pin.
3. `deploy/sandbox` pinned to it, and a probe in `pricing` admitted with this file removed — repeated and unanimous, since a single ADMITTED is roughly one-in-five a false pass.

## Context

Found because the `pricing` namespace was deleted and then restored during today's audit. The console had in fact been undeployable since #8847 landed on 2026-09-05; nobody noticed because the running pods were never re-admitted. The deletion converted a latent breakage into a visible one.

## Checks

`kubectl apply --dry-run=server` accepted · `yamllint` (gates.yaml config) exit 0 · `gitops-duplicate-resources` OK, 738 manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
