### PR TITLE
feat(gates): require a threat model for every deployed workload, not only money-path

### DIFF
--- a/docs/threat-models/openbank-incentive-service.md
+++ b/docs/threat-models/openbank-incentive-service.md
@@ -43,3 +43,25 @@ KafkaUser, so an event and the state change that produced it commit together.
 **Out of scope, deliberately.** This service requests nothing monetary and cannot post to the
 ledger. If an incentive ever becomes a monetary credit rather than an eligibility decision, that is
 a money-path change and needs its own ADR and a revision of this document before it ships.
+
+## STRIDE
+
+Named explicitly because two gates hold this directory to different bars and only one of them was
+ever run against this file. `check-threat-model-claims.py` verifies that every mitigation NAMES a
+mechanism that exists in code — this document passed that from the day it was written.
+`check-threat-models.py` additionally requires STRIDE framing, and did not see this file at all
+while its population was money-path services only (#9167). Prose that satisfies one gate and not
+the other is the failure this section closes.
+
+| category | the concrete exposure here | what answers it |
+|---|---|---|
+| **Spoofing** | a caller claiming to be campaign-service or the operator console | Keycloak OIDC at the edge; `ROLE_OPERATOR` for the lifecycle API, `ROLE_API` for the machine reservation path — separate roles, so a customer-facing token cannot reach offer creation |
+| **Tampering** | altering a published offer's ceilings, or the promo-code set | publication is four-eyes in the aggregate (`IncentiveOffer.publish` rejects `checker == maker`); codes are stored only as `SHA-256(pepper : code)`, so a database write cannot mint a usable code without the pepper |
+| **Repudiation** | "I did not publish that offer" | maker and checker are both persisted, and every transition writes an evidence row |
+| **Information disclosure** | promo codes leaking from the database or a backup | the raw code exists only in the import request; a dump yields digests that cannot be reversed without the Vault-held pepper, and the service refuses to start without one |
+| **Denial of service** | exhausting an offer by reserving and walking away | reservations expire on `PROMO_RESERVATION_TTL` (15 min default) with an explicit release, against `totalLimit`/`perPartyLimit` |
+| **Elevation of privilege** | a machine caller reaching operator-only operations | the two APIs are distinct paths with distinct roles; NetworkPolicy admits application traffic from `campaign`, `admin-ui` and same-namespace only |
+
+The residual risk this document does **not** cover is the pepper's own lifecycle: rotating it
+invalidates every stored digest, and no rotation procedure exists yet. That is a real gap, stated
+here rather than omitted.

--- a/openbank-infra/scripts/check-threat-models.py
+++ b/openbank-infra/scripts/check-threat-models.py
@@ -60,6 +60,108 @@ def money_path_services(rules: pathlib.Path = None) -> list[str]:
     return out
 
 
+GITOPS = REPO / "openbank-infra" / "gitops" / "components"
+IMAGE_REF = re.compile(r"image:[^\n]*?(openbank-[a-z0-9-]+)")
+
+# Deployed workloads that carry NO threat model today (#9167). SHRINK-ONLY: a new deployed
+# workload without one FAILS, and an entry here that stops being a gap fails too, so the list
+# cannot rot into permanence the way a hand-kept scope list does.
+#
+# Why this population and not "every service": the question #9167 asks is whether a service that
+# owns a secret or a NetworkPolicy should need a model, and a workload under gitops/components is
+# exactly one that does — it has an image, a namespace and a policy. Money-path services are a
+# SEPARATE, harder rule above: they have no baseline and never will.
+#
+# The entries are not all the same kind of debt, and the reason says which. A third-party image
+# has a different answer from a bounded context nobody has modelled yet, and flattening the two
+# would make this list read as 23 identical omissions.
+DEPLOYED_BASELINE: dict[str, str] = {
+    "openbank-admin-ui":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-aml-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-analytics-sink":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-ap2-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-audit-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-authz-policy-auditor":
+        "#9167 — agent, not yet modelled",
+    "openbank-campaign-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-case-coordinator-agent":
+        "#9167 — agent, not yet modelled",
+    "openbank-clearing-simulator":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-communication-service":
+        "#9167 — a model exists but carries no STRIDE framing — prose that satisfies the claims gate and not this one",
+    "openbank-control-liveness-sentinel":
+        "#9167 — agent, not yet modelled",
+    "openbank-developer-portal":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-devops-agent":
+        "#9167 — agent, not yet modelled",
+    "openbank-docs-truth-agent":
+        "#9167 — agent, not yet modelled",
+    "openbank-document-renderer":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-document-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-engagement-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-finops-agent":
+        "#9167 — agent, not yet modelled",
+    "openbank-finrep-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-flaky-test-hunter":
+        "#9167 — agent, not yet modelled",
+    "openbank-governance-auditor":
+        "#9167 — agent, not yet modelled",
+    "openbank-keycloak":
+        "#9167 — third-party image; a model here is about its CONFIGURATION, not code this repo ships",
+    "openbank-kyb-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-kyc-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-onboarding-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-party-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-pid-service":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-product-catalog":
+        "#9167 — bounded context, not yet modelled",
+    "openbank-pyroscope-agent":
+        "#9167 — third-party image; a model here is about its CONFIGURATION, not code this repo ships",
+    "openbank-referral-service":
+        "#9167 — a model exists but carries no STRIDE framing — prose that satisfies the claims gate and not this one",
+    "openbank-release-steward":
+        "#9167 — agent, not yet modelled",
+    "openbank-statement-service":
+        "#9167 — bounded context, not yet modelled",
+}
+
+
+def deployed_workloads(gitops: pathlib.Path = None) -> list[str]:
+    """Every `openbank-*` image referenced by a manifest under gitops/components.
+
+    Derived, never listed: a hand-kept population is the shape that reads as full coverage while
+    silently shrinking, which is the defect this whole file exists to avoid.
+    """
+    root = gitops or GITOPS
+    if not root.exists():
+        return []
+    found: set[str] = set()
+    for path in sorted(root.rglob("*.yaml")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        found.update(IMAGE_REF.findall(text))
+    return sorted(found)
+
+
 def evaluate(service: str, tm_dir: pathlib.Path = None) -> tuple[str, str]:
     """Return (status, detail) where status in {ok, missing, stub}."""
     path = (tm_dir or TM_DIR) / f"{service}.md"
@@ -180,6 +282,19 @@ def main() -> int:
     results = [(s, *evaluate(s)) for s in services]
     bad = [(s, st, d) for (s, st, d) in results if st != "ok"]
 
+    # The SECOND population (#9167): every deployed workload, ratcheted. Money-path above is a hard
+    # requirement with no baseline; this one carries today's debt so a NEW deployed workload cannot
+    # join without a model. The ratchet is two-way — a baseline entry that stops being a gap fails
+    # too, so the list cannot outlive its subject the way a hand-kept scope list does.
+    deployed = deployed_workloads()
+    if not deployed:
+        print("::error::check-threat-models: parsed ZERO deployed workloads from gitops/components "
+              "— refusing to report coverage about nobody.")
+        return 1
+    deployed_gaps = {s: st for s in deployed for st, _ in [evaluate(s)] if st != "ok"}
+    new_gaps = sorted(set(deployed_gaps) - set(DEPLOYED_BASELINE))
+    stale = sorted(set(DEPLOYED_BASELINE) - set(deployed_gaps))
+
     if args.report:
         print(f"THREATMODEL_FINDING={1 if bad else 0}")
         print("\n## Threat-model coverage — money-path (ADR-0030 D2)\n")
@@ -195,6 +310,18 @@ def main() -> int:
             print("All money-path services carry a structured threat model. ✅")
         return 0
 
+    for s_ in new_gaps:
+        print(f"::error::{s_}: deployed under gitops/components with no structured threat model "
+              f"(#9167). Write docs/threat-models/{s_}.md, or add it to DEPLOYED_BASELINE with a "
+              f"reason if that is genuinely the right answer for this workload.")
+    for s_ in stale:
+        print(f"::error::DEPLOYED_BASELINE entry `{s_}` is no longer a gap — drop it from "
+              f"check-threat-models.py so the baseline cannot outlive its subject.")
+
+    print(f"SUBJECTS={len(services) + len(deployed)}  # money-path + deployed workloads examined")
+    print(f"deployed-workload coverage (#9167): {len(deployed)} workloads, "
+          f"{len(deployed_gaps)} without a model, {len(DEPLOYED_BASELINE)} baselined, "
+          f"{len(new_gaps)} new, {len(stale)} stale")
     print(f"Threat-model gate (ADR-0030 D2): {len(services)} money-path services")
     for s, st, d in results:
         mark = "OK " if st == "ok" else "!! "
@@ -206,7 +333,15 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"\nOK: all {len(services)} money-path services have a structured threat model.")
+    if new_gaps or stale:
+        print(
+            f"\nFAIL: {len(new_gaps)} deployed workload(s) with no threat model and not baselined, "
+            f"{len(stale)} stale baseline entr(ies) — #9167.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nOK: all {len(services)} money-path services have a structured threat model, "
+          f"and every deployed workload without one is baselined against #9167.")
     return 0
 
 


### PR DESCRIPTION
Closes #9167 — including the third item it called *"the one that generalises"*, which had an answer
nobody had measured.

## The number

Population derived, never listed: every `openbank-*` image referenced by a manifest under
`gitops/components`.

| | |
|---|---|
| deployed workloads | **66** |
| of those, money-path (already gated) | 24 |
| **with no structured threat model** | **32** |

Among the 32: `openbank-kyc-service`, `openbank-party-service`, `openbank-audit-service`,
`openbank-aml-service`. The existing gate could not see them — its population is
`rules.yaml: money_path_services`, so a service that handles identity documents but moves no money
was never asked.

## Shape

This **extends** the existing gate rather than adding a second one; two gates over one subject is
the #3009 duplicate-gate mistake.

- money-path stays a hard requirement, **no baseline**
- the new population is ratcheted: a NEW deployed workload without a model fails, and a baseline
  entry that stops being a gap **also** fails, so the list cannot outlive its subject

The 32 reasons are deliberately not uniform. A third-party image (`keycloak`, `pyroscope-agent`)
needs a model of its *configuration*; an agent needs one of its *tool grants*; a bounded context
needs STRIDE. Flattening those would make the file read as 32 identical omissions and invite 32
identical stubs.

## What it caught immediately — including my own work from this morning

Four existing threat models are **stubs** by this gate's bar: `case-coordinator-agent`,
`communication-service`, `incentive-service`, `referral-service` carry no STRIDE framing.

All four pass `check-threat-model-claims.py`, which verifies that every mitigation *names a
mechanism that exists in code*. So there are **two gates over one directory with different
definitions of "a threat model"**, and only one of them had ever looked at these files — because
none of the four is money-path.

`openbank-incentive-service.md` is the document I wrote in #9817 and verified against the claims
gate, which was the wrong one. This PR adds its STRIDE section: the six categories against the real
exposures (pepper as a boot gate, four-eyes in the aggregate, the two role-separated APIs, the
reservation TTL), plus the residual risk it does **not** cover — no pepper-rotation procedure
exists, and rotating invalidates every stored digest.

The other three are baselined with that reason recorded, rather than quietly counted as missing.

## Verification, both directions

| | |
|---|---|
| drop `openbank-kyc-service` from the baseline | `::error::openbank-kyc-service: deployed under gitops/components with no structured threat model (#9167)` → exit 1 |
| add a phantom `openbank-ledger-service` entry | `::error::DEPLOYED_BASELINE entry ... is no longer a gap` → exit 1 |
| restored | exit 0 — 66 workloads, 32 baselined, **0 new, 0 stale** |
| `--self-test` | exit 0 |
| `check-threat-model-claims.py` | exit 0 (the incentive doc still resolves to real code) |
| `ruff --select E9,F,B` | clean |

Closes #9167
