### PR TITLE
fix(libs): join the caller's coroutine instead of blocking an event loop in @Authorize

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -22,20 +22,22 @@ import jakarta.ws.rs.core.HttpHeaders
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.SecurityContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.kotlinFunction
 
 /**
  * CDI interceptor that turns [Authorize]-annotated methods into a call to
  * the injected [PolicyDecisionPoint] (ADR-0034 D5 Phase 2). Bound by the
- * [Authorize] annotation itself (it is also an `@InterceptorBinding`); no
+ * [Authorize] annotation itself (it is also an `
+@InterceptorBinding`); no
  * `beans.xml` is required because Quarkus discovers CDI components via
  * Jandex from the libs JAR (ADR-0014).
  *
@@ -171,18 +173,79 @@ class AuthorizeInterceptor {
     @ConfigProperty(name = "authz.four-eyes.enforce", defaultValue = "false")
     var fourEyesEnforce: Boolean = false
 
+    /**
+     * Two dispatches of one decision, because WHERE the wait happens decides whether it deadlocks.
+     *
+     * The authorization pipeline is suspending end to end: [PolicyDecisionPoint.allow] and every
+     * [ApprovalStore] call are `suspend`. An `@AroundInvoke` method is not, so bridging was
+     * unavoidable — and the bridge was `runBlocking`, which parks the thread it runs on.
+     *
+     * For a **suspend** endpoint that thread is a Vert.x EVENT LOOP, and the pool has one thread
+     * per CPU. Measured 2026-09-13 (#9874) with `-XX:ActiveProcessorCount=2`, the hosted runner's
+     * shape: the first four-eyes request parks loop 0, the second parks loop 1, the reactive Redis
+     * completion then has no loop left to run on, and every subsequent request times out. A thread
+     * dump showed both loops inside `runBlocking` in this class. It is not a test artefact — the
+     * same arithmetic applies to a pod with `requests.cpu: 2`, and 27 of the fleet's 40 four-eyes
+     * endpoints are suspend functions.
+     *
+     * `@Blocking` is not available as an escape: Quarkus rejects it outright —
+     * `Suspendable @Blocking methods are not supported yet`. Raising
+     * `quarkus.vertx.event-loops-pool-size` only buys a bigger window, since N concurrent
+     * four-eyes calls still need N+1 loops.
+     *
+     * So a suspend endpoint is joined in ITS OWN coroutine instead:
+     * [startCoroutineUninterceptedOrReturn] runs [decide] on the calling thread until it genuinely
+     * suspends, and [proceedSuspending] hands the target a continuation of ours. Nothing is parked,
+     * so nothing has to be free for the continuation to run.
+     *
+     * A **plain** endpoint keeps the `runBlocking` bridge, and that is correct rather than a
+     * leftover: RESTEasy Reactive dispatches a non-suspend method on a WORKER thread, so the wait
+     * parks a worker the pool exists to have parked. 13 of the 40 four-eyes endpoints are this
+     * shape.
+     */
     @AroundInvoke
     fun authorize(ctx: InvocationContext): Any? {
         val annotation = ctx.method.getAnnotation(Authorize::class.java)
             ?: return ctx.proceed()
 
+        val continuationIndex = ctx.parameters.indexOfLast { it is Continuation<*> }
+        if (continuationIndex < 0) {
+            runBlocking { decide(ctx, annotation) }
+            return ctx.proceed()
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val caller = ctx.parameters[continuationIndex] as Continuation<Any?>
+        val pipeline: suspend () -> Any? = {
+            decide(ctx, annotation)
+            // Invoke the target with a continuation of OURS in place of the caller's, so its
+            // completion resumes THIS coroutine rather than the endpoint's directly. That single
+            // substitution is what makes the pipeline suspending instead of blocking; inline
+            // because it is meaningless anywhere except right here.
+            suspendCoroutineUninterceptedOrReturn { own ->
+                val params = ctx.parameters
+                params[continuationIndex] = own
+                ctx.parameters = params
+                ctx.proceed()
+            }
+        }
+        return pipeline.startCoroutineUninterceptedOrReturn(caller)
+    }
+
+    /**
+     * The whole authorization verdict, and nothing else: it returns normally to let the call
+     * through and THROWS to refuse. It deliberately never calls `ctx.proceed()` — that belongs to
+     * whichever of the two dispatches in [authorize] invoked it, which is what lets one decision
+     * serve both a blocking and a suspending call path with no branch duplicated.
+     */
+    private suspend fun decide(ctx: InvocationContext, annotation: Authorize) {
         if (!pdp.isResolvable) {
             return onMissingPdp(ctx, annotation)
         }
         val decisionPoint = pdp.get()
 
         val query = buildQuery(ctx, annotation)
-        val decision: AuthzDecision = runBlocking {
+        val decision: AuthzDecision = run {
             runCatching { decisionPoint.allow(query) }
                 .getOrElse { ex ->
                     record(annotation.action, "pdp_unavailable", query.principal.type)
@@ -192,7 +255,7 @@ class AuthorizeInterceptor {
                             annotation.action,
                             ex.message,
                         )
-                        return@runBlocking null
+                        return@run null
                     }
                     // Propagate the domain PolicyDecisionException (503 via its ExceptionMapper in
                     // openbank-libs-runtime). A thrown JAX-RS ServiceUnavailableException was being
@@ -200,7 +263,7 @@ class AuthorizeInterceptor {
                     // mapper keyed on the concrete domain type is immune to that.
                     throw PolicyDecisionException("policy decision point unavailable: ${ex.message}", ex)
                 }
-        } ?: return ctx.proceed() // advisory + PDP unavailable: observe, do not block
+        } ?: return // advisory + PDP unavailable: observe, do not block
 
         if (!decision.allow) {
             // The rollout signal: outcome=deny + enforced=false is the "would DENY" population that
@@ -214,7 +277,7 @@ class AuthorizeInterceptor {
                     query.principal.id,
                     decision.reason ?: "unspecified",
                 )
-                return ctx.proceed()
+                return
             }
             log.debugf(
                 "deny: action=%s resource=%s principal=%s reason=%s",
@@ -226,7 +289,7 @@ class AuthorizeInterceptor {
             throw ForbiddenException(decision.reason ?: "policy denied")
         }
         record(annotation.action, "allow", query.principal.type, decision.reason ?: "unspecified")
-        return requireFourEyesOrProceed(ctx, annotation, query, decision)
+        requireFourEyes(annotation, query, decision)
     }
 
     /**
@@ -235,7 +298,7 @@ class AuthorizeInterceptor {
      * a decision must not silently allow, and an outage must not read as a flurry of policy denials
      * in the audit trail.
      */
-    private fun onMissingPdp(ctx: InvocationContext, annotation: Authorize): Any? {
+    private fun onMissingPdp(ctx: InvocationContext, annotation: Authorize) {
         // No query was built yet, so the principal type is not yet known — hence the "unknown" tag.
         record(annotation.action, "pdp_unconfigured", "unknown")
         if (!enforce) {
@@ -244,7 +307,7 @@ class AuthorizeInterceptor {
                 ctx.method.declaringClass.simpleName,
                 ctx.method.name,
             )
-            return ctx.proceed()
+            return
         }
         log.errorf(
             "no PolicyDecisionPoint bean for @Authorize method %s.%s — failing closed",
@@ -294,15 +357,10 @@ class AuthorizeInterceptor {
      * immediately) unless the service opted in via [fourEyesEnforce] AND wired
      * an [ApprovalStore] — see the class KDoc.
      */
-    private fun requireFourEyesOrProceed(
-        ctx: InvocationContext,
-        annotation: Authorize,
-        query: AuthzQuery,
-        decision: AuthzDecision,
-    ): Any? {
+    private suspend fun requireFourEyes(annotation: Authorize, query: AuthzQuery, decision: AuthzDecision) {
         val fourEyesRequired = decision.attributes["four_eyes_required"] == true
         if (!fourEyesRequired) {
-            return ctx.proceed()
+            return
         }
         if (!fourEyesEnforce) {
             // OPA asked for a second approver and we are about to proceed without one. Nothing
@@ -321,7 +379,7 @@ class AuthorizeInterceptor {
                     "— proceeding without the second-approver gate (advisory)",
                 annotation.action,
             )
-            return ctx.proceed()
+            return
         }
         if (!approvalStore.isResolvable) {
             meters?.authzFourEyes(annotation.action, "no_approval_store")
@@ -337,7 +395,7 @@ class AuthorizeInterceptor {
                     "Wire an ApprovalStore for this service or set authz.four-eyes.enforce=false until it is.",
                 annotation.action,
             )
-            return ctx.proceed()
+            return
         }
         val store = approvalStore.get()
         val maker = query.principal.id
@@ -345,11 +403,11 @@ class AuthorizeInterceptor {
 
         val approvalId = resolveApprovalIdHeader()
         if (approvalId != null) {
-            val approval = awaitOffEventLoop { store.find(approvalId) }
+            val approval = store.find(approvalId)
             if (approval.satisfies(annotation.action, resourceId, maker)) {
-                awaitOffEventLoop { store.markExecuted(approvalId) }
+                store.markExecuted(approvalId)
                 meters?.authzFourEyes(annotation.action, "approval_satisfied")
-                return ctx.proceed()
+                return
             }
             log.warnf(
                 "four-eyes: approval id=%s not valid for action=%s maker=%s " +
@@ -360,7 +418,7 @@ class AuthorizeInterceptor {
             )
         }
 
-        val pending = awaitOffEventLoop { store.create(annotation.action, resourceId, maker) }
+        val pending = store.create(annotation.action, resourceId, maker)
         meters?.authzFourEyes(annotation.action, "pending_approval")
         log.infof(
             "four-eyes: action=%s resource=%s maker=%s requires a second approver — approvalId=%s",
@@ -381,14 +439,6 @@ class AuthorizeInterceptor {
         if (!httpHeaders.isResolvable) return null
         return httpHeaders.get().getRequestHeader(APPROVAL_ID_HEADER)?.firstOrNull()
     }
-
-    /** A supplied approval only unlocks THIS exact action, resource, and original maker. */
-    private fun PendingApproval?.satisfies(action: String, resourceId: String?, maker: String): Boolean =
-        this != null &&
-            status == ApprovalStatus.APPROVED &&
-            this.action == action &&
-            this.resourceId == resourceId &&
-            makerId == maker
 
     private fun buildQuery(ctx: InvocationContext, annotation: Authorize): AuthzQuery {
         val sc = securityContext.get()
@@ -483,36 +533,32 @@ private fun resolveResourceField(target: Any, fieldName: String, log: Logger): A
     null
 }
 
-/**
- * Bridges a suspend [ApprovalStore] call to a synchronous result from inside
- * [AuthorizeInterceptor]'s non-suspend `@AroundInvoke` method (issue #5631).
+/*
+ * `awaitOffEventLoop` lived here until #9874: a `runBlocking { withContext(Dispatchers.IO) { … } }`
+ * bridge used by the three suspending call sites above.
  *
- * A `suspend` REST resource method is, by default, dispatched on the Vert.x
- * event-loop thread itself — the resource method's own suspension only happens
- * *after* the interceptor chain (including [AuthorizeInterceptor]) has already
- * run. Naively `runBlocking { store.find(...) }` on that same thread
- * self-deadlocks against a reactive [com.openbank.libs.approval.impl.RedisApprovalStore]:
- * Quarkus's per-request "duplicated context" is captured by whatever reactive
- * call is made while it is current, and that call's completion is dispatched
- * back onto THAT SAME context/thread — but this thread is the one parked
- * inside `runBlocking`, so the callback that would unblock it can never run.
- * This is not limited to the underlying I/O: `Vertx.executeBlocking` (an
- * earlier version of this fix) moves the actual work to a worker thread but
- * STILL explicitly propagates the calling duplicated context to its own
- * `Future`, so blocking on `future.get()` reproduces the identical deadlock
- * one hop later — measured directly (issue #5631): a Vert.x "Thread blocked"
- * warning pointing at that bridge, same shape as the original bug.
+ * Its KDoc's diagnosis of #5631 was right and is worth keeping: `Vertx.executeBlocking` propagates
+ * the CALLING duplicated context into its own `Future`, so blocking on that future self-deadlocks
+ * one hop later, and `Dispatchers.IO` avoids that because it is not a Vert.x construct and carries
+ * no context to propagate.
  *
- * The fix that actually works is `withContext(Dispatchers.IO)`: a plain
- * kotlinx-coroutines thread-pool hop that is NOT a Vert.x construct at all, so
- * it carries no duplicated context to propagate. [block] resumes on a thread
- * Vert.x has no thread-local context for; `Vertx.currentContext()` there is
- * null, so the reactive redis call inside it completes without needing to
- * round-trip back through the request's original (blocked) event-loop thread.
- * This is exactly the pattern [OpaSidecarPolicyDecisionPoint.allow] already
- * relies on for its own blocking HTTP call — which is why that PDP call never
- * hit this bug.
+ * What that fix could not avoid is the OUTER `runBlocking`. It parks whichever thread the
+ * interceptor runs on, and for a suspend endpoint that is a Vert.x event loop — of which there is
+ * one per CPU. Measured with `-XX:ActiveProcessorCount=2`: two four-eyes requests park both loops
+ * and the reactive Redis completion has nowhere left to run. [AuthorizeInterceptor.authorize] now
+ * joins the caller's coroutine instead, so no thread is parked at all and the helper has no
+ * remaining call site.
  */
-private fun <T> awaitOffEventLoop(block: suspend () -> T): T = runBlocking {
-    withContext(Dispatchers.IO) { block() }
-}
+
+/**
+ * A supplied approval only unlocks THIS exact action, resource, and original maker.
+ *
+ * Top-level rather than a class member because it reads no interceptor state, and
+ * [AuthorizeInterceptor] sits at detekt's `TooManyFunctions` bound — which fires AT the threshold,
+ * not above it.
+ */
+private fun PendingApproval?.satisfies(action: String, resourceId: String?, maker: String): Boolean = this != null &&
+    status == ApprovalStatus.APPROVED &&
+    this.action == action &&
+    this.resourceId == resourceId &&
+    makerId == maker

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorSuspendDispatchTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorSuspendDispatchTest.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.authz
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.interceptor.InvocationContext
+import jakarta.ws.rs.core.SecurityContext
+import kotlinx.coroutines.CompletableDeferred
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import java.security.Principal as JavaPrincipal
+
+/**
+ * The interceptor must not BLOCK the thread it is called on when the endpoint is a suspend
+ * function (#9874).
+ *
+ * Why this is a unit test and not only the integration one: the deadlock is only observable on a
+ * machine with few CPUs, because Vert.x sizes its event-loop pool per CPU — measured, the
+ * transaction-service IT passes on a developer laptop and fails at `-XX:ActiveProcessorCount=2`
+ * with all four of its cases timing out and the Gradle task dying at its 25-minute bound. A test
+ * that can only fail on a 2-CPU runner is a test this repo cannot rely on, so this asserts the
+ * MECHANISM instead: given a policy decision that has not answered yet, `authorize` must hand back
+ * `COROUTINE_SUSPENDED` rather than sit on the thread waiting.
+ *
+ * The bound matters. If someone reintroduces `runBlocking`, this test must FAIL rather than hang:
+ * the call runs on its own executor and the assertion is on a 2-second `get`, so a blocking bridge
+ * is reported as a timeout, not as a stuck suite.
+ */
+class AuthorizeInterceptorSuspendDispatchTest {
+
+    @Suppress("UnusedParameter")
+    @Authorize(action = "balance.credit")
+    suspend fun suspendEndpoint(amount: Long): String = "executed-$amount"
+
+    private val suspendMethod: Method =
+        AuthorizeInterceptorSuspendDispatchTest::class.java.getDeclaredMethod(
+            "suspendEndpoint",
+            Long::class.java,
+            Continuation::class.java,
+        )
+
+    /** A PDP that never answers during the test — it stands in for a store/PDP round trip in flight. */
+    private class NeverAnsweringPdp : PolicyDecisionPoint {
+        val gate = CompletableDeferred<AuthzDecision>()
+        override suspend fun allow(query: AuthzQuery): AuthzDecision = gate.await()
+    }
+
+    private fun interceptor(pdp: PolicyDecisionPoint): AuthorizeInterceptor {
+        val sc = mockk<SecurityContext>()
+        every { sc.userPrincipal } returns JavaPrincipal { "maker-1" }
+        val securityIdentity = mockk<SecurityIdentity>()
+        every { securityIdentity.roles } returns emptySet()
+        return AuthorizeInterceptor().apply {
+            this.pdp = mockk {
+                every { isResolvable } returns true
+                every { get() } returns pdp
+            }
+            securityContext = mockk { every { get() } returns sc }
+            identity = mockk { every { get() } returns securityIdentity }
+            httpHeaders = mockk { every { isResolvable } returns false }
+            metrics = mockk { every { isResolvable } returns false }
+            securityTelemetry = mockk { every { isResolvable } returns false }
+            approvalStore = mockk { every { isResolvable } returns false }
+            enforce = true
+            fourEyesEnforce = false
+            clock = Clock.fixed(Instant.parse("2026-09-13T07:00:00Z"), ZoneOffset.UTC)
+        }
+    }
+
+    private fun suspendCtx(): Pair<InvocationContext, Continuation<Any?>> {
+        val caller = object : Continuation<Any?> {
+            override val context: CoroutineContext = EmptyCoroutineContext
+            override fun resumeWith(result: Result<Any?>) = Unit
+        }
+        val params = arrayOf<Any?>(1L, caller)
+        val ctx = mockk<InvocationContext>()
+        every { ctx.method } returns suspendMethod
+        every { ctx.parameters } returns params
+        every { ctx.parameters = any() } just runs
+        every { ctx.proceed() } returns COROUTINE_SUSPENDED
+        return ctx to caller
+    }
+
+    @Test
+    fun `a suspend endpoint suspends instead of blocking the calling thread`() {
+        val pdp = NeverAnsweringPdp()
+        val sut = interceptor(pdp)
+        val (ctx, _) = suspendCtx()
+
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val call = pool.submit<Any?> { sut.authorize(ctx) }
+            // A blocking bridge parks HERE and the get() below times out — which is the point:
+            // the regression is reported as a failure, never as a hung suite.
+            val result = call.get(2, TimeUnit.SECONDS)
+            assertThat(result)
+                .describedAs(
+                    "authorize must hand back COROUTINE_SUSPENDED while the decision is in flight; " +
+                        "a returned value or a timeout means the thread was blocked (#9874)",
+                )
+                .isSameAs(COROUTINE_SUSPENDED)
+        } finally {
+            pdp.gate.cancel()
+            pool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `the interceptor hands the target a continuation of its own, not the caller's`() {
+        // The hop that makes the pipeline suspending: the target must resume the interceptor's
+        // coroutine, which then resumes the caller. Asserting the substitution directly, because a
+        // version that forwards the caller's continuation unchanged would double-resume it.
+        val pdp = NeverAnsweringPdp()
+        val sut = interceptor(pdp)
+        val (ctx, caller) = suspendCtx()
+        val handed = mutableListOf<Any?>()
+        every { ctx.proceed() } answers {
+            handed += ctx.parameters.last()
+            COROUTINE_SUSPENDED
+        }
+
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            pool.submit<Any?> { sut.authorize(ctx) }
+            pdp.gate.complete(AuthzDecision(allow = true, reason = "test"))
+            pool.shutdown()
+            pool.awaitTermination(5, TimeUnit.SECONDS)
+            assertThat(handed).hasSize(1)
+            assertThat(handed.single())
+                .describedAs("the target must be handed the interceptor's continuation, not the endpoint's")
+                .isNotSameAs(caller)
+                .isInstanceOf(Continuation::class.java)
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`@Authorize`'s suspending pipeline no longer blocks a Vert.x event-loop thread. A suspend endpoint
is joined in its own coroutine; a plain endpoint keeps the blocking bridge, which is correct there.
Closes #9874.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #9874 · Refs #5043, #5631, #9836, ADR-0155

## Changes

- `AuthorizeInterceptor.authorize` dispatches on whether the intercepted method is a suspend
  function (`ctx.parameters` ends with a `Continuation`).
  - **suspend target**: `pipeline.startCoroutineUninterceptedOrReturn(caller)`, and the target is
    invoked with a continuation of the interceptor's own — the one hop that makes the pipeline
    suspending rather than blocking. Nothing is parked, so nothing has to be free for the
    continuation to run.
  - **plain target**: the `runBlocking` bridge stays, deliberately. RESTEasy Reactive dispatches a
    non-suspend method on a **worker** thread, so the wait parks a worker the pool exists to have
    parked.
- The verdict is extracted into one `private suspend fun decide(...)` that **throws to refuse and
  returns to allow**, and never calls `ctx.proceed()` itself. That is what lets both dispatches
  share every branch (advisory/enforce, PDP missing, PDP unavailable, deny, four-eyes) instead of
  duplicating them.
- `awaitOffEventLoop` is removed; its #5631 diagnosis is kept as a comment next to what replaced it,
  because that part was right and is still worth knowing.
- `satisfies` moved to a top-level private function — it reads no interceptor state, and the class
  sits exactly at detekt's `TooManyFunctions` bound, which fires **at** the threshold.

## Why — measured, not argued

The defect is invisible on a developer machine. Vert.x sizes its event-loop pool per CPU, so with
many cores a spare loop is always free and the blocking bridge gets away with it. At the hosted
runner's shape it does not:

```
-XX:ActiveProcessorCount=2, blocking bridge (today's main)
  4 tests completed, 2 failed
  > Timeout has been exceeded
  BUILD FAILED in 25m 32s
```

`jstack` during the hang — both of the two loops that exist at 2 CPUs, same frame:

```
"vert.x-eventloop-thread-0"  TIMED_WAITING (parking)
  kotlinx.coroutines.BlockingCoroutine.joinBlocking
  AuthorizeInterceptorKt.awaitOffEventLoop(AuthorizeInterceptor.kt:516)
  AuthorizeInterceptor.requireFourEyesOrProceed(:348)
  AuthorizeInterceptor.authorize(:229)
  TransactionResource_Subclass.mergeSweep
"vert.x-eventloop-thread-1"  — identical
```

This is not a test-only problem: **27 of the fleet's 40 four-eyes endpoints are suspend functions**
(13 are plain and therefore already safe), and the same arithmetic applies to any pod with
`requests.cpu: 2`.

Two alternatives were tried and rejected on evidence, not taste:

| attempt | result |
|---|---|
| `@Blocking` on the endpoint | Quarkus refuses at augmentation: `Suspendable @Blocking methods are not supported yet` |
| `quarkus.vertx.event-loops-pool-size=8` | passes, but it is a bigger window, not a fix — N concurrent four-eyes calls need N+1 loops |
| eager `RedisApprovalStore` command init | 4-of-4 failing → 2-of-4; removes context pinning, does not fix the deadlock |

## Verification

| run | outcome |
|---|---|
| suspend-aware, `ActiveProcessorCount=2`, transaction-service four-eyes IT | **4 tests, 0 failures** (14 s) |
| blocking bridge restored, same CPU cap | 4 tests, **2 failed**, task timeout 25m32s |
| `:openbank-libs-runtime:test` full suite | **326 tests, 0 failures, 0 skipped** |
| `ktlintCheck` + `detekt` on libs-runtime | clean |

The IT that exposes this lives on #5043's branch, so the regression guard here is
`AuthorizeInterceptorSuspendDispatchTest`, which needs no 2-CPU machine: it asserts the mechanism —
`COROUTINE_SUSPENDED` returned while the decision is still in flight, and the substituted
continuation handed to the target. It is bounded by a 2-second `Future.get`, so reintroducing the
bridge **fails in 15 s instead of hanging the suite**; falsified by reverting the interceptor, where
both cases go red.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved). — the IT that covers this is
      on #5043's branch; this PR adds the machine-independent unit guard instead.
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). — the mechanism and both rejected alternatives
      are documented in the KDoc where the next reader will hit them.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification — two: `@Suppress("UNCHECKED_CAST")`
      on the continuation cast (the JVM signature of a suspend function guarantees the last parameter's
      type) and `@Suppress("UnusedParameter")` on the test's dummy endpoint.
- [x] No new third-party dependency — `kotlin.coroutines.intrinsics` is stdlib.
- [x] Auth / crypto / payment code changed? → **yes, this is the authorization interceptor** — tagging
      for security review is appropriate. Behaviour is unchanged by construction: every branch of the
      verdict moved into `decide` verbatim, and the 34 existing interceptor tests plus 10 approval-store
      tests pass untouched.
- [x] PII path changed? → no.
- [x] Cardholder data path changed? → no.

## Compliance impact

- [ ] PCI DSS
- [x] DORA — availability of a money-path control: today the gate deadlocks the request instead of
      answering it.
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
