### PR TITLE
fix(ci): make the security-checklist failure name its own remediation

### DIFF
--- a/.github/scripts/check-security-checklist.py
+++ b/.github/scripts/check-security-checklist.py
@@ -138,6 +138,18 @@ def run(root: Path, body: str, base: str, enforce: bool) -> int:
     if res is None:
         print("::error::PR touches money-path code but the body has no '## Security checklist' "
               "section — restore it from the template and tick every box (or state why in the PR).")
+        # Name the remediation, including the part that used to make it fail silently. A PR opened
+        # with `gh pr create --body-file` NEVER carries the template (GitHub applies it only when no
+        # body is supplied), and CLAUDE.md mandates that flag — so for an agent-opened PR this error
+        # is the normal path, not an oversight, and the fix is two steps whose ORDER used to matter.
+        # Since #8940 the gate reads the LIVE body, so editing the description and re-running is
+        # enough; before that the gate saw `github.event.pull_request.body`, frozen at the last
+        # synchronize, and an edit-then-rerun reproduced the identical failure with no signal why
+        # (#8757). Saying it here is the difference between a 30-second fix and a hunt.
+        print("::notice::How to fix: copy the '## Security checklist' block from "
+              ".github/PULL_REQUEST_TEMPLATE.md into the PR body, answer each line, then RE-RUN "
+              "this check — this gate reads the live PR body (#8940), so no empty commit is needed. "
+              "A PR created with `gh pr create --body-file` never gets the template automatically.")
         return 1 if enforce else 0
     _, missing = res
     if missing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -852,6 +852,14 @@ touch `.github/`. What stays here is what fires from OUTSIDE that tree: editing
   `gh release create --notes` and `-f body=`; for an edit, `-F body=@file`.
   If you did use `--body`, re-read what was published (`gh pr view <n> --json body`) — grep it
   for `()` and for the phrases you meant to include.
+  **And `--body-file` has its own consequence: GitHub applies `.github/PULL_REQUEST_TEMPLATE.md`
+  only when no body is supplied, so a PR opened this way never carries the `## Security checklist`
+  section — which the enforced `security-checklist-money-path` gate requires on any PR touching a
+  money-path service.** The two rules are both right and cannot both be followed without a third
+  step: append that block to the body file yourself. Measured 2026-09-05: 50 of 67 open PRs had no
+  such section at all (#8757). The remediation is now cheap — the gate reads the LIVE body since
+  #8940, so editing the description and re-running is enough, where it previously needed an
+  otherwise-pointless empty commit to re-emit the event.
 - **`gh` needs a repo context: outside a checkout it fails with `failed to run git: fatal: not
   a git repository`,** which reads like a content or permissions problem rather than a cwd one.
   Pass `-R <owner>/<repo>` explicitly in any script whose working directory is not guaranteed —


### PR DESCRIPTION
Refs #8757 — the cheap half of the fix, plus a re-measurement.

## What changed since the issue was filed

**The expensive half is already gone.** #8940 made the gate read the **live** PR body instead of `github.event.pull_request.body`, so the documented remediation now works: edit the description, re-run the check. No empty commit. I verified it by accident tonight — a PR of mine failed this gate, I added the section to the body, re-ran, and it went green with no push.

The issue's own description of that trap ("the wrong order silently does nothing") is therefore stale, and it was the half that cost people hours.

## Re-measured today

```
open non-draft PRs WITH a '## Security checklist' section:  19
open non-draft PRs WITHOUT:                                 11
```

Against the filed 17 / 50. Better, and **not fixed** — the mechanism is untouched: `gh pr create --body-file` never gets the template, and `CLAUDE.md` mandates that flag.

## What this PR does, and what it deliberately does not

It does **not** claim to be the control. The issue is right that the real fix belongs where the body file is composed, and right that skills are machine-local and cannot be reviewed here.

What it does is make the failure self-explaining at the only moment that matters — when it fires:

- the error now names the file the block lives in, says a **re-run is enough** (citing #8940), and says plainly that a `--body-file` PR never gets the template automatically;
- `CLAUDE.md`'s gh section states the consequence next to the mandate that causes it. That section documented `--body-file` as an unconditional rule without mentioning what it costs.

I hit this twice tonight on my own PRs. That is the evidence that knowing the rule does not help: the cost lands when the body file is written, and the error message is the only thing present when it fails.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No** — this changes an error message and a doc line.
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS
