### PR TITLE
test(transaction): size the forked test JVM, not just the Gradle daemon

### DIFF
--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -104,6 +104,21 @@ kover {
 // fleet-standard block, so nothing service-specific remains here.
 
 tasks.withType<Test> {
+    // The forked test JVM, not the Gradle daemon (issue #5043). `org.gradle.jvmargs=-Xmx3g` in
+    // gradle.properties and `GRADLE_OPTS` in `_service-ci.yml` both size the DAEMON; a Test task
+    // forks its own JVM and takes Gradle's default heap unless told otherwise, so this module ran
+    // the fleet's heaviest IT suite on that default while nine siblings (account, balance,
+    // delegation, fx, ledger, lending, notification, sepa-payment, product-catalog) set a value.
+    //
+    // Measured 2026-09-12 on #5043's branch, which adds one profiled @QuarkusTest to this module:
+    //   default heap -> `OutOfMemoryError: Java heap space`, task FAILED after 232 tests
+    //   2g           -> 256 tests, 0 failures
+    // `main` itself fits in the default, which is why nothing has flagged this: the module sits on
+    // the edge, and the next IT is what goes over it. An exhausted fork does not fail as an OOM at
+    // the assertion — on CI the same branch failed with all four of that IT's tests timing out at a
+    // uniform ~30s `SocketTimeoutException`, i.e. a starved fork looks like the SUBJECT hanging.
+    maxHeapSize = "2g"
+
     // Fail fast, not fail wide (issue #5940). This module boots a real Kafka producer against a
     // Redpanda Testcontainer, and Quarkus tears that container down whenever the set of
     // @QuarkusTestResource classes changes between test classes. A producer left over from the


### PR DESCRIPTION
## Summary

The forked test JVM of `openbank-transaction-service` ran on Gradle's default heap while nine
sibling modules set one. `maxHeapSize = "2g"` on the Test task, with the measurement that justifies
it written next to it.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #5043

## Changes

- `openbank-transaction-service/build.gradle.kts`: `maxHeapSize = "2g"` inside the existing
  `tasks.withType<Test>` block, beside the JUnit 8-minute and Gradle 25-minute timeouts already
  there.
- The comment records the measurement and the trap: `org.gradle.jvmargs=-Xmx3g` (gradle.properties)
  and `GRADLE_OPTS` (`_service-ci.yml`) size the Gradle **daemon**, not the forked test JVM.

## Why, measured

Full `:openbank-transaction-service:test` on #5043's branch, which adds one profiled `@QuarkusTest`
to this module:

| heap | outcome |
|---|---|
| default | `OutOfMemoryError: Java heap space`, task FAILED after 232 tests |
| `2g` | **256 tests, 0 failures**, including the IT that was red |

Control that this is headroom rather than a leak: **`main` passes at the default** (252 tests, 0
failures). The module sits on the edge; the next IT added goes over it.

Worth carrying beyond this PR: a starved fork does not fail as an OOM at the assertion. On CI that
branch failed with all four tests of the new IT timing out at a uniform ~30 s
`SocketTimeoutException` — including the step that only needs a 202 from the four-eyes gate and
touches no workflow — so an exhausted fork reads as the subject under test hanging. That shape cost
two wrong diagnoses before comparing the two attempts of the same job; trail on #5043.

## What this does NOT claim

That it fixes #5043's CI red. Locally that branch OOMs, on CI it times out; both are "the fork ran
out of resources" and the remedy is the fleet standard, but I have not reproduced the CI timeout
itself. #5043's own run settles whether anything remains.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

No test is added because the change has no behaviour to assert: the evidence is the two full-module
runs above, and the module's own suite is what exercises it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in
      this PR). — none added.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — no
      dependency change; this is a Gradle Test-task setting only.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. — no production code
      is touched; the diff is 15 lines in a build script, 14 of them comment.
- [x] PII path changed? → tag `gdpr-review-required`. — no.
- [x] Cardholder data path changed? → tag `pci-review-required`. — no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
