### PR TITLE
feat(ci): ask the cluster what nothing scrapes — and what nothing protects

### DIFF
--- a/.github/scripts/runtime-conformance.py
+++ b/.github/scripts/runtime-conformance.py
@@ -68,6 +68,7 @@ PROBES = (
     "canary_realisability",
     "image_tag_exists",
     "audit_attribution",
+    "scrape_coverage",
 )
 
 
@@ -417,12 +418,48 @@ def cmp_audit_attribution(claims: dict, facts: dict) -> list[str]:
     return findings
 
 
+# Namespaces that legitimately run pods nothing in this fleet scrapes. Declared rather than
+# pattern-matched: "does it look like infrastructure" is a judgement, and a judgement that lives in
+# a regex silently widens. Each entry is a decision someone can argue with.
+SCRAPE_EXEMPT_NAMESPACES = frozenset({
+    "kube-system", "kube-public", "kube-node-lease",
+    "argocd", "argo-rollouts", "cert-manager", "external-secrets", "kyverno",
+    "monitoring", "observability", "cnpg-system", "strimzi", "keycloak",
+    "arc-systems", "arc-runners", "openbao", "trivy-system",
+})
+
+
+def cmp_scrape_coverage(claims: dict, facts: dict) -> list[str]:
+    """A namespace running workloads that the fleet PodMonitor does not select.
+
+    Starts from the LIVE side on purpose — the claim side is only the scrape list, and the facts are
+    the namespaces that actually hold running pods, so a namespace declared nowhere in this repo is
+    visible instead of out of scope (#9072). Same shape as the backup comparator above (#9834): the
+    gitops-scoped gate is complete about gitops, and only the side holding the snapshot can ask the
+    other question.
+    """
+    findings = []
+    for ns, fact in sorted(facts.items()):
+        if ns in SCRAPE_EXEMPT_NAMESPACES or claims.get(ns, {}).get("scraped"):
+            continue
+        pods = fact.get("pods", 0)
+        if not pods:
+            continue
+        findings.append(
+            f"{ns}: {pods} running pod(s) and the fleet PodMonitor does not select this namespace — "
+            f"nothing scrapes it, and no gitops-scoped gate can see that, because the namespace is "
+            f"declared nowhere in this repo"
+        )
+    return findings
+
+
 COMPARATORS = {
     "backup_recoverability": cmp_backup_recoverability,
     "outbox_liveness": cmp_outbox_liveness,
     "canary_realisability": cmp_canary_realisability,
     "image_tag_exists": cmp_image_tag_exists,
     "audit_attribution": cmp_audit_attribution,
+    "scrape_coverage": cmp_scrape_coverage,
 }
 
 
@@ -433,6 +470,24 @@ def _sh(args: list[str]) -> str:
         return subprocess.run(args, capture_output=True, text=True, check=False).stdout
     except OSError:
         return ""
+
+
+def claim_scraped_namespaces(root: pathlib.Path) -> dict[str, dict]:
+    """The namespaces the fleet PodMonitor says Prometheus scrapes.
+
+    `check-podmonitor-namespace-coverage.py` answers "does every workload DECLARED IN GITOPS sit in
+    a scraped namespace". That is the right question about this repo and it cannot ask the other
+    one: a namespace that exists in the cluster and is declared nowhere here is outside its subject
+    set entirely, so it reads as covered (#9072 — `pricing`, deployed from a separate repository
+    into the shared sandbox, is scraped by nothing and no gate can see it).
+
+    Same shape as `backup_recoverability` (#9834): the gitops-scoped control is complete about
+    gitops, and only the side holding the live snapshot can start from what is actually running.
+    """
+    sys.path.insert(0, str(root / "openbank-infra" / "scripts"))
+    from gitops_facts import podmonitor_namespaces  # noqa: PLC0415
+
+    return {ns: {"scraped": True} for ns in podmonitor_namespaces(root / "openbank-infra" / "gitops")}
 
 
 def collect() -> dict:
@@ -467,6 +522,21 @@ def collect() -> dict:
             "replicas": item.get("spec", {}).get("replicas"),
         }
     snap["facts"]["canary_realisability"] = rollouts
+
+    # Namespaces that actually hold running pods. `kubectl get pods -A` rather than a label
+    # selector: the point is to see workloads this repo does NOT label, which is exactly what a
+    # selector would filter out (#9072). Non-Running phases are excluded so a namespace left
+    # holding Completed Job pods is not reported as an unscraped workload.
+    namespaces: dict[str, dict] = {}
+    raw = _sh(["kubectl", "get", "pods", "-A", "-o", "json"])
+    for item in _items(raw):
+        if (item.get("status", {}) or {}).get("phase") != "Running":
+            continue
+        ns = (item.get("metadata", {}) or {}).get("namespace")
+        if not ns:
+            continue
+        namespaces.setdefault(ns, {"pods": 0})["pods"] += 1
+    snap["facts"]["scrape_coverage"] = namespaces
 
     outbox: dict[str, dict] = {}
     audit: dict = {}
@@ -550,6 +620,7 @@ def check(root: pathlib.Path, snapshot: dict) -> int:
         "canary_realisability": claim_canary_rollouts(root),
         "image_tag_exists": claim_image_pins(root),
         "audit_attribution": claim_audit_producers(root),
+        "scrape_coverage": claim_scraped_namespaces(root),
     }
     facts = snapshot.get("facts", {})
     total = 0
@@ -852,6 +923,32 @@ def self_test() -> int:
         "audit: no facts at all is skipped, not passed",
         cmp_audit_attribution({"subscribed_topics": 21}, {}),
         [])
+
+    # scrape coverage (#9072): the live side is the subject, the PodMonitor list is the claim.
+    expect(
+        "scrape: a namespace with running pods that no PodMonitor selects is flagged",
+        len(cmp_scrape_coverage({"payments": {"scraped": True}}, {"pricing": {"pods": 2}})),
+        1)
+    expect(
+        "scrape: ... and the finding says nothing scrapes it",
+        "nothing scrapes it" in (cmp_scrape_coverage({}, {"pricing": {"pods": 2}}) or [""])[0],
+        True)
+    expect(
+        "scrape: a scraped namespace is clean",
+        cmp_scrape_coverage({"payments": {"scraped": True}}, {"payments": {"pods": 9}}),
+        [])
+    expect(
+        "scrape: a declared-exempt infrastructure namespace is not a finding",
+        cmp_scrape_coverage({}, {"kube-system": {"pods": 30}, "argocd": {"pods": 4}}),
+        [])
+    expect(
+        "scrape: a namespace with NO running pods is not a finding",
+        cmp_scrape_coverage({}, {"leftover": {"pods": 0}}),
+        [])
+    expect(
+        "scrape: the exemption list is DECLARED, not a pattern — 'pricing' is not in it",
+        "pricing" in SCRAPE_EXEMPT_NAMESPACES,
+        False)
 
     if fails:
         print("runtime-conformance: self-test FAIL")

--- a/.github/scripts/runtime-conformance.py
+++ b/.github/scripts/runtime-conformance.py
@@ -69,6 +69,7 @@ PROBES = (
     "image_tag_exists",
     "audit_attribution",
     "scrape_coverage",
+    "netpol_coverage",
 )
 
 
@@ -453,6 +454,33 @@ def cmp_scrape_coverage(claims: dict, facts: dict) -> list[str]:
     return findings
 
 
+def cmp_netpol_coverage(claims: dict, facts: dict) -> list[str]:
+    """A live namespace running pods with NO NetworkPolicy object in it at all.
+
+    The VPC CNI network-policy agent has no audit mode (runbook 0010): a pod some policy selects is
+    default-deny for that direction, and **a pod none select is fully reachable**. So "zero policies
+    in a namespace that runs pods" is not a coverage percentage — it is every workload there being
+    open, and it is fully decidable without matching a single selector.
+
+    Selector matching is deliberately NOT attempted. Deciding whether a given policy selects a given
+    pod means reimplementing label semantics, and two earlier attempts at that shape in this repo
+    produced 12 and then ~40 false findings about correct code. Counting objects cannot.
+    """
+    findings = []
+    for ns, fact in sorted(facts.items()):
+        if ns in SCRAPE_EXEMPT_NAMESPACES:
+            continue
+        pods, policies = fact.get("pods", 0), fact.get("policies", 0)
+        if not pods or policies:
+            continue
+        where = "declared in gitops" if claims.get(ns, {}).get("declared") else "declared NOWHERE in gitops"
+        findings.append(
+            f"{ns}: {pods} running pod(s) and ZERO NetworkPolicy objects — with no audit mode in the "
+            f"CNI agent, every pod in this namespace is fully reachable; the namespace is {where}"
+        )
+    return findings
+
+
 COMPARATORS = {
     "backup_recoverability": cmp_backup_recoverability,
     "outbox_liveness": cmp_outbox_liveness,
@@ -460,6 +488,7 @@ COMPARATORS = {
     "image_tag_exists": cmp_image_tag_exists,
     "audit_attribution": cmp_audit_attribution,
     "scrape_coverage": cmp_scrape_coverage,
+    "netpol_coverage": cmp_netpol_coverage,
 }
 
 
@@ -470,6 +499,24 @@ def _sh(args: list[str]) -> str:
         return subprocess.run(args, capture_output=True, text=True, check=False).stdout
     except OSError:
         return ""
+
+
+def claim_gitops_namespaces(root: pathlib.Path) -> dict[str, dict]:
+    """Namespaces this repo declares at all — the subject set every gitops-scoped gate is bounded by.
+
+    `check-netpol-coverage.py` asks whether each gitops COMPONENT carries the generated ingress
+    allow-list, and says so in its own docstring: "a manifest can only prove intent". Both halves of
+    that sentence are limits. A namespace that exists in the cluster and is declared nowhere here
+    has no component, so it is not merely un-audited — it is outside the question.
+    """
+    ns: dict[str, dict] = {}
+    components = root / "openbank-infra" / "gitops" / "components"
+    if not components.is_dir():
+        return ns
+    for path in components.rglob("*.y*ml"):
+        for m in re.finditer(r"^\s*namespace:\s*([a-z0-9-]+)\s*$", _read(path), re.M):
+            ns.setdefault(m.group(1), {"declared": True})
+    return ns
 
 
 def claim_scraped_namespaces(root: pathlib.Path) -> dict[str, dict]:
@@ -537,6 +584,16 @@ def collect() -> dict:
             continue
         namespaces.setdefault(ns, {"pods": 0})["pods"] += 1
     snap["facts"]["scrape_coverage"] = namespaces
+
+    # Same namespaces, plus how many NetworkPolicy objects each holds. Counting objects rather than
+    # matching selectors is the whole point — see cmp_netpol_coverage.
+    netpol = {ns: {"pods": v["pods"], "policies": 0} for ns, v in namespaces.items()}
+    raw = _sh(["kubectl", "get", "networkpolicy", "-A", "-o", "json"])
+    for item in _items(raw):
+        ns = (item.get("metadata", {}) or {}).get("namespace")
+        if ns in netpol:
+            netpol[ns]["policies"] += 1
+    snap["facts"]["netpol_coverage"] = netpol
 
     outbox: dict[str, dict] = {}
     audit: dict = {}
@@ -621,6 +678,7 @@ def check(root: pathlib.Path, snapshot: dict) -> int:
         "image_tag_exists": claim_image_pins(root),
         "audit_attribution": claim_audit_producers(root),
         "scrape_coverage": claim_scraped_namespaces(root),
+        "netpol_coverage": claim_gitops_namespaces(root),
     }
     facts = snapshot.get("facts", {})
     total = 0
@@ -949,6 +1007,37 @@ def self_test() -> int:
         "scrape: the exemption list is DECLARED, not a pattern — 'pricing' is not in it",
         "pricing" in SCRAPE_EXEMPT_NAMESPACES,
         False)
+
+    # netpol coverage: zero policies in a namespace that runs pods = every pod fully reachable.
+    expect(
+        "netpol: a namespace with pods and NO NetworkPolicy is flagged",
+        len(cmp_netpol_coverage({}, {"pricing": {"pods": 2, "policies": 0}})),
+        1)
+    expect(
+        "netpol: ... and the finding says every pod there is fully reachable",
+        "fully reachable" in (cmp_netpol_coverage({}, {"pricing": {"pods": 2, "policies": 0}}) or [""])[0],
+        True)
+    expect(
+        "netpol: ... and it says whether the namespace is declared in gitops at all",
+        "declared NOWHERE in gitops" in (cmp_netpol_coverage({}, {"pricing": {"pods": 2, "policies": 0}}) or [""])[0],
+        True)
+    expect(
+        "netpol: a declared namespace says so instead",
+        "declared in gitops" in (cmp_netpol_coverage(
+            {"payments": {"declared": True}}, {"payments": {"pods": 3, "policies": 0}}) or [""])[0],
+        True)
+    expect(
+        "netpol: ONE policy is enough to leave the finding set — this counts objects, not coverage",
+        cmp_netpol_coverage({}, {"payments": {"pods": 30, "policies": 1}}),
+        [])
+    expect(
+        "netpol: a namespace with no running pods is not a finding",
+        cmp_netpol_coverage({}, {"empty": {"pods": 0, "policies": 0}}),
+        [])
+    expect(
+        "netpol: infrastructure namespaces use the same declared exemption list",
+        cmp_netpol_coverage({}, {"kube-system": {"pods": 30, "policies": 0}}),
+        [])
 
     if fails:
         print("runtime-conformance: self-test FAIL")


### PR DESCRIPTION
Refs #9072 — the half this repo can fix.

## The gap, precisely

`check-podmonitor-namespace-coverage.py` derives its subject set from gitops (`NOT_SCRAPED = {}` at
line 68). It answers *"does every workload declared in gitops sit in a scraped namespace"* — and it
answers that correctly. It cannot ask the other question: a namespace that exists in the cluster and
is declared nowhere here is outside its subject set entirely, so **it reads as covered**.

`openbank-pricing` deploys into the shared sandbox from a **separate repository**. Nothing in this
monorepo declares it, so nothing here scrapes it and no gate here can say so.

## The change

A sixth probe in `runtime-conformance.py` — the one control that already holds a live snapshot, and
the same remedy applied to the backup gates in #9834:

- **claim**: the fleet PodMonitor's `namespaceSelector.matchNames` (reuses `gitops_facts.podmonitor_namespaces`).
- **fact**: namespaces with running pods, from `kubectl get pods -A` — deliberately **no label
  selector**, because a selector would filter out precisely the workloads this repo does not label.
  Non-Running phases are excluded so a namespace holding Completed Job pods is not reported.
- **comparator**: starts from the live side.

The exemption list is **declared, not pattern-matched**. "Does it look like infrastructure" is a
judgement, and a judgement inside a regex widens silently; each entry is something a reviewer can
argue with. One of the self-test cases asserts `pricing` is *not* in it — a guard's own scope is the
thing that goes quietly wrong.

## Verification

Six cases. Falsified in three directions, each reddening its own case and no other:

| sabotage | red case |
|---|---|
| drop the "already scraped" check | `a scraped namespace is clean` |
| drop the exemption check | `a declared-exempt infrastructure namespace is not a finding` |
| drop the empty-namespace check | `a namespace with NO running pods is not a finding` |

## What this does NOT do

- **It is not run against the cluster here.** I have no cluster access, so the comparator is
  exercised against fixtures shaped like the cluster. The first run on a real snapshot is the
  measurement, and it should report `pricing`. **A clean first run means the collector is what needs
  looking at, not the estate.**
- It does not decide what to do about `pricing` — whether the monorepo should scrape a namespace it
  does not own, or whether that belongs to the other repository, is a decision this issue can now
  make with a number instead of without one.


## Second commit: the same blind spot, higher stakes

`check-netpol-coverage.py` asks whether each gitops **component** carries the generated ingress
allow-list. Its own docstring says *"a manifest can only prove intent"* — and both halves of that
sentence are limits. A namespace that exists in the cluster and is declared nowhere here has no
component at all, so it is not un-audited; it is **outside the question**.

That matters more than the scrape gap. Per runbook 0010, the VPC CNI network-policy agent has **no
audit mode**: a pod some policy selects is default-deny for that direction, and **a pod none select
is fully reachable**. So "zero NetworkPolicy objects in a namespace that runs pods" is not a coverage
percentage — it is every workload there being open.

A seventh probe reports exactly that, and the finding says whether the namespace is declared in
gitops, because the two cases need different people: an undeclared one is a conversation with
whoever deploys it, a declared one with zero policies is a generator gap.

**Selector matching is deliberately not attempted.** Deciding whether a given policy selects a given
pod means reimplementing label semantics, and two earlier attempts at that shape in this repo
produced 12 and then ~40 false findings about correct code (`entity-column-names`). Counting objects
per namespace cannot do that, and it answers the binary question the CNI actually asks.

Seven more self-test cases, falsified in two directions: ignoring the policy count reddens the
one-policy case, and dropping the gitops-declared distinction reddens the case asserting it.

The same limitation applies as above — no cluster access here, so the first real snapshot is the
measurement.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No.**
- [x] PII path changed? **No** — the probe reads namespace names and pod counts, nothing from inside a pod.
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS

