### PR TITLE
fix(settlement): stop binding balance fields balance-service has never emitted

### DIFF
--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -358,3 +358,31 @@ replacing the former in-memory stub), so settlement state is durable across rest
   **No new trust boundary**: this restores the M2M identity the ports were always meant to
   present, on the existing edges, against the existing confidential client. Enforced fleet-wide by
   `check-oidc-client-configured.py` (six services fixed; ledger and settlement money-path).
+
+- **2026-09-13** (#8673) — the `balance-port` response binding was narrowed, and the edge it sits on
+  is unchanged. `BalanceResponse` bound `availableBalance` and `currentBalance` as non-nullable
+  `BigDecimal`; neither name has ever been on the wire, because `BalanceResource.credit/debit`
+  serialises the domain `Balance` (`bookedAmount`, `availableAmount`, `reservedAmount`,
+  `pendingAmount`). A missing non-nullable Kotlin property is a deserialisation failure, so **every
+  real credit and debit failed on the way back — after the money had moved**, and the workflow saw
+  a failed activity for a movement that had in fact been applied.
+
+  Threat-model consequence, stated precisely because the failure looks worse than it is: the money
+  movement itself was never at risk of duplication. The reference-id idempotency in T1 is what made
+  the Temporal retry of a "failed" debit a no-op at balance-service (`applied = false`), so the
+  realised harm was a settlement stalling and entering compensation, not a double debit. This is
+  the same lesson as R2 one layer out — a status that disagrees with what the counterparty actually
+  did.
+
+  **No new trust boundary.** The two fields are removed rather than renamed: nothing in
+  settlement-service reads a balance off this response, Jackson ignores the unknown remainder, and
+  the request side, the destination, the OIDC client-credentials identity and the idempotency keys
+  are all untouched. The binding is strictly narrower than before, so the client now depends on two
+  fields (`accountId`, `currency`) instead of four.
+
+  Why no test caught it: the WireMock stub's body was copied from settlement's own DTO and the
+  adapter unit tests construct `BalanceResponse` in Kotlin, so both sides of every assertion came
+  from the same wrong shape. The stub now carries balance-service's real wire shape, and with the
+  old DTO against it `SettlementReversalIT` fails 3 of 7 with `value failed for JSON property
+  availableBalance` — the production failure, reproduced in CI.
+

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/BalanceRestClient.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/BalanceRestClient.kt
@@ -41,9 +41,25 @@ data class MoneyMovementRequest(
     val description: String,
 )
 
-data class BalanceResponse(
-    val accountId: UUID,
-    val currency: String,
-    val availableBalance: BigDecimal,
-    val currentBalance: BigDecimal,
-)
+/**
+ * What balance-service actually puts on the wire for `POST /balances/{id}/{credit,debit}`, narrowed
+ * to what this service reads.
+ *
+ * It used to bind `availableBalance` and `currentBalance` as non-nullable [BigDecimal]. Those two
+ * names have never been on the wire: `BalanceResource.credit/debit` returns the domain `Balance`
+ * straight to Jackson, so the payload carries that class's property names — `bookedAmount`,
+ * `availableAmount`, `reservedAmount`, `pendingAmount`. A missing non-nullable Kotlin property is a
+ * deserialisation failure, so every real credit and debit failed on the way back, AFTER the money
+ * had moved (#8673).
+ *
+ * Nothing could see it. The only test coverage constructed `BalanceResponse` in Kotlin or stubbed
+ * WireMock with a body copied from this class, so both sides of the assertion came from the same
+ * wrong shape and agreed with each other — the consumer-pact trap in the repo guide, one layer
+ * down.
+ *
+ * The fields are not renamed, they are REMOVED: no code path in settlement-service reads a balance
+ * off this response, and a field that is never read is a way to fail on someone else's schema for
+ * nothing. Jackson ignores the unknown remainder, so this binds only the two values that identify
+ * the movement, and it cannot break again when balance-service adds a field.
+ */
+data class BalanceResponse(val accountId: UUID, val currency: String)

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
@@ -46,7 +46,7 @@ class BalanceCreditAdapterTest {
         val request = slot<MoneyMovementRequest>()
         every { balanceClient.credit(settlement.payeeAccountId, capture(request)) } returns
             Uni.createFrom().item(
-                BalanceResponse(settlement.payeeAccountId, "EUR", BigDecimal("42"), BigDecimal("42")),
+                BalanceResponse(settlement.payeeAccountId, "EUR"),
             )
 
         BalanceCreditAdapter(balanceClient, repo).credit(settlement.id)

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
@@ -46,7 +46,7 @@ class BalanceDebitAdapterTest {
         val request = slot<MoneyMovementRequest>()
         every { balanceClient.debit(settlement.payerAccountId, capture(request)) } returns
             Uni.createFrom().item(
-                BalanceResponse(settlement.payerAccountId, "CZK", BigDecimal("100"), BigDecimal("100")),
+                BalanceResponse(settlement.payerAccountId, "CZK"),
             )
 
         BalanceDebitAdapter(balanceClient, repo).debit(settlement.id)

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
@@ -86,11 +86,26 @@ class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
             stubLedgerHasNoJournal()
         }
 
-        /** Both movement verbs succeed, echoing a balance back. */
+        /**
+         * Both movement verbs succeed, echoing a balance back.
+         *
+         * The body is balance-service's REAL wire shape, not this service's idea of it (#8673).
+         * `BalanceResource.credit/debit` returns the domain `Balance` straight to Jackson, so the
+         * payload carries that class's property names. The previous body was copied from
+         * settlement's own `BalanceResponse` — `availableBalance`/`currentBalance`, names that have
+         * never been emitted — so the stub agreed with the client about a shape the real service
+         * does not produce, and every test passed against a payload that fails in production.
+         *
+         * Keep this body in step with `openbank-balance-service/.../domain/model/Balance.kt`. A
+         * stub written from the consumer's expectation cannot fail the way the consumer does.
+         */
         fun stubMovementsAccepted() {
             val body = """
-                {"accountId":"00000000-0000-0000-0000-000000000001","currency":"CZK",
-                 "availableBalance":0.00,"currentBalance":0.00}
+                {"id":"22222222-2222-2222-2222-222222222222",
+                 "accountId":"00000000-0000-0000-0000-000000000001","currency":"CZK",
+                 "bookedAmount":0.00,"availableAmount":0.00,"reservedAmount":0.00,
+                 "pendingAmount":0.00,"updatedAt":"2026-09-12T00:00:00Z","version":1,
+                 "arrangedOverdraftLimit":0.00,"notYetEffectiveCredit":0.00}
             """.trimIndent()
             server.stubFor(post(urlPathMatching(CREDIT_PATH)).willReturn(okJson(body)))
             server.stubFor(post(urlPathMatching(DEBIT_PATH)).willReturn(okJson(body)))


### PR DESCRIPTION
Closes #8673.

## The defect

`BalanceResponse` bound `availableBalance` and `currentBalance` as **non-nullable** `BigDecimal`.
Neither name has ever been on the wire: `BalanceResource.credit/debit` returns the domain `Balance`
straight to Jackson, so the payload carries `bookedAmount`, `availableAmount`, `reservedAmount`,
`pendingAmount`. A missing non-nullable Kotlin property is a deserialisation failure — so every real
credit and debit failed on the way back, **after the money had moved**.

## Why nothing caught it

The WireMock stub's body was copied from this service's own DTO, and the adapter unit tests
construct `BalanceResponse` in Kotlin. Both sides of every assertion came from the same wrong shape
and agreed with each other — the consumer-pact trap from the repo guide, one layer down: a mock
answers whatever you ask it for.

## The fix

The two fields are **removed, not renamed**. No code path in settlement-service reads a balance off
this response; Jackson ignores the unknown remainder, so the client binds only the two values that
identify the movement and cannot break again when balance-service adds a field. Binding a field you
never read is a way to fail on someone else's schema for nothing.

The stub now carries balance-service's real wire shape, taken from `Balance.kt`.

## Verification

Old DTO + truthful stub:

```
SettlementReversalIT   tests=7  failures=3
  value failed for JSON property availableBalance
```

That is the production failure, reproduced in CI for the first time. With the fix: `tests=78
skipped=0 failures=0` for the module, ktlint and detekt green.

## Left for a separate change

`openbank-balance-service/src/main/resources/openapi.yaml` declares `BalanceResponse` as
`availableBalance`/`currentBalance` — the spec documents a shape the service does not serve, and is
almost certainly where this client's author got the names. That is a money-path spec `correction`
under ADR-0048 and does not belong in a settlement-service PR; it needs its own, touching nothing
else in balance-service.


## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification — none added.
- [x] No new third-party dependency.
- [x] **Payment code changed** → tagged `security-review-required`. The change is on settlement's outbound money-movement client; it removes two response fields nothing reads and cannot alter what is sent.
- [x] PII path changed? **No** — the response binding is narrowed to `accountId` + `currency`, both already bound.
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS
