### PR TITLE
test(sca,consent): put the two security-critical domains under mutation testing

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -13,7 +13,7 @@ on:
       services:
         description: "Space-separated list of service modules to run pitest on (the matrix below is the source of truth)"
         required: false
-        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service openbank-sdd-service openbank-interest-service openbank-delegation-service openbank-vop-service openbank-standing-order-service"
+        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service openbank-sdd-service openbank-interest-service openbank-delegation-service openbank-vop-service openbank-standing-order-service openbank-sca-service openbank-consent-service"
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); the pitest job below already declares contents: read too, belt-and-suspenders.
@@ -74,6 +74,16 @@ jobs:
           - openbank-delegation-service
           - openbank-vop-service
           - openbank-standing-order-service
+          # Security-critical, NOT money-path (#8349). The exclusion above is about THIN domains —
+          # one model file with nothing worth mutating — not about money-path membership. sca
+          # carries ScaChallenge + DeviceApproval (283 lines of lifecycle and attempt counting) and
+          # consent carries Consent + Suppression: a surviving mutant in either is an authentication
+          # check that never fires, or a revocation that does not revoke.
+          # Measured baselines on 2026-09-13 (`./gradlew :<svc>:pitest`, local, isolated home):
+          #   sca      56 mutations, 50 killed = 89%  (already above the 70% ambition)
+          #   consent 119 mutations, 78 killed = 66%  (just under; the gap is worth a look, not a gate)
+          - openbank-sca-service
+          - openbank-consent-service
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/openbank-consent-service/build.gradle.kts
+++ b/openbank-consent-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -83,3 +86,24 @@ kover {
 // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
+
+// Mutation testing on the security-critical domain (ADR-0063 / ADR-0030 D3, issue #8349). Weekly +
+// manual via pitest.yml, advisory — never a per-PR gate.
+//
+// Why this service is in scope while clearing/swift/lending are deliberately not: the exclusion in
+// pitest.yml is about THIN domains (one model file, no branching worth mutating), not about
+// money-path membership. PSD2/GDPR consent: the lifecycle decides whether a third party may read an account at all, and the
+// suppression rules decide whether a customer contact is lawful. A surviving mutant there is a
+// revocation that does not revoke.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.consent.domain.*")
+    targetTests = setOf("com.openbank.consent.domain.*", "com.openbank.consent.application.usecase.*")
+    // Advisory (ADR-0063): pitest.yml reports the score and warns below 70%; the Gradle task itself
+    // must not fail the run, so the threshold is 0 until the score is measured and sustained.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.consent.domain.*Kt")
+}

--- a/openbank-sca-service/build.gradle.kts
+++ b/openbank-sca-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -79,3 +82,24 @@ kover {
 // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
+
+// Mutation testing on the security-critical domain (ADR-0063 / ADR-0030 D3, issue #8349). Weekly +
+// manual via pitest.yml, advisory — never a per-PR gate.
+//
+// Why this service is in scope while clearing/swift/lending are deliberately not: the exclusion in
+// pitest.yml is about THIN domains (one model file, no branching worth mutating), not about
+// money-path membership. Strong customer authentication (PSD2 RTS Art. 4/5): the challenge lifecycle decides whether an
+// authentication succeeds, and the attempt counter is what makes brute force bounded. A surviving
+// mutant there is an authentication check that never fires.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.sca.domain.*")
+    targetTests = setOf("com.openbank.sca.domain.*", "com.openbank.sca.application.usecase.*")
+    // Advisory (ADR-0063): pitest.yml reports the score and warns below 70%; the Gradle task itself
+    // must not fail the run, so the threshold is 0 until the score is measured and sustained.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.sca.domain.*Kt")
+}


### PR DESCRIPTION
Refs #8349 — acceptance criterion 2.

## What was missing

pitest ran on 15 money-path services and on **nothing outside that set**. So the two services whose
domain logic decides *whether an authentication succeeds* and *whether a third party may read an
account* had no kill-score signal at all.

## Why they are not the excluded case

The exclusion comment in `pitest.yml` is about **thin domains** — clearing/swift/lending carry one
model file each, where mutation testing is noise, not signal (ADR-0063). It is not about money-path
membership, which is how it has been read.

- `openbank-sca-service`: `ScaChallenge` + `DeviceApproval`, 283 lines of lifecycle and attempt
  counting. A surviving mutant is an authentication check that never fires.
- `openbank-consent-service`: `Consent` + `Suppression`. A surviving mutant is a revocation that
  does not revoke.

## Baselines — measured, not asserted

`./gradlew :<svc>:pitest`, local, isolated Gradle home, 2026-09-13:

| service | mutations | killed | score |
|---|---:|---:|---:|
| `openbank-sca-service` | 56 | 50 | **89 %** |
| `openbank-consent-service` | 119 | 78 | **66 %** |

sca is already above the 70 % ambition. consent is just under, and that gap is worth a look rather
than a gate.

A note on how nearly this went wrong: my first read of those reports counted `status="KILLED"` in
the XML and printed **0 %** for both. That is not what a 0 % score looks like — it is what a broken
probe looks like, and the discriminator was pitest's own summary line (`Generated 56 mutations
Killed 50`). Worth stating because the number in a table is the thing people quote later.

## Advisory, as everywhere else

`mutationThreshold = 0` in both build files: `pitest.yml` reports the score and warns below 70 %, and
a service is flipped to blocking only once it sustains it. Same contract as the existing 15.

## Not done here

AC1 ("all money-path services") is left open deliberately: it collides with the thin-domain
exclusion above, which is a documented decision (ADR-0063). Adding clearing/swift/lending to satisfy
a count would produce exactly the noise that decision exists to avoid — if AC1 is to be met, the
decision is what has to change first, and that belongs in the issue, not in a matrix edit.


## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] New build-time dependency: the `info.solidsoft.pitest` Gradle plugin, already used by the 15 services in the matrix, at the same pinned 1.19.0. Test-only, never on a runtime classpath.
- [x] Auth / crypto / payment code changed? **No** — this adds mutation testing over sca and consent; no production source is touched.
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS
