### PR TITLE
fix(admin-ui): bring hardcoded badge and toggle colours to AA

### DIFF
--- a/openbank-admin-ui/src/app/docs/api/page.tsx
+++ b/openbank-admin-ui/src/app/docs/api/page.tsx
@@ -144,7 +144,7 @@ const GROUP_COLORS: Record<string, string> = {
   'Payments':     '#7c3aed',
   'PSD2':         '#d97706',
   'Platform':     '#6b7280',
-  'Cards':        '#db2777',
+  'Cards':        '#d02571',
   'Other':        '#64748b',
 }
 
@@ -621,8 +621,8 @@ export default function ApiCatalogPage() {
           <button key={g} type="button" aria-pressed={groupFilter === g} onClick={() => setGroupFilter(g)}
             style={{
               padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
-              border: `1px solid ${groupFilter === g ? (GROUP_COLORS[g] || 'var(--accent)') : 'var(--border)'}`,
-              background: groupFilter === g ? (GROUP_COLORS[g] || 'var(--accent)') : 'var(--surface)',
+              border: `1px solid ${groupFilter === g ? (GROUP_COLORS[g] || 'var(--accent-strong)') : 'var(--border)'}`,
+              background: groupFilter === g ? (GROUP_COLORS[g] || 'var(--accent-strong)') : 'var(--surface)',
               color: groupFilter === g ? '#fff' : 'var(--text-secondary)',
               cursor: 'pointer', fontFamily: 'inherit',
             }}>{groupLabel(g)}</button>
@@ -755,7 +755,7 @@ export default function ApiCatalogPage() {
                     display: 'flex', alignItems: 'center', gap: '4px',
                     padding: '5px 10px', fontSize: '11px', fontWeight: 600,
                     background: '#fdf4ff', border: '1px solid #fbcfe8',
-                    borderRadius: '6px', color: '#db2777', textDecoration: 'none',
+                    borderRadius: '6px', color: '#d02571', textDecoration: 'none',
                     flexShrink: 0,
                   }}>
                   <FileCode size={11} />

--- a/openbank-admin-ui/src/app/docs/control-tower/page.tsx
+++ b/openbank-admin-ui/src/app/docs/control-tower/page.tsx
@@ -19,7 +19,7 @@ export const dynamic = 'force-dynamic'
 function statusStyle(s: ControlStatus): { color: string; bg: string } {
   switch (s) {
     case 'enforced': return { color: 'var(--success-text)', bg: 'var(--success-bg)' }
-    case 'partial':  return { color: 'var(--info, #2563eb)', bg: 'var(--info-bg, #dbeafe)' }
+    case 'partial':  return { color: 'var(--info-text)', bg: 'var(--info-bg)' }
     case 'audit':    return { color: 'var(--warning-text)', bg: 'var(--warning-bg)' }
     default:         return { color: 'var(--text-tertiary)', bg: 'var(--surface-2)' }
   }
@@ -159,7 +159,7 @@ export default async function ControlTowerPage() {
                     {c.frameworks.map(f => (
                       <span key={f} title={fwName(f)} style={{
                         fontSize: '10px', fontWeight: 600, padding: '2px 7px', borderRadius: '4px',
-                        background: 'var(--accent-bg)', color: 'var(--accent)',
+                        background: 'var(--accent-bg)', color: 'var(--accent-text)',
                       }}>
                         {f}
                       </span>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -106,6 +106,10 @@
   --accent-bg:            #eef2ff;
   --accent-border:        #c7d2fe;
   --accent-text:          #4338ca;
+  /* A selected toggle fills with the accent and puts WHITE text on it, which is 4.47:1 on
+     --accent — under AA. This is that fill: same hue, dark enough for white text (6.29:1). It is
+     deliberately not --accent-hover, whose name promises an interaction state (#9749). */
+  --accent-strong:        #4f46e5;
 
   /* ── Semantic ── */
   --success:              #10b981;
@@ -638,7 +642,8 @@ main {
   font-weight: 850;
   letter-spacing: .04em;
 }
-.campaign-section-heading p { margin: .03rem 0 .18rem; color: #8190a6; font-size: .64rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-section-heading p { margin: .03rem 0 .18rem; color: var(--text-secondary); /* was #8190a6:
+   3.24:1 on white, below the 4.5:1 AA floor for this 0.64rem label (#9749). */ font-size: .64rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
 .campaign-section-heading h2 { color: var(--campaign-ink); font-size: .95rem; font-weight: 780; letter-spacing: -.025em; }
 .campaign-section-heading > p { margin: .08rem 0 0 auto; max-width: 19rem; color: var(--campaign-muted); line-height: 1.4; }
 .campaign-entry-card { container-type: inline-size; }

--- a/openbank-admin-ui/src/components/docs/ProcessView.tsx
+++ b/openbank-admin-ui/src/components/docs/ProcessView.tsx
@@ -67,7 +67,7 @@ export function ProcessView({ proc }: { proc: Process }) {
             <button key={m} type="button" aria-pressed={mode === m} onClick={() => setMode(m)} style={{
               padding: '6px 14px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: 'pointer',
               fontFamily: 'inherit',
-              background: mode === m ? 'var(--accent)' : 'var(--surface)',
+              background: mode === m ? 'var(--accent-strong)' : 'var(--surface)',
               color: mode === m ? '#fff' : 'var(--text-secondary)',
             }}>{m === 'reality' ? 'Realita (dnes)' : 'Cíl (CNB/EBA)'}</button>
           ))}
@@ -90,7 +90,7 @@ export function ProcessView({ proc }: { proc: Process }) {
           <button key={id} type="button" aria-pressed={lens === id} onClick={() => setLens(id)} style={{
             padding: '8px 16px', fontSize: '13px', fontWeight: 600, borderRadius: '8px',
             border: `1px solid ${lens === id ? 'var(--accent)' : 'var(--border)'}`,
-            background: lens === id ? 'var(--accent)' : 'var(--surface)',
+            background: lens === id ? 'var(--accent-strong)' : 'var(--surface)',
             color: lens === id ? '#fff' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
           }}>{label}</button>
         ))}

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -342,14 +342,18 @@ export function hasAnyRole(roles: string[], ...required: Role[]): boolean {
   return required.some(r => roles.includes(r))
 }
 
+// These badges carry text, so each `color` has to clear AA 4.5:1 on its own `bg`. Four of the seven
+// did not — Admin 4.41:1, Payments 3.60:1, Auditor 3.07:1, API 3.54:1 — and the values below are the
+// measured minimum plus headroom. API is the one worth noting: no axe sweep could have found it,
+// because that role never rendered in a test session, so the table had to be measured directly (#9749).
 export const ROLE_LABELS: Record<string, { label: string; color: string; bg: string }> = {
-  ROLE_ADMIN:      { label: "Admin",      color: "#dc2626", bg: "#fef2f2" },
+  ROLE_ADMIN:      { label: "Admin",      color: "#d52424", bg: "#fef2f2" },
   ROLE_OPERATOR:   { label: "Operator",   color: "#2563eb", bg: "#eff6ff" },
   ROLE_VIEWER:     { label: "Viewer",     color: "#6b7280", bg: "#f9fafb" },
   ROLE_COMPLIANCE: { label: "Compliance", color: "#7c3aed", bg: "#faf5ff" },
-  ROLE_PAYMENTS:   { label: "Payments",   color: "#059669", bg: "#f0fdf4" },
-  ROLE_AUDITOR:    { label: "Auditor",    color: "#d97706", bg: "#fffbeb" },
-  ROLE_API:        { label: "API",        color: "#0891b2", bg: "#ecfeff" },
+  ROLE_PAYMENTS:   { label: "Payments",   color: "#04815a", bg: "#f0fdf4" },
+  ROLE_AUDITOR:    { label: "Auditor",    color: "#ab5e04", bg: "#fffbeb" },
+  ROLE_API:        { label: "API",        color: "#067b98", bg: "#ecfeff" },
   ROLE_SUPERVISOR: { label: "Supervisor", color: "#be185d", bg: "#fdf2f8" },
   ROLE_KYC:        { label: "KYC",        color: "#0d9488", bg: "#f0fdfa" },
   ROLE_KYC_OPENER: { label: "KYC Opener", color: "#0d9488", bg: "#f0fdfa" },


### PR DESCRIPTION
## Summary

The **second mechanism** behind #9749's contrast failures, after #9854 fixed the tone-token one:
colour literals, and tone tokens used where a `*-text` variant belongs.

Targets come from an axe sweep that recorded **each failing node's HTML**, so this fixes the measured
set rather than every syntactic match — the mistake #9854's description documents.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9749

## Changes

| what | measured |
|---|---|
| `--accent-strong` (#4f46e5) added, used by the 3 selected-toggle fills that put **white text on `--accent`** | 4.47:1 → 6.29:1 |
| /docs/control-tower: `--accent` and `--info` used **as text** on their own tint → `*-text` | 3.99:1 and 3.37:1 |
| /docs/api release-notes link pink #db2777 on #fdf4ff → #d02571 | 4.28:1 → 4.67:1 |
| `.campaign-section-heading p` #8190a6 on white → `--text-secondary` | 3.24:1 → 7.58:1 |

`--accent-strong` is deliberately **not** `--accent-hover` (same value today): a name that promises an
interaction state should not be doing duty as a resting fill.

The control-tower `info` badge also carried hex fallbacks *inside* the var() —
`var(--info, #2563eb)`, `var(--info-bg, #dbeafe)` — which silently bypass theming if the token is
ever renamed.

## Four of seven role badges fail AA, and one is invisible to any sweep

`ROLE_LABELS` carries a `color`/`bg` pair per role. Measured:

| role | was | ratio | now |
|---|---|---:|---|
| ROLE_ADMIN | #dc2626 on #fef2f2 | 4.41 | #d52424 (4.67) |
| ROLE_PAYMENTS | #059669 on #f0fdf4 | 3.60 | #04815a (4.67) |
| ROLE_AUDITOR | #d97706 on #fffbeb | 3.07 | #ab5e04 (4.67) |
| **ROLE_API** | #0891b2 on #ecfeff | **3.54** | #067b98 (4.70) |
| ROLE_OPERATOR / VIEWER / COMPLIANCE | — | 4.75 / 4.63 / 5.31 | unchanged |

**ROLE_API is the one worth noting: no axe sweep could have found it**, because that role never
rendered in a test session. Only measuring the table directly surfaces it — which is the concrete
argument for the token-level guard (#9825) over runtime scanning alone, and a limit on the sweep
evidence I have been quoting: it sees rendered states, not possible ones.

## This PR needs a human review by rule, and I am not routing around that

The role-badge change is in `src/lib/auth/roles.ts`. It alters **no permission, role, mapping or
capability** — only the presentational `color` / `bg` fields of `ROLE_LABELS` — but the file is
classified as authorization policy, so the merge guardrail requires a human. Correct outcome; stating
it rather than splitting the file to dodge it.

## Rebase note

Rebased onto #9854, which touched the same control-tower badge map. Resolved as a **union**, not by
taking a side: #9854 fixed `success`/`warning` there, this branch fixes `info`, and choosing either
version would have reverted the other.

## Not fixed here

`--accent` as **text** on white (4.46:1, /infrastructure version links). It is the brand colour, used
fleet-wide for links and buttons, so darkening it is a design decision for #9749 rather than a
contrast patch. /infrastructure's amber lifecycle badge was fixed by #9854 in `LifecycleStrip`.

- Suite: **560 files, 3003 passed, 1 skipped**

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert; the badges and toggles return to 3.07–4.47:1.
- Data migration reversible: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
