### PR TITLE
feat(customer-edge): compose net worth from the services that own each figure (ADR-0301 D2)

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -67,6 +67,7 @@ V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:153: plai
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:155: plaintext http:// env value http://balance-service.balances.svc:8103
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:160: plaintext http:// env value http://interest-service.interest.svc:8125
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:165: plaintext http:// env value http://kyc-service.kyc.svc:8114
+V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:173: plaintext http:// env value http://wealth-service.wealth.svc:8154
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:169: plaintext http:// env value http://lending-service.lending.svc:8126
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:171: plaintext http:// env value http://transaction-service.payments.svc:8102
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:173: plaintext http:// env value http://domestic-payment.payments.svc:8116

--- a/docs/adr/0301-wealth-service-declared-holdings-and-net-worth-composition.md
+++ b/docs/adr/0301-wealth-service-declared-holdings-and-net-worth-composition.md
@@ -81,16 +81,18 @@ outbox-published (ADR-0003) as `openbank.wealth.events` with `HoldingDeclared`, 
 ledger.
 
 **D2 — Net worth is composed at the customer edge from owning services and is never persisted
-by wealth-service.** `openbank-customer-edge` gains a `GET /api/v1/net-worth` that fans out to
+by wealth-service.** `openbank-customer-edge` gains a `GET /customer/v1/net-worth` that fans out to
 `balance-service` (on-platform balances), `lending-service` (loans, and approved collateral), the
 ADR-0284 owner graph (stakes in onboarded entities) and `wealth-service` (declared holdings), and
 returns a typed tree whose every leaf names its source service and its `asOf`. `wealth-service`
 holds no copy of any on-platform figure. The customer-facing rule of ADR-0089 is kept by
 construction: an authoritative figure is only ever a proxied answer from its owner, and a declared
 holding is labelled `CUSTOMER_DECLARED` on the wire so no consumer can mistake it for a bank
-position. The route is a flat noun because that is the edge's convention — every resource there is
-`/accounts`, `/cards`, `/activity`, `/complaints`, with the party taken from the `party_id` JWT
-claim — and no `/me` namespace exists to join.
+position. The route is a flat noun under the edge's own prefix, which is `/customer/v1` and not
+`/api/v1`: every resource there is `/accounts`, `/cards`, `/activity`, `/complaints`, with the party
+taken from the `party_id` JWT claim, and no `/me` namespace exists to join. This ADR said
+`/api/v1/net-worth` when it was written and that prefix belongs to the backing services, not to the
+edge; corrected in the change that built it (#9772).
 
 **D3 — A declared holding can be promoted to lending collateral; lending never reads
 wealth-service.** Promotion is a lending operation: the existing `POST

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -121,6 +121,9 @@ class CustomerEdgeResource(
     @Inject
     lateinit var creditFunnel: com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
 
+    @Inject
+    lateinit var netWorthComposer: NetWorthComposer
+
     @ConfigProperty(name = "openbank.edge.account-service-url")
     lateinit var accountServiceUrl: String
 
@@ -760,6 +763,31 @@ class CustomerEdgeResource(
         }
         out.set<com.fasterxml.jackson.databind.JsonNode>("checks", checks)
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    // --- Net worth (ADR-0301 D2) ---
+
+    /**
+     * The caller's net worth, composed from the services that OWN each figure.
+     *
+     * A flat noun, not `/me/net-worth`: every resource here is `/accounts`, `/cards`, `/activity`,
+     * with the party taken from the JWT, and there is no `/me` namespace to join (ADR-0301 D2).
+     *
+     * Never fails soft to a smaller number. Each branch reports its own status, and a branch whose
+     * owner did not answer is UNAVAILABLE rather than zero — see [NetWorthComposer] for why that
+     * distinction is the whole design. The endpoint therefore answers 200 with an honest partial
+     * tree rather than 5xx when one upstream is down: the customer can still see their cash when
+     * lending is unavailable, and cannot mistake the total for a complete one.
+     */
+    @GET
+    @Path("/net-worth")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun netWorth(): Response {
+        val customer = customer()
+        return Response.ok(netWorthComposer.compose(customer.partyId))
+            .type(MediaType.APPLICATION_JSON)
+            .build()
     }
 
     // --- Loans (ADR lending; read-only customer view) ---

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
@@ -323,8 +323,7 @@ class NetWorthComposer {
      * Null means "could not ask", which the caller turns into UNAVAILABLE. An empty array is a
      * different return and means the owner answered with nothing.
      */
-    private fun fetchArray(url: String, partyId: UUID): ArrayNode? =
-        fetchNode(url, partyId) as? ArrayNode
+    private fun fetchArray(url: String, partyId: UUID): ArrayNode? = fetchNode(url, partyId) as? ArrayNode
 
     private fun fetchNode(url: String, partyId: UUID): JsonNode? {
         val response = runCatching { upstream.get(url, partyId.toString()) }.getOrElse {

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.rest
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Composes the customer's net worth from the services that OWN each figure (ADR-0301 D2).
+ *
+ * This holds no data of its own and caches nothing. Every leaf names the service that answered
+ * for it, so a reader can always tell an authoritative bank figure from a customer's assertion —
+ * which is the whole reason the composition lives here and not in a projection.
+ *
+ * ## The rule that shapes the whole class: a branch that did not answer is UNAVAILABLE, never zero
+ *
+ * A fan-out has one dangerous failure: an upstream that is down contributes 0, the total still
+ * renders, and the customer reads a smaller number as fact. Every existing edge read in this
+ * service fails soft to `[]` — `listLoans` says so in its own KDoc — which is right for a list the
+ * app draws as a section and wrong for a summand. A missing loan branch does not make someone
+ * richer by the size of their mortgage.
+ *
+ * So each branch carries its own [BranchStatus], the totals carry the set of branches that fed
+ * them, and a caller that ignores all of it still cannot silently read a partial total as complete:
+ * `complete` is false whenever any branch failed.
+ *
+ * ## No currency conversion, ever (ADR-0302 D7)
+ *
+ * Totals are per currency. Converting here would make this a second FX authority whose rate ages
+ * invisibly; `openbank-fx-service` is the one that knows, and the app converts for display with
+ * the rate and its timestamp shown. A consolidated cross-currency figure is indicative only
+ * (ADR-0024) and this service does not produce one.
+ */
+@ApplicationScoped
+@Suppress("TooManyFunctions") // one private fetcher per branch, plus the assemblers
+class NetWorthComposer {
+
+    /** What happened when we asked the service that owns this branch. */
+    enum class BranchStatus {
+        /** The owner answered. `leaves` is what it said, and may legitimately be empty. */
+        AVAILABLE,
+
+        /**
+         * The owner did not answer, or answered unusably. Distinct from an empty AVAILABLE branch:
+         * "this customer has no loans" and "we could not ask about loans" are different facts and
+         * must not render the same (the ADR-0210 D9 lesson, one layer up).
+         */
+        UNAVAILABLE,
+    }
+
+    @Inject
+    lateinit var upstream: UpstreamClient
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    @Inject
+    lateinit var clock: Clock
+
+    @ConfigProperty(name = "openbank.edge.account-service-url")
+    lateinit var accountServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.balance-service-url")
+    lateinit var balanceServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.lending-service-url")
+    lateinit var lendingServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.wealth-service-url")
+    lateinit var wealthServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.party-service-url")
+    lateinit var partyServiceUrl: String
+
+    /**
+     * The number of accounts whose balances we will fetch individually.
+     *
+     * balance-service exposes no bulk read — only `/api/v1/balances/{accountId}` — so this branch
+     * costs one upstream call per account. The cap is not a performance nicety: without it a party
+     * with many accounts turns one customer request into an unbounded fan-out against a money-path
+     * service. Past the cap the branch reports what it fetched and says it is TRUNCATED rather than
+     * pretending the rest are zero.
+     */
+    private val maxAccounts = MAX_ACCOUNTS
+
+    fun compose(partyId: UUID): ObjectNode {
+        val root = objectMapper.createObjectNode()
+        root.put("partyId", partyId.toString())
+        root.put("asOf", Instant.now(clock).toString())
+
+        val branches = objectMapper.createArrayNode()
+        branches.add(cashBranch(partyId))
+        branches.add(loansBranch(partyId))
+        branches.add(declaredBranch(partyId))
+        branches.add(entityStakesBranch(partyId))
+        root.set<ArrayNode>("branches", branches)
+
+        root.set<ObjectNode>("totals", totals(branches))
+        return root
+    }
+
+    // ── branches ────────────────────────────────────────────────────────────
+
+    /** On-platform cash: the caller's accounts, then one balance read per account. */
+    private fun cashBranch(partyId: UUID): ObjectNode {
+        val accounts = fetchArray("$accountServiceUrl/api/v1/accounts", partyId)
+            ?: return branch(CASH, BranchStatus.UNAVAILABLE, "account-service did not answer")
+
+        val leaves = objectMapper.createArrayNode()
+        var truncated = false
+        var anyBalanceFailed = false
+        accounts.forEachIndexed { index, account ->
+            if (index >= maxAccounts) {
+                truncated = true
+                return@forEachIndexed
+            }
+            val accountId = account.path("id").asText(null)
+                ?: account.path("accountId").asText(null)
+                ?: return@forEachIndexed
+            val balance = fetchNode("$balanceServiceUrl/api/v1/balances/$accountId", partyId)
+            if (balance == null) {
+                // One account's balance missing does not zero it — the branch says so instead.
+                anyBalanceFailed = true
+                return@forEachIndexed
+            }
+            balance.path("balances").forEach { pocket ->
+                leaves.add(
+                    leaf(
+                        sourceService = "balance-service",
+                        kind = "CASH",
+                        label = account.path("iban").asText(accountId),
+                        amount = pocket.path("bookedBalance").decimalValue(),
+                        currency = pocket.path("currency").asText(null) ?: return@forEach,
+                        liability = false,
+                    ),
+                )
+            }
+        }
+
+        val b = branch(
+            CASH,
+            if (anyBalanceFailed) BranchStatus.UNAVAILABLE else BranchStatus.AVAILABLE,
+            if (anyBalanceFailed) "at least one balance read failed" else null,
+        )
+        b.put("truncated", truncated)
+        b.set<ArrayNode>("leaves", leaves)
+        return b
+    }
+
+    /** Outstanding loans, as liabilities. */
+    private fun loansBranch(partyId: UUID): ObjectNode {
+        val loans = fetchArray("$lendingServiceUrl/api/v1/lending/loans?partyId=$partyId", partyId)
+            ?: return branch(LOANS, BranchStatus.UNAVAILABLE, "lending-service did not answer")
+
+        val leaves = objectMapper.createArrayNode()
+        loans.forEach { loan ->
+            val amount = loan.path("outstandingPrincipal").takeIf { !it.isMissingNode }
+                ?: loan.path("principal")
+            leaves.add(
+                leaf(
+                    sourceService = "lending-service",
+                    kind = "LOAN",
+                    label = loan.path("productCode").asText(loan.path("id").asText("loan")),
+                    amount = amount.decimalValue(),
+                    currency = loan.path("currency").asText("CZK"),
+                    liability = true,
+                ),
+            )
+        }
+        return branch(LOANS, BranchStatus.AVAILABLE, null).also { it.set<ArrayNode>("leaves", leaves) }
+    }
+
+    /**
+     * Customer-declared off-platform holdings (ADR-0301).
+     *
+     * Every leaf here carries `valuationSource` and `valuationAgeDays` verbatim from
+     * wealth-service. That labelling is not decoration: `CUSTOMER_DECLARED` means the customer
+     * typed the number and nobody checked it, and a years-old figure looks identical to a fresh
+     * one without the age. The app must render both; this composer refuses to strip them.
+     */
+    private fun declaredBranch(partyId: UUID): ObjectNode {
+        val holdings = fetchArray("$wealthServiceUrl/api/v1/holdings", partyId)
+            ?: return branch(DECLARED, BranchStatus.UNAVAILABLE, "wealth-service did not answer")
+
+        val leaves = objectMapper.createArrayNode()
+        holdings.forEach { h ->
+            val l = leaf(
+                sourceService = "wealth-service",
+                kind = h.path("holdingType").asText("DECLARED"),
+                label = h.path("label").asText(""),
+                amount = h.path("attributableAmount").decimalValue(),
+                currency = h.path("currency").asText(null) ?: return@forEach,
+                liability = h.path("isLiability").asBoolean(false),
+            )
+            l.put("valuationSource", h.path("valuationSource").asText(null))
+            l.put("valuationAgeDays", h.path("valuationAgeDays").asLong(-1))
+            leaves.add(l)
+        }
+        return branch(DECLARED, BranchStatus.AVAILABLE, null).also { it.set<ArrayNode>("leaves", leaves) }
+    }
+
+    /**
+     * Companies the caller may act for (ADR-0284 D8), listed WITHOUT a value.
+     *
+     * A stake's worth is not knowable from the owner graph — party-service returns who may
+     * represent whom, not what the entity is worth — so these leaves carry no amount and are
+     * excluded from every total. Putting a zero here would be the same lie as a missing branch
+     * contributing zero; naming them with `valued: false` lets the app show the customer their
+     * companies without implying they are worthless. Valuing them is ADR-0302 D4 look-through.
+     */
+    private fun entityStakesBranch(partyId: UUID): ObjectNode {
+        val profiles = fetchArray("$partyServiceUrl/api/v1/parties/$partyId/acting-for", partyId)
+            ?: return branch(ENTITIES, BranchStatus.UNAVAILABLE, "party-service did not answer")
+
+        val leaves = objectMapper.createArrayNode()
+        profiles.forEach { p ->
+            val l = objectMapper.createObjectNode()
+            l.put("sourceService", "party-service")
+            l.put("kind", "ENTITY_STAKE")
+            l.put("label", p.path("legalName").asText(p.path("partyId").asText("")))
+            l.put("entityPartyId", p.path("partyId").asText(null))
+            l.put("valued", false)
+            leaves.add(l)
+        }
+        return branch(ENTITIES, BranchStatus.AVAILABLE, null).also { it.set<ArrayNode>("leaves", leaves) }
+    }
+
+    // ── assembly ────────────────────────────────────────────────────────────
+
+    /**
+     * Per-currency totals, plus the honesty fields.
+     *
+     * `complete` is false whenever ANY branch is UNAVAILABLE or truncated. A client that renders
+     * the totals and ignores everything else still cannot present a partial figure as final,
+     * because the field it would have to ignore to do so says otherwise.
+     */
+    private fun totals(branches: ArrayNode): ObjectNode {
+        val byCurrency = linkedMapOf<String, BigDecimal>()
+        var complete = true
+        val contributing = objectMapper.createArrayNode()
+        val missing = objectMapper.createArrayNode()
+
+        branches.forEach { b ->
+            val name = b.path("branch").asText()
+            if (b.path("status").asText() != BranchStatus.AVAILABLE.name || b.path("truncated").asBoolean(false)) {
+                complete = false
+                missing.add(name)
+                return@forEach
+            }
+            contributing.add(name)
+            b.path("leaves").forEach { l ->
+                if (!l.path("valued").asBoolean(true)) return@forEach
+                val currency = l.path("currency").asText(null) ?: return@forEach
+                val amount = l.path("amount").decimalValue()
+                val signed = if (l.path("liability").asBoolean(false)) amount.negate() else amount
+                byCurrency[currency] = (byCurrency[currency] ?: BigDecimal.ZERO).add(signed)
+            }
+        }
+
+        val out = objectMapper.createObjectNode()
+        val arr = objectMapper.createArrayNode()
+        byCurrency.forEach { (currency, amount) ->
+            val n = objectMapper.createObjectNode()
+            n.put("currency", currency)
+            n.put("amount", amount)
+            arr.add(n)
+        }
+        out.set<ArrayNode>("byCurrency", arr)
+        out.put("complete", complete)
+        out.set<ArrayNode>("contributingBranches", contributing)
+        out.set<ArrayNode>("missingBranches", missing)
+        // Stated on the wire, not only in the docs: there is no converted grand total here, and a
+        // client that wants one must convert through fx-service and show the rate (ADR-0024).
+        out.put("converted", false)
+        return out
+    }
+
+    private fun branch(name: String, status: BranchStatus, reason: String?): ObjectNode {
+        val b = objectMapper.createObjectNode()
+        b.put("branch", name)
+        b.put("status", status.name)
+        if (reason != null) b.put("reason", reason)
+        b.put("truncated", false)
+        b.set<ArrayNode>("leaves", objectMapper.createArrayNode())
+        return b
+    }
+
+    @Suppress("LongParameterList") // one field per wire property; a DTO here would be the same list
+    private fun leaf(
+        sourceService: String,
+        kind: String,
+        label: String,
+        amount: BigDecimal,
+        currency: String,
+        liability: Boolean,
+    ): ObjectNode {
+        val l = objectMapper.createObjectNode()
+        l.put("sourceService", sourceService)
+        l.put("kind", kind)
+        l.put("label", label)
+        l.put("amount", amount)
+        l.put("currency", currency)
+        l.put("liability", liability)
+        l.put("valued", true)
+        return l
+    }
+
+    // ── upstream access ─────────────────────────────────────────────────────
+
+    /**
+     * Null means "could not ask", which the caller turns into UNAVAILABLE. An empty array is a
+     * different return and means the owner answered with nothing.
+     */
+    private fun fetchArray(url: String, partyId: UUID): ArrayNode? =
+        fetchNode(url, partyId) as? ArrayNode
+
+    private fun fetchNode(url: String, partyId: UUID): JsonNode? {
+        val response = runCatching { upstream.get(url, partyId.toString()) }.getOrElse {
+            Log.warnf(it, "net-worth: %s threw", url)
+            return null
+        }
+        if (response.status != OK) {
+            Log.debugf("net-worth: %s answered %d", url, response.status)
+            return null
+        }
+        val body = response.entity as? String ?: return null
+        return runCatching { objectMapper.readTree(body) }.getOrElse {
+            Log.warnf(it, "net-worth: %s returned unparseable JSON", url)
+            null
+        }
+    }
+
+    private companion object {
+        private val Log = Logger.getLogger(NetWorthComposer::class.java)
+        const val OK = 200
+        const val MAX_ACCOUNTS = 50
+        const val CASH = "CASH"
+        const val LOANS = "LOANS"
+        const val DECLARED = "DECLARED_HOLDINGS"
+        const val ENTITIES = "ENTITY_STAKES"
+    }
+}

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/NetWorthComposer.kt
@@ -138,7 +138,7 @@ class NetWorthComposer {
             balance.path("balances").forEach { pocket ->
                 leaves.add(
                     leaf(
-                        sourceService = "balance-service",
+                        owningService = "balance-service",
                         kind = "CASH",
                         label = account.path("iban").asText(accountId),
                         amount = pocket.path("bookedBalance").decimalValue(),
@@ -170,7 +170,7 @@ class NetWorthComposer {
                 ?: loan.path("principal")
             leaves.add(
                 leaf(
-                    sourceService = "lending-service",
+                    owningService = "lending-service",
                     kind = "LOAN",
                     label = loan.path("productCode").asText(loan.path("id").asText("loan")),
                     amount = amount.decimalValue(),
@@ -197,7 +197,7 @@ class NetWorthComposer {
         val leaves = objectMapper.createArrayNode()
         holdings.forEach { h ->
             val l = leaf(
-                sourceService = "wealth-service",
+                owningService = "wealth-service",
                 kind = h.path("holdingType").asText("DECLARED"),
                 label = h.path("label").asText(""),
                 amount = h.path("attributableAmount").decimalValue(),
@@ -227,7 +227,7 @@ class NetWorthComposer {
         val leaves = objectMapper.createArrayNode()
         profiles.forEach { p ->
             val l = objectMapper.createObjectNode()
-            l.put("sourceService", "party-service")
+            l.put("owningService", "party-service")
             l.put("kind", "ENTITY_STAKE")
             l.put("label", p.path("legalName").asText(p.path("partyId").asText("")))
             l.put("entityPartyId", p.path("partyId").asText(null))
@@ -298,8 +298,18 @@ class NetWorthComposer {
     }
 
     @Suppress("LongParameterList") // one field per wire property; a DTO here would be the same list
+    /**
+     * The wire field is `owningService`, NOT `sourceService`.
+     *
+     * `sourceService` is a contract word in this fleet: it means the module that EMITTED an event,
+     * and audit-service's TopicAttribution falls back to it, so a value disagreeing with the module
+     * directory splits one producer into two in every group-by (#5256/#5902). This is a REST
+     * response, not an event, and the value is deliberately a DIFFERENT service from the one
+     * answering the request — reusing the name would have been a collision with an established
+     * meaning, which `check-source-service-convention.py` caught.
+     */
     private fun leaf(
-        sourceService: String,
+        owningService: String,
         kind: String,
         label: String,
         amount: BigDecimal,
@@ -307,7 +317,7 @@ class NetWorthComposer {
         liability: Boolean,
     ): ObjectNode {
         val l = objectMapper.createObjectNode()
-        l.put("sourceService", sourceService)
+        l.put("owningService", owningService)
         l.put("kind", kind)
         l.put("label", label)
         l.put("amount", amount)

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -130,6 +130,7 @@ openbank:
     interest-service-url: ${INTEREST_SERVICE_URL:http://interest-service.interest.svc:8125}
     kyc-service-url: ${KYC_SERVICE_URL:http://kyc-service.kyc.svc:8114}
     lending-service-url: ${LENDING_SERVICE_URL:http://lending-service.lending.svc:8126}
+    wealth-service-url: ${WEALTH_SERVICE_URL:http://wealth-service.wealth.svc:8154}
     transaction-service-url: ${TRANSACTION_SERVICE_URL:http://transaction-service.payments.svc:8102}
     domestic-payment-service-url: ${DOMESTIC_PAYMENT_SERVICE_URL:http://domestic-payment.payments.svc:8116}
     sepa-payment-service-url: ${SEPA_PAYMENT_SERVICE_URL:http://sepa-payment.payments.svc:8115}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -19,7 +19,11 @@ info:
   # (1.57.0) in the same turn as this edit and confirmed free with
   # `git log -S 'version: 1.58.0' -- <this file>` (no hits) — a taken version is textually identical
   # to a free one, which is why the git merge reconciled two claims to 1.55.0 as ordinary text.
-  version: 1.58.0
+  # 1.58.0 -> 1.62.0 (#9772): additive — GET /net-worth, the ADR-0301 D2 composition.
+  # NOT 1.59.0: that and 1.60.0/1.61.0 are claimed by open PRs #9215/#9237/#9417 against this
+  # same file. A skipped number is harmless; a collided one is not, and whoever lands second
+  # takes the next free version (ADR-0048).
+  version: 1.62.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -71,6 +75,36 @@ tags:
   - name: Complaints
 
 paths:
+  /net-worth:
+    get:
+      tags: [Profiles]
+      operationId: getNetWorth
+      summary: The caller's net worth, composed from the services that own each figure
+      description: |
+        Fans out to balance-service, lending-service, wealth-service and the ADR-0284 owner graph
+        (ADR-0301 D2). The party comes from the JWT; there is no path or query parameter.
+
+        A branch whose owner did not answer is UNAVAILABLE, never zero. This endpoint answers 200
+        with an honest partial tree rather than 5xx when one upstream is down, so a customer can
+        still see their cash while lending is unavailable. `totals.complete` is false whenever any
+        branch failed or was truncated, and `totals.missingBranches` names them. A client that
+        renders the totals while ignoring those fields is presenting a partial figure as final.
+
+        No currency conversion. Totals are per currency and `totals.converted` is always false; a
+        consolidated cross-currency figure is indicative only (ADR-0024) and is the client's to
+        compute through fx-service, showing the rate and its timestamp.
+
+        Declared holdings are labelled. Every leaf from wealth-service carries `valuationSource`
+        and `valuationAgeDays`: `CUSTOMER_DECLARED` means the customer typed the number and nobody
+        checked it, and a years-old figure is otherwise indistinguishable from a fresh one.
+
+        Entity stakes carry no amount at all (`valued: false`) and move no total: party-service
+        returns who may represent whom, not what an entity is worth.
+      responses:
+        '200':
+          description: The net-worth tree, possibly partial
+        '401':
+          description: Missing or invalid bearer token
   /products:
     get:
       tags: [Products]

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/NetWorthComposerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/NetWorthComposerTest.kt
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.NetWorthComposer
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The composition has exactly one property worth defending, and every test here is about it:
+ * **a branch whose owner did not answer must never contribute zero.**
+ *
+ * A fan-out that fails soft produces a smaller number that still renders, and the customer reads
+ * it as fact. So each test that exercises a failure asserts BOTH that the branch says UNAVAILABLE
+ * and that the totals refuse to call themselves complete — either alone would pass against a
+ * composer that had quietly dropped the branch.
+ */
+class NetWorthComposerTest {
+
+    private val party = UUID.randomUUID()
+    private val accountId = UUID.randomUUID()
+    private val entityId = UUID.randomUUID()
+    private val accountBase = "http://account-service.core.svc:8100"
+    private val balanceBase = "http://balance-service.balances.svc:8104"
+    private val lendingBase = "http://lending-service.lending.svc:8126"
+    private val wealthBase = "http://wealth-service.wealth.svc:8154"
+    private val partyBase = "http://party-service.party.svc:8111"
+
+    private val mapper = ObjectMapper()
+
+    private fun composer(upstream: UpstreamClient) = NetWorthComposer().apply {
+        this.upstream = upstream
+        this.objectMapper = mapper
+        this.clock = Clock.fixed(Instant.parse("2026-09-13T08:00:00Z"), ZoneOffset.UTC)
+        this.accountServiceUrl = accountBase
+        this.balanceServiceUrl = balanceBase
+        this.lendingServiceUrl = lendingBase
+        this.wealthServiceUrl = wealthBase
+        this.partyServiceUrl = partyBase
+    }
+
+    private fun ok(json: String): Response = Response.ok(json).build()
+    private fun down(): Response = Response.status(503).build()
+
+    /** Every upstream healthy, unless a test overrides one. */
+    private fun healthyUpstream(): UpstreamClient = mockk<UpstreamClient>().also { u ->
+        every { u.get("$accountBase/api/v1/accounts", party.toString()) } returns
+            ok("""[{"id":"$accountId","iban":"CZ6508000000192000145399"}]""")
+        every { u.get("$balanceBase/api/v1/balances/$accountId", party.toString()) } returns
+            ok("""{"balances":[{"currency":"CZK","bookedBalance":150000.00}]}""")
+        every { u.get("$lendingBase/api/v1/lending/loans?partyId=$party", party.toString()) } returns
+            ok("""[{"id":"l1","productCode":"MORTGAGE","outstandingPrincipal":2000000.00,"currency":"CZK"}]""")
+        every { u.get("$wealthBase/api/v1/holdings", party.toString()) } returns
+            ok(
+                """[{"holdingType":"REAL_ESTATE","label":"Flat","attributableAmount":5000000.00,
+                   "currency":"CZK","isLiability":false,"valuationSource":"CUSTOMER_DECLARED",
+                   "valuationAgeDays":1200}]
+                """.trimIndent().replace("\n", ""),
+            )
+        every { u.get("$partyBase/api/v1/parties/$party/acting-for", party.toString()) } returns
+            ok("""[{"partyId":"$entityId","legalName":"Příklad s.r.o."}]""")
+    }
+
+    private fun branch(root: com.fasterxml.jackson.databind.JsonNode, name: String) =
+        root.path("branches").first { it.path("branch").asText() == name }
+
+    private fun czk(root: com.fasterxml.jackson.databind.JsonNode) =
+        root.path("totals").path("byCurrency").first { it.path("currency").asText() == "CZK" }
+            .path("amount").decimalValue()
+
+    @Test
+    fun `the happy path nets liabilities against assets, per currency`() {
+        val root = composer(healthyUpstream()).compose(party)
+
+        // 150 000 cash + 5 000 000 declared - 2 000 000 mortgage
+        assertThat(czk(root)).isEqualByComparingTo("3150000.00")
+        assertThat(root.path("totals").path("complete").asBoolean()).isTrue()
+        assertThat(root.path("totals").path("converted").asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `a branch whose owner is down is UNAVAILABLE and the total refuses to call itself complete`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$lendingBase/api/v1/lending/loans?partyId=$party", party.toString()) } returns down()
+
+        val root = composer(upstream).compose(party)
+        val loans = branch(root, "LOANS")
+
+        // Both halves matter. Without the first, a composer that dropped the branch silently would
+        // pass; without the second, one that reported UNAVAILABLE and still summed zero would.
+        assertThat(loans.path("status").asText()).isEqualTo("UNAVAILABLE")
+        assertThat(loans.path("leaves")).isEmpty()
+        assertThat(root.path("totals").path("complete").asBoolean()).isFalse()
+        assertThat(root.path("totals").path("missingBranches").map { it.asText() }).contains("LOANS")
+
+        // And the decisive one: the mortgage must NOT have been netted off as zero. Had the branch
+        // contributed zero, this would read 5 150 000 and look like a perfectly good answer.
+        assertThat(czk(root)).isEqualByComparingTo("5150000.00")
+        assertThat(root.path("totals").path("contributingBranches").map { it.asText() })
+            .doesNotContain("LOANS")
+    }
+
+    @Test
+    fun `an upstream that throws is UNAVAILABLE, not a 500 for the whole composition`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$wealthBase/api/v1/holdings", party.toString()) } throws
+            RuntimeException("connection reset")
+
+        val root = composer(upstream).compose(party)
+
+        assertThat(branch(root, "DECLARED_HOLDINGS").path("status").asText()).isEqualTo("UNAVAILABLE")
+        // The customer can still see their cash while one upstream is down.
+        assertThat(branch(root, "CASH").path("status").asText()).isEqualTo("AVAILABLE")
+        assertThat(root.path("totals").path("complete").asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `unparseable JSON is UNAVAILABLE, not an empty AVAILABLE branch`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$lendingBase/api/v1/lending/loans?partyId=$party", party.toString()) } returns
+            ok("not json at all")
+
+        assertThat(branch(composer(upstream).compose(party), "LOANS").path("status").asText())
+            .isEqualTo("UNAVAILABLE")
+    }
+
+    @Test
+    fun `an owner that answers with nothing is AVAILABLE and empty, which is a different fact`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$lendingBase/api/v1/lending/loans?partyId=$party", party.toString()) } returns ok("[]")
+
+        val root = composer(upstream).compose(party)
+        val loans = branch(root, "LOANS")
+
+        assertThat(loans.path("status").asText()).isEqualTo("AVAILABLE")
+        assertThat(loans.path("leaves")).isEmpty()
+        // "no loans" is a complete answer; "could not ask" is not.
+        assertThat(root.path("totals").path("complete").asBoolean()).isTrue()
+    }
+
+    @Test
+    fun `a declared holding keeps its source and its age on the wire`() {
+        val root = composer(healthyUpstream()).compose(party)
+        val leaf = branch(root, "DECLARED_HOLDINGS").path("leaves").first()
+
+        // Without these two the app cannot tell a bank figure from something the customer typed
+        // years ago, and ADR-0301 D2 exists to prevent exactly that.
+        assertThat(leaf.path("valuationSource").asText()).isEqualTo("CUSTOMER_DECLARED")
+        assertThat(leaf.path("valuationAgeDays").asLong()).isEqualTo(1200L)
+        assertThat(leaf.path("sourceService").asText()).isEqualTo("wealth-service")
+    }
+
+    @Test
+    fun `entity stakes carry no amount and move no total`() {
+        val root = composer(healthyUpstream()).compose(party)
+        val stakes = branch(root, "ENTITY_STAKES")
+        val leaf = stakes.path("leaves").first()
+
+        assertThat(stakes.path("status").asText()).isEqualTo("AVAILABLE")
+        assertThat(leaf.path("valued").asBoolean()).isFalse()
+        assertThat(leaf.has("amount")).isFalse()
+        // The total is unchanged by their presence — a zero here would be the same lie as a
+        // missing branch contributing zero.
+        assertThat(czk(root)).isEqualByComparingTo("3150000.00")
+    }
+
+    @Test
+    fun `currencies are never mixed`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$balanceBase/api/v1/balances/$accountId", party.toString()) } returns
+            ok("""{"balances":[{"currency":"CZK","bookedBalance":100.00},{"currency":"EUR","bookedBalance":50.00}]}""")
+
+        val totals = composer(upstream).compose(party).path("totals").path("byCurrency")
+        val eur = totals.first { it.path("currency").asText() == "EUR" }.path("amount").decimalValue()
+
+        assertThat(eur).isEqualByComparingTo("50.00")
+        assertThat(totals).hasSize(2)
+    }
+
+    @Test
+    fun `a balance read that fails does not silently zero that account`() {
+        val upstream = healthyUpstream()
+        every { upstream.get("$balanceBase/api/v1/balances/$accountId", party.toString()) } returns down()
+
+        val root = composer(upstream).compose(party)
+
+        assertThat(branch(root, "CASH").path("status").asText()).isEqualTo("UNAVAILABLE")
+        assertThat(root.path("totals").path("complete").asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `every leaf names the service that answered for it`() {
+        val root = composer(healthyUpstream()).compose(party)
+        val sources = root.path("branches").flatMap { b -> b.path("leaves").map { it.path("sourceService").asText() } }
+
+        assertThat(sources).isNotEmpty
+        assertThat(sources).allSatisfy { assertThat(it).isNotBlank() }
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/NetWorthComposerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/NetWorthComposerTest.kt
@@ -158,7 +158,7 @@ class NetWorthComposerTest {
         // years ago, and ADR-0301 D2 exists to prevent exactly that.
         assertThat(leaf.path("valuationSource").asText()).isEqualTo("CUSTOMER_DECLARED")
         assertThat(leaf.path("valuationAgeDays").asLong()).isEqualTo(1200L)
-        assertThat(leaf.path("sourceService").asText()).isEqualTo("wealth-service")
+        assertThat(leaf.path("owningService").asText()).isEqualTo("wealth-service")
     }
 
     @Test
@@ -202,7 +202,7 @@ class NetWorthComposerTest {
     @Test
     fun `every leaf names the service that answered for it`() {
         val root = composer(healthyUpstream()).compose(party)
-        val sources = root.path("branches").flatMap { b -> b.path("leaves").map { it.path("sourceService").asText() } }
+        val sources = root.path("branches").flatMap { b -> b.path("leaves").map { it.path("owningService").asText() } }
 
         assertThat(sources).isNotEmpty
         assertThat(sources).allSatisfy { assertThat(it).isNotBlank() }

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -167,6 +167,10 @@ spec:
             # Declared here so gen-network-policies.py opens the edge->lending ingress allow.
             - name: LENDING_SERVICE_URL
               value: http://lending-service.lending.svc:8126
+            # Declared off-platform holdings (ADR-0301 D2): one branch of the net-worth
+            # composition. The edge reads them and never stores them.
+            - name: WEALTH_SERVICE_URL
+              value: http://wealth-service.wealth.svc:8154
             # Delegated access / sharing (ADR-0232): the edge asks delegation-service whether an
             # ACTIVE grant lets the caller read someone else's account, card or document. The URL
             # was already correct as a CODE default, which is exactly why this was invisible: the

--- a/openbank-infra/gitops/components/wealth/network-policies.yaml
+++ b/openbank-infra/gitops/components/wealth/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: wealth-service
     app.kubernetes.io/part-of: wealth
   annotations:
-    openbank.tech/policy-checksum: "db1b0275a3ad618a"
+    openbank.tech/policy-checksum: "5530493061636048"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -933,6 +933,22 @@ data:
         - '*.write'
         - secrets.read.raw
     - id: card-scheme-bulletin-agent
+      tools:
+        allow:
+        - tier: read
+          resources:
+          - read.governance
+        - tier: write_proposal
+          resources:
+          - draft.ticket
+        deny:
+        - tier: write
+          resources:
+          - '*'
+        - tier: execute
+          resources:
+          - '*'
+    - id: card-dispute-evidence-agent
       tools:
         allow:
         - tier: read

--- a/openbank-infra/gitops/components/wealth/wealth-service.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-wealth-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db1b0275a3ad618a"
+        openbank.tech/policy-checksum: "5530493061636048"
       labels:
         app.kubernetes.io/name: wealth-service
         app.kubernetes.io/part-of: wealth


### PR DESCRIPTION
## Summary

`GET /customer/v1/net-worth` — the ADR-0301 D2 composition. Fans out to balance-service, lending-service, wealth-service and the ADR-0284 owner graph, and returns a tree whose every leaf names the service that owns the figure.

### The one property worth defending

**A branch whose owner did not answer is UNAVAILABLE, never zero.**

A fan-out that fails soft produces a smaller number that still renders, and the customer reads it as fact. Every existing edge read fails soft to an empty list — `listLoans` says so in its own KDoc — which is right for a section the app draws and wrong for a summand. A missing loan branch must not make someone richer by the size of their mortgage.

So each branch carries its own status, the totals name which branches fed them, and `complete` is false whenever any branch failed or truncated. A client that renders the totals while ignoring those fields is presenting a partial figure as final, and has to ignore a field that says so to do it.

Three related decisions:

- **Entity stakes carry no amount** (`valued: false`) and move no total. party-service returns who may represent whom, not what an entity is worth; a zero there would be the same lie as a missing branch contributing zero. Valuing them is ADR-0302 D4 look-through.
- **No currency conversion** (ADR-0302 D7). Totals are per currency and the response carries `converted: false`. Converting here would make the edge a second FX authority whose rate ages invisibly.
- **Declared holdings keep `valuationSource` and `valuationAgeDays`.** `CUSTOMER_DECLARED` means the customer typed it and nobody checked; a years-old figure is otherwise indistinguishable from a fresh one.

### Three things the work corrected rather than assumed

**ADR-0301 D2 named a path that does not exist.** It said `GET /api/v1/net-worth`; the customer edge is `@Path("/customer/v1")`, so that prefix belongs to the backing services, not to the edge. Corrected in the ADR and documented in the spec relative to the `/customer/v1` server base.

**`sourceService` is a contract word and I collided with it.** `check-source-service-convention.py` failed on four write sites, correctly: that field means the module that EMITTED an event, and audit-service's attribution falls back to it, so a disagreeing value splits one producer into two in every group-by. These are REST leaves, not events, and the value is deliberately a different service from the one answering. Renamed to `owningService`, with the reason recorded next to the code.

**The spec version skips three numbers.** 1.58.0 to 1.62.0, not 1.59.0: read off live `origin/main` in the same turn, 1.59.0/1.60.0/1.61.0 are claimed by open PRs #9215, #9237 and #9417 against this same file. A skipped number is harmless; a collided one fails the gate for whoever lands second.

### Verification

| Check | Result |
|---|---|
| `test` | 489 tests, 0 failures, 1 skipped (10 new) |
| `ktlintCheck` `detekt` | clean |
| `run-gates.py --all` | **adds zero gate failures** against a clean `origin/main` baseline |

That last row is a measured diff: clean `origin/main` fails 16 gates already, this branch opened two more and both are closed.

The new tests were **falsified before being trusted**: making a failed branch report AVAILABLE with zero loans — the classic fail-soft defect — turns two of them red.

### One honest cost

The ASVS baseline grows by one line. The edge's hop to wealth-service is plaintext http, like every in-cluster hop it makes, and wealth-service serves no TLS at all. Twenty-seven customer-edge lines in that baseline are the identical class. Giving in-cluster hops TLS is a fleet decision, not something this PR settles by making one service an exception.

## Linked issues

Closes #9772. Refs #9770, #9771, and ADR-0302 for the deferred look-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
