### PR TITLE
fix(kyc): exclude parties that predate the auto-open consumer from the orphan gauge

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
@@ -84,10 +84,18 @@ spec:
         - alert: KycPartiesWithoutCase
           # Issue #5698. PartyEventConsumer caught every exception, logged it and returned — which
           # ACKS the Kafka message. A few seconds of kyc-db downtime therefore destroyed the only
-          # copy of a PARTY_CREATED: no KYC case, party stuck in PENDING_KYC forever, accounts stuck
-          # in PENDING_ACTIVATION, no welcome bonus. 10 of 73 sandbox parties were in that state,
-          # the oldest since 2026-06-07, and it was found only because a human noticed an account
-          # did not work.
+          # copy of a PARTY_CREATED: no KYC case, party stuck in PENDING_KYC forever, and it was
+          # found only because a human noticed an account did not work. (The "10 of 73" figure this
+          # comment used to carry was WITHDRAWN on #5698 and must not be reinstated — a later
+          # re-measure took it from the issue body rather than from the correction, and it has been
+          # quoted as fact twice since. Whatever the count is, read it off the gauge.)
+          #
+          # #9726: what this gauge counts changed. Parties created BEFORE the oldest KYC case in the
+          # store predate the auto-open consumer, so no case was ever possible for them; they are
+          # excluded here and published separately as openbank_kyc_orphaned_parties_pre_consumer.
+          # Without that split the sandbox floor was 6 and `> 0` was unsatisfiable, so the alert was
+          # permanently lit and structurally silent about a genuine new orphan. A step change in the
+          # pre_consumer series is worth a look in its own right — it means the derived cutoff moved.
           #
           # Why the two rules above could not catch it. PartyEventDeadLettered needs a DLQ record,
           # and the whole defect is that the event was acked and never dead-lettered.
@@ -112,8 +120,8 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: "{{ $value }} party(ies) have no KYC case at all"
-            description: "openbank_kyc_orphaned_parties is {{ $value }} — that many parties, all past the detection grace period, have NO kyc_cases row. Each is a customer permanently stuck: PENDING_KYC party, accounts stuck in PENDING_ACTIVATION, no welcome bonus, and nothing retries because the PARTY_CREATED event was acked and dropped (#5698). Not self-healing — the event is gone, so it needs a replay per party. The stranded party ids are logged by kyc-service under `[orphan-detection]`; openbank_kyc_orphaned_parties_oldest_age_seconds says how long the worst one has been waiting."
+            summary: "{{ $value }} eligible party(ies) have no KYC case at all"
+            description: "openbank_kyc_orphaned_parties is {{ $value }} — that many parties, all past the detection grace period and all created after the auto-open consumer demonstrably worked, have NO kyc_cases row. Each is a customer stuck in PENDING_KYC, and nothing retries because the PARTY_CREATED event was acked and dropped (#5698). Not self-healing — the event is gone, so it needs a replay per party. Before remediating, CHECK what these parties are: parties that predate the consumer are already excluded (openbank_kyc_orphaned_parties_pre_consumer), but an e2e fixture party is indistinguishable from a real customer here, and a triage pass has twice ranked ineligible rows as the estate's top finding (#9726). The ids are logged by kyc-service under `[orphan-detection]`; openbank_kyc_orphaned_parties_oldest_age_seconds says how long the worst one has been waiting. Do not quote the party count as a customer-impact figure without confirming each id has an account."
         - alert: OnboardingProjectionWireFormatMismatch
           # #4353/#4692/#6248. sca-service published DEVICE_ENROLLED without the discriminator in
           # the payload body; onboarding's parser fell through to `?: return`, and 15 enrolments

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/OrphanedPartyDetector.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/OrphanedPartyDetector.kt
@@ -131,9 +131,29 @@ class OrphanedPartyDetector(
             .filter { it.id !in withCases }
             .sortedBy { it.createdAt }
 
+        // Split the orphans by an eligibility cutoff DERIVED from the data (issue #9726). A party
+        // created before the oldest KYC case in the store predates every case that has ever been
+        // opened, so the auto-open consumer cannot have been running when it was created: no case
+        // was opened for it and none ever could have been. Counting those alongside genuinely
+        // stranded parties put a permanent floor of 6 under the sandbox gauge, so `> 0` was a
+        // threshold the environment could never satisfy and a real seventh orphan would have been
+        // indistinguishable from the floor.
+        //
+        // A null cutoff (no case has ever existed, including a wiped store) classifies NOTHING as
+        // ineligible. The other direction would let an empty kyc-db report a clean register, which
+        // is the report-clean failure this whole control exists to prevent.
+        val firstCaseAt = kycCaseRepository.earliestCaseCreatedAt()
+        val (preConsumer, stranded) = if (firstCaseAt == null) {
+            emptyList<PartySummary>() to orphans
+        } else {
+            orphans.partition { it.createdAt.isBefore(firstCaseAt) }
+        }
+
         return OrphanedPartyReport(
-            orphanedPartyIds = orphans.map { it.id },
-            oldestOrphanCreatedAt = orphans.firstOrNull()?.createdAt,
+            orphanedPartyIds = stranded.map { it.id },
+            preConsumerPartyIds = preConsumer.map { it.id },
+            firstCaseCreatedAt = firstCaseAt,
+            oldestOrphanCreatedAt = stranded.firstOrNull()?.createdAt,
             partiesScanned = scanned,
             checkedAt = now,
         )
@@ -167,15 +187,27 @@ class OrphanedPartyDetector(
  *   is indistinguishable from a healthy register unless the denominator is published alongside. The
  *   fleet has been bitten by exactly this shape — a probe that cannot express its own failure
  *   reports "clean".
+ * @param preConsumerPartyIds parties with no case that were created BEFORE the oldest case this
+ *   store holds — i.e. before the auto-open consumer demonstrably worked. They are reported
+ *   separately rather than dropped: the exclusion is a claim about the environment, and a claim
+ *   nobody can see is one nobody can falsify. Empty when [firstCaseCreatedAt] is null.
+ * @param firstCaseCreatedAt the derived cutoff itself, so a reader can check what was excluded and
+ *   why without re-deriving it. Null means the store holds no case at all, in which case nothing
+ *   was excluded.
  * @param oldestOrphanCreatedAt creation time of the longest-stranded orphan, or `null` when there
  *   are none. Drives the age gauge that tells a fresh mis-configuration apart from the months-old
  *   backlog #5698 found.
  */
 data class OrphanedPartyReport(
     val orphanedPartyIds: List<UUID>,
+    val preConsumerPartyIds: List<UUID> = emptyList(),
+    val firstCaseCreatedAt: Instant? = null,
     val oldestOrphanCreatedAt: Instant?,
     val partiesScanned: Long,
     val checkedAt: Instant,
 ) {
     val orphanCount: Int get() = orphanedPartyIds.size
+
+    /** How many orphans were excluded as structurally ineligible. Published, never silently dropped. */
+    val preConsumerCount: Int get() = preConsumerPartyIds.size
 }

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/KycRepositoryPort.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/KycRepositoryPort.kt
@@ -61,6 +61,24 @@ interface KycCaseRepository {
      */
     suspend fun findPartyIdsWithAnyCase(partyIds: Collection<UUID>): Set<UUID>
 
+    /**
+     * Creation time of the OLDEST KYC case in the store, or null when no case has ever existed.
+     *
+     * This is the reconciliation's eligibility cutoff, derived rather than declared (issue #9726).
+     * `PartyEventConsumer` — the thing that opens a case when a party is created — was added on
+     * 2026-06-26; every party created before it existed has no case and never could have had one,
+     * so counting those as stranded customers puts a permanent floor under
+     * `openbank_kyc_orphaned_parties` and makes the alert structurally unable to clear. The date
+     * itself must not be hardcoded: the first case this store holds IS the first moment the
+     * auto-open path demonstrably worked, and it moves with the environment instead of with a
+     * comment someone has to remember to update.
+     *
+     * Returning null must NOT be read as "everything is ineligible" — an empty or wiped kyc-db
+     * would then silence the control completely, which is the reporting-clean failure the whole
+     * of #5698 is about. The caller treats null as "no cutoff available, report every orphan".
+     */
+    suspend fun earliestCaseCreatedAt(): Instant?
+
     suspend fun listAll(page: Int, size: Int): List<KycCase>
 
     /** Filter by [status]. Used by the onboarding cockpit funnel view (ADR-0068). */

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
@@ -32,6 +32,11 @@ import java.util.concurrent.atomic.AtomicLong
  *    longest-stranded party has been waiting, `0` when there are none. Triage: separates a
  *    mis-configuration that started this morning from the months-old backlog #5698 found.
  *  - `openbank_kyc_orphan_detection_parties_scanned{service="kyc"}` — the DENOMINATOR.
+ *  - `openbank_kyc_orphaned_parties_pre_consumer{service="kyc"}` — orphans excluded from the first
+ *    gauge because they were created before the oldest KYC case in the store, so the auto-open
+ *    consumer cannot have been running when they appeared (issue #9726). Published rather than
+ *    silently dropped, because the exclusion is a claim about the environment: this series is what
+ *    lets someone check it, and a step change in it is itself worth a look.
  *
  * ### Why the denominator is published
  *
@@ -99,6 +104,7 @@ class OrphanedPartyGauge(
     private val orphanCount = AtomicLong(0)
     private val oldestOrphanAgeSeconds = AtomicLong(0)
     private val partiesScanned = AtomicLong(0)
+    private val preConsumerParties = AtomicLong(0)
     private var liveness: WorkflowLivenessRecorder? = null
 
     @PostConstruct
@@ -107,6 +113,7 @@ class OrphanedPartyGauge(
         gauge(r, "openbank.kyc.orphaned.parties", orphanCount)
         gauge(r, "openbank.kyc.orphaned.parties.oldest.age.seconds", oldestOrphanAgeSeconds)
         gauge(r, "openbank.kyc.orphan.detection.parties.scanned", partiesScanned)
+        gauge(r, "openbank.kyc.orphaned.parties.pre.consumer", preConsumerParties)
     }
 
     fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
@@ -144,12 +151,27 @@ class OrphanedPartyGauge(
             val report = detector.detect()
             orphanCount.set(report.orphanCount.toLong())
             partiesScanned.set(report.partiesScanned)
+            preConsumerParties.set(report.preConsumerCount.toLong())
             oldestOrphanAgeSeconds.set(
                 report.oldestOrphanCreatedAt
                     ?.let { maxOf(0L, Duration.between(it, Instant.now(clock)).seconds) }
                     ?: 0L,
             )
             liveness?.recordSuccess()
+            if (report.preConsumerCount > 0) {
+                // Not a warning: these are not stranded customers and nothing is to be done about
+                // them. It is here so the number in the gauge has a visible composition — the
+                // absence of one is what let two separate readers rank a pile of pre-consumer rows
+                // and e2e fixtures as the estate's highest-severity finding (#9726).
+                log.infof(
+                    "[orphan-detection] %d party(ies) with no case predate the oldest case in this " +
+                        "store (%s) — created before the auto-open consumer existed, so no case was " +
+                        "ever possible; excluded from openbank_kyc_orphaned_parties: %s",
+                    report.preConsumerCount,
+                    report.firstCaseCreatedAt,
+                    report.preConsumerPartyIds.joinToString(),
+                )
+            }
             if (report.orphanCount > 0) {
                 // The ids, not just the count: remediation is a manual replay per party (#5698), so
                 // the log line has to be actionable on its own. Party ids are opaque identifiers,

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepository.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepository.kt
@@ -175,6 +175,15 @@ class KycRepository(private val outboxRepository: KycOutboxRepository) :
         return found
     }
 
+    // Scalar MIN rather than `find("order by createdAt asc").firstResult()`: the ordered-row form
+    // hydrates a whole KycCaseEntity and parses its checksJson to then read one column off it, on
+    // every tick of a monitoring job. The aggregate is an index-only read of one value.
+    override suspend fun earliestCaseCreatedAt(): Instant? = Panache.withSession {
+        Panache.getSession().flatMap { session ->
+            session.createQuery(EARLIEST_CASE_CREATED_AT_HQL, Instant::class.java).singleResultOrNull
+        }
+    }.awaitSuspending()
+
     override suspend fun listAll(page: Int, size: Int): List<KycCase> =
         Panache.withSession { findAll().page(page, size).list() }.awaitSuspending().map { it.toDomain(objectMapper) }
 
@@ -282,6 +291,11 @@ class KycRepository(private val outboxRepository: KycOutboxRepository) :
          * count of one statement (`KycRepositoryBatchingTest`).
          */
         internal fun idBatches(partyIds: Collection<UUID>): List<List<UUID>> = partyIds.toList().chunked(ID_BATCH_SIZE)
+
+        // MIN over an empty table is a single NULL row, not an empty result — `singleResultOrNull`
+        // is therefore about the VALUE being null, and the query always returns exactly one row.
+        private const val EARLIEST_CASE_CREATED_AT_HQL =
+            "SELECT MIN(c.createdAt) FROM KycCaseEntity c"
 
         private const val PARTY_IDS_WITH_CASE_HQL =
             "SELECT c.partyId FROM KycCaseEntity c WHERE c.partyId IN :ids"

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/OrphanedPartyDetectorTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/OrphanedPartyDetectorTest.kt
@@ -12,6 +12,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Duration
@@ -56,6 +57,20 @@ class OrphanedPartyDetectorTest {
 
     private fun casesExistFor(vararg ids: UUID) {
         coEvery { repository.findPartyIdsWithAnyCase(any()) } returns ids.toSet()
+    }
+
+    /**
+     * Default: no cutoff available, so nothing is excluded as pre-consumer. That is the
+     * conservative direction the detector must take for an empty store, and it keeps every case
+     * below about the rule it was written for rather than about #9726's eligibility split.
+     */
+    @BeforeEach
+    fun noEligibilityCutoffByDefault() {
+        coEvery { repository.earliestCaseCreatedAt() } returns null
+    }
+
+    private fun oldestCaseAt(at: Instant) {
+        coEvery { repository.earliestCaseCreatedAt() } returns at
     }
 
     @Test
@@ -167,6 +182,73 @@ class OrphanedPartyDetectorTest {
                     "is looking at nothing' — both report zero orphans",
             )
             .isZero()
+    }
+
+    @Test
+    fun `a party created before the oldest case is pre-consumer, not stranded`(): Unit = runBlocking {
+        // The sandbox's six 2026-06-07 parties (#9726): PartyEventConsumer did not exist yet, so no
+        // case was opened for them and none ever could have been. Counting them as stranded put a
+        // permanent floor under the gauge and made `> 0` unsatisfiable.
+        val preConsumer = party(ageMinutes = 10_000)
+        val stranded = party(ageMinutes = 1_000)
+        directoryHolds(preConsumer, stranded)
+        casesExistFor()
+        oldestCaseAt(now.minus(Duration.ofMinutes(5_000)))
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds).containsExactly(stranded.id)
+        assertThat(report.preConsumerPartyIds).containsExactly(preConsumer.id)
+        assertThat(report.oldestOrphanCreatedAt)
+            .describedAs("the age gauge must age the ACTIONABLE orphan, not the excluded one")
+            .isEqualTo(stranded.createdAt)
+    }
+
+    @Test
+    fun `with no case in the store NOTHING is excluded`(): Unit = runBlocking {
+        // A wiped or brand-new kyc-db has no cutoff to derive. Excluding on a null cutoff would let
+        // an empty store report a clean register — the report-clean failure #5698 is about.
+        val ancient = party(ageMinutes = 100_000)
+        directoryHolds(ancient)
+        casesExistFor()
+        coEvery { repository.earliestCaseCreatedAt() } returns null
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds).containsExactly(ancient.id)
+        assertThat(report.preConsumerPartyIds).isEmpty()
+    }
+
+    @Test
+    fun `a party created at the same instant as the oldest case is NOT excluded`(): Unit = runBlocking {
+        // The boundary is strict: the cutoff is the first moment the auto-open path is known to
+        // have worked, so a party created AT that instant was eligible and its missing case is real.
+        val at = now.minus(Duration.ofMinutes(5_000))
+        val boundary = PartySummary(id = UUID.randomUUID(), status = "PENDING_KYC", createdAt = at)
+        directoryHolds(boundary)
+        casesExistFor()
+        oldestCaseAt(at)
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds).containsExactly(boundary.id)
+        assertThat(report.preConsumerPartyIds).isEmpty()
+    }
+
+    @Test
+    fun `the cutoff excludes only parties with no case, never parties that have one`(): Unit = runBlocking {
+        // The split runs AFTER the case lookup, so a pre-consumer party that does have a case is
+        // not an orphan at all and must appear in neither list.
+        val oldButHandled = party(ageMinutes = 10_000)
+        directoryHolds(oldButHandled)
+        casesExistFor(oldButHandled.id)
+        oldestCaseAt(now.minus(Duration.ofMinutes(5_000)))
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds).isEmpty()
+        assertThat(report.preConsumerPartyIds).isEmpty()
+        assertThat(report.firstCaseCreatedAt).isNotNull()
     }
 
     private companion object {

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/integration/OrphanedPartyDetectionSchedulerIT.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/integration/OrphanedPartyDetectionSchedulerIT.kt
@@ -85,7 +85,9 @@ class OrphanedPartyDetectionSchedulerIT {
     }
 
     /**
-     * A two-party register: one that never got a KYC case (the #5698 defect) and one that did.
+     * A three-party register: one that never got a KYC case (the #5698 defect), one that did, and
+     * one created before the oldest case in the store — which is #9726's eligibility cutoff, so it
+     * must be reported as pre-consumer rather than counted as stranded.
      * Both ids are hardcoded literals for the classloader reason above.
      */
     @Alternative
@@ -98,6 +100,7 @@ class OrphanedPartyDetectionSchedulerIT {
                 items = listOf(
                     PartySummary(UUID.fromString(STRANDED_PARTY_ID), "PENDING_KYC", CREATED_AT),
                     PartySummary(UUID.fromString(HANDLED_PARTY_ID), "PENDING_KYC", CREATED_AT),
+                    PartySummary(UUID.fromString(PRE_CONSUMER_PARTY_ID), "PENDING_KYC", PRE_CONSUMER_CREATED_AT),
                 ),
                 total = TOTAL,
             )
@@ -118,11 +121,13 @@ class OrphanedPartyDetectionSchedulerIT {
             c.prepareStatement(
                 """
                 INSERT INTO kyc_cases (case_id, party_id, status, risk_level, checks_json, created_at, updated_at)
-                VALUES (?, ?, 'OPEN', 'MEDIUM', '[]', NOW(), NOW())
+                VALUES (?, ?, 'OPEN', 'MEDIUM', '[]', ?, ?)
                 """.trimIndent(),
             ).use { st ->
                 st.setObject(1, UUID.randomUUID())
                 st.setObject(2, UUID.fromString(HANDLED_PARTY_ID))
+                st.setObject(3, java.sql.Timestamp.from(CASE_CREATED_AT))
+                st.setObject(4, java.sql.Timestamp.from(CASE_CREATED_AT))
                 st.executeUpdate()
             }
         }
@@ -171,9 +176,17 @@ class OrphanedPartyDetectionSchedulerIT {
 
         assertThat(awaitGaugeValue("openbank.kyc.orphaned.parties") { it == 1.0 })
             .describedAs(
-                "exactly one of the two seeded parties has no kyc_cases row, so the orphan gauge " +
-                    "must read 1 — 0 would mean the batched IN projection matched everything, 2 " +
-                    "that it matched nothing",
+                "of the three seeded parties one has a case, one predates the oldest case and one " +
+                    "is genuinely stranded, so the orphan gauge must read 1 — 0 would mean the " +
+                    "batched IN projection matched everything, 2 that the #9726 cutoff is not " +
+                    "applied at all",
+            )
+            .isEqualTo(1.0)
+
+        assertThat(gauge("openbank.kyc.orphaned.parties.pre.consumer"))
+            .describedAs(
+                "the excluded party is PUBLISHED, not dropped: without this series the exclusion " +
+                    "is a claim about the environment that nobody can check (#9726)",
             )
             .isEqualTo(1.0)
 
@@ -226,13 +239,32 @@ class OrphanedPartyDetectionSchedulerIT {
         assertThat(scrape)
             .describedAs("the denominator that separates 'no orphans' from 'scanned nothing'")
             .contains("openbank_kyc_orphan_detection_parties_scanned{")
+        assertThat(scrape)
+            .describedAs("the composition series the alert's description points a reader at (#9726)")
+            .contains("openbank_kyc_orphaned_parties_pre_consumer{")
     }
 
     private companion object {
         const val STRANDED_PARTY_ID = "fad8c8db-0000-4000-8000-000000005698"
         const val HANDLED_PARTY_ID = "58fb3ae8-0000-4000-8000-000000005698"
-        const val TOTAL = 2L
+        const val PRE_CONSUMER_PARTY_ID = "7c1f0a44-0000-4000-8000-000000009726"
+        const val TOTAL = 3L
         val CREATED_AT: Instant = Instant.parse("2026-06-07T10:00:00Z")
+
+        /**
+         * Before [CASE_CREATED_AT], so this party predates every case the store holds — the
+         * structural shape of the six sandbox parties that predated `PartyEventConsumer` (#9726).
+         */
+        val PRE_CONSUMER_CREATED_AT: Instant = Instant.parse("2026-05-01T10:00:00Z")
+
+        /**
+         * The seeded case's `created_at`, and therefore the derived cutoff. Written explicitly
+         * rather than `NOW()`: with `NOW()` every party in the register predates the only case and
+         * the whole register classifies as pre-consumer, which is a true answer to the wrong
+         * question — this test exists to exercise the split, not to demonstrate it swallowing
+         * everything.
+         */
+        val CASE_CREATED_AT: Instant = Instant.parse("2026-06-01T10:00:00Z")
 
         /** Generous vs the 2s cron so a slow CI runner cannot flake the wait. */
         const val SCAN_BUDGET_NANOS = 60_000_000_000L


### PR DESCRIPTION
Refs #9726.

## What was wrong

`openbank_kyc_orphaned_parties` counted every party with no KYC case, including parties created
**before the auto-open consumer existed**. `PartyEventConsumer` landed 2026-06-26; six of the
sandbox's nine "orphans" were created 2026-06-07, nineteen days earlier. No case was ever opened
for them and none ever could have been.

So `expr: openbank_kyc_orphaned_parties > 0` was a threshold the environment could never satisfy.
The alert has been continuously lit, and a genuine tenth orphan would have been indistinguishable
from the floor — the control was structurally silent about the thing it exists to detect. Twice now
a reader has ranked those rows as the estate's highest-severity finding and would have gone
remediating pre-consumer rows and e2e fixtures.

## The change

The cutoff is **derived, not declared**: `earliestCaseCreatedAt()` — the oldest case the store
holds — is the first moment the auto-open path demonstrably worked. An orphan created before it is
reported as `preConsumerPartyIds` and published as `openbank_kyc_orphaned_parties_pre_consumer`,
not dropped: the exclusion is a claim about the environment, and a claim nobody can see is one
nobody can falsify. The 2026-06-26 date appears in no code.

Three properties that matter, each with a test that goes red without it:

- a **null** cutoff (empty or wiped kyc-db) excludes **nothing**. The other direction would let an
  empty store report a clean register — the report-clean failure the whole of #5698 is about.
- the boundary is **strict**: a party created at the same instant as the oldest case was eligible,
  so its missing case is real.
- the split runs **after** the case lookup, so a pre-consumer party that does have a case appears
  in neither list.

Also fixed: the rule comment still carried the `10 of 73` figure #5698 **withdrew**, which is the
number the next reader meets first. Replaced with an instruction to read the gauge, and a note not
to reinstate it.

## Verification

Falsified in three directions (`:openbank-kyc-service:test`, all 11 cases run, 0 skipped):

| sabotage | red |
|---|---|
| remove the split (nothing ever excluded) | `a party created before the oldest case is pre-consumer, not stranded` |
| make the boundary inclusive | `a party created at the same instant as the oldest case is NOT excluded` |
| make a null cutoff exclude everything | 5 cases, including `with no case in the store NOTHING is excluded` |

## What this does NOT fix — stated, not glossed

The sandbox floor goes 9 to **3**, not to 0. The remaining three are the 2026-07-16/17 e2e fixture
parties, and kyc-service **cannot** tell them from a real stranded customer: the evidence that
separates them is "zero accounts", and accounts live in account-service, behind a port this control
deliberately does not have (`PartyDirectoryPort` exposes id, status, createdAt and nothing else).

So the alert still cannot clear today. The remaining fix is a data action, not code — remove the
fixture parties from the sandbox register, or give fixtures a marker party-service exposes — and it
is the onboarding funnel owner's call. #9726 stays open on that tail; the alert description now
tells whoever it wakes to check each id has an account before quoting the count as customer impact.
