### PR TITLE
fix(admin-ui): white text on an accent fill, and three tone-as-text leftovers

### DIFF
--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -658,7 +658,7 @@ export default function ServiceMapPage() {
               style={{
                 padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
                 border: `1px solid ${filter === key ? 'var(--accent)' : 'var(--border)'}`,
-                background: filter === key ? 'var(--accent)' : 'var(--surface)',
+                background: filter === key ? 'var(--accent-strong)' : 'var(--surface)',
                 color: filter === key ? 'var(--text-inverse)' : 'var(--text-secondary)',
                 cursor: 'pointer', fontFamily: 'inherit',
               }}>{label}</button>

--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -726,7 +726,7 @@ function FinOpsContent() {
                         background: v.isCurrent ? 'var(--accent-bg)' : 'transparent',
                       }}>
                       <td style={{ padding: '10px 12px', fontFamily: 'monospace', fontWeight: v.isCurrent ? 800 : 500, color: v.isCurrent ? 'var(--accent-text)' : 'var(--text-primary)', whiteSpace: 'nowrap' }}>
-                        {v.isCurrent && <span style={{ marginRight: '6px', fontSize: '10px', background: 'var(--accent)', color: 'var(--text-inverse)', padding: '1px 5px', borderRadius: '4px', verticalAlign: 'middle' }}>CURRENT</span>}
+                        {v.isCurrent && <span style={{ marginRight: '6px', fontSize: '10px', background: 'var(--accent-strong)', color: 'var(--text-inverse)', padding: '1px 5px', borderRadius: '4px', verticalAlign: 'middle' }}>CURRENT</span>}
                         {v.version}
                       </td>
                       <td style={{ padding: '10px 12px', color: 'var(--text-secondary)' }}>{v.eksRelease}</td>

--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -721,7 +721,7 @@ export default function FxPage() {
                                 const days = p.days ?? [...s.days]
                                 return { ...p, days: active ? days.filter(d => d !== day) : [...days, day] }
                               })}
-                              style={{ padding: '4px 8px', fontSize: '11px', fontWeight: 700, borderRadius: '5px', cursor: 'pointer', border: `1px solid ${active ? 'var(--accent)' : 'var(--border)'}`, background: active ? 'var(--accent)' : 'var(--surface-2)', color: active ? '#fff' : 'var(--text-tertiary)', transition: 'all 0.1s' }}>
+                              style={{ padding: '4px 8px', fontSize: '11px', fontWeight: 700, borderRadius: '5px', cursor: 'pointer', border: `1px solid ${active ? 'var(--accent-strong)' : 'var(--border)'}`, background: active ? 'var(--accent-strong)' : 'var(--surface-2)', color: active ? '#fff' : 'var(--text-tertiary)', transition: 'all 0.1s' }}>
                               {t(DAY_LABELS_CS[day], DAY_LABELS_EN[day])}
                             </button>
                           )
@@ -765,7 +765,7 @@ export default function FxPage() {
                     <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
                       <td style={{ padding: '6px 16px', fontSize: '11px', color: 'var(--text-secondary)' }}>{new Date(h.timestamp).toLocaleTimeString(numberLocale)}</td>
                       <td style={{ padding: '6px 16px', fontSize: '11px', fontWeight: 600 }}>
-                        <span style={{ padding: '2px 6px', borderRadius: '4px', background: h.source === 'CNB' ? 'var(--accent)' : h.source.includes('Override') ? 'var(--warning)' : h.source.includes('Margin') ? 'var(--info)' : 'var(--info)', color: '#fff', opacity: 0.85 }}>{h.source}</span>
+                        <span style={{ padding: '2px 6px', borderRadius: '4px', background: h.source === 'CNB' ? 'var(--accent-strong)' : h.source.includes('Override') ? 'var(--warning)' : h.source.includes('Margin') ? 'var(--info)' : 'var(--info)', color: '#fff', opacity: 0.85 }}>{h.source}</span>
                       </td>
                       <td style={{ padding: '6px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{h.pair}</td>
                       <td style={{ padding: '6px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-primary)' }}>{h.rate.toFixed(4)}</td>

--- a/openbank-admin-ui/src/app/lending/risk/page.tsx
+++ b/openbank-admin-ui/src/app/lending/risk/page.tsx
@@ -227,7 +227,7 @@ function CreditRiskConsole() {
         {(['decisions', 'policy', 'portfolio'] as const).map(id => (
           <button key={id} type="button" onClick={() => setTab(id)} aria-pressed={tab === id}
             aria-label={id === 'decisions' ? t('Zobrazit rozhodnutí', 'Show decisions') : id === 'policy' ? t('Zobrazit politiku', 'Show policy') : t('Zobrazit portfolio', 'Show portfolio')}
-            style={{ padding: '6px 12px', fontSize: 12, fontWeight: 600, borderRadius: 6, border: 'none', cursor: 'pointer', background: tab === id ? 'var(--accent)' : 'var(--surface-3)', color: tab === id ? '#fff' : 'var(--text-secondary)' }}>
+            style={{ padding: '6px 12px', fontSize: 12, fontWeight: 600, borderRadius: 6, border: 'none', cursor: 'pointer', background: tab === id ? 'var(--accent-strong)' : 'var(--surface-3)', color: tab === id ? '#fff' : 'var(--text-secondary)' }}>
             {id === 'decisions' ? t('Rozhodnutí', 'Decisions') : id === 'policy' ? t('Politika', 'Policy') : t('Portfolio IFRS 9', 'IFRS 9 portfolio')}
           </button>
         ))}

--- a/openbank-admin-ui/src/app/observability/stack/page.tsx
+++ b/openbank-admin-ui/src/app/observability/stack/page.tsx
@@ -253,7 +253,7 @@ export default function ObservabilityStackPage() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
             {flow.map((s) => (
               <div key={s.n} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start' }}>
-                <div style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--accent)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{s.n}</div>
+                <div style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--accent-strong)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{s.n}</div>
                 <div>
                   <div style={{ fontSize: '13px', fontWeight: 700 }}>{s.title}</div>
                   <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '2px', lineHeight: 1.5 }}>{s.detail}</div>

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -179,7 +179,7 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
       <div role="group" aria-label={t('Karty detailu produktu', 'Product detail sections')} style={{ display: 'flex', gap: '2px', padding: '8px 12px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap', flexShrink: 0 }}>
         {tabs.map(tabItem => (
           <button key={tabItem.id} type="button" aria-pressed={tab === tabItem.id} onClick={() => setTab(tabItem.id as typeof tab)}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '5px 10px', fontSize: '11px', fontWeight: 600, borderRadius: '5px', border: 'none', cursor: 'pointer', background: tab === tabItem.id ? 'var(--accent)' : 'transparent', color: tab === tabItem.id ? '#fff' : 'var(--text-secondary)', transition: 'all 0.1s' }}>
+            style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '5px 10px', fontSize: '11px', fontWeight: 600, borderRadius: '5px', border: 'none', cursor: 'pointer', background: tab === tabItem.id ? 'var(--accent-strong)' : 'transparent', color: tab === tabItem.id ? '#fff' : 'var(--text-secondary)', transition: 'all 0.1s' }}>
             <span aria-hidden="true">{tabItem.icon}</span>{tabItem.label}
           </button>
         ))}

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -113,7 +113,7 @@ function CronEditor({ list, onSave }: { list: SanctionsList; onSave: (id: string
       </div>
       <button type="button" onClick={save} disabled={saving}
         style={{ alignSelf: 'flex-start', padding: '5px 12px', borderRadius: '5px', fontSize: '12px', fontWeight: 600,
-          background: 'var(--accent)', color: 'var(--text-inverse)', border: 'none', cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.7 : 1,
+          background: 'var(--accent-strong)', color: 'var(--text-inverse)', border: 'none', cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.7 : 1,
           display: 'flex', alignItems: 'center', gap: '5px' }}>
         {saving ? <Loader2 size={11} style={{ animation: 'spin 0.8s linear infinite' }} /> : null}
         {t('Uložit plán', 'Save schedule')}
@@ -798,7 +798,7 @@ export default function SanctionsPage() {
                                   </code>
                                   <div style={{ display: 'flex', gap: '8px' }}>
                                     <button onClick={() => submitReview(c.id, pendingApproval.id)} disabled={reviewBusy}
-                                      style={{ padding: '6px 12px', borderRadius: '6px', border: 'none', background: 'var(--accent)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 600, cursor: 'pointer' }}>
+                                      style={{ padding: '6px 12px', borderRadius: '6px', border: 'none', background: 'var(--accent-strong)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 600, cursor: 'pointer' }}>
                                       {reviewBusy ? <Loader2 size={12} className="spin" /> : t('Zopakovat po schválení', 'Retry once approved')}
                                     </button>
                                     <button onClick={() => { setReviewFor(null); setPendingApproval(null) }}
@@ -836,7 +836,7 @@ export default function SanctionsPage() {
                                   )}
                                   <div style={{ display: 'flex', gap: '8px' }}>
                                     <button onClick={() => submitReview(c.id)} disabled={reviewBusy}
-                                      style={{ padding: '6px 14px', borderRadius: '6px', border: 'none', background: 'var(--accent)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 600, cursor: reviewBusy ? 'default' : 'pointer' }}>
+                                      style={{ padding: '6px 14px', borderRadius: '6px', border: 'none', background: 'var(--accent-strong)', color: 'var(--text-inverse)', fontSize: '12px', fontWeight: 600, cursor: reviewBusy ? 'default' : 'pointer' }}>
                                       {reviewBusy ? <Loader2 size={12} className="spin" /> : t('Odeslat rozhodnutí', 'Submit decision')}
                                     </button>
                                     <button onClick={() => setReviewFor(null)}
@@ -1031,7 +1031,7 @@ export default function SanctionsPage() {
 
                 <button type="button" aria-busy={screening} aria-label={screening ? t('Prověřování probíhá', 'Screening in progress') : t('Spustit prověření sankcí', 'Run sanctions screening')} onClick={handleScreen} disabled={screening || !searchName.trim() || selectedListTypes.length === 0}
                   style={{ padding: '10px 20px', borderRadius: '7px', fontSize: '13px', fontWeight: 700,
-                    background: 'var(--accent)', color: 'var(--text-inverse)', border: 'none',
+                    background: 'var(--accent-strong)', color: 'var(--text-inverse)', border: 'none',
                     cursor: screening || !searchName.trim() || selectedListTypes.length === 0 ? 'not-allowed' : 'pointer',
                     opacity: screening || !searchName.trim() || selectedListTypes.length === 0 ? 0.6 : 1,
                     display: 'flex', alignItems: 'center', gap: '8px', alignSelf: 'flex-start' }}>
@@ -1122,7 +1122,7 @@ export default function SanctionsPage() {
                   <Can permission="sanctions:manage">
                   <button type="button" aria-busy={refreshingAll} aria-label={t('Stáhnout všechny sankční listy', 'Download all sanctions lists')} onClick={handleRefreshAll} disabled={refreshingAll}
                     style={{ padding: '7px 14px', borderRadius: '6px', fontSize: '12px', fontWeight: 600,
-                      background: 'var(--accent)', color: 'var(--text-inverse)', border: 'none',
+                      background: 'var(--accent-strong)', color: 'var(--text-inverse)', border: 'none',
                       cursor: refreshingAll ? 'not-allowed' : 'pointer', opacity: refreshingAll ? 0.7 : 1,
                       display: 'flex', alignItems: 'center', gap: '6px' }}>
                     {refreshingAll ? <Loader2 size={12} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} /> : <Download size={12} aria-hidden="true" />}

--- a/openbank-admin-ui/src/app/system/config/page.tsx
+++ b/openbank-admin-ui/src/app/system/config/page.tsx
@@ -279,7 +279,7 @@ export default function ServiceConfigPage() {
         alignItems: 'flex-start',
       }}>
         <Info size={14} style={{ color: 'var(--info)', flexShrink: 0, marginTop: '1px' }} />
-        <p style={{ fontSize: '13px', color: 'var(--info)', lineHeight: 1.6 }}>
+        <p style={{ fontSize: '13px', color: 'var(--info-text)', lineHeight: 1.6 }}>
           {t('Hodnoty jsou načítány', 'Values are fetched')} <strong>{t('živě', 'live')}</strong> {t('z endpointu', 'from each service\'s')}{' '}
           <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', background: 'var(--info-bg)', padding: '1px 5px', borderRadius: '3px' }}>/api/v1/config</code>{' '}
           {t('každé služby. Pro změnu hodnot aktualizujte', 'endpoint. To change values, update')}{' '}

--- a/openbank-admin-ui/src/app/temporal/flow/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/flow/page.tsx
@@ -88,7 +88,7 @@ export default function TemporalFlowPage() {
             display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
             borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
             border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
-            background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+            background: flow ? 'var(--accent-strong)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
           }}>
           {flow ? <Pause size={13} aria-hidden="true" /> : <Play size={13} aria-hidden="true" />}{t('Tok', 'Flow')}
         </button>

--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -109,7 +109,7 @@ export function AgentDock() {
         style={{
           position: 'fixed', bottom: 24, right: 24, zIndex: 1000,
           width: 52, height: 52, borderRadius: '50%', border: 'none', cursor: 'pointer',
-          background: 'var(--accent)', color: '#fff',
+          background: 'var(--accent-strong)', color: '#fff',
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           boxShadow: '0 6px 20px rgba(0,0,0,0.18)',
         }}
@@ -227,7 +227,7 @@ export function AgentDock() {
               disabled={busy || !input.trim()}
               style={{
                 width: 38, borderRadius: 8, border: 'none', cursor: busy ? 'default' : 'pointer',
-                background: 'var(--accent)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: 'var(--accent-strong)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
                 opacity: busy || !input.trim() ? 0.5 : 1,
               }}
             >

--- a/openbank-admin-ui/src/components/docs/BpmnView.tsx
+++ b/openbank-admin-ui/src/components/docs/BpmnView.tsx
@@ -315,7 +315,7 @@ export function BpmnView({ processes }: { processes: BpmnProcess[] }) {
             style={{
               padding: '8px 16px', fontSize: '13px', fontWeight: 600, borderRadius: '8px',
               border: `1px solid ${active === p.slug ? 'var(--accent)' : 'var(--border)'}`,
-              background: active === p.slug ? 'var(--accent)' : 'var(--surface)',
+              background: active === p.slug ? 'var(--accent-strong)' : 'var(--surface)',
               color: active === p.slug ? '#fff' : 'var(--text-secondary)',
               cursor: 'pointer', fontFamily: 'inherit',
             }}>{p.name}</button>
@@ -330,8 +330,10 @@ export function BpmnView({ processes }: { processes: BpmnProcess[] }) {
             <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>{process.desc}</div>
           </div>
           <div style={{
-            padding: '6px 12px', background: '#fef2f2', border: '1px solid #fecaca',
-            borderRadius: '6px', fontSize: '11px', fontWeight: 600, color: '#dc2626',
+            // The regulation chip carries 11px TEXT, so it needs AA on its own tint: #dc2626 on
+            // #fef2f2 measured 4.41:1. The tokens are tuned for this and follow dark theme (#9749).
+            padding: '6px 12px', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)',
+            borderRadius: '6px', fontSize: '11px', fontWeight: 600, color: 'var(--danger-text)',
           }}>
             📋 {process.regulation}
           </div>

--- a/openbank-admin-ui/src/components/docs/Mermaid.tsx
+++ b/openbank-admin-ui/src/components/docs/Mermaid.tsx
@@ -46,7 +46,7 @@ export function Mermaid({ chart }: { chart: string }) {
     return (
       <div style={{
         padding: '10px', border: '1px solid var(--danger-border, #fecaca)',
-        background: 'var(--danger-bg, #fef2f2)', color: 'var(--danger, #dc2626)',
+        background: 'var(--danger-bg)', color: 'var(--danger-text)',
         borderRadius: '6px', fontFamily: 'JetBrains Mono, monospace', fontSize: '12px',
         whiteSpace: 'pre-wrap',
       }}>


### PR DESCRIPTION
## Summary

Continues #9749 from a **fresh sweep of all 103 routes against current `main`** (after #9854, #9870):
**13 failing pairs / 25 nodes**, down from 21/57 this morning.

**16 sites where white text sits on an `--accent` fill** (4.47:1) now use `--accent-strong`, the token
#9870 added for exactly that. Plus three tone-as-text leftovers.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #9749

## The sweep found 5 of the 16; the other 11 were derived statically

A toggle has to be in its **selected** state to render white-on-accent, so a runtime scan sees only
the ones that happened to be selected. Same limit as `ROLE_API` in #9870 — **a runtime scan sees
rendered states, not possible ones** — so the set came from reading the code instead.

**Not a blanket rewrite this time.** Each site was classified by text size first, because WCAG's floor
for large text is **3:1, not 4.5:1**:

- `settings/page.tsx:57` is the 20px/700 avatar initial — passes at 4.47 and is **left alone**
- two of the sixteen are **multi-line** (`background:` and `color:` on different lines), which a
  same-line regex misses; found by reading the elements

## Three tone-as-text leftovers

| where | was | note |
|---|---|---|
| `Mermaid.tsx` "render failed" box | `var(--danger, #dc2626)` on `--danger-bg`, 4.41:1 | renders on **every page with a diagram**, not just the route the sweep caught |
| `BpmnView.tsx` regulation chip | hardcoded #dc2626 on #fef2f2 at 11px | |
| `system/config` paragraph | `var(--info)` on `--info-bg`, 3.37:1 | 13px body text |

The hex fallbacks *inside* the var() — `var(--danger, #dc2626)` — are dropped: they silently bypass
theming if a token is renamed.

## Eight of the thirteen pairs are NOT defects, and I am not fixing them

Eight are on /sanctions in a **loading** state (`aria-busy`, "Loading…", "Checking service…"), and
their colours are **no token at all**: `#519e88` is `--success-text` (#037454) at **~70% opacity**
over white — a=0.7 computes `#4f9e87` against the measured `#519e88`.

The sweep runs with no backends, so that page never finishes loading, and `globals.css:362` animates
`pulse` down to `opacity: .5`, which axe samples mid-dip.

So the **tokens are right and the composition divides the contrast**. No token-level guard can see
that, and in production the state lasts about a second. Same class as #9808/#9809, where the
dark-theme scan was measuring a crossfade. Retuning the palette to satisfy a transient skeleton would
make it worse for the states users actually read.

## What this does not claim

**I cannot say "zero new pairs" from the run-to-run comparison.** Two /docs/service-map pairs appeared
in the first sweep, were absent from the second, and are back in the third — that page renders
different badges per filter state, so consecutive runs are not a reliable regression signal for it.
Both are known rather than new, and both remain open: those spans carry no inline colour, so they
inherit it, and tracing that is its own task.

Also still open, unchanged: `--accent` as **text** on white (4.46:1, /infrastructure links) is a brand
decision for #9749, and the /settings tab strip.

- Suite: **560 files, 3003 passed, 1 skipped**

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert; selected toggles return to 4.47:1 and the three text spots to 3.37-4.41:1.
- Data migration reversible: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
