### PR TITLE
docs: record that a whole-file take is silent, and why it is not a gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -684,6 +684,28 @@ fire from *outside* it, so they stay here:
   Note the file list `gh pr view --json files` shows is computed against the MERGE-BASE, so after
   a competing PR squash-merges it still lists the overlap as a diff even when the content already
   agrees. Read the content, not the diff.
+- **`git checkout <ref> -- <file>` is a WHOLE-FILE take, and it reads in the diff exactly like an
+  ordinary conflict resolution.** Resolving a conflict that way took `main`'s version of one page
+  entire and dropped 112 lines — including the feature the branch existed for. The PR stayed titled
+  "protect document template drafts" while protecting nothing, and nothing in the diff said so: the
+  file simply equalled main's. Same class three times in one queue (#9685); the other two were
+  smaller but identical in shape — one side's implementation taken wholesale, the other side's
+  tests left asserting behaviour that no longer exists.
+  **Two rules, and the second is the one that actually caught them.** Prefer a union merge to a
+  whole-file take when both sides changed the file; where the whole-file take really is right
+  (main carries an equivalent implementation), *say so in the commit message*, because that
+  sentence is the only thing distinguishing a considered decision from an accident. Then, after
+  resolving ANY merge, run the WHOLE module suite — not the tests you touched. In the worst of the
+  three, the single edited test was green while the suite was already red on a file never opened;
+  in another the assertion was e2e, so a local green proved nothing at all.
+  **Deliberately NOT a gate, and the measurement is why.** The mechanical signature is exact (a
+  file where the merge's blob equals main's while the branch had changed it), but across 69 open
+  PRs it fired 577 times over 21 PRs — mostly lockfiles and migrations legitimately superseded.
+  Narrowed to "a symbol the branch declared that exists nowhere in the merged tree" it gives 3 rows,
+  of which **1 is real**: symbol-level detection cannot tell a deletion from a rename, which is
+  inherent rather than a tuning problem. Same conclusion as `entity-column-names`: a gate that
+  cries wolf about correct code is worth less than nothing. Run it as a one-off audit after a bulk
+  conflict-resolution session instead.
 - **A merge git calls CLEAN can still DELETE content — it reports no conflict when two sides add
   neighbouring entries to the same list, and keeps only one.** Not a conflict resolved badly:
   nothing to resolve, nothing printed, exit 0. Twice on 2026-08-02, both while merging `main` into


### PR DESCRIPTION
Closes #9685 — takes the issue's own conclusion, including its refusal.

The issue's only outstanding deliverable was the lesson, and it was not written down anywhere: root
`CLAUDE.md` covered the neighbouring case (a clean merge dropping one of two adjacent list entries)
but nothing about a **whole-file take**.

The bullet carries three things, in the order that makes them useful:

1. **What is silent about it.** `git checkout <ref> -- <file>` reads in the diff exactly like an
   ordinary conflict resolution — the file simply equals main's. 112 lines went, including the
   feature the branch existed for, and the PR kept its title.
2. **The procedural rule that actually caught all three**: after resolving any merge, run the WHOLE
   module suite, not the tests you touched. Plus: say so in the commit message when a whole-file
   take really is right, since that sentence is the only thing distinguishing a considered decision
   from an accident.
3. **Why there is no gate**, with the numbers — 577 hits across 21 PRs for the exact mechanical
   signature, and 1 real of 3 for the narrowed symbol-level form, because it cannot tell a deletion
   from a rename. Same conclusion as `entity-column-names`.

Point 3 is the part worth keeping in the file rather than in a closed issue: without it, the next
reader meets the same idea and re-derives the same negative result.

The audit script stays a one-off, as the issue proposes — not added to `.github/scripts/`, where its
presence would imply it is wired to something.
