### PR TITLE
fix(infra): take the first base backup at cluster creation, not at the first schedule

### DIFF
--- a/openbank-infra/gitops/components/accounts/postgres.yaml
+++ b/openbank-infra/gitops/components/accounts/postgres.yaml
@@ -92,6 +92,10 @@ metadata:
   name: accounts-db-daily
   namespace: accounts
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/accounts/product-catalog-db.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog-db.yaml
@@ -68,6 +68,10 @@ metadata:
   name: product-catalog-db-daily
   namespace: accounts
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 39 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/agent/postgres.yaml
+++ b/openbank-infra/gitops/components/agent/postgres.yaml
@@ -67,6 +67,10 @@ metadata:
   name: agent-db-daily
   namespace: platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/ai-platform/langfuse-postgres.yaml
+++ b/openbank-infra/gitops/components/ai-platform/langfuse-postgres.yaml
@@ -77,6 +77,10 @@ metadata:
   name: langfuse-db-daily
   namespace: ai-platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/ai-platform/postgres.yaml
+++ b/openbank-infra/gitops/components/ai-platform/postgres.yaml
@@ -103,6 +103,10 @@ metadata:
   name: litellm-db-daily
   namespace: ai-platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 49 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/aml/postgres.yaml
+++ b/openbank-infra/gitops/components/aml/postgres.yaml
@@ -65,6 +65,10 @@ metadata:
   name: aml-db-daily
   namespace: aml
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
@@ -77,6 +77,10 @@ metadata:
   name: anacredit-db-daily
   namespace: anacredit
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 3 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/apicurio/postgres.yaml
+++ b/openbank-infra/gitops/components/apicurio/postgres.yaml
@@ -89,6 +89,10 @@ metadata:
   name: apicurio-db-daily
   namespace: messaging
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/audit/postgres.yaml
+++ b/openbank-infra/gitops/components/audit/postgres.yaml
@@ -69,6 +69,10 @@ metadata:
   name: audit-db-daily
   namespace: audit
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 47 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/authz-policy-auditor/postgres.yaml
+++ b/openbank-infra/gitops/components/authz-policy-auditor/postgres.yaml
@@ -75,6 +75,10 @@ metadata:
   name: authzaudit-db-daily
   namespace: authz-policy-auditor
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 7 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/balances/postgres.yaml
+++ b/openbank-infra/gitops/components/balances/postgres.yaml
@@ -92,6 +92,10 @@ metadata:
   name: balances-db-daily
   namespace: balances
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 12 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/billing/billing-db.yaml
+++ b/openbank-infra/gitops/components/billing/billing-db.yaml
@@ -90,6 +90,10 @@ metadata:
   name: billing-db-daily
   namespace: billing
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 11 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/campaign/postgres.yaml
+++ b/openbank-infra/gitops/components/campaign/postgres.yaml
@@ -80,6 +80,10 @@ metadata:
   name: campaign-db-daily
   namespace: campaign
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 20 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/case-coordinator/postgres.yaml
+++ b/openbank-infra/gitops/components/case-coordinator/postgres.yaml
@@ -61,6 +61,10 @@ metadata:
   name: case-coordinator-db-daily
   namespace: platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 23 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/communication/postgres.yaml
+++ b/openbank-infra/gitops/components/communication/postgres.yaml
@@ -62,6 +62,10 @@ metadata:
   name: communication-db-daily
   namespace: communication
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 52 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/consent/postgres.yaml
+++ b/openbank-infra/gitops/components/consent/postgres.yaml
@@ -88,6 +88,10 @@ metadata:
   name: consent-db-daily
   namespace: consent
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 33 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/control-liveness-sentinel/postgres.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/postgres.yaml
@@ -75,6 +75,10 @@ metadata:
   name: liveness-db-daily
   namespace: control-liveness-sentinel
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 35 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/copilot/postgres.yaml
+++ b/openbank-infra/gitops/components/copilot/postgres.yaml
@@ -73,6 +73,10 @@ metadata:
   name: copilot-db-daily
   namespace: platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 20 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/delegation/postgres.yaml
+++ b/openbank-infra/gitops/components/delegation/postgres.yaml
@@ -68,6 +68,10 @@ metadata:
   name: delegation-db-daily
   namespace: delegation
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 35 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/devops-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/devops-agent/postgres.yaml
@@ -82,6 +82,10 @@ metadata:
   name: devops-db-daily
   namespace: devops-agent
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 15 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/dispute-service/postgres.yaml
+++ b/openbank-infra/gitops/components/dispute-service/postgres.yaml
@@ -66,6 +66,10 @@ metadata:
   name: dispute-db-daily
   namespace: dispute
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
@@ -82,6 +82,10 @@ metadata:
   name: docstruth-db-daily
   namespace: docs-truth-agent
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/document-service/document-service-db.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-db.yaml
@@ -94,6 +94,10 @@ metadata:
   name: document-service-db-daily
   namespace: documents
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 23 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/engagement/postgres.yaml
+++ b/openbank-infra/gitops/components/engagement/postgres.yaml
@@ -76,6 +76,10 @@ metadata:
   name: engagement-db-daily
   namespace: engagement
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 51 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/finops-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/finops-agent/postgres.yaml
@@ -71,6 +71,10 @@ metadata:
   name: finops-db-daily
   namespace: finops-agent
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 15 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/flaky-test-hunter/postgres.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/postgres.yaml
@@ -75,6 +75,10 @@ metadata:
   name: flakytest-db-daily
   namespace: flaky-test-hunter
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 27 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/fraud-service/postgres.yaml
+++ b/openbank-infra/gitops/components/fraud-service/postgres.yaml
@@ -86,6 +86,10 @@ metadata:
   name: fraud-db-daily
   namespace: fraud
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/fx-service/postgres.yaml
+++ b/openbank-infra/gitops/components/fx-service/postgres.yaml
@@ -86,6 +86,10 @@ metadata:
   name: fx-db-daily
   namespace: fx
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/governance-auditor/postgres.yaml
+++ b/openbank-infra/gitops/components/governance-auditor/postgres.yaml
@@ -75,6 +75,10 @@ metadata:
   name: govaudit-db-daily
   namespace: governance-auditor
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 31 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/incentive/postgres.yaml
+++ b/openbank-infra/gitops/components/incentive/postgres.yaml
@@ -64,6 +64,10 @@ metadata:
   name: incentive-db-daily
   namespace: incentive
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 57 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/interest-service/postgres.yaml
+++ b/openbank-infra/gitops/components/interest-service/postgres.yaml
@@ -66,6 +66,10 @@ metadata:
   name: interest-db-daily
   namespace: interest
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/keycloak/postgres.yaml
+++ b/openbank-infra/gitops/components/keycloak/postgres.yaml
@@ -76,6 +76,10 @@ metadata:
   name: keycloak-db-daily
   namespace: iam
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/kyb/postgres.yaml
+++ b/openbank-infra/gitops/components/kyb/postgres.yaml
@@ -66,6 +66,10 @@ metadata:
   name: kyb-db-daily
   namespace: kyb
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 50 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/kyc/postgres.yaml
+++ b/openbank-infra/gitops/components/kyc/postgres.yaml
@@ -69,6 +69,10 @@ metadata:
   name: kyc-db-daily
   namespace: kyc
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 26 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/ledger/postgres.yaml
+++ b/openbank-infra/gitops/components/ledger/postgres.yaml
@@ -92,6 +92,10 @@ metadata:
   name: ledger-db-daily
   namespace: ledger
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 5 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/lending/postgres.yaml
+++ b/openbank-infra/gitops/components/lending/postgres.yaml
@@ -99,6 +99,10 @@ metadata:
   name: lending-db-daily
   namespace: lending
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 17 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/mcp/postgres.yaml
+++ b/openbank-infra/gitops/components/mcp/postgres.yaml
@@ -78,6 +78,10 @@ metadata:
   name: mcp-db-daily
   namespace: platform
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 44 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/notifications/postgres.yaml
+++ b/openbank-infra/gitops/components/notifications/postgres.yaml
@@ -85,6 +85,10 @@ metadata:
   name: notifications-db-daily
   namespace: notifications
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/observability/goalert.yaml
+++ b/openbank-infra/gitops/components/observability/goalert.yaml
@@ -83,6 +83,10 @@ metadata:
   name: goalert-db-daily
   namespace: observability
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 20 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/onboarding/postgres.yaml
+++ b/openbank-infra/gitops/components/onboarding/postgres.yaml
@@ -70,6 +70,10 @@ metadata:
   name: onboarding-db-daily
   namespace: onboarding
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/pact-broker/postgres.yaml
+++ b/openbank-infra/gitops/components/pact-broker/postgres.yaml
@@ -93,6 +93,10 @@ metadata:
   name: pact-broker-db-daily
   namespace: pact-broker
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/party/namespace.yaml
+++ b/openbank-infra/gitops/components/party/namespace.yaml
@@ -83,6 +83,10 @@ metadata:
   name: party-db-daily
   namespace: party
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 5 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore

--- a/openbank-infra/gitops/components/payments/postgres.yaml
+++ b/openbank-infra/gitops/components/payments/postgres.yaml
@@ -551,6 +551,10 @@ metadata:
   name: sepa-payment-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:
@@ -717,6 +721,10 @@ metadata:
   name: transaction-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 25 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -729,6 +737,10 @@ metadata:
   name: sepa-instant-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 35 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -741,6 +753,10 @@ metadata:
   name: domestic-payment-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 45 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -753,6 +769,10 @@ metadata:
   name: clearing-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 55 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -765,6 +785,10 @@ metadata:
   name: swift-service-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 5 4 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -777,6 +801,10 @@ metadata:
   name: settlement-service-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 15 4 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -789,6 +817,10 @@ metadata:
   name: standing-order-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 25 4 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
@@ -801,6 +833,10 @@ metadata:
   name: card-issuance-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 35 4 * * *"
   backupOwnerReference: self
   method: barmanObjectStore

--- a/openbank-infra/gitops/components/payments/vop-postgres.yaml
+++ b/openbank-infra/gitops/components/payments/vop-postgres.yaml
@@ -90,6 +90,10 @@ metadata:
   name: vop-db-daily
   namespace: payments
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 41 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/pid/namespace.yaml
+++ b/openbank-infra/gitops/components/pid/namespace.yaml
@@ -88,6 +88,10 @@ metadata:
   name: pid-db-daily
   namespace: pid
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 15 3 * * *"
   backupOwnerReference: self
   method: barmanObjectStore

--- a/openbank-infra/gitops/components/psd2-service/postgres.yaml
+++ b/openbank-infra/gitops/components/psd2-service/postgres.yaml
@@ -62,6 +62,10 @@ metadata:
   name: psd2-db-daily
   namespace: psd2
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/referral/postgres.yaml
+++ b/openbank-infra/gitops/components/referral/postgres.yaml
@@ -61,6 +61,10 @@ metadata:
   name: referral-db-daily
   namespace: referral
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 47 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/release-steward/postgres.yaml
+++ b/openbank-infra/gitops/components/release-steward/postgres.yaml
@@ -75,6 +75,10 @@ metadata:
   name: releasesteward-db-daily
   namespace: release-steward
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 43 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/sanctions-service/postgres.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/postgres.yaml
@@ -96,6 +96,10 @@ metadata:
   name: sanctions-db-daily
   namespace: sanctions
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 54 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/sca/postgres.yaml
+++ b/openbank-infra/gitops/components/sca/postgres.yaml
@@ -88,6 +88,10 @@ metadata:
   name: sca-db-daily
   namespace: sca
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 40 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/sdd/postgres.yaml
+++ b/openbank-infra/gitops/components/sdd/postgres.yaml
@@ -60,6 +60,10 @@ metadata:
   name: sdd-db-daily
   namespace: sdd
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 23 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/security-scanner/postgres.yaml
+++ b/openbank-infra/gitops/components/security-scanner/postgres.yaml
@@ -81,6 +81,10 @@ metadata:
   name: security-scanner-db-daily
   namespace: security-scanner
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 19 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/statements/postgres.yaml
+++ b/openbank-infra/gitops/components/statements/postgres.yaml
@@ -77,6 +77,10 @@ metadata:
   name: statements-db-daily
   namespace: statements
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 10 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/temporal/temporal-helmrelease.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-helmrelease.yaml
@@ -200,6 +200,10 @@ metadata:
   name: temporal-db-daily
   namespace: temporal
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 30 3 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/tpp-registry/postgres.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/postgres.yaml
@@ -60,6 +60,10 @@ metadata:
   name: tpp-registry-db-daily
   namespace: tpp-registry
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 31 2 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/gitops/components/wealth/postgres.yaml
+++ b/openbank-infra/gitops/components/wealth/postgres.yaml
@@ -54,6 +54,10 @@ metadata:
   name: wealth-db-daily
   namespace: wealth
 spec:
+  # CNPG reads this only at creation: without it the cluster has no recovery
+  # point until the first scheduled run, while Ready and ContinuousArchiving
+  # both read True. Adding it to a cluster that already exists is inert.
+  immediate: true
   schedule: "0 55 4 * * *"
   backupOwnerReference: self
   cluster:

--- a/openbank-infra/scripts/check-cnpg-backup-declared.py
+++ b/openbank-infra/scripts/check-cnpg-backup-declared.py
@@ -80,6 +80,28 @@ def cnpg_clusters(gitops_dir: pathlib.Path):
             )
 
 
+def scheduled_backups(gitops_dir: pathlib.Path):
+    """Yield (namespace, cluster name, relpath, immediate) per ScheduledBackup."""
+    for path in sorted(gitops_dir.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text()))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "ScheduledBackup":
+                continue
+            if not str(doc.get("apiVersion", "")).startswith(CNPG_API_PREFIX):
+                continue
+            meta = doc.get("metadata") or {}
+            spec = doc.get("spec") or {}
+            yield (
+                meta.get("namespace", "<no-namespace>"),
+                ((spec.get("cluster") or {}).get("name") or "<no-cluster>"),
+                str(path),
+                bool(spec.get("immediate")),
+            )
+
+
 def check(gitops_dir: pathlib.Path) -> tuple[int, int]:
     findings = 0
     subjects = 0
@@ -97,6 +119,32 @@ def check(gitops_dir: pathlib.Path) -> tuple[int, int]:
             f"reports it — check-db-backup-associations only inspects clusters that DO declare "
             f"one. Either add a barmanObjectStore, or annotate the cluster with "
             f'{EXEMPT_ANNOTATION}: "<why this database is disposable>".'
+        )
+
+    # SECOND RULE: a declared backup is not a recovery point until a BASE backup exists.
+    #
+    # WAL archiving starts with the cluster; the first base backup waits for the schedule, and
+    # until it lands `status.firstRecoverabilityPoint` is empty and no restore is possible while
+    # `Ready` and `ContinuousArchiving` both read True. Measured 2026-09-13: `wealth/wealth-db`
+    # was created at 22:58Z with a daily schedule of 04:55 and spent FIVE HOURS unrestorable,
+    # with WALs in the bucket and zero base backups. Nothing alerts on that window.
+    #
+    # `spec.immediate` closes it — the operator takes the first backup at creation
+    # ("Scheduled immediate backup now", measured on a fresh object). The reason it must be in
+    # the MANIFEST, and cannot be added to a running estate as a remediation, is that CNPG reads
+    # it only on the first reconcile: an object whose `status.lastCheckTime` is already set never
+    # evaluates it again, so patching one is inert (measured on two live ScheduledBackups, zero
+    # new backups). It is a property of the object's birth, which makes it a gate's business.
+    for ns, cluster, rel, immediate in scheduled_backups(gitops_dir):
+        if immediate:
+            continue
+        findings += 1
+        print(
+            f"::error file={rel}::ScheduledBackup for {ns}/{cluster} does not set "
+            f"spec.immediate: true, so the cluster has no recovery point between its creation "
+            f"and the first scheduled run — up to a full schedule interval, during which Ready "
+            f"and ContinuousArchiving both read True. Set immediate: true; CNPG honours it only "
+            f"at creation, so it cannot be added later to a cluster that already exists."
         )
     return subjects, findings
 
@@ -132,6 +180,26 @@ def self_test() -> int:
                          "annotations": {EXEMPT_ANNOTATION: "   "}},
             "spec": {"instances": 1},
         }, 1),
+        ("a ScheduledBackup with immediate: true", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "ScheduledBackup",
+            "metadata": {"name": "f-daily", "namespace": "n"},
+            "spec": {"schedule": "0 0 3 * * *", "immediate": True, "cluster": {"name": "f"}},
+        }, 0),
+        ("a ScheduledBackup WITHOUT immediate — MUST fire", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "ScheduledBackup",
+            "metadata": {"name": "g-daily", "namespace": "n"},
+            "spec": {"schedule": "0 0 3 * * *", "cluster": {"name": "g"}},
+        }, 1),
+        ("immediate: false is not immediate — MUST fire", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "ScheduledBackup",
+            "metadata": {"name": "h-daily", "namespace": "n"},
+            "spec": {"schedule": "0 0 3 * * *", "immediate": False, "cluster": {"name": "h"}},
+        }, 1),
+        ("a non-CNPG ScheduledBackup is not a subject", {
+            "apiVersion": "example.com/v1", "kind": "ScheduledBackup",
+            "metadata": {"name": "i-daily", "namespace": "n"},
+            "spec": {"cluster": {"name": "i"}},
+        }, 0),
         ("a non-CNPG kind: Cluster is not a subject", {
             "apiVersion": "cluster.x-k8s.io/v1", "kind": "Cluster",
             "metadata": {"name": "e", "namespace": "n"}, "spec": {},


### PR DESCRIPTION
## The window

`wealth/wealth-db` was created 2026-09-12 22:58Z with a daily schedule of 04:55. For **five hours**
it had no recovery point:

```
Ready True · ContinuousArchiving True · firstRecoverabilityPoint: <empty>
s3://…/wealth-db/wals/…  6 objects      s3://…/wealth-db/base/   0 objects
```

Every signal read healthy; a restore was impossible. Every new database here has that window — up
to a full schedule interval — and **64 of 64** ScheduledBackups in the tree omitted `spec.immediate`.

## What actually closes it — measured, not assumed

`immediate: true` on the ScheduledBackup. On a freshly created object against the live cluster:

```
BackupSchedule  Scheduled immediate backup now: 2026-09-13 04:05:57 UTC
backups before=1 after=2
```

I first reported the opposite, from a probe with the cron `0 0 5 31 2 *` — February 31st never
comes, so the operator never scheduled anything and my probe falsified itself rather than the
mechanism. The run above uses a valid schedule.

## Why it must live in the manifest, and why this diff costs nothing today

CNPG reads `immediate` **only on the first reconcile**. An object whose `status.lastCheckTime` is
set never evaluates it again — patching two live ScheduledBackups produced zero new backups. So:

- it cannot be applied as a remediation to a running estate;
- this diff is **inert against the current cluster** — no backup burst, no extra S3 cost — and takes
  effect for the next database, which is the one with the window;
- being a property of an object's birth rather than its state, a gate is the only thing that can
  hold it.

## The gate

`check-cnpg-backup-declared.py` gains the rule. Self-test falsifies in both directions: present,
absent, `immediate: false`, and a non-CNPG ScheduledBackup that is not a subject. Against the real
tree, dropping one `immediate` fires exactly one error; restoring it returns to zero.

## The two already in that state

`communication-db` and `wealth-db` were given a base backup by hand; both now report a
`firstRecoverabilityPoint`, verified by listing objects under `base/`, not by reading a condition.

Refs #9834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
