### PR TITLE
security(vex): dispose CVE-2025-14969 for copilot-service on measured artifact identity

### DIFF
--- a/openbank-libs/governance/vex/copilot-service.openvex.json
+++ b/openbank-libs/governance/vex/copilot-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/copilot-service",
   "author": "OpenBank Security",
-  "version": 2,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -259,6 +259,15 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Every openbank-*-service image shares the fleet-standard base pinned in .github/workflows/Dockerfile.deploy (FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e), itself built on ubuntu:26.04 via Canonical rockcraft. That base ships usr/bin/pebble, Canonical's Pebble service manager - not a dpkg-tracked package (dpkg -S finds no owning package on the running image), so it is baked into the upstream rockcraft build and not something this fleet installs or can remove. Verified against the CURRENT eclipse-temurin:25-jre manifest (sha256:20723ef8e8a0a332c6cc569f32484f7c5beefc207354465eb95c89227d52ae93, published 2026-08-04, newer than our pin) with a fresh trivy image scan: pebble's embedded Go stdlib is still v1.26.5 there too, so no upstream rebuild against a patched Go toolchain exists yet and bumping the pinned digest would not clear this finding. Exploitability: the base image's own ENTRYPOINT (/__cacert_entrypoint.sh, confirmed via `crane config`) is overridden by Dockerfile.deploy's `ENTRYPOINT [\"java\",\"-XX:+UseZGC\",...,\"-jar\",\"/app/quarkus-run.jar\"]`; nothing in this repo's Dockerfiles, gitops manifests or k8s probes invokes usr/bin/pebble, execs into it, or opens its control socket (PEBBLE_SOCKET, default /var/lib/pebble/default/.pebble.socket) - grep across openbank-infra confirms no reference. The binary is present on disk but never started as a process in any deployed pod, so none of this CVE's Go stdlib code paths are ever reached. Tracked fleet-wide in issue #5206 pending an upstream eclipse-temurin rebuild against a patched Go toolchain.",
       "timestamp": "2026-08-17T09:38:36Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "openbank-copilot-service resolves the SAME artifact this verdict was measured on, which is why the fleet evidence transfers rather than being assumed: `./gradlew :openbank-copilot-service:dependencies --configuration runtimeClasspath` reports hibernate-reactive-core:3.4.2.Final, the version pinned in gradle/verification-metadata.xml at sha256 7e7443b2b5313b043af3d9448499f44059fa77729ddb9e369c4a2b9a9cea075c. The same command against openbank-ledger-service, where this verdict was first established, reports the identical coordinate. That check is not a formality: the fleet pins THREE hibernate-reactive-core versions (3.2.11.Final, 3.4.1.Final, 3.4.2.Final), and the artifact inspection below was performed on 3.4.2.Final only, so a service resolving one of the other two would NOT be covered by it.\n\nThe advisory expresses its affected range as a single interval (< 4.2.1), which under Maven version ordering sweeps in the entire hibernate-reactive 3.x line. That expression misclassifies this fleet. Hibernate Reactive maintains two parallel release lines, and 3.4.x was branched and released AFTER the fix, not before it: 4.2.1.Final was released 2025-12-21, while 3.4.0.Final was released 2026-05-27 and 3.4.2.Final on 2026-06-16 (Maven Central publication dates). The upstream fix commit cd7f104e10de918004707ca0e26e3840976f780a ('[#2926] Roll back open transactions on close', 2025-12-18), the only code change the advisory references, is PRESENT in the 3.4.2.Final artifact this fleet resolves. Measured by disassembling the exact jar the build verifies (sha256 7e7443b2b5313b043af3d9448499f44059fa77729ddb9e369c4a2b9a9cea075c, the value already pinned for this artifact in gradle/verification-metadata.xml, so the inspected bytes are the shipped bytes): SqlClientConnection.close() calls the post-fix validateNoTransactionInProgressOnClose(); the class carries the post-fix 'private boolean closed' field in place of the pre-fix 'private io.vertx.sqlclient.Transaction transaction'; and Log declares the fix's new liveTransactionDetectedOnClose() message. Control for the probe: the same javap check reports the fix ABSENT in 4.2.0.Final (the last release before the patch) and PRESENT in 4.2.1.Final (the advisory's stated first patched version), so it discriminates fixed from unfixed rather than always answering yes. No Quarkus platform ships hibernate-reactive-core >= 4.2.1 (quarkus-bom 3.38.0, 3.38.1, 3.38.2 and 3.39.0.CR1 all resolve 3.4.2.Final), and none is needed: the vulnerable code is not present in the resolved artifact. This supersedes the earlier 'affected' statements, which reasoned from the advisory's version range alone and did not inspect the artifact.",
+      "timestamp": "2026-09-13T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
Refs #9022.

Of the three components the bot named, **only `copilot-service` was still missing the statement** — `case-coordinator-agent` and `referral-service` already carry it.

## The verdict, and why it is a transfer rather than a judgement call

The fleet's `CVE-2025-14969` verdict is `not_affected` / `vulnerable_code_not_present` on **artifact** evidence, not on the advisory's version range: the advisory's single interval (`< 4.2.1`) sweeps the entire hibernate-reactive 3.x line, while the fix commit is demonstrably present in `3.4.2.Final` (established by disassembling the exact jar pinned in `gradle/verification-metadata.xml`, with a control showing the probe reports ABSENT for 4.2.0.Final).

That evidence transfers to copilot-service **only if copilot resolves the same artifact**, so I measured it instead of assuming it, and the measurement is part of the statement:

```
:openbank-copilot-service:dependencies --configuration runtimeClasspath  -> hibernate-reactive-core:3.4.2.Final
:openbank-ledger-service:dependencies  --configuration runtimeClasspath  -> hibernate-reactive-core:3.4.2.Final
```

The check is load-bearing rather than ceremonial: the fleet pins **three** versions of that artifact — `3.2.11.Final`, `3.4.1.Final`, `3.4.2.Final` — and the inspection covers `3.4.2.Final` only. A service resolving either of the other two is **not** covered by this reasoning and needs its own measurement. That sentence is in the statement so the next reader does not copy it blind.

Gates after the change: `check-vex-overlay-coverage` OK (61 components), `check-vex-fleet-scope` ok, `check-vex-range-reasoning` 0 range-only verdicts without pinned-artifact evidence, `check-vex-resolved-version` unchanged.

The issue closes itself on the next weekly `vex-triage.yml` run once this is on `main`, so I have left it open rather than closing it by hand.
