### PR TITLE
fix(infra): regenerate the stale wealth OPA bundle and its pod-roll annotation

### DIFF
--- a/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: wealth-service
     app.kubernetes.io/part-of: wealth
   annotations:
-    openbank.tech/policy-checksum: "db1b0275a3ad618a"
+    openbank.tech/policy-checksum: "5530493061636048"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -933,6 +933,22 @@ data:
         - '*.write'
         - secrets.read.raw
     - id: card-scheme-bulletin-agent
+      tools:
+        allow:
+        - tier: read
+          resources:
+          - read.governance
+        - tier: write_proposal
+          resources:
+          - draft.ticket
+        deny:
+        - tier: write
+          resources:
+          - '*'
+        - tier: execute
+          resources:
+          - '*'
+    - id: card-dispute-evidence-agent
       tools:
         allow:
         - tier: read

--- a/openbank-infra/gitops/components/wealth/wealth-service.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-wealth-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db1b0275a3ad618a"
+        openbank.tech/policy-checksum: "5530493061636048"
       labels:
         app.kubernetes.io/name: wealth-service
         app.kubernetes.io/part-of: wealth


### PR DESCRIPTION
## The defect is on `main`, not on the PR that found it

`bash .github/scripts/regen-derived.sh --all` on a **clean checkout of `origin/main`** rewrites:

```
 M openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
 M openbank-infra/gitops/components/wealth/wealth-service.yaml
```

So the committed derived files disagree with the policy source they are generated from, and the
step *Verify service OPA bundles + pod-roll annotations are in sync with the policy source* fails
on PRs that have nothing to do with wealth. Found on #9884, whose diff is ScheduledBackup
manifests plus one gate script.

`wealth` is a new component and its bundle predates the generators' current output. Regenerated
with the repo's own script — nothing hand-edited, regenerate → commit order per the derived-file
rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
