### PR TITLE
ci(dependency-review): say which failure this is, without converting it to a pass

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -157,6 +157,25 @@ jobs:
             echo "Dependency-diff API unavailable; retrying after bounded backoff."
           done
           cat /tmp/dependency-diff.error >&2
+          # Say WHICH failure this is. The step stays red either way — that is a deliberate
+          # decision recorded above, and this does not reverse it — but "could not run" and
+          # "found something" must not render identically, which is the distinction #4162 cost
+          # this repo to learn. An installation-quota 403 is an environmental answer about the
+          # API, not a statement about this PR's dependencies, and on 2026-09-13 it was red on
+          # 11 open PRs at once: a red that is never about the diff is how a real finding gets
+          # scrolled past.
+          if grep -qi "rate limit exceeded for installation" /tmp/dependency-diff.error; then
+            echo "::error title=dependency-review: could not run::The dependency-diff API answered" \
+                 "HTTP 403 rate-limit for the whole bounded wait (${#delays[@]} attempts). This is" \
+                 "the INSTALLATION API quota, exhausted fleet-wide — NOT a dependency finding and" \
+                 "not a fault in this PR. Re-run once the quota window resets; if it is red again," \
+                 "the quota is the thing to fix (#8690 measures the per-build API cost), not this" \
+                 "PR's dependencies."
+          else
+            echo "::error title=dependency-review: could not run::The dependency-diff API was" \
+                 "unreadable for the whole bounded wait and the error is NOT a rate limit — see the" \
+                 "text above. This is still not a dependency finding; it is a failure to measure."
+          fi
           exit 1
 
       - name: Dependency Review retry


### PR DESCRIPTION
Refs #8690.

## What is red, and why it is not about dependencies

Measured 2026-09-13: **11 open PRs** are red on `dependency-review` at once. Every one of them for
the same reason — the dependency-diff API answered HTTP 403 for the whole bounded wait because the
**installation API quota** was exhausted fleet-wide:

```
gh: API rate limit exceeded for installation. ... (HTTP 403)
##[error]Process completed with exit code 1.
```

That is an answer about the API, not a statement about any PR's dependencies.

## What this changes, and what it deliberately does not

It does **not** convert the failure to a pass. The workflow already says, in a comment written on
purpose, *"API errors remain red after the bounded wait; no result is converted to a pass"* — that is
someone's decision and reversing it is not mine to make in passing.

What it changes is that **"could not run" and "found something" stop rendering identically**. The
annotation now names the branch it took:

- installation-quota 403 → says so explicitly, and points at the quota as the thing to fix (#8690
  measures the per-build API cost), not at this PR's dependencies;
- any other unreadable answer → says plainly that it is a failure to measure.

Both still `exit 1`.

This is the `could-not-run` vs `gap` distinction the repo learned from #4162, where three shards died
of `Java heap space` and the issue nonetheless asserted unpinned artifacts on `main`.

## Why it is worth the lines

A red that is **never** about the thing it names is how a real finding gets scrolled past. Eleven
simultaneous false reds is exactly the condition under which the twelfth — a genuine high-severity
dependency — gets waved through.

## Verified

Drove the classifier against both fixtures and confirmed each takes its own branch:

```
gh: API rate limit exceeded for installation   -> INSTALLATION-QUOTA branch
gh: Not Found (HTTP 404)                       -> NOT-A-RATE-LIMIT branch
```

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No** — an error message in a workflow step.
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS
