### PR TITLE
fix(statement): skip a debris account on the per-pocket read too, not only the account read

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -178,8 +178,15 @@ BASELINE: dict[str, str] = {
     "openbank-sepa-payment:CANCELLED,COMPLETED,PROCESSING,REJECTED,RETURNED,VALIDATED":
         "#5962 — targetStatus: deliberate subset of SepaPaymentStatus; RECEIVED is unreachable "
         "as a transition target (SepaPayment.canTransitionTo).",
+    # NOT drift — a DELIBERATE SUBSET, reason corrected (#5962). `CloseFailure.reason` can never
+    # be NOT_VIABLE: a debris account is SKIPPED, never FAILED (#862), on BOTH orchestrator paths
+    # since the per-pocket read gained the same guard the account-level read already had. So
+    # publishing NOT_VIABLE would advertise a value this schema cannot carry, which is the
+    # opposite of the fix the old reason ("undeclared NOT_VIABLE") invited. The gate pairs a
+    # failure-record enum with the full reason enum and cannot see the restriction.
     "openbank-statement-service:RECONCILIATION,UNKNOWN,UPSTREAM":
-        "#5962 — CloseFailureReason: undeclared NOT_VIABLE",
+        "#5962 — CloseFailure.reason: NOT drift. A deliberate subset of CloseFailureReason; "
+        "NOT_VIABLE is skipped rather than recorded, on both paths, so no CloseFailure can carry it.",
 }
 
 SPEC_ENUM_INLINE = re.compile(r"enum:\s*\[([^\]]*)\]")

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
@@ -169,8 +169,31 @@ class CloseOrchestrator(
                         Uni.createFrom().item(Unit)
                     }
                     .onFailure().recoverWithUni { e ->
-                        failed.incrementAndGet()
                         val reason = classify(e)
+                        if (reason == CloseFailureReason.NOT_VIABLE) {
+                            // Same rule as the account-level path above, and for the same reason
+                            // (#862): a debris account is SKIPPED, never FAILED, so
+                            // StatementCloseFailures does not fire on data noise.
+                            //
+                            // It is reachable here and not only there because closePocketMonth
+                            // calls accountInfo.pocketAccount AGAIN, once per pocket — the outer
+                            // guard covers the outer read, not this one. Without this branch the
+                            // same account is skipped or failed depending on WHICH of the two
+                            // reads saw the debris, and a CloseFailure row is written carrying a
+                            // `reason` the published CloseFailure schema cannot express.
+                            skipped.incrementAndGet()
+                            metrics.pocketSkipped()
+                            log.infof(
+                                "Close skipped for %s/%s %s..%s (NOT_VIABLE): %s",
+                                accountId,
+                                currency,
+                                from,
+                                to,
+                                e.message,
+                            )
+                            return@recoverWithUni Uni.createFrom().item(Unit)
+                        }
+                        failed.incrementAndGet()
                         metrics.pocketFailed(reason)
                         log.errorf(e, "Close failed for %s/%s %s..%s (%s)", accountId, currency, from, to, reason)
                         recordFailure(runId, accountId, currency, from, to, reason, e)

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/CloseOrchestratorTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/CloseOrchestratorTest.kt
@@ -85,6 +85,38 @@ class CloseOrchestratorTest {
         assertThat(result.pocketsFailed).isEqualTo(0)
     }
 
+    /**
+     * The SECOND read. `closePocketMonth` calls `accountInfo.pocketAccount` again, once per pocket,
+     * so a debris account can surface as NOT_VIABLE on the per-pocket path even after the
+     * account-level read succeeded. The rule must be the same on both: skipped, never failed
+     * (#862) — otherwise the same account is counted differently depending on which read saw the
+     * debris, and a CloseFailure row is written carrying a `reason` the published CloseFailure
+     * schema has no value for.
+     */
+    @Test
+    fun `debris surfacing on the per-pocket read is skipped, not recorded as a failure`() {
+        val accountId = UUID.randomUUID()
+        every { accountRegistry.allAccountIds() } returns Uni.createFrom().item(listOf(accountId))
+        // The account-level read SUCCEEDS — this is the case the outer guard does not cover.
+        every { accountInfo.pocketAccount(accountId) } returns
+            Uni.createFrom().item(PocketAccountInfo(accountId, "CZ6500000000000000000001", "Holder", listOf("CZK")))
+        every { periods.latestClosedPeriodTo(accountId, "CZK") } returns Uni.createFrom().nullItem()
+        every { closePocket.closePocketMonth(accountId, "CZK", any(), any()) } returns
+            Uni.createFrom().failure(NotViableAccountException(accountId, "no active pockets — debris account (#862)"))
+
+        val result = orchestrator.runClose(CloseTrigger.SCHEDULED).subscribe().withSubscriber(
+            io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create(),
+        ).awaitItem().item
+
+        assertThat(result.pocketsSkipped).isEqualTo(1)
+        assertThat(result.pocketsFailed).isEqualTo(0)
+        // COMPLETED, not COMPLETED_WITH_FAILURES: data noise must not colour the run's verdict.
+        assertThat(result.status).isEqualTo(CloseRunStatus.COMPLETED)
+        // And nothing is persisted or published — the two observable side effects of "failed".
+        verify(exactly = 0) { runs.recordFailure(any()) }
+        verify(exactly = 0) { outbox.append(any()) }
+    }
+
     @Test
     fun `transient upstream failure is counted as failed not skipped`() {
         val accountId = UUID.randomUUID()


### PR DESCRIPTION
Found while burning down #5962 — and the burn-down's own note was pointing at the wrong fix.

## The rule, and the path that did not implement it

#862 established it and `CloseFailureReason.NOT_VIABLE`'s KDoc states it:

> Debris from broken early-onboarding attempts. **SKIPPED in the run counts (not FAILED)**, so the
> StatementCloseFailures alert does not fire for data noise (#862).

`CloseOrchestrator` has two failure paths. The account-level one implements the rule. The
per-pocket one did not — and it is reachable, because **`closePocketMonth` calls
`accountInfo.pocketAccount` again, once per pocket**:

```kotlin
override fun closePocketMonth(accountId, currency, from, to) =
    accountInfo.pocketAccount(accountId).flatMap { account -> closePocket(account, currency, from, to) }
```

So the outer guard covers the outer read, not that one. A NOT_VIABLE surfacing on the per-pocket
read was counted **failed**, written as a `CloseFailure` row, and published as a `close_failed`
event — while the identical condition one frame earlier was silently skipped. The same account is
classified differently depending on *which* read saw the debris, which also means the run's verdict
(`COMPLETED` vs `COMPLETED_WITH_FAILURES`) turns on a race.

## The row it wrote could not be read

`openapi.yaml` publishes `CloseFailure.reason: [RECONCILIATION, UPSTREAM, UNKNOWN]`. A NOT_VIABLE
row is therefore a value no generated client can decode.

That is how #5962's baseline entry described it — *"CloseFailureReason: undeclared NOT_VIABLE"* —
which invites publishing NOT_VIABLE in the spec. **That would have been the wrong fix**: it would
make the schema describe a row the rule says must never exist. With both paths guarded the 3-value
enum is correct, so this PR corrects the baseline's *reason* instead of the spec, from "undeclared"
to "NOT drift — a deliberate subset".

## Verification, both directions

| | |
|---|---|
| fixed | `CloseOrchestratorTest` `tests=4 skipped=0 failures=0` |
| sabotaged (per-pocket branch removed) | *"debris surfacing on the per-pocket read is skipped, not recorded as a failure"* **FAILED**, `tests=4 failures=1` |
| restored | `BUILD SUCCESSFUL` — test + `ktlintCheck` + `detekt` |
| enum gate | 13 drifts, all baselined, no stale declaration |

The new test asserts the two **observable side effects** of "failed" — `verify(exactly = 0) { runs.recordFailure(any()) }`
and `verify(exactly = 0) { outbox.append(any()) }` — not only the counter. A counter-only assertion
would pass against a version that still wrote the row and emitted the event, which is precisely the
half that reaches other systems.

Refs #5962, #862
