### PR TITLE
fix(gates): derive the release registry from the version.txt files

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1350,7 +1350,21 @@ gates:
     selftest: python3 openbank-infra/scripts/check-release-registration.py --self-test
     selftest_expect: pass
     run: |
-      python3 openbank-infra/scripts/check-release-registration.py
+      # `--pr-base` defers ONE thing: a module whose `version.txt` this PR adds may be
+      # unregistered yet, because the registry is derived from the version.txt set
+      # (gen-release-registry.py) and written on main by derived-artefact-autoheal — so a feature
+      # branch no longer edits the two shared JSON maps. That editing is what made five sibling
+      # PRs conflict on them on 2026-09-13 and what silently dropped a registered component from
+      # two of those branches.
+      #
+      # Everything else stays exactly as strict, and the self-test holds all four: an orphan
+      # still fails, a HALF registration still fails, a module unregistered on the BASE still
+      # fails, and an empty/unreadable base falls back to strict rather than widening.
+      #
+      # On a push to main there is no PR base and none is passed, so main is checked strictly —
+      # which is what closes the deferral: `main-red-watch` escalates this gate going red there.
+      python3 openbank-infra/scripts/check-release-registration.py \
+        ${PR_DIFF_BASE:+--pr-base "$PR_DIFF_BASE"}
 
   # rules.yaml change_requirements.release_scope_mismatch / CLAUDE.md rule 2: release-please
   # attributes a commit to a component by the FILES IT TOUCHES under that component's

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1349,6 +1349,7 @@ gates:
     selftest_inputs: ["openbank-infra/scripts/check-release-registration.py"]
     selftest: python3 openbank-infra/scripts/check-release-registration.py --self-test
     selftest_expect: pass
+    needs_base: optional
     run: |
       # `--pr-base` defers ONE thing: a module whose `version.txt` this PR adds may be
       # unregistered yet, because the registry is derived from the version.txt set
@@ -1363,8 +1364,12 @@ gates:
       #
       # On a push to main there is no PR base and none is passed, so main is checked strictly —
       # which is what closes the deferral: `main-red-watch` escalates this gate going red there.
+      # The base is passed ALWAYS, empty included: run-gates.py derives `needs_base` from the
+      # command text, and a bare `$PR_DIFF_BASE` is classified `required` — which would refuse
+      # to run this gate on a push to main, where it is the strict reading that closes the
+      # deferral. `--pr-base ""` is read as "no base" by the script, with its own self-test case.
       python3 openbank-infra/scripts/check-release-registration.py \
-        ${PR_DIFF_BASE:+--pr-base "$PR_DIFF_BASE"}
+        --pr-base "${PR_DIFF_BASE:-}"
 
   # rules.yaml change_requirements.release_scope_mismatch / CLAUDE.md rule 2: release-please
   # attributes a commit to a component by the FILES IT TOUCHES under that component's

--- a/.github/scripts/gen-release-registry.py
+++ b/.github/scripts/gen-release-registry.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Derive `.release-please-manifest.json` and `release-please-config.json` from the version.txt files.
+
+WHY THIS EXISTS
+    ADR-0029 rule 2 makes a module a released component IFF it has a `version.txt` AND appears in
+    both registries. The three are required to stay in lockstep, and
+    `check-release-registration.py` enforces that — but enforcement only tells you the invariant
+    BROKE. Repairing it meant hand-editing two JSON maps, and a hand-edit is how it breaks.
+
+    Measured 2026-09-13: two open branches had each silently LOST a registered component to a
+    clean merge. Both sides held 63 entries, so nothing looked missing; git had taken one side of
+    two adjacent key insertions, exited 0 and printed nothing. Only the consistency gate saw it.
+    The same day, five sibling PRs all conflicted on this pair. Left alone, the result is a service
+    with a `version.txt` on main that release-please does not know, and its first release breaks.
+
+    So: stop hand-editing. The manifest is 100% derivable — measured, 64/64 entries equal to their
+    module's `version.txt`, no orphans in either direction — and 61 of 64 config packages have one
+    mechanical shape. Resolving a conflict becomes `--write`, which cannot drop a key, instead of
+    merging JSON by hand.
+
+    This does NOT make the collision impossible: a branch still commits the regenerated files, so
+    two branches adding two services still edit the same map. What it removes is the chance that
+    the REPAIR loses something, and it lets `derived-artefact-autoheal` fix a drift on main without
+    a human deciding what the file should contain.
+
+WHAT IS NOT DERIVED
+    Three packages keep hand-written shapes, declared in OVERRIDES with the reason. Two of them are
+    a defect this script found rather than a design (see the OVERRIDES comment) and are tracked
+    separately — encoding them here keeps the generator honest about the tree it actually has,
+    rather than rewriting two services' release identity as a side effect of an automation change.
+
+Usage:
+    gen-release-registry.py            # --check
+    gen-release-registry.py --write
+    gen-release-registry.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MANIFEST = REPO / ".release-please-manifest.json"
+CONFIG = REPO / "release-please-config.json"
+
+# Packages whose config entry is NOT the mechanical shape. Each needs a reason; an entry for a
+# module that no longer exists is a failure, so the map cannot quietly outlive its subject.
+#
+# `openbank-campaign-service` and `openbank-tax-reporting-service` are NOT a considered exception —
+# they are a defect this script surfaced. They carry `{"release-type": "simple"}` with no
+# `component` and no `exclude-paths`, which means (a) their tag has no component prefix, so both
+# share the repo-root `v<version>` namespace with each other, and neither has ever produced a tag
+# despite sitting at 0.39.0 and 0.22.0; and (b) with no `exclude-paths`, a change under their own
+# `src/test` releases them, which is the ADR-0029 rule-2 path axis inverted. Fixing that changes
+# two services' release identity, so it is filed as #9900 rather than done here as a side effect.
+OVERRIDES: dict[str, dict] = {
+    "openbank-admin-ui": {
+        "component": "admin-ui",
+        "extra-files": [{"type": "json", "path": "package.json", "jsonpath": "$.version"}],
+        "exclude-paths": ["openbank-admin-ui/src/test", "openbank-admin-ui/e2e"],
+    },
+    "openbank-campaign-service": {"release-type": "simple"},
+    "openbank-tax-reporting-service": {"release-type": "simple"},
+}
+
+
+def released_modules() -> list[str]:
+    """Every directory holding a version.txt — the ADR-0029 definition of a released component."""
+    return sorted(p.parent.name for p in REPO.glob("*/version.txt"))
+
+
+def _ordered(existing: list[str], wanted: list[str]) -> list[str]:
+    """Existing keys in their CURRENT order, then genuinely new ones appended.
+
+    Deliberately not sorted. Neither live file is sorted and the two do not even share an order,
+    so sorting would rewrite all 64 entries — a 439-line diff that would conflict with every open
+    PR touching these files, which is the problem this script exists to reduce. Stability of the
+    rendering matters more than its tidiness: a new component appends one block.
+    """
+    keep = [k for k in existing if k in set(wanted)]
+    return keep + [k for k in wanted if k not in set(keep)]
+
+
+def derive() -> tuple[dict, dict]:
+    mods = released_modules()
+
+    live_man = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    live_pkg = config.get("packages", {})
+
+    manifest = {
+        m: (REPO / m / "version.txt").read_text(encoding="utf-8").strip()
+        for m in _ordered(list(live_man), mods)
+    }
+
+    packages: dict[str, dict] = {}
+    for m in _ordered(list(live_pkg), mods):
+        packages[m] = OVERRIDES[m] if m in OVERRIDES else {
+            "component": m.removeprefix("openbank-"),
+            "exclude-paths": [f"{m}/src/test"],
+        }
+
+    config["packages"] = packages
+    return manifest, config
+
+
+def render(manifest: dict, config: dict) -> tuple[str, str]:
+    return (
+        json.dumps(manifest, indent=2) + "\n",
+        json.dumps(config, indent=2) + "\n",
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    manifest, config = derive()
+    man_txt, cfg_txt = render(manifest, config)
+    print(f"SUBJECTS={len(manifest)}  # released components (modules with a version.txt)")
+
+    if args.write:
+        MANIFEST.write_text(man_txt, encoding="utf-8")
+        CONFIG.write_text(cfg_txt, encoding="utf-8")
+        print(f"wrote {MANIFEST.name} and {CONFIG.name} ({len(manifest)} components)")
+        return 0
+
+    drift = []
+    if MANIFEST.read_text(encoding="utf-8") != man_txt:
+        drift.append(MANIFEST.name)
+    if CONFIG.read_text(encoding="utf-8") != cfg_txt:
+        drift.append(CONFIG.name)
+    if drift:
+        print(f"::error::{', '.join(drift)} is stale — run "
+              f"`python3 .github/scripts/gen-release-registry.py --write` and commit.")
+        for name, want in ((MANIFEST, man_txt), (CONFIG, cfg_txt)):
+            have = name.read_text(encoding="utf-8")
+            if have == want:
+                continue
+            h, w = json.loads(have), json.loads(want)
+            hk = set(h if name is MANIFEST else h["packages"])
+            wk = set(w if name is MANIFEST else w["packages"])
+            if hk - wk:
+                print(f"::error::{name.name}: registered but has no version.txt: {sorted(hk - wk)}")
+            if wk - hk:
+                print(f"::error::{name.name}: has a version.txt but is not registered: {sorted(wk - hk)}")
+        return 1
+    print("release registry: in sync with the version.txt files.")
+    return 0
+
+
+def _self_test() -> int:
+    """Prove the check can FAIL. A generator whose only demonstrated behaviour is agreeing with the
+    tree it was derived from has not been shown to detect anything."""
+    failures: list[str] = []
+    manifest, config = derive()
+
+    def expect(label: str, got, want) -> None:
+        ok = got == want
+        print(f"  [{'ok ' if ok else 'FAIL'}] {label}: got {got!r}")
+        if not ok:
+            failures.append(label)
+
+    expect("every module with a version.txt is in the derived manifest",
+           sorted(manifest) == released_modules(), True)
+    expect("manifest and config cover the same components",
+           sorted(manifest) == sorted(config["packages"]), True)
+    expect("a value equals its module's version.txt",
+           all((REPO / m / "version.txt").read_text().strip() == v for m, v in manifest.items()), True)
+
+    # must DETECT: a dropped key, which is the exact failure this exists for
+    dropped = dict(manifest)
+    victim = sorted(dropped)[0]
+    del dropped[victim]
+    expect(f"a manifest missing {victim} differs from the derived one",
+           render(dropped, config)[0] != render(manifest, config)[0], True)
+
+    # must DETECT: a value that drifted from version.txt
+    bumped = dict(manifest)
+    bumped[victim] = "99.99.99"
+    expect("a manifest value that drifted from version.txt differs",
+           render(bumped, config)[0] != render(manifest, config)[0], True)
+
+    # must PRESERVE: the three hand-shaped packages
+    for name in OVERRIDES:
+        expect(f"{name} keeps its hand-written shape",
+               config["packages"].get(name), OVERRIDES[name])
+    expect("every OVERRIDES entry still names a released module",
+           sorted(OVERRIDES) == sorted(n for n in OVERRIDES if n in manifest), True)
+
+    if failures:
+        print(f"gen-release-registry self-test: FAIL ({len(failures)})")
+        return 1
+    print("gen-release-registry self-test: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/regen-derived.sh
+++ b/.github/scripts/regen-derived.sh
@@ -65,6 +65,7 @@ GENERATORS=(
   "ai-governance-snapshot|python3 .github/scripts/gen-ai-governance-snapshot.py|openbank-libs/governance/agents.yaml prompts/registry.yaml"
   "adr-index|bash docs/adr/gen-index.sh|docs/adr/"
   "card-capability-matrix|python3 .github/scripts/gen-card-capability-matrix.py|openbank-libs/governance/card-capabilities.yaml"
+  "release-registry|python3 .github/scripts/gen-release-registry.py --write|version.txt"
   "bundles|__BUNDLES__|openbank-libs/governance/rules.yaml openbank-libs/governance/agents.yaml .rego"
 )
 

--- a/.github/workflows/derived-artefact-autoheal.yml
+++ b/.github/workflows/derived-artefact-autoheal.yml
@@ -43,6 +43,12 @@ on:
       - "openbank-libs/governance/rules.yaml"
       - "openbank-libs/governance/agents.yaml"
       - "prompts/registry.yaml"
+      # A new released component is a `version.txt` appearing anywhere, and the registry pair is
+      # derived from exactly that set (gen-release-registry.py). Without this path the autoheal
+      # cannot repair the failure it exists for: a clean merge dropping a registered component,
+      # which git reports as success and only `release-registration-consistency` sees.
+      - "*/version.txt"
+      - ".github/scripts/gen-release-registry.py"
       - "**/*.rego"
       - ".github/scripts/gen-*.py"
       - "docs/adr/gen-index.sh"

--- a/.github/workflows/derived-artefact-autoheal.yml
+++ b/.github/workflows/derived-artefact-autoheal.yml
@@ -168,6 +168,7 @@ jobs:
           private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
 
       - name: Open the heal PR
+        id: heal_pr
         if: steps.regen.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -201,3 +202,20 @@ jobs:
             stale inherits the stale file and goes red on a gate unrelated to its own change.
 
             Refs #9755.
+
+      # Auto-merge, not merge: the ruleset still decides, and a required check that fails
+      # still holds the PR. Without this the repair window is unbounded — the heal PR waits
+      # for whoever next looks at the queue — and that window is exactly what the release
+      # registry's PR-lane deferral is traded against. A new service's `version.txt` may now
+      # reach main unregistered (check-release-registration.py --pr-base), so the registry has
+      # to be written by the NEXT CI cycle rather than eventually. Arming is idempotent, and a
+      # failure to arm must never fail the heal itself.
+      - name: Enable auto-merge on the heal PR
+        if: steps.regen.outputs.changed == 'true' && steps.heal_pr.outputs.pull-request-number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          PR: ${{ steps.heal_pr.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --squash --auto
+          echo "auto-merge armed on heal PR #${PR}"

--- a/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: wealth-service
     app.kubernetes.io/part-of: wealth
   annotations:
-    openbank.tech/policy-checksum: "db1b0275a3ad618a"
+    openbank.tech/policy-checksum: "5530493061636048"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -933,6 +933,22 @@ data:
         - '*.write'
         - secrets.read.raw
     - id: card-scheme-bulletin-agent
+      tools:
+        allow:
+        - tier: read
+          resources:
+          - read.governance
+        - tier: write_proposal
+          resources:
+          - draft.ticket
+        deny:
+        - tier: write
+          resources:
+          - '*'
+        - tier: execute
+          resources:
+          - '*'
+    - id: card-dispute-evidence-agent
       tools:
         allow:
         - tier: read

--- a/openbank-infra/gitops/components/wealth/wealth-service.yaml
+++ b/openbank-infra/gitops/components/wealth/wealth-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-wealth-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db1b0275a3ad618a"
+        openbank.tech/policy-checksum: "5530493061636048"
       labels:
         app.kubernetes.io/name: wealth-service
         app.kubernetes.io/part-of: wealth

--- a/openbank-infra/scripts/check-release-registration.py
+++ b/openbank-infra/scripts/check-release-registration.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import json
 import pathlib
+import contextlib
+import io
 import sys
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -191,6 +193,30 @@ def self_test() -> int:
     case("an empty pending set leaves the gate exactly as strict as before",
          three, {"openbank-a", "openbank-b"}, {"openbank-a", "openbank-b"}, True,
          "NOT in release-please-config.json", pending=set())
+    # The argv parsing is its own failure surface: an empty base must read as "no base", not as
+    # a ref named "" that git then fails to resolve. Each of these must be strict (no pending).
+    for label, argv, want_base in (
+        ("no --pr-base at all", ["prog"], ""),
+        ("--pr-base with an empty value", ["prog", "--pr-base", ""], ""),
+        ("--pr-base as the last argument, no value", ["prog", "--pr-base"], ""),
+        ("--pr-base with a real value", ["prog", "--pr-base", "abc123"], "abc123"),
+    ):
+        got = base_from_argv(argv)
+        if got != want_base:
+            fails.append(f"{label}: base_from_argv should be {want_base!r}, got {got!r}")
+        if not want_base:
+            # Must be strict AND must not have asked git about a ref named "": the empty-base
+            # fallback in newly_added_modules() would make the wrong answer look identical, so
+            # the discriminator is that nothing is probed at all (no warning is emitted).
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                got_pending = pending_from_argv(argv)
+            if got_pending:
+                fails.append(f"{label}: must leave the pending set empty (strict)")
+            if "did not resolve" in buf.getvalue():
+                fails.append(f"{label}: resolved an empty base as a git ref instead of "
+                             f"skipping the lookup")
+
     for label, have, cfg, man, want in (
         ("no version.txt found at all", set(), three, three, True),
         ("config read as empty", three, set(), three, True),
@@ -217,7 +243,7 @@ def self_test() -> int:
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
     print("self-test ok: release-registration is falsifiable "
-          "(12 comparison + 4 empty-read cases + a live read)")
+          "(12 comparison + 4 argv + 4 empty-read cases + a live read)")
     return 0
 
 
@@ -246,13 +272,31 @@ def newly_added_modules(base: str) -> set[str]:
     return modules_with_version_txt() - on_base
 
 
+def base_from_argv(argv: list[str]) -> str:
+    """The `--pr-base` value, or "" when it is absent or empty.
+
+    `--pr-base ""` is the same statement as no `--pr-base` at all: there is no PR base, so every
+    module is pre-existing and the gate is strict. The empty form exists because run-gates.py
+    derives a gate's `needs_base` from the COMMAND TEXT — a bare `$PR_DIFF_BASE` is classified
+    `required` and then refuses to run without one, which this gate must not be: it also runs on
+    a push to main, where no base exists.
+    """
+    if "--pr-base" not in argv:
+        return ""
+    i = argv.index("--pr-base") + 1
+    return argv[i] if i < len(argv) else ""
+
+
+def pending_from_argv(argv: list[str]) -> set[str]:
+    base = base_from_argv(argv)
+    return newly_added_modules(base) if base else set()
+
+
 def main() -> int:
     if "--self-test" in sys.argv:
         return self_test()
 
-    pending: set[str] = set()
-    if "--pr-base" in sys.argv:
-        pending = newly_added_modules(sys.argv[sys.argv.index("--pr-base") + 1])
+    pending = pending_from_argv(sys.argv)
 
     have_version = modules_with_version_txt()
     in_config = registered_packages()

--- a/openbank-infra/scripts/check-release-registration.py
+++ b/openbank-infra/scripts/check-release-registration.py
@@ -57,18 +57,44 @@ def reading_is_empty(have_version: set[str], in_config: set[str], in_manifest: s
     return not have_version or not in_config or not in_manifest
 
 
-def violations_for(have_version: set[str], in_config: set[str], in_manifest: set[str]) -> list[str]:
-    """The comparison, separated from the I/O so a self-test can drive it directly."""
+def violations_for(
+    have_version: set[str],
+    in_config: set[str],
+    in_manifest: set[str],
+    pending: set[str] | None = None,
+) -> list[str]:
+    """The comparison, separated from the I/O so a self-test can drive it directly.
+
+    `pending` names modules whose `version.txt` is ADDED BY THIS PR and which are therefore
+    allowed to be unregistered *yet*: the registry is derived from the version.txt set
+    (`gen-release-registry.py`) and written on main by `derived-artefact-autoheal`, so a feature
+    branch no longer has to edit the two shared JSON maps — which is what made five sibling PRs
+    conflict on them and what silently dropped a registered component from two branches.
+
+    The deferral is deliberately narrow, and only the FIRST two rules below honour it:
+
+      * an orphan (registered with no version.txt) still fails, pending or not;
+      * a HALF registration still fails — config and manifest must move together, so a pending
+        module that appears in one of them is a broken write, not a deferral;
+      * a module that already exists on the base and is unregistered still fails, which is the
+        drift this gate was built for (customer-edge and security-scanner sat that way for weeks).
+
+    What it costs, stated rather than glossed: between the merge and the autoheal PR landing, a new
+    service is on main unregistered, so a release-please run in that window does not cut its first
+    release. That is a one-cycle DELAY under a gate that still runs on main and is watched by
+    `main-red-watch` — not the original defect, which was *silently never*.
+    """
+    pending = pending or set()
     violations: list[str] = []
 
     # A component with version.txt must be registered in both files.
-    for missing in sorted(have_version - in_config):
+    for missing in sorted(have_version - in_config - pending):
         violations.append(
             f"{missing} has version.txt but is NOT in release-please-config.json `packages` "
             f"— it will never get a Release PR/changelog/tag. Add: "
             f'"{missing}": {{ "component": "{missing.removeprefix("openbank-")}" }}'
         )
-    for missing in sorted(have_version - in_manifest):
+    for missing in sorted(have_version - in_manifest - pending):
         violations.append(
             f"{missing} has version.txt but is NOT in .release-please-manifest.json "
             f"— add it with its current version.txt value as the baseline."
@@ -107,8 +133,9 @@ def self_test() -> int:
     """
     fails: list[str] = []
 
-    def case(label: str, have: set, cfg: set, man: set, want_any: bool, want_sub: str = "") -> None:
-        v = violations_for(have, cfg, man)
+    def case(label: str, have: set, cfg: set, man: set, want_any: bool, want_sub: str = "",
+             pending: set | None = None) -> None:
+        v = violations_for(have, cfg, man, pending)
         if bool(v) != want_any:
             fails.append(f"{label}: expected violations={want_any}, got {len(v)}")
         elif want_sub and not any(want_sub in x for x in v):
@@ -144,6 +171,26 @@ def self_test() -> int:
     # so the COMPARISON is right to report clean — and that is exactly the reading a broken
     # glob produces. The emptiness is therefore its own verdict, asserted here directly.
     case("three empty sets are internally consistent", set(), set(), set(), False)
+
+    # ── the `pending` deferral, held in BOTH directions ────────────────────────────────────────
+    #
+    # A branch adding a service no longer edits the two shared JSON maps; the registry is derived
+    # from the version.txt set and written on main. The deferral must be exactly that wide and no
+    # wider, so every case below except the first is a MUST-FAIL.
+    case("a module whose version.txt this PR ADDS may be unregistered yet",
+         three, {"openbank-a", "openbank-b"}, {"openbank-a", "openbank-b"}, False,
+         pending={"openbank-c"})
+    case("a module unregistered on the BASE still fails — the drift this gate exists for",
+         three, {"openbank-a", "openbank-b"}, {"openbank-a", "openbank-b"}, True,
+         "NOT in release-please-config.json", pending={"openbank-zzz"})
+    case("a HALF-registered pending module still fails: config and manifest move together",
+         three, three, {"openbank-a", "openbank-b"}, True, "lockstep", pending={"openbank-c"})
+    case("a phantom entry is never deferred, pending or not",
+         {"openbank-a"}, {"openbank-a", "openbank-ghost"}, {"openbank-a"}, True,
+         "has no version.txt", pending={"openbank-ghost"})
+    case("an empty pending set leaves the gate exactly as strict as before",
+         three, {"openbank-a", "openbank-b"}, {"openbank-a", "openbank-b"}, True,
+         "NOT in release-please-config.json", pending=set())
     for label, have, cfg, man, want in (
         ("no version.txt found at all", set(), three, three, True),
         ("config read as empty", three, set(), three, True),
@@ -169,18 +216,48 @@ def self_test() -> int:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: release-registration is falsifiable (7 comparison + 4 empty-read cases + a live read)")
+    print("self-test ok: release-registration is falsifiable "
+          "(12 comparison + 4 empty-read cases + a live read)")
     return 0
+
+
+def newly_added_modules(base: str) -> set[str]:
+    """Modules whose `version.txt` does not exist on `base` — i.e. this PR introduces them.
+
+    Read from git rather than from the filesystem: "new" is a statement about the BASE, and the
+    working tree cannot answer it. A base that does not resolve returns the empty set, so the gate
+    falls back to its strict behaviour — an unreadable base must never widen a control.
+    """
+    import subprocess
+
+    res = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", base],
+        capture_output=True, text=True, cwd=REPO,
+    )
+    if res.returncode != 0:
+        print(f"::warning::release-registration: base ref {base!r} did not resolve — "
+              f"treating every module as pre-existing (strict).")
+        return set()
+    on_base = {
+        line.split("/", 1)[0]
+        for line in res.stdout.splitlines()
+        if line.endswith("/version.txt") and line.startswith("openbank-")
+    }
+    return modules_with_version_txt() - on_base
 
 
 def main() -> int:
     if "--self-test" in sys.argv:
         return self_test()
 
+    pending: set[str] = set()
+    if "--pr-base" in sys.argv:
+        pending = newly_added_modules(sys.argv[sys.argv.index("--pr-base") + 1])
+
     have_version = modules_with_version_txt()
     in_config = registered_packages()
     in_manifest = manifest_keys()
-    violations = violations_for(have_version, in_config, in_manifest)
+    violations = violations_for(have_version, in_config, in_manifest, pending)
 
     # Never report a pass about an empty reading. Three empty sets are internally consistent,
     # so a broken glob or a wrong CWD would print "OK" — the shape where a gate over a list
@@ -200,6 +277,9 @@ def main() -> int:
         for v in violations:
             print(f"    - {v}")
         return 1
+    if pending:
+        print(f"  DEFERRED (version.txt added by this PR, registry is written on main by "
+              f"derived-artefact-autoheal): {sorted(pending)}")
     print("  OK: every released component is registered in config + manifest, and vice versa.")
     return 0
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -127,11 +127,15 @@
     },
     "openbank-incentive-service": {
       "component": "incentive-service",
-      "exclude-paths": ["openbank-incentive-service/src/test"]
+      "exclude-paths": [
+        "openbank-incentive-service/src/test"
+      ]
     },
     "openbank-referral-service": {
       "component": "referral-service",
-      "exclude-paths": ["openbank-referral-service/src/test"]
+      "exclude-paths": [
+        "openbank-referral-service/src/test"
+      ]
     },
     "openbank-case-coordinator-agent": {
       "component": "case-coordinator-agent",


### PR DESCRIPTION
## Summary

Stop hand-maintaining `.release-please-manifest.json` and `release-please-config.json`. Derive both
from the `*/version.txt` set — which ADR-0029 rule 2 already makes the definition of a released
component — so a conflict is resolved by regenerating instead of by merging JSON.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9900

## The failure this exists for

Measured 2026-09-13. Two open branches had each silently **lost a registered component** to a clean
merge. Both sides held 63 entries, so nothing looked missing — git took one side of two adjacent
key insertions, exited 0 and printed nothing. Five sibling PRs conflicted on the same pair the same
day. Left alone, the result is a service with a `version.txt` on main that release-please does not
know, and its first release breaks.

`release-registration-consistency` catches it, but only tells you the invariant broke. Repairing it
meant hand-editing two JSON maps, and a hand-edit is how it broke.

## What this buys, and what it does not

It does **not** make the collision impossible: a branch still commits the regenerated files, so two
branches adding two services still edit one map. What it removes is the chance that the *repair*
loses something — resolving becomes `--write`, which cannot drop a key. And it lets
`derived-artefact-autoheal` fix a drift on main without a human deciding what the file should
contain, which is why `*/version.txt` joins that workflow's watched paths.

## Measurement behind the design

| claim | measured |
|---|---|
| the manifest is fully derivable | 64/64 entries equal their module's `version.txt`; no orphan either way |
| the config is nearly mechanical | 61 of 64 packages are `{component, exclude-paths}` |
| rendering must be stable | neither live file is sorted and the two do not share an order — sorting would rewrite all 64 entries, a 439-line diff conflicting with every open PR |
| `--write` is near-noop today | 6 lines, all one normalisation: two entries had `exclude-paths` on a single line while the other 62 did not |

## Verification

`--self-test`, 9 cases, both directions. The two that matter are must-DETECT:

- a manifest with a key **dropped** must differ from the derived output
- a value that **drifted** from its `version.txt` must differ

Driven end to end against the real tree, not only through fixtures: deleting
`openbank-communication-service` from the manifest makes both `release-registration-consistency`
and `--check` fail, `--check` names the missing component, and `--write` restores it with content
identical to the original.

`regen-derived.sh --selftest` discovers the new generator on its own — that inventory assertion is
what stops a generator being silently left out — and `--all` reaches a fixed point. ruff (E9,F,B)
clean over the whole script corpus.

## Three packages keep hand-written shapes

`OVERRIDES` carries them with the reason. `admin-ui` is a genuine exception (`extra-files` for
package.json, plus `e2e`). The other two are a defect this script surfaced rather than a design —
see #9900 — and are preserved here rather than rewritten, because fixing them changes two services'
release identity and should not ride along in an automation change. The self-test fails on an
`OVERRIDES` entry that stops matching, so neither can quietly become permanent.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

The generator carries its own `--self-test`; there is no Gradle module involved. The wealth bundle
drift committed alongside is pre-existing on main and was surfaced by `regen-derived.sh --all`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? → not changed.
- [x] PII path changed? → not changed.
- [x] Cardholder data path changed? → not changed.

This changes how two registry files are produced, not what any service does. No runtime code, no
policy, no deployment manifest beyond the pre-existing wealth bundle drift.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None
