### PR TITLE
fix(ci): auto-deploy red watch reads the scheduled lane only, and gh steps carry a token

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -426,6 +426,24 @@
   answers `GroupAuthorizationException` — which is silent, because a consumer that cannot join a
   group looks exactly like a topic with nothing on it (#8877, #8882).
 
+### A watch about ONE lane must read ONE lane
+- **`auto-deploy-red-watch` ran green through 27 hours of red — its population was every lane.**
+  auto-deploy has three triggers; only `schedule` deploys the whole fleet, and `push` runs (the
+  services one merge touched) land green between scheduled ticks. The watch read the three newest
+  completed runs of any event: `2271 schedule ✗ | 2270 schedule ✗ | 2269 push ✓` was `stuck =
+  false`, ten times over, and the not-stuck branch would have CLOSED an open issue on that push
+  green. Filter the population server-side (`event=schedule`), close only on the same lane's
+  green, bound the query (it paginated ~2 300 runs to look at three, and was failing on the
+  installation rate limit the same morning), and keep the decision in a script with a
+  `--self-test` whose known-positive is the interleaved fixture
+  (`detect-auto-deploy-stuck.py`, gate `auto-deploy-red-watch-declaration`, rules.yaml
+  `ci_watches.lane_scoped_population`). Whether the other watches share the class is a thing to
+  measure per watch, not assert.
+- **A tokenless `gh` on a recovery path is red only on the day you need it.** `gh pr list` in
+  admin-ui-deploy's deploy-source guard ran only when a deploy branch already existed and had no
+  `GH_TOKEN`; `set -e` ended the step there. Gate `workflow-gh-token-declared` matches the
+  COMMAND position, not the substring — an echoed `gh workflow run …` remediation is not a call.
+
 ### main-protection: the bypass has two halves, and only one had a reader
 - **`rulesets/rule-suites` (the bypass LOG) is private and rejects fine-grained tokens;
   `rulesets/{id}` (the bypass CONFIG) is world-readable.** Same feature, opposite access, and it

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2229,6 +2229,39 @@ gates:
     run: |
       python3 .github/scripts/check-main-red-watch.py --check-declaration
 
+  # The DECLARATION half of the auto-deploy red watch (issue #9130). Measured 2026-09-13: the
+  # scheduled auto-deploy lane had been red for 27 hours — ten scheduled runs in a row — and
+  # the watch had run green throughout, because its population was the three newest completed
+  # runs of ANY event. auto-deploy also runs on `push` (the services one merge touched), those
+  # runs are green about a different subject, and they land between scheduled ticks:
+  # `2271 schedule ✗ | 2270 schedule ✗ | 2269 push ✓` read as not stuck, and the not-stuck branch
+  # would have closed any issue on that push green. The decision was inline in a github-script
+  # block, unreachable by any test — the same shape this repo already refused for
+  # classify-can-i-deploy-block.sh.
+  #
+  # The population rule (rules.yaml: ci_watches.lane_scoped_population) now lives in
+  # detect-auto-deploy-stuck.py, whose --self-test holds it to exactly that fixture as the
+  # known-positive plus the known-negatives; this gate keeps the workflow invoking the script
+  # and refuses an inline `listWorkflowRuns`, so the decision cannot quietly move back to where
+  # nothing can falsify it.
+  - id: auto-deploy-red-watch-declaration
+    name: "auto-deploy red watch reads the scheduled lane only, via a falsified script (issue #9130, enforced)"
+    group: registry
+    mode: enforced
+    review_after: "2027-03-13"
+    rationale: >-
+      A watch that asserts a verdict about one lane of a workflow must draw its population from
+      that lane; drawn from all lanes it is green about a different subject. Re-examine when the
+      subject-based watch (per-service durable-block verdicts published by auto-deploy) lands,
+      which subsumes the run-streak proxy this protects.
+    min_subjects: 1
+    selftest: |
+      python3 .github/scripts/detect-auto-deploy-stuck.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/detect-auto-deploy-stuck.py", ".github/workflows/auto-deploy-red-watch.yml"]
+    run: |
+      python3 .github/scripts/detect-auto-deploy-stuck.py --check-declaration
+
   # The spot-kill auto-retry is a control with no audience: it is `workflow_run`-triggered, so
   # its red is addressed to nobody, and its whole design is to act unattended. Until #6255 its
   # decision logic was a `run:` block, which means GitHub Actions on a real `workflow_run` event
@@ -4643,6 +4676,34 @@ gates:
   # Needs GH_TOKEN, which the shard job already exports. Exit 2 = the verdict could not be
   # computed, which is a failure and not a clean — a permission-shaped absence is
   # byte-identical to a real one.
+  # `gh` without a token in scope does not degrade, it exits non-zero on the first call — and
+  # under `set -e` that ends the step. Measured 2026-09-13: 31 steps invoke gh, exactly one had
+  # no GH_TOKEN/GITHUB_TOKEN — admin-ui-deploy.yml's deploy-source guard, where `gh pr list`
+  # sits in the if-branch taken only when a deploy branch for the SHA already exists. That is
+  # the recovery path, so the path that existed to re-admit a stuck build was the one that could
+  # not run, and no green run ever reached it. Point-fixed alongside this gate; baseline EMPTY.
+  #
+  # Design constraint, learned on the first scan of this tree: match the COMMAND POSITION, not
+  # the substring. `gh workflow run auto-deploy.yml -f services=<svc>` inside an echoed
+  # remediation message is not a call (auto-deploy.yml), and a gate that flags correct code is
+  # worth less than nothing. Comment lines are stripped; that echoed message is a self-test
+  # known-negative.
+  - id: workflow-gh-token-declared
+    name: "every workflow step that invokes gh has a token in scope (enforced)"
+    group: lint
+    mode: enforced
+    review_after: "2027-03-13"
+    rationale: >-
+      A tokenless gh call fails closed, and the one measured instance sat on a recovery path no
+      green run exercises. Re-examine if gh ever starts falling back to an ambient credential in
+      Actions, which would make the absence harmless.
+    min_subjects: 20   # 31 today
+    selftest: python3 .github/scripts/check-workflow-gh-token.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/check-workflow-gh-token.py"]
+    run: |
+      python3 .github/scripts/check-workflow-gh-token.py
+
   - id: agent-pr-guard
     name: "agent PR guard (autonomous agents may not land protected paths, enforced)"
     group: lint

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2248,6 +2248,7 @@ gates:
     name: "auto-deploy red watch reads the scheduled lane only, via a falsified script (issue #9130, enforced)"
     group: registry
     mode: enforced
+    budget_seconds: 10   # 0.3s measured; offline, two files read
     review_after: "2027-03-13"
     rationale: >-
       A watch that asserts a verdict about one lane of a workflow must draw its population from
@@ -4692,6 +4693,7 @@ gates:
     name: "every workflow step that invokes gh has a token in scope (enforced)"
     group: lint
     mode: enforced
+    budget_seconds: 15   # 0.7s measured over 34 workflow files
     review_after: "2027-03-13"
     rationale: >-
       A tokenless gh call fails closed, and the one measured instance sat on a recovery path no

--- a/.github/scripts/check-workflow-gh-token.py
+++ b/.github/scripts/check-workflow-gh-token.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every workflow step that INVOKES the gh CLI must have a token in scope (gate workflow-gh-token-declared).
+
+WHY THIS EXISTS
+---------------
+`gh` without `GH_TOKEN`/`GITHUB_TOKEN` in the environment does not degrade — it exits non-zero
+with `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable`,
+and under `set -e` that ends the step. Measured 2026-09-13: 31 steps across the workflows invoke
+gh; exactly one had no token — admin-ui-deploy.yml's "Reject stale or self-generated deploy
+source", where `gh pr list` sits inside an `if` branch taken only when a deploy branch for the
+SHA already exists. That is the RECOVERY path (re-admit a stuck build), so the path that existed
+to recover was the one that could not run, and no green run ever exercised it. Point-fixed in
+the same PR; this gate is the systemic half, with an empty baseline.
+
+WHAT COUNTS AS AN INVOCATION
+----------------------------
+Only `gh <subcommand>` in COMMAND POSITION — start of a line, or after `;`, `&&`, `||`, `|`,
+`(`, `$(`, `then`, `do`, `else`. A mention inside a string is not a call: the first scan of this
+tree produced a false positive on `gh workflow run auto-deploy.yml -f services=<svc>` inside an
+`echo`ed remediation message for a human (auto-deploy.yml). A gate that cries wolf about correct
+code is worth less than nothing (`\\bpact\\b` vs `compact`, the entity-column-names lesson), so
+the match is positional and comment lines are stripped first. The known-negative for exactly that
+echoed remediation is in --self-test.
+
+A token is "in scope" when `GH_TOKEN` or `GITHUB_TOKEN` is set in the step's `env:`, the job's,
+or the workflow's. `gh` also honours `GH_ENTERPRISE_TOKEN`, not used here; add it if it ever is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+TOKEN_KEYS = {"GH_TOKEN", "GITHUB_TOKEN"}
+SUBCOMMANDS = (
+    "pr|issue|api|run|workflow|release|label|repo|search|variable|secret|cache|auth|gist|"
+    "project|ruleset|codespace|extension|status|browse"
+)
+CMD = re.compile(
+    r"(?:^|[;&|(!]|\$\(|\b(?:then|do|else|if|while|until|elif)\b)\s*(?:env\s+(?:\S+=\S*\s+)+)?gh\s+(?:" + SUBCOMMANDS + r")\b",
+    re.M,
+)
+
+
+def _code_only(run: str) -> str:
+    return "\n".join(ln for ln in run.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def invokes_gh(run: str) -> bool:
+    return bool(CMD.search(_code_only(run or "")))
+
+
+def scan_workflow(doc: dict, path: str) -> tuple[int, list[str]]:
+    """Returns (steps invoking gh, problems)."""
+    n = 0
+    problems: list[str] = []
+    wenv = doc.get("env") or {}
+    for jn, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        jenv = job.get("env") or {}
+        for i, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str) or not invokes_gh(run):
+                continue
+            n += 1
+            env = {**(wenv if isinstance(wenv, dict) else {}),
+                   **(jenv if isinstance(jenv, dict) else {}),
+                   **((step.get("env") or {}) if isinstance(step.get("env"), dict) else {})}
+            if not (TOKEN_KEYS & set(env)):
+                label = step.get("name") or step.get("id") or f"step[{i}]"
+                problems.append(
+                    f"{path}: job `{jn}` step `{label}` invokes gh with no GH_TOKEN/GITHUB_TOKEN "
+                    f"in step, job or workflow env — under `set -e` the step dies on the first call"
+                )
+    return n, problems
+
+
+def scan(root: Path) -> tuple[int, list[str]]:
+    total = 0
+    problems: list[str] = []
+    for f in sorted(glob.glob(str(root / ".github/workflows/*.yml"))):
+        doc = gatelib.load_yaml(f)
+        if not isinstance(doc, dict):
+            continue
+        n, p = scan_workflow(doc, str(Path(f).relative_to(root)))
+        total += n
+        problems += p
+    return total, problems
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        print(("  ok   " if cond else "  FAIL ") + label)
+        if not cond:
+            failures.append(label)
+
+    def wf(run: str, env: dict | None = None, jenv: dict | None = None, wenv: dict | None = None) -> dict:
+        step = {"name": "s", "run": run}
+        if env is not None:
+            step["env"] = env
+        job = {"steps": [step]}
+        if jenv is not None:
+            job["env"] = jenv
+        doc = {"jobs": {"j": job}}
+        if wenv is not None:
+            doc["env"] = wenv
+        return doc
+
+    tok = {"GH_TOKEN": "${{ github.token }}"}
+    # Known-positive: the live defect's shape.
+    live = 'if git ls-remote --exit-code --heads origin x >/dev/null; then\n  open="$(gh pr list --repo "$R" --state open --json number --jq \'length > 0\')"\nfi\n'
+    n, p = scan_workflow(wf(live), "w.yml")
+    check("known-positive: `$(gh pr list …)` inside an if-branch with no token is red", n == 1 and len(p) == 1)
+    check("known-positive: a step-level token clears it", scan_workflow(wf(live, env=tok), "w.yml")[1] == [])
+    check("known-positive: a job-level token clears it", scan_workflow(wf(live, jenv=tok), "w.yml")[1] == [])
+    check("known-positive: a workflow-level token clears it", scan_workflow(wf(live, wenv=tok), "w.yml")[1] == [])
+    check("GITHUB_TOKEN is accepted too",
+          scan_workflow(wf(live, env={"GITHUB_TOKEN": "x"}), "w.yml")[1] == [])
+    # Known-negatives: mentions that are not invocations.
+    echoed = 'echo "re-dispatch to recover (\\`gh workflow run auto-deploy.yml -f services=<svc>\\`), or"\n'
+    check("known-negative: `gh workflow run` inside an echoed message is not a call",
+          scan_workflow(wf(echoed), "w.yml") == (0, []))
+    check("known-negative: a comment line is not a call",
+          scan_workflow(wf("# gh api repos/x\necho hi\n"), "w.yml") == (0, []))
+    check("known-negative: `ghcr.io` / `ghost` do not match",
+          scan_workflow(wf("docker pull ghcr.io/x\nghost pr list\n"), "w.yml") == (0, []))
+    check("known-negative: a uses: step with no run: is skipped",
+          scan_workflow({"jobs": {"j": {"steps": [{"uses": "actions/checkout@x"}]}}}, "w.yml") == (0, []))
+    # Positional forms that ARE calls.
+    for form in ("gh api x", "foo && gh api x", "foo | gh issue list", "x=$(gh run list)", "if gh pr view 1; then :; fi",
+                 "  env GH_PAGER= gh api x"):
+        check(f"positional form is a call: {form!r}", invokes_gh(form))
+
+    # The real tree: the baseline is EMPTY. A new tokenless call is red immediately.
+    total, problems = scan(Path("."))
+    check(f"real tree: {total} steps invoke gh, all with a token in scope", total >= 20 and problems == [])
+    for p in problems:
+        print("         " + p)
+
+    if failures:
+        print(f"self-test: {len(failures)} case(s) FAILED")
+        return 1
+    print("self-test: all cases behaved as required")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--root", default=".")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    total, problems = scan(Path(a.root))
+    gatelib.subjects(total, "workflow steps invoking the gh CLI")
+    for p in problems:
+        print("::error::" + p)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/detect-auto-deploy-stuck.py
+++ b/.github/scripts/detect-auto-deploy-stuck.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Is the SCHEDULED auto-deploy lane stuck red? The logic behind auto-deploy-red-watch.yml.
+
+WHY THIS EXISTS
+---------------
+auto-deploy-red-watch.yml (#9130) escalates a stuck auto-deploy pipeline onto one
+`fleet-health` issue (marker `<!-- auto-deploy-red -->`) after three consecutive failures.
+Measured 2026-09-13: the scheduled lane had been red for 27 hours, ten scheduled runs in a
+row, no issue existed, and the watch had run GREEN the whole time. Its population was wrong:
+it read the three newest completed `auto-deploy.yml` runs with no filter on the triggering
+EVENT, and auto-deploy also runs on `push` (a merge to main deploys the services that merge
+touched). Those push runs land between scheduled ticks and are green, legitimately, because
+their can-i-deploy selector covers only the services the push changed. The real sequence was
+
+    2271 schedule failure | 2270 schedule failure | 2269 push success   -> stuck = false
+
+A green run about a DIFFERENT subject broke the streak every time. Two things made it worse:
+the not-stuck branch actively CLOSED an open issue on any green run, so even a lucky escalation
+would have been tidied away by the next push; and the issue text the watch writes describes
+exactly this trap ("partial deploys still land, so the fleet looks healthy while blocked
+services stay pinned") — the watch was that trap's own victim. Side effect, also real: the
+watch used `github.paginate(..., per_page: 10)` over the whole run history, ~228 API calls per
+tick to look at three runs, and by 04:25Z that same day it was failing on
+`API rate limit exceeded for installation`.
+
+THE RULE this script embodies (rules.yaml: `ci_watches.lane_scoped_population`)
+--------------------------------------------------------------------------------
+A watch that asserts a verdict about ONE lane of a workflow must draw its population from
+that lane only. `auto-deploy.yml` has three lanes — `schedule` (reconcile: every service,
+the only lane whose red means "the fleet cannot deploy"), `push` (the changed services) and
+`workflow_dispatch` (an operator's explicit refresh). Only the scheduled lane is a verdict on
+the fleet, so:
+
+  R1  the population is `event == schedule`, `status == completed`, cancelled runs dropped
+      (a concurrency-group supersede is not a verdict, #2185);
+  R2  stuck := the THRESHOLD newest scheduled verdicts are all `failure`;
+  R3  the issue is closed only by a green SCHEDULED run newer than the streak — never by a
+      green push, which is a fact about other services;
+  R4  the query is bounded (one page, `per_page` a little above the threshold) — a watch that
+      reads the whole history to look at three runs is the rate-limit outage it reports on.
+
+Three lanes
+-----------
+  --self-test          offline fixtures, including the KNOWN-POSITIVE that was measured live
+                       (ten scheduled failures interleaved with green pushes MUST escalate)
+                       and the known-negatives. Gate `auto-deploy-red-watch-declaration`.
+  --check-declaration  offline: auto-deploy-red-watch.yml invokes THIS script and carries no
+                       inline `listWorkflowRuns` — the decision logic must not be re-inlined
+                       into a `github-script` block, where no test can reach it.
+  --evaluate           online: one `gh api` call, JSON verdict on stdout/--json. Exit 0 = not
+                       stuck, 2 = stuck, 1 = the watch itself could not answer (which is a
+                       failure of the watch, never a "not stuck").
+
+WHAT THIS CANNOT DO
+-------------------
+"Three red scheduled runs" is still a proxy for the subject that matters — a SERVICE that is
+durably blocked (REGRESSION / UNVERIFIABLE, per classify-can-i-deploy-block.sh). A tick that
+happens to pass because the blocked service was not selected that time, or a partial fleet
+where only money-path services are pinned, is invisible here. The subject-based watch (a
+per-service verdict artifact published by auto-deploy, escalation on "service X durable-blocked
+longer than N", closure only on "service X deployed at current main") is tracked as the
+follow-up issue named in the PR that introduced this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WORKFLOW = ".github/workflows/auto-deploy-red-watch.yml"
+WORKFLOW_ID = "auto-deploy.yml"
+LANE = "schedule"
+THRESHOLD = 3
+# R4: one page, a little above the threshold so a couple of cancelled runs still leave enough
+# verdicts. NOT a paginate; NOT the history.
+PER_PAGE = 8
+
+
+# --------------------------------------------------------------------------- pure logic
+
+
+def lane_verdicts(runs: list[dict], lane: str = LANE) -> list[dict]:
+    """R1: the population is the lane's completed, non-cancelled runs, newest first."""
+    kept = [
+        r for r in runs
+        if r.get("event") == lane
+        and r.get("status") == "completed"
+        and r.get("conclusion") != "cancelled"
+    ]
+    return sorted(kept, key=lambda r: r.get("created_at", ""), reverse=True)
+
+
+def evaluate(runs: list[dict], threshold: int = THRESHOLD, lane: str = LANE) -> dict:
+    """R2 + R3 over an arbitrary (possibly multi-lane) list of runs.
+
+    Returns a JSON-able verdict. `close_on` is the green SCHEDULED run that licenses closing an
+    open issue, or None; a green run from any other lane never appears there (R3).
+    """
+    verdicts = lane_verdicts(runs, lane)
+    recent = verdicts[:threshold]
+    stuck = len(recent) >= threshold and all(r.get("conclusion") == "failure" for r in recent)
+    # R3: only a green run of THIS lane, and only the newest verdict — a green tick older than
+    # the current streak is history, not a licence to close.
+    newest = verdicts[0] if verdicts else None
+    close_on = newest if (newest and newest.get("conclusion") == "success") else None
+    return {
+        "lane": lane,
+        "threshold": threshold,
+        "population": len(verdicts),
+        "stuck": stuck,
+        "recent": [_slim(r) for r in recent],
+        "close_on": _slim(close_on) if close_on else None,
+    }
+
+
+def _slim(r: dict) -> dict:
+    return {
+        "id": r.get("id"),
+        "run_number": r.get("run_number"),
+        "event": r.get("event"),
+        "conclusion": r.get("conclusion"),
+        "created_at": r.get("created_at"),
+        "head_sha": r.get("head_sha"),
+        "html_url": r.get("html_url"),
+    }
+
+
+# --------------------------------------------------------------------------- online lane
+
+
+def fetch_runs(repo: str, per_page: int = PER_PAGE) -> list[dict]:
+    """One bounded call (R4). `event=` is a server-side filter, so the page IS the lane."""
+    path = (
+        f"repos/{repo}/actions/workflows/{WORKFLOW_ID}/runs"
+        f"?event={LANE}&status=completed&per_page={per_page}"
+    )
+    out = subprocess.run(
+        ["gh", "api", path, "--jq", ".workflow_runs"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    runs = json.loads(out)
+    if not isinstance(runs, list):
+        raise RuntimeError(f"unexpected shape from {path}: {type(runs).__name__}")
+    return runs
+
+
+# --------------------------------------------------------------------------- declaration
+
+
+def check_declaration(root: Path) -> list[str]:
+    """The workflow must call THIS script and must not carry the decision inline."""
+    wf = root / WORKFLOW
+    problems: list[str] = []
+    if not wf.exists():
+        return [f"{WORKFLOW}: missing"]
+    text = wf.read_text()
+    code = "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+    me = Path(__file__).name
+    if not re.search(rf"python3\s+\.github/scripts/{re.escape(me)}\s+--evaluate", code):
+        problems.append(f"{WORKFLOW}: does not invoke `python3 .github/scripts/{me} --evaluate`")
+    if not re.search(rf"python3\s+\.github/scripts/{re.escape(me)}\s+--self-test", code):
+        problems.append(f"{WORKFLOW}: does not run `{me} --self-test` before trusting a verdict")
+    if "listWorkflowRuns" in code:
+        problems.append(
+            f"{WORKFLOW}: carries an inline `listWorkflowRuns` — the population decision "
+            f"must live in {me}, where --self-test can reach it"
+        )
+    return problems
+
+
+# --------------------------------------------------------------------------- self-test
+
+
+def _run(n: int, event: str, conclusion: str, status: str = "completed") -> dict:
+    return {
+        "id": 1000 + n, "run_number": n, "event": event, "status": status,
+        "conclusion": conclusion, "created_at": f"2026-09-13T{n:02d}:00:00Z",
+        "head_sha": f"{n:09x}", "html_url": f"https://example.invalid/runs/{n}",
+    }
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        print(("  ok   " if cond else "  FAIL ") + label)
+        if not cond:
+            failures.append(label)
+
+    # KNOWN-POSITIVE, measured live 2026-09-13: ten scheduled failures, green pushes between
+    # them. Under the old population (newest three, any event) this was `stuck = false`.
+    seq = []
+    n = 23
+    for i in range(10):
+        seq.append(_run(n, "schedule", "failure")); n -= 1
+        if i % 2 == 0:
+            seq.append(_run(n, "push", "success")); n -= 1
+    v = evaluate(seq)
+    check("known-positive: 10 scheduled failures interleaved with green pushes -> stuck", v["stuck"])
+    check("known-positive: population counts only the scheduled lane", v["population"] == 10)
+    check("known-positive: a green push never licenses closing", v["close_on"] is None)
+    check("known-positive: every run in the streak is a scheduled failure",
+          all(r["event"] == "schedule" and r["conclusion"] == "failure" for r in v["recent"]))
+
+    # The exact live triple.
+    live = [_run(2271, "schedule", "failure"), _run(2270, "schedule", "failure"),
+            _run(2269, "push", "success"), _run(2268, "push", "failure"),
+            _run(2267, "schedule", "failure")]
+    check("live 2271/2270/2269: stuck (the push success is not in the population)",
+          evaluate(live)["stuck"])
+
+    # The OLD population, reproduced, must read the same input as not stuck — this is the
+    # assertion that the fix is a fix and not a coincidence of the fixture.
+    old_recent = [r for r in sorted(live, key=lambda r: r["created_at"], reverse=True)
+                  if r["conclusion"] != "cancelled"][:THRESHOLD]
+    check("old population (no lane filter) reads the same input as NOT stuck",
+          not all(r["conclusion"] == "failure" for r in old_recent))
+
+    # Known-negatives.
+    check("two scheduled failures only -> not stuck (below threshold)",
+          not evaluate([_run(3, "schedule", "failure"), _run(2, "schedule", "failure")])["stuck"])
+    green_newest = [_run(5, "schedule", "success"), _run(4, "schedule", "failure"),
+                    _run(3, "schedule", "failure"), _run(2, "schedule", "failure")]
+    v = evaluate(green_newest)
+    check("newest scheduled run green -> not stuck", not v["stuck"])
+    check("newest scheduled run green -> licenses closing", v["close_on"] is not None
+          and v["close_on"]["run_number"] == 5)
+    v = evaluate([_run(5, "schedule", "failure"), _run(4, "schedule", "success"),
+                  _run(3, "schedule", "failure"), _run(2, "schedule", "failure")])
+    check("a green tick INSIDE the window breaks the streak", not v["stuck"])
+    check("...but an older green does not license closing (newest is red)", v["close_on"] is None)
+    v = evaluate([_run(6, "schedule", "cancelled"), _run(5, "schedule", "failure"),
+                  _run(4, "schedule", "cancelled"), _run(3, "schedule", "failure"),
+                  _run(2, "schedule", "failure")])
+    check("cancelled scheduled runs are skipped, not counted as red or green", v["stuck"]
+          and v["population"] == 3)
+    v = evaluate([_run(6, "schedule", "failure", status="in_progress"),
+                  _run(5, "schedule", "failure"), _run(4, "schedule", "failure"),
+                  _run(3, "schedule", "failure")])
+    check("an in-progress run is not a verdict yet", v["stuck"] and v["population"] == 3)
+    check("empty population -> not stuck, nothing to close",
+          evaluate([]) == {"lane": LANE, "threshold": THRESHOLD, "population": 0,
+                           "stuck": False, "recent": [], "close_on": None})
+    v = evaluate([_run(3, "push", "failure"), _run(2, "push", "failure"),
+                  _run(1, "push", "failure")])
+    check("three red PUSH runs are not a scheduled-lane verdict", not v["stuck"]
+          and v["population"] == 0)
+
+    # Declaration lane, held to a known-positive and two sabotages on a synthetic tree.
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        wf = root / WORKFLOW
+        wf.parent.mkdir(parents=True)
+        me = Path(__file__).name
+        good = (f"run: python3 .github/scripts/{me} --self-test\n"
+                f"run: python3 .github/scripts/{me} --evaluate --repo x\n")
+        wf.write_text(good)
+        check("declaration: the committed shape passes", check_declaration(root) == [])
+        wf.write_text(good + "script: |\n  github.rest.actions.listWorkflowRuns({})\n")
+        check("declaration: re-inlined listWorkflowRuns is rejected",
+              any("listWorkflowRuns" in p for p in check_declaration(root)))
+        wf.write_text(good + "# github.rest.actions.listWorkflowRuns in a comment is fine\n")
+        check("declaration: a commented mention is not an inline decision",
+              check_declaration(root) == [])
+        wf.write_text(f"run: python3 .github/scripts/{me} --self-test\n")
+        check("declaration: a workflow that never evaluates is rejected",
+              any("--evaluate" in p for p in check_declaration(root)))
+
+    # The real tree, so the gate is red the moment the workflow drifts.
+    real = check_declaration(Path(os.environ.get("GATE_ROOT", ".")))
+    check("declaration: the real auto-deploy-red-watch.yml conforms", real == [])
+    for p in real:
+        print("         " + p)
+
+    if failures:
+        print(f"self-test: {len(failures)} case(s) FAILED")
+        return 1
+    print("self-test: all cases behaved as required")
+    return 0
+
+
+# --------------------------------------------------------------------------- main
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--check-declaration", action="store_true")
+    ap.add_argument("--evaluate", action="store_true")
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    ap.add_argument("--json", metavar="PATH", help="also write the verdict here")
+    ap.add_argument("--root", default=".")
+    a = ap.parse_args()
+
+    if a.self_test:
+        return self_test()
+
+    if a.check_declaration:
+        problems = check_declaration(Path(a.root))
+        print("SUBJECTS=1  # auto-deploy-red-watch.yml")
+        for p in problems:
+            print("::error::" + p)
+        return 1 if problems else 0
+
+    if a.evaluate:
+        if not a.repo:
+            print("::error::--repo (or GITHUB_REPOSITORY) is required", file=sys.stderr)
+            return 1
+        try:
+            runs = fetch_runs(a.repo)
+        except (subprocess.CalledProcessError, ValueError, RuntimeError) as e:
+            err = getattr(e, "stderr", "") or str(e)
+            print(f"::error::the watch could not read the {LANE} lane of {WORKFLOW_ID}: "
+                  f"{err.strip()[:400]}", file=sys.stderr)
+            return 1
+        v = evaluate(runs)
+        text = json.dumps(v, indent=2)
+        print(text)
+        if a.json:
+            Path(a.json).write_text(text)
+        return 2 if v["stuck"] else 0
+
+    ap.error("pick one of --self-test / --check-declaration / --evaluate")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -149,6 +149,10 @@ jobs:
         name: Reject stale or self-generated deploy source
         env:
           EVENT_NAME: ${{ github.event_name }}
+          # `gh pr list` below runs only on the recovery path (a deploy branch for this SHA
+          # already exists). Without a token gh exits non-zero under `set -e`, so that path —
+          # the one that exists to re-admit a stuck build — was the one that could not run.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"

--- a/.github/workflows/auto-deploy-red-watch.yml
+++ b/.github/workflows/auto-deploy-red-watch.yml
@@ -16,14 +16,25 @@
 #   scheduled job going red would reproduce the blind spot it exists to close.
 #   So this opens or refreshes ONE issue (label `fleet-health`, marker
 #   `<!-- auto-deploy-red -->`), reopens it if hand-closed while the pipeline is
-#   still failing, and closes it itself on the next green run.
+#   still failing, and closes it itself on the next green SCHEDULED run.
 #
-# THRESHOLD: three consecutive completed failures. One failure can be a
-#   transient broker hiccup the next tick clears; three in a row (≈ 2 hours at
-#   the deploy cadence) is a stuck pipeline by any reading, and the gate itself
-#   says a REGRESSION block "will not clear on its own" (ADR-0092, #2549).
-#   Cancelled runs are not failures (concurrency-group supersede is normal,
-#   #2185) and in-progress runs are simply not a verdict yet.
+# THE POPULATION IS THE SCHEDULED LANE ONLY. Until 2026-09-13 this read the three
+#   newest completed runs of any event. auto-deploy also runs on `push` (the
+#   services a merge touched) and those runs are green legitimately — about a
+#   different subject — and they land between scheduled ticks. Ten scheduled
+#   failures over 27 hours never escalated: `2271 schedule ✗ | 2270 schedule ✗ |
+#   2269 push ✓` read as not stuck, and the not-stuck branch would have CLOSED
+#   any issue on that push green. The decision now lives in
+#   .github/scripts/detect-auto-deploy-stuck.py, where --self-test holds it to
+#   exactly that fixture, and the `auto-deploy-red-watch-declaration` gate keeps
+#   it from being re-inlined here where no test can reach it.
+#
+# THRESHOLD: three consecutive completed scheduled failures. One failure can be
+#   a transient broker hiccup the next tick clears; three in a row is a stuck
+#   pipeline by any reading, and the gate itself says a REGRESSION block "will
+#   not clear on its own" (ADR-0092, #2549). Cancelled runs are not failures
+#   (concurrency-group supersede is normal, #2185) and in-progress runs are
+#   simply not a verdict yet.
 # -----------------------------------------------------------------------------
 name: auto-deploy red watch
 
@@ -35,6 +46,8 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
+  actions: read
   issues: write
 
 concurrency:
@@ -44,24 +57,46 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A verdict from logic that has never been falsified is not a verdict.
+      - name: Self-test the watcher
+        run: python3 .github/scripts/detect-auto-deploy-stuck.py --self-test
+
+      # One bounded API call (event=schedule, one page). The previous shape
+      # paginated the whole run history (~228 calls per tick to look at three
+      # runs) and was itself failing on the installation rate limit by 04:25Z
+      # on 2026-09-13.
+      - name: Evaluate the scheduled lane
+        id: verdict
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          python3 .github/scripts/detect-auto-deploy-stuck.py --evaluate \
+            --repo "$GITHUB_REPOSITORY" --json /tmp/auto-deploy-red.json
+          code=$?
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          case "$code" in
+            0) echo "scheduled auto-deploy lane not stuck." ;;
+            2) echo "::warning::scheduled auto-deploy lane is stuck red — escalating." ;;
+            1) echo "::error::The watch could not read the scheduled lane. That is a"
+               echo "::error::failure of THIS WATCH, not a 'not stuck' verdict."
+               exit 1 ;;
+            *) echo "::error::Unexpected exit $code."; exit "$code" ;;
+          esac
+
+      - name: Escalate or stand down
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const fs = require('fs')
+            const v = JSON.parse(fs.readFileSync('/tmp/auto-deploy-red.json', 'utf8'))
             const LABEL = 'fleet-health'
             const MARKER = '<!-- auto-deploy-red -->'
-            const THRESHOLD = 3
-
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              ...context.repo, workflow_id: 'auto-deploy.yml',
-              status: 'completed', per_page: 10,
-            })
-            // completed excludes cancelled? No — completed INCLUDES cancelled/failure/success.
-            // A cancelled run is a superseded verdict, not a red one (#2185): skip it.
-            const verdicts = runs.filter(r => r.conclusion !== 'cancelled')
-            const recent = verdicts.slice(0, THRESHOLD)
-            const stuck = recent.length >= THRESHOLD && recent.every(r => r.conclusion === 'failure')
-            const latestGreen = verdicts.find(r => r.conclusion === 'success')
 
             const findOpen = async (state) => {
               const issues = await github.paginate(github.rest.issues.listForRepo, {
@@ -71,41 +106,52 @@ jobs:
               return issues.find(i => (i.body || '').includes(MARKER))
             }
 
-            if (!stuck) {
+            if (!v.stuck) {
               const open = await findOpen('open')
-              if (open && latestGreen) {
+              // Only a green SCHEDULED run newer than the streak closes the issue
+              // (R3). A green push is a fact about other services; the script
+              // never puts one in close_on.
+              if (open && v.close_on) {
                 await github.rest.issues.createComment({
                   ...context.repo, issue_number: open.number,
-                  body: `auto-deploy is green again ([run ${latestGreen.id}](${latestGreen.html_url}), ${latestGreen.created_at}) — closing. _(\`${context.workflow}\` run ${context.runId})_`,
+                  body: `the scheduled auto-deploy lane is green again ([run ${v.close_on.id}](${v.close_on.html_url}), ${v.close_on.created_at}) — closing. _(\`${context.workflow}\` run ${context.runId})_`,
                 })
                 await github.rest.issues.update({ ...context.repo, issue_number: open.number, state: 'closed' })
                 core.info(`closed #${open.number}`)
+              } else if (open) {
+                core.info(`#${open.number} stays open: below threshold but no green scheduled run yet.`)
               } else {
-                core.info('auto-deploy not stuck; nothing to do.')
+                core.info('scheduled auto-deploy lane not stuck; nothing to do.')
               }
               return
             }
 
+            const recent = v.recent
             const first = recent[0]
             const last = recent[recent.length - 1]
-            const title = `auto-deploy has failed ${THRESHOLD}+ runs in a row — services pinned to their last deployable images`
+            const title = `auto-deploy has failed ${v.threshold}+ scheduled runs in a row — services pinned to their last deployable images`
             const body = [
               MARKER,
               '## auto-deploy is stuck red — the estate looks deployed and is not',
               '',
-              `${THRESHOLD} consecutive completed auto-deploy runs failed:`,
+              `${v.threshold} consecutive completed SCHEDULED auto-deploy runs failed:`,
               '',
               ...recent.map(r => `- [run ${r.id}](${r.html_url}) — ${r.created_at} — head \`${(r.head_sha || '').slice(0, 9)}\``),
               '',
               `Newest: ${first.created_at}; oldest of the streak: ${last.created_at}.`,
               '',
+              'Only the scheduled (reconcile) lane counts here: a green `push` run deploys the',
+              'services one merge touched and says nothing about the services that are pinned.',
+              '',
               'A REGRESSION/PENDING_BUILD block does not clear on its own — the reconcile tick',
               're-offers it forever (ADR-0092, #2549). Partial deploys still land, so the fleet',
-              'looks healthy while blocked services stay pinned. See #9130 for the first measured',
-              'instance (four failures over seven hours, found by accident).',
+              'looks healthy while blocked services stay pinned. Read the can-i-deploy job of the',
+              'newest run above for the per-service class and the failing pact verification.',
+              'See #9130 for the first measured instance (four failures over seven hours, found',
+              'by accident).',
               '',
               'This issue refreshes in place while the streak continues and closes itself on the',
-              `next green run. Hand-closing while still red reopens it. _(\`${context.workflow}\` run ${context.runId})_`,
+              `next green scheduled run. Hand-closing while still red reopens it. _(\`${context.workflow}\` run ${context.runId})_`,
             ].join('\n')
 
             const open = await findOpen('open')

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1865,6 +1865,32 @@ temporal_worker_switch_naming:
   # the allowlist mechanism stays (and fails stale in either direction) for the next exception
   # that genuinely cannot be renamed.
 
+ci_watches:
+  lane_scoped_population: true
+  # A watch that asserts a verdict about ONE lane of a workflow (one trigger event, one
+  # subject) must draw its population from that lane only. Drawn from every lane, it is green
+  # about a different subject and reads the thing it exists to catch as background noise.
+  #
+  # Measured 2026-09-13 on auto-deploy-red-watch.yml (#9130): ten consecutive SCHEDULED
+  # auto-deploy failures over 27 hours, no fleet-health issue, the watch green throughout. Its
+  # population was the three newest completed runs of any event, and auto-deploy's `push` lane
+  # (the services one merge touched) lands green between scheduled ticks —
+  # `2271 schedule ✗ | 2270 schedule ✗ | 2269 push ✓` was `stuck = false`. Worse, the not-stuck
+  # branch closed an open issue on ANY green run, so a lucky escalation would have been tidied
+  # away by the next merge while money-path services stayed pinned. The watch's own issue text
+  # describes exactly that trap.
+  #
+  # Rule: filter the population to the lane (server-side where the API allows it), bound the
+  # query (a watch that paginates history to look at three runs is the rate-limit outage it
+  # reports on — this one was failing on the installation limit the same morning), close only
+  # on the same lane's green, and keep the decision in a script with a --self-test whose
+  # known-positive is the interleaved fixture.
+  #
+  # Whether the other watches (main-red-watch, service-build-stall-watch,
+  # merged-past-red-check-watch) share this class is a thing to MEASURE, not assert: each has
+  # a different trigger shape and main-red-watch already filters on head_branch + event.
+  ci_producer: .github/scripts/detect-auto-deploy-stuck.py   # gate auto-deploy-red-watch-declaration
+
 scheduled_methods:
   no_runblocking_in_scheduled_body: true
   # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,


### PR DESCRIPTION
## Summary

`auto-deploy-red-watch` ran green through 27 hours of red because its population was every auto-deploy lane, and green `push` runs (about the services one merge touched) broke the scheduled streak every time. The decision now lives in a self-tested script scoped to the scheduled lane, guarded by a gate; plus a tokenless `gh` on admin-ui-deploy's recovery path is fixed and gated fleet-wide.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9130, Refs #9898 (V0 unblock + V1 subject-based watch follow-up)

## Changes

- `.github/scripts/detect-auto-deploy-stuck.py` — population `event=schedule`, completed, non-cancelled, ONE bounded page (was `paginate` over ~2 300 runs, ~228 calls/tick, failing on the installation rate limit since 04:25Z today); stuck = 3 newest scheduled verdicts all failure; `close_on` only a green scheduled run newer than the streak. `--self-test` known-positive is the live fixture (10 scheduled failures interleaved with green pushes → must escalate) and asserts the OLD population reads the same input as not stuck.
- `auto-deploy-red-watch.yml` — checkout + self-test + evaluate + escalate/stand-down reading the script's JSON; never closes on a push green.
- Gate `auto-deploy-red-watch-declaration` (registry): workflow invokes the script, no inline `listWorkflowRuns`. Negative case measured: the `origin/main` workflow fails it (3 findings).
- `rules.yaml: ci_watches.lane_scoped_population`.
- `admin-ui-deploy.yml` — `GH_TOKEN: ${{ github.token }}` on the deploy-source guard (its `gh pr list` ran only when a deploy branch already existed, under `set -e`, with no token).
- Gate `workflow-gh-token-declared` (`check-workflow-gh-token.py`): command-position match, comments stripped, echoed `gh workflow run …` remediation is a self-test known-negative; 31 subjects, baseline empty. Negative case measured: `origin/main`'s admin-ui-deploy fails it.
- `.github/CLAUDE.md` — two bullets.

Live verdict from the new script against the repo right now: `stuck=true`, population 8, streak 2271/2270/2267, `close_on=null` (exit 2). The first scheduled tick after merge opens the issue.

Not in this PR: the wealth OPA-bundle restamp `regen-derived.sh` produced is pre-existing drift owned by #9873, dropped from the commit.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). (N/A — CI only)
- [x] Unit tests added/updated. (`--self-test` on both scripts, positive and negative)
- [x] Integration tests added/updated (if service boundary involved). (N/A)
- [x] Contract tests updated (if public API changed). (N/A)
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A — no Kotlin)
- [x] No new lint warnings. (actionlint + yamllint + 7 gates via run-gates locally)
- [x] OpenAPI spec regenerated (if REST API changed). (N/A)
- [x] Flyway migration added + rollback note (if DB changed). (N/A)
- [x] Avro schema versioned backward-compatibly (if event changed). (N/A)
- [x] Docs updated (README, ADR if architectural). (`.github/CLAUDE.md`, `rules.yaml`)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → no.
- [x] PII path changed? → no.
- [x] Cardholder data path changed? → no.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: workflow change, live on the next scheduled tick after merge.
- Rollback plan: revert the PR; the old watch shape returns (with its blindness).
- Data migration reversible: N/A

## Reviewer notes

The watch's runtime half now needs `contents: read` + `actions: read` (checkout + reading runs); `issues: write` unchanged. Falsify after merge with `gh workflow run auto-deploy-red-watch.yml` — expected: issue opened with marker `<!-- auto-deploy-red -->`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
