### PR TITLE
fix(ci): let runtime-conformance see a database the repo never mentions

### DIFF
--- a/.github/scripts/runtime-conformance.py
+++ b/.github/scripts/runtime-conformance.py
@@ -51,6 +51,7 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import pathlib
 import re
@@ -93,6 +94,38 @@ def claim_cnpg_clusters(root: pathlib.Path) -> dict[str, dict]:
                 "declares_backup": "barmanObjectStore" in doc,
                 "source": str(path.relative_to(root)),
             }
+    return out
+
+
+def claim_app_backup_exemptions(root: pathlib.Path) -> dict[str, str]:
+    """ArgoCD Application name -> the backup exemption its manifest declares, if any.
+
+    The live annotation is the primary route and stays so. This is the fallback for a cluster
+    whose metadata nobody in this repository controls: `glitchtip-pg` is rendered by a chart
+    whose `postgresql.cluster` passthrough accepts only instances and storage, so the annotation
+    can never reach it, and without a second route the check reports a settled decision forever.
+    A permanently red check is one people learn to skip, which reproduces #9834 one level up.
+
+    It is deliberately NOT a list of cluster names beside the manifests — that is the drift the
+    annotation design exists to prevent. The Application is joined to the cluster by the
+    tracking-id the live object already carries, so the exemption cannot outlive what it excuses,
+    and a cluster nobody manages carries no tracking-id and cannot be excused at all.
+
+    Parsed with the same regex idiom as the rest of the claim side; this script has no YAML
+    dependency on purpose.
+    """
+    out: dict[str, str] = {}
+    for path in sorted(root.glob("openbank-infra/gitops/apps/*.yaml")):
+        text = _read(path)
+        if "kind: Application" not in text:
+            continue
+        name = _field(text, "name")
+        m = re.search(rf"^\s+{re.escape(BACKUP_EXEMPT_ANNOTATION)}:\s*(.+)$", text, re.M)
+        if not (name and m):
+            continue
+        reason = m.group(1).strip().strip("\"'")
+        if reason:
+            out[name] = reason
     return out
 
 
@@ -179,7 +212,7 @@ def claim_image_pins(root: pathlib.Path) -> dict[str, str]:
 BACKUP_EXEMPT_ANNOTATION = "openbank.io/backup-exempt-reason"
 
 
-def cmp_backup_recoverability(claims: dict, facts: dict) -> list[str]:
+def cmp_backup_recoverability(claims: dict, facts: dict, app_exemptions: dict | None = None) -> list[str]:
     """A cluster that declares a backup must have a recovery point.
 
     `Ready` and `ContinuousArchiving` are deliberately NOT consulted: on 2026-08-07 all three
@@ -214,11 +247,29 @@ def cmp_backup_recoverability(claims: dict, facts: dict) -> list[str]:
         reason = (fact.get("backup_exempt_reason") or "").strip()
         if reason:
             continue
+        # Second route to the same decision, for a cluster whose metadata this repository does
+        # not author. Joined by the tracking-id the live object carries, so it excuses exactly
+        # the cluster that Application renders and nothing else.
+        app = (fact.get("argocd_app") or "").strip()
+        if app and app in (app_exemptions or {}):
+            continue
         where = "is declared nowhere in gitops" if claim is None else "declares no backup destination"
         findings.append(
             f"{key}: live cluster {where} and carries no {BACKUP_EXEMPT_ANNOTATION} "
             f"annotation — it has no recovery point and nobody has said that is intended"
         )
+
+    # An exemption that excuses nothing is the failure mode this design exists to avoid: one left
+    # behind after the cluster was deleted, or after it was given a real backup, silently becomes
+    # cover for whatever lands under that Application next. Report it, so removing it is someone's
+    # job rather than a later audit's discovery.
+    live_apps = {(f.get("argocd_app") or "").strip() for f in facts.values()}
+    for app, reason in sorted((app_exemptions or {}).items()):
+        if app not in live_apps:
+            findings.append(
+                f"{app}: declares {BACKUP_EXEMPT_ANNOTATION} ({reason!r}) but renders no live "
+                f"CNPG cluster — the exemption excuses nothing and should be removed"
+            )
     return findings
 
 
@@ -358,6 +409,13 @@ def collect() -> dict:
             # Read from the LIVE object, not from gitops: a chart-rendered cluster has no manifest
             # in this tree, so the only place its exemption can be seen is here (#9834).
             "backup_exempt_reason": (meta.get("annotations") or {}).get(BACKUP_EXEMPT_ANNOTATION),
+            # Which ArgoCD Application renders this object, read off the object itself. The
+            # annotation above is the right home for an exemption and is not always reachable:
+            # a third-party chart decides its own metadata, and glitchtip's passes through only
+            # instances and storage. This is the join key that lets such a cluster be excused
+            # from its Application instead — without a list of cluster names that could drift.
+            "argocd_app": ((meta.get("annotations") or {}).get(
+                "argocd.argoproj.io/tracking-id") or "").split(":", 1)[0].strip(),
         }
     snap["facts"]["backup_recoverability"] = clusters
 
@@ -459,7 +517,10 @@ def check(root: pathlib.Path, snapshot: dict) -> int:
         if probe not in facts:
             print(f"::warning::{probe}: no facts in the snapshot — NOT CHECKED (this is not a pass)")
             continue
-        for finding in COMPARATORS[probe](claims[probe], facts[probe]):
+        comparator = COMPARATORS[probe]
+        if probe == "backup_recoverability":
+            comparator = functools.partial(comparator, app_exemptions=claim_app_backup_exemptions(root))
+        for finding in comparator(claims[probe], facts[probe]):
             print(f"::warning::{probe}: {finding}")
             total += 1
     verb = "divergence(s)" if total != 1 else "divergence"
@@ -543,6 +604,30 @@ def self_test() -> int:
         "backup: a BLANK exemption reason does not count as an exemption",
         len(cmp_backup_recoverability({}, {"observability/glitchtip-pg": {"backup_exempt_reason": "   "}})),
         1)
+    expect(
+        "backup: an exemption on the ARGOCD APPLICATION excuses the cluster it renders",
+        cmp_backup_recoverability(
+            {}, {"observability/glitchtip-pg": {"argocd_app": "glitchtip"}},
+            app_exemptions={"glitchtip": "rebuildable from the app; no customer data"}),
+        [])
+    expect(
+        "backup: ... and it excuses ONLY that Application's cluster, not a neighbour",
+        len(cmp_backup_recoverability(
+            {}, {"pricing/pricing-db": {"argocd_app": "pricing"},
+                 "observability/glitchtip-pg": {"argocd_app": "glitchtip"}},
+            app_exemptions={"glitchtip": "rebuildable from the app; no customer data"})),
+        1)
+    expect(
+        "backup: ... and a cluster carrying NO tracking-id cannot be excused by any Application",
+        len(cmp_backup_recoverability(
+            {}, {"pricing/pricing-db": {}},
+            app_exemptions={"": "an empty join key must never match"})),
+        1)
+    expect(
+        "backup: an Application exemption that renders no live cluster is itself a finding",
+        "excuses nothing" in first(cmp_backup_recoverability(
+            {}, {}, app_exemptions={"glitchtip": "rebuildable from the app"})),
+        True)
     expect(
         "backup: the annotation key is the one the gitops gate honours",
         BACKUP_EXEMPT_ANNOTATION,

--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -30,6 +30,19 @@ kind: Application
 metadata:
   name: glitchtip
   namespace: argocd
+  annotations:
+    # WHY THE EXEMPTION LIVES HERE AND NOT ON THE CLUSTER: the runtime-conformance backup control
+    # honours this annotation on the CNPG Cluster itself, which is the right home for it. This
+    # chart renders its own Cluster and its `postgresql.cluster` passthrough accepts only
+    # `instances` and `storage` — there is no values key that can put an annotation on that object,
+    # so the primary route is unreachable here. The control joins this Application to the cluster
+    # by the tracking-id the live object already carries, so this excuses exactly glitchtip-pg and
+    # stops excusing anything the day this Application renders no cluster.
+    #
+    # WHY IT IS EXEMPT: GlitchTip holds pseudonymous crash events with a short retention, all of
+    # which are re-sent by devices in the field; losing the database costs visibility, not records.
+    # It holds no customer, money-path or regulatory data, so it has no recovery-point requirement.
+    openbank.io/backup-exempt-reason: "crash-event sink only — pseudonymous, short-retention, re-emitted by clients; no customer or money-path data"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
## What this is now

Rebuilt on top of **#9845**, which merged while this PR was open and implemented the
live-side comparison independently. My first commit was a duplicate of that work and is gone;
what remains is one commit that builds on their implementation and uses their names
(`BACKUP_EXEMPT_ANNOTATION`, `backup_exempt_reason`).

## The defect it fixes

#9845 honours the exemption annotation on the CNPG `Cluster`. That is the right home for the
decision, and it is not always reachable. Measured against the live cluster, main right now
reports:

```
observability/glitchtip-pg: live cluster is declared nowhere in gitops and carries no
  openbank.io/backup-exempt-reason annotation — it has no recovery point and nobody has
  said that is intended
```

`glitchtip-pg` is rendered by a third-party chart whose `postgresql.cluster` passthrough
accepts only `instances` and `storage` — nothing in this repository can put an annotation on
that object. So the remediation the control prints cannot be carried out, and the control is
permanently red. A check people learn to skip reproduces #9834 one level up.

## The change

A second route to the same decision, not a second mechanism. The exemption may also be declared
on the ArgoCD `Application`, joined to the cluster by the `tracking-id` the live object already
carries. Consequences of that join, rather than of a list:

- it cannot name a cluster that does not exist;
- it excuses only what that Application renders;
- a cluster with no tracking-id (nobody manages it) cannot be excused at all;
- an exemption that renders no live cluster is reported as its own divergence, so a stale one
  is someone's job rather than a later audit's discovery.

`apps/glitchtip.yaml` carries the first such exemption, with why-here and why-exempt next to it.

## Measured, against the live cluster

```
without the Application route (main today):        with it (this branch):
  incentive/incentive-db  …not found at runtime      incentive/incentive-db  …not found at runtime
  observability/glitchtip-pg  …no annotation         pricing/pricing-db      …no annotation
  pricing/pricing-db          …no annotation
```

glitchtip excused; `pricing-db` still reported (it is a separate repo's database with no backup —
the finding is correct and stays); `incentive-db` untouched.

Self-test covers the positive, the neighbour-cluster negative, the no-tracking-id negative and
the stale-exemption case: `python3 .github/scripts/runtime-conformance.py --self-test`.

Refs #9834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
