### PR TITLE
ci(onboarding): put kyb-events-in on its own consumer group now the image carries the channel

### DIFF
--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -43,12 +43,20 @@ metadata:
     app.kubernetes.io/name: onboarding-service
     app.kubernetes.io/part-of: onboarding
 data:
-  # NOT here yet: kyb-events-in. This ConfigMap is applied by Argo BEFORE auto-deploy bumps the
-  # image, so naming a channel here that the RUNNING image has no connector for is SRMSG00071 —
-  # a hard boot failure, not a degraded consumer (`msg-channel-image-parity` enforces exactly
-  # this ordering). Add the two kyb-events-in lines in a follow-up, once an image carrying the
-  # channel is deployed. Until then the channel runs on the fallback group id
-  # (quarkus.application.name), which the KafkaUser grants Read on for that reason.
+  # kyb-events-in is here now (#8882). The ordering constraint that kept it out is satisfied by
+  # measurement, not by assumption: this ConfigMap is applied by Argo BEFORE auto-deploy bumps the
+  # image, so naming a channel the RUNNING image has no connector for is SRMSG00071 — a hard boot
+  # failure, not a degraded consumer (`msg-channel-image-parity` enforces the ordering). The
+  # declared image is `sandbox-8db73dbb` (onboarding-service.yaml), and that commit's
+  # application.yaml carries `mp.messaging.incoming.kyb-events-in` with a `connector:` — checked
+  # with `git show 8db73dbb:openbank-onboarding-service/src/main/resources/application.yaml`, not
+  # inferred from the channel being on main. The channel landed in 3766d3de2 (#8863), which is an
+  # ancestor of that image.
+  #
+  # Effect of the change: the consumer moves off the fallback group id (quarkus.application.name)
+  # onto `onboarding-service-kyb`. Both names already carry a Read ACL on the onboarding KafkaUser,
+  # and `openbank.kyb.events` is new with no backlog, so forcing `earliest` here replays nothing of
+  # consequence — the reason this was safe to defer and is safe to land.
   override.properties: |
     config_ordinal=500
     mp.messaging.incoming.party-events-in.group.id=onboarding-service-party
@@ -57,3 +65,5 @@ data:
     mp.messaging.incoming.kyc-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.sca-events-in.group.id=onboarding-service-sca
     mp.messaging.incoming.sca-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.kyb-events-in.group.id=onboarding-service-kyb
+    mp.messaging.incoming.kyb-events-in.auto.offset.reset=earliest

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -174,12 +174,11 @@ mp:
         # See the party-events-in comment above for why failure-strategy and an EXPLICIT
         # dead-letter topic are both required, and why the topic key is nested rather than
         # written as the dotted leaf `dead-letter-queue.topic:` (#686, #5745, #5751).
-        # This channel is NOT yet in the msg-override ConfigMap, unlike its three siblings: that
-        # file is applied before the image is bumped, so naming a channel there that the running
-        # image cannot serve is SRMSG00071, a hard boot failure (`msg-channel-image-parity`).
-        # Until the follow-up adds it, the deployed consumer runs on the fallback group id
-        # (quarkus.application.name) with auto.offset.reset at the Kafka default — acceptable only
-        # because this topic is new and carries no backlog. Both group ids are granted Read.
+        # The group id and auto.offset.reset for this channel live in the msg-override ConfigMap
+        # with its three siblings (#8882) — a dotted leaf key written here would be inert. They
+        # were deliberately absent until an image carrying this channel was deployed: that
+        # ConfigMap is applied before the image is bumped, so naming a channel the running image
+        # cannot serve is SRMSG00071, a hard boot failure (`msg-channel-image-parity`).
         failure-strategy: dead-letter-queue
         dead-letter-queue:
           topic: openbank.dlq.onboarding.kyb-events-in


### PR DESCRIPTION
Closes #8882.

`kyb-events-in` was deliberately kept out of `onboarding-service-msg-override`: Argo applies that
ConfigMap **before** auto-deploy bumps the image, so naming a channel the running image has no
connector for is `SRMSG00071` — a hard boot failure of the whole service, not a degraded consumer.
`msg-channel-image-parity` enforces that ordering and caught it on the original PR.

## The precondition, measured

Not "the channel is on main" — that was already true and is not the question. The question is what
the **declared image** serves:

```
onboarding-service.yaml:58   image: ...openbank-onboarding-service:sandbox-8db73dbb
git show 8db73dbb:openbank-onboarding-service/src/main/resources/application.yaml
  -> mp.messaging.incoming.kyb-events-in ... connector: smallrye-kafka
```

The channel landed in `3766d3de2` (#8863), an ancestor of that image. The KafkaUser already grants
group `onboarding-service-kyb` (`kafka-onboarding-mtls.yaml:92`).

## Effect

The consumer moves off the fallback group id (`quarkus.application.name`) onto
`onboarding-service-kyb`, with `auto.offset.reset=earliest`. Forcing `earliest` onto a group that
has been running as the default is normally a mass replay — here it is not, because
`openbank.kyb.events` is new and carries no backlog. That is the same fact that made deferring this
safe in the first place.

Also drops the now-false "NOT here yet" notes in both files, so the next reader is not told to do
work that is done.
