### PR TITLE
fix(ci): print the cosign stderr an ABSENT or UNATTESTED verdict was classified from

### DIFF
--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -99,6 +99,24 @@ classify_failure() {
   printf 'UNKNOWN\n'
 }
 
+# Echo the stderr a verdict was classified FROM. Only UNKNOWN used to do this, and that is the one
+# class nobody has to diagnose — it already says "no verdict about this image". The two classes that
+# accuse something (ABSENT, UNATTESTED) discarded their evidence, so a wrong accusation could not be
+# told apart from a right one after the fact.
+#
+# Measured 2026-09-12 (issue #9860): run 34721055657 reported
+# `UNATTESTED openbank-security-scanner:sandbox-062c26af`, and a hand
+# `cosign verify-attestation --key <same> --type cyclonedx <same digest>` verified cleanly 25 minutes
+# later, with `.att` and `.sig` both present in ECR and the tag unmoved on main. cosign must
+# therefore have emitted one of the phrases `classify_failure` treats as positive-UNATTESTED, and
+# which one is the whole question — it was not retained anywhere. Note the retry loop cannot help
+# here by design: it breaks on any verdict that is not UNKNOWN, so a transient whose wording lands in
+# the UNATTESTED set is accepted on the first attempt.
+print_classified_stderr() {
+  [ -n "$1" ] || return 0
+  printf '%s\n' "$1" | sed 's/^/                  | /' | tail -5
+}
+
 selftest() {
   # `cases` is the SUBJECT COUNT this gate reports (gates.yaml min_subjects). A checker whose
   # corpus is its own fixtures examines nothing the day someone deletes them, and the floor is
@@ -230,6 +248,27 @@ STUB
   run_fixture "unattested + absent -> exit 1" 1 \
     "1 attested / 1 unattested / 1 absent / 0 allowlisted placeholder / 0 unknown" \
     "openbank-fixture-ok:t" "openbank-fixture-bare:t" "openbank-fixture-gone:t"
+  # The accusing verdicts must carry the stderr they were classified FROM (#9860). Asserted on the
+  # fixture above rather than as its own run: LAST_OUT holds that run's output, and the point is that
+  # the evidence sits next to the accusation in the log a reader actually opens. Without the echo in
+  # the UNATTESTED branch this assertion fails, which is the only reason to trust the echo is there.
+  cases=$((cases + 1))
+  if ! grep -qF '| Error: no matching attestations:' <<< "$LAST_OUT"; then
+    printf '  FAIL: an UNATTESTED verdict does not print the cosign stderr it was classified from\n'
+    printf '        (a wrong accusation would then be indistinguishable from a right one, #9860)\n'
+    printf '%s\n' "$LAST_OUT" | grep -A3 'UNATTESTED' | sed 's/^/          | /'
+    failures=$((failures + 1))
+  else
+    printf '  ok: an UNATTESTED verdict prints the stderr it was classified from\n'
+  fi
+  cases=$((cases + 1))
+  if ! grep -qF '| Error: MANIFEST_UNKNOWN: manifest unknown' <<< "$LAST_OUT"; then
+    printf '  FAIL: an ABSENT verdict does not print the cosign stderr it was classified from\n'
+    failures=$((failures + 1))
+  else
+    printf '  ok: an ABSENT verdict prints the stderr it was classified from\n'
+  fi
+
   # ONLY a probe failure -> 2, and crucially NOT 1: this is the case that used to be
   # published as a fleet gap, and the exit code is the only thing the caller reads.
   run_fixture "probe failure only -> exit 2 (not 1)" 2 \
@@ -587,12 +626,14 @@ for image in "${IMAGES[@]}"; do
         ALLOWED=$((ALLOWED + 1))
       else
         printf '  ABSENT      %s  <-- declared in gitops but NOT in the registry\n' "$short"
+        print_classified_stderr "$err"
         ABSENT=$((ABSENT + 1))
         ABSENT_IMAGES+=("$image")
       fi
       ;;
     UNATTESTED)
       printf '  UNATTESTED  %s  <-- no valid CycloneDX SBOM attestation\n' "$short"
+      print_classified_stderr "$err"
       UNATTESTED=$((UNATTESTED + 1))
       UNATTESTED_IMAGES+=("$image")
       ;;


### PR DESCRIPTION
## Summary

Only the `UNKNOWN` branch of `check-fleet-attestations.sh` echoed cosign's stderr — and `UNKNOWN` is
the one class nobody has to diagnose, because it already says *"no verdict about this image"*. The two
branches that **accuse** something, `ABSENT` and `UNATTESTED`, threw their evidence away, so a wrong
accusation could not be told apart from a right one after the fact.

## The measurement that prompted it

`Verify fleet attestations` on #8873 (run 34721055657, 2026-09-12T21:49:51Z):

```
UNATTESTED  openbank-security-scanner:sandbox-062c26af  <-- no valid CycloneDX SBOM attestation
```

25 minutes later, by hand, same key and same predicate type the gate uses:

```
$ cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx \
    ...openbank-security-scanner@sha256:f87df166541853957936199c60c12bf66a96bdbc2eaade315cc4685d97da7d45
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The signatures were verified against the specified public key
  predicateType: https://cyclonedx.org/bom
```

`.att` and `.sig` are both present in ECR for that digest, `main` still pins the same tag unchanged,
and `main`'s own fleet run that morning (34668567735, 02:46:10Z) reported `65 attested / 0 unattested`
for it. So the image was attested before, is attested after, and the verdict was wrong.

Since `classify_failure` is positive in both directions (#1915), cosign *did* emit one of the phrases
it treats as `UNATTESTED` — `no matching attestations`, `no signatures found`, `signature not found`,
… — and **which one was not recorded anywhere**. Grepping the whole run for the image yields two
lines: the verdict, and the image's entry in the declared list.

## What this changes, and what it deliberately does not

Adds `print_classified_stderr` and calls it from the `ABSENT` and `UNATTESTED` branches, in the same
`| `-prefixed `tail -5` form `UNKNOWN` already uses. No classification moves.

The retry loop cannot help here and is untouched: it breaks on any verdict that is not `UNKNOWN`, so a
transient whose wording lands in the `UNATTESTED` set is accepted on the first attempt. Whether some
of those phrases belong in the `UNKNOWN` branch instead is the decision #9860 asks for — and it needs
this output to be answerable, which is why this PR only surfaces evidence.

## Falsified, not merely green

The selftest now asserts the stderr appears under **both** accusing verdicts, driven off the existing
`unattested + absent` fixture so the evidence is checked where a reader would actually look:

```
ok: an UNATTESTED verdict prints the stderr it was classified from
ok: an ABSENT verdict prints the stderr it was classified from
```

With the `UNATTESTED` echo removed again:

```
FAIL: an UNATTESTED verdict does not print the cosign stderr it was classified from
selftest FAILED (1 case(s))
```

- [x] `--selftest`: OK, `SUBJECTS` 18 → 20.
- [x] `run-gates.py --only fleet-attestation-classifier`: PASS.
- [x] `run-gates.py --only gate-observability-declarations`: PASS (subject floor still satisfied).
- [x] `bash -n`: clean.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — the diff adds a `sed`
      prefix over cosign's own stderr. Worth naming the risk explicitly since this PR exists to print
      more: cosign's failure stderr carries image references, registry hostnames and error codes, all
      of which this repo's logs already contain in abundance (the `UNKNOWN` branch has printed the
      same field for as long as it has existed), and it is capped at `tail -5`. No credential material
      passes through that variable — the KMS key is referenced by alias, never by value.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`. — shell only.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no. This touches how a supply-chain **verdict is
      reported**, not how it is reached; no classification threshold or key handling moves.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

Refs #9860, #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
