### PR TITLE
fix(kyb): publish requiredSignerRoles, the last request-schema gap in the fleet

### DIFF
--- a/openbank-kyb-service/src/main/resources/openapi.yaml
+++ b/openbank-kyb-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: OpenBank KYB Service API
   # 1.2.0 -> 1.3.0 (#9711): additive — representation attestation. 1.2.0 shipped the name
   # search (#9707); this is the next free minor as of live main.
-  version: 1.3.0
+  version: 1.4.0
   description: |
     Legal-entity verification and business onboarding (ADR-0284). Business identifiers are
     verified against public registers (ARES for CZ, GLEIF for LEI, manual attestation elsewhere);
@@ -778,6 +778,17 @@ components:
         requiredSignatures:
           type: integer
           minimum: 1
+        requiredSignerRoles:
+          type: array
+          items:
+            type: string
+          description: >-
+            The offices that must sign, when the register names them. Absent or empty means a plain
+            count — any listed representative may sign. Optional, and additive: the server has
+            always parsed it (ResolveReviewRequest.requiredSignerRoles), and it decides whether the
+            case goes straight to READY_TO_SIGN or waits for the named offices
+            (BusinessOnboardingCase.reviewResolved). Publishing it is what lets a generated client
+            send it at all.
     RejectRequest:
       type: object
       required: [reason]


### PR DESCRIPTION
Closes #8828 — the last of the 122 findings.

## The defect

`ResolveReviewRequest.requiredSignerRoles` is **parsed and load-bearing**: the DTO carries it into
`ResolveReviewCommand`, and `BusinessOnboardingCase.reviewResolved` uses it to decide whether a case
goes straight to `READY_TO_SIGN` or waits for the named offices. The spec did not publish it, so a
client generated from that document could not send it — and every such case silently took the
plain-count branch, which is the "any listed representative may sign" rule instead of "these offices
must sign".

Additive and optional, so MINOR: `info.version` 1.3.0 → 1.4.0, re-read off **live `main`** rather
than off this branch's base.

## Verification

Rebuilt the service and re-ran the checker against the freshly generated document:

```
openbank-kyb-service: 9 request schema(s) compared, 0 finding(s)
```

And across the whole fleet, with this fix applied:

```
56 services with an openapi.yaml, 138 request schemas compared, 0 findings
0 services would fail under --enforce
```

The probe was held to a known-positive first — a phantom property added to sepa-payment's
`CreateSepaPaymentRequest` produces a `published-not-parsed` finding and removing it returns to 0 —
because "one finding in a 56-service scan" is also what a broken scan reports.

## Two things this does NOT do, on purpose

1. **It does not flip the gate to `enforce`.** It is now demonstrably passable (0 of 56 would fail),
   and its `target_enforce_date` is 2026-09-30, so graduation is the right next step — but changing
   fleet-wide PR behaviour is a governance change, not a rider on a spec fix.
2. **It does not touch the 14 services that compare ZERO request schemas** — `ap2, audit, billing,
   communication, customer-edge, finrep, incentive, mcp, onboarding, psd2, referral,
   security-scanner, statement, tpp-registry`. They publish no `$ref`'d request body the gate can
   pair, so they are *not checked*, which today reads exactly like *clean*. Two of them
   (`customer-edge`, `psd2`) are public API surfaces. That is a scope decision on an enforced gate
   and deserves to be recorded as one, which is why it is written into #8828's thread rather than
   quietly widened here.
