### PR TITLE
ci(auto-deploy): size the fleet build's daemon where the job actually reads it

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -484,7 +484,18 @@ jobs:
       id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
     timeout-minutes: 90
     env:
-      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
+      # This line, not gradle.properties, is what sizes the daemon for this job (#9832). A
+      # `-Dorg.gradle.jvmargs` in GRADLE_OPTS takes precedence over the file, so editing
+      # `gradle.properties` — the obvious place, and the one the issue named first — changes
+      # nothing here. It also silently dropped the file's `-XX:MaxMetaspaceSize`, which is why the
+      # two observed exhaustion modes (Java heap space, Metaspace) came from different lanes.
+      #
+      # 6g on a 4-core/16 GB arm runner, against `--parallel --max-workers=4`: the fleet build runs
+      # several `quarkusGenerateAppModel` tasks at once, each holding a full application model in
+      # the daemon's heap, and one service exhausting it strands every service in the wave.
+      # Metaspace is capped explicitly rather than left unbounded — an unbounded metaspace does not
+      # remove the limit, it moves the failure to a container OOM kill with no Java stack to read.
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       ECR_REGISTRY: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"


### PR DESCRIPTION
Refs #9832.

## The part that changes the fix

The issue's first candidate is "raise the caps in `gradle.properties`". **That would have been
inert for this job.** `auto-deploy.yml:487` sets

```yaml
GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
```

and a `-Dorg.gradle.jvmargs` in `GRADLE_OPTS` takes precedence over the file. The same override
also silently drops the file's `-XX:MaxMetaspaceSize=512m` — which is why the two observed
exhaustion modes (`Java heap space` and `Metaspace`) are not the same lane: one of them cannot be
this job at all.

So the change is here, where the job actually reads it:

```yaml
GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
```

6 GB on a 4-core/16 GB arm runner against `--parallel --max-workers=4`. Metaspace is capped
explicitly rather than left unbounded: unbounded does not remove the limit, it moves the failure to
a container OOM kill with no Java stack to read.

## What this does not claim

Not a share of `auto-deploy`'s failure rate. The issue's own classification was unstable across
sample sizes (1 of 14 vs 27 of 40), and it says so; an intermittent OOM is not proven fixed by the
next green run. The measurement that settles it is the issue's own classify-by-failing-job loop over
comparable windows before and after — which needs a post-merge window to exist first, so the issue
stays open for that.

Candidate 2 (bounding parallelism) is already in place: `--max-workers=4` at line 600. Candidate 3
(splitting the wave) changes the deploy topology and is deliberately untouched.
