### PR TITLE
feat(admin-ui): render rollout-attested browser evidence distinctly from CI evidence

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -54,6 +54,42 @@ def trusted_run_url(url: str, run_id: str) -> bool:
             and re.fullmatch(rf"/[^/]+/[^/]+/actions/runs/{re.escape(str(run_id))}", parsed.path) is not None)
 
 
+SHA_PATTERN = re.compile(r"[0-9a-f]{7,40}")
+
+
+def build_attestation_from(vitals: dict | None) -> dict | None:
+    """The rollout attestation the browser synthetic recorded, or None when none was requested.
+
+    Returned only when the run was ASKED to prove a specific build (`requestedSha` present). A run
+    with no requested SHA is ordinary CI/browser evidence and must not acquire an attestation it
+    never made. `matched` is derived here from the two SHAs, never trusted from the sidecar: the
+    script that wrote the sidecar is the thing being checked, and a boolean it asserts about
+    itself is not evidence (#7451).
+    """
+    raw = (vitals or {}).get("buildAttestation")
+    if not isinstance(raw, dict):
+        return None
+    requested = raw.get("requestedSha")
+    observed = raw.get("observedSha")
+    if not isinstance(requested, str) or not SHA_PATTERN.fullmatch(requested.lower()):
+        return None
+    requested = requested.lower()
+    observed = observed.lower() if isinstance(observed, str) and SHA_PATTERN.fullmatch(observed.lower()) else None
+    # A short requested SHA matches the full observed one it prefixes, never the other way round:
+    # the attestation endpoint is the authority on the full identity.
+    matched = observed is not None and observed.startswith(requested)
+    return {"requestedSha": requested, "observedSha": observed, "matched": matched}
+
+
+def valid_build_attestation(value) -> bool:
+    return (isinstance(value, dict) and set(value) == {"requestedSha", "observedSha", "matched"}
+            and isinstance(value["requestedSha"], str) and SHA_PATTERN.fullmatch(value["requestedSha"]) is not None
+            and (value["observedSha"] is None
+                 or (isinstance(value["observedSha"], str) and SHA_PATTERN.fullmatch(value["observedSha"]) is not None))
+            and isinstance(value["matched"], bool)
+            and value["matched"] == (value["observedSha"] is not None and value["observedSha"].startswith(value["requestedSha"])))
+
+
 def validate_envelope(envelope: dict) -> None:
     """Fail closed before CI publishes an envelope that violates the v1 contract."""
     required = {"schemaVersion", "run", "component", "suites", "coverage", "testInfrastructure"}
@@ -121,12 +157,14 @@ def validate_envelope(envelope: dict) -> None:
         if observed_at - run_observed_at > MAX_FUTURE_SKEW:
             raise ValueError("runtime observation occurs after its run beyond the allowed clock skew")
     for item in envelope.get("specializedEvidence", []):
-        if set(item) - {"kind", "state", "source", "detail", "variant"} or not {"kind", "state", "source"}.issubset(item):
+        if set(item) - {"kind", "state", "source", "detail", "variant", "buildAttestation"} or not {"kind", "state", "source"}.issubset(item):
             raise ValueError("specialized evidence fields are invalid")
         if item["kind"] not in SPECIALIZED_KINDS or item["state"] not in SPECIALIZED_STATES or not item["source"]:
             raise ValueError("specialized evidence values are invalid")
         if "variant" in item and (item["kind"] != "synthetic" or item["variant"] not in {"chromium", "firefox", "webkit"}):
             raise ValueError("synthetic evidence variant is invalid")
+        if "buildAttestation" in item and (item["kind"] != "synthetic" or not valid_build_attestation(item["buildAttestation"])):
+            raise ValueError("synthetic build attestation is invalid")
     for item in envelope.get("testCases", []):
         required_case_fields = {"fingerprint", "kind", "classname", "name", "state", "durationMs"}
         retry_fields = {"retryFlaky", "failedAttemptCount", "failedAttemptDurationMs"}
@@ -744,9 +782,17 @@ def specialized_evidence(
         state = e2e["state"] if e2e and e2e["state"] == "failed" else "passed" if e2e and valid else "not-run"
         detail = (f"{e2e['executed']}/{e2e['discovered']} browser E2E checks; FCP {round(metrics['fcpMs'])}ms, CLS {metrics['cls']:.3f}"
                   if e2e and valid else "browser Web Vitals sample absent or unattributable" if e2e else "browser E2E JUnit report absent")
+        attestation = build_attestation_from(vitals)
+        if attestation and not attestation["matched"]:
+            # The run was asked to prove one build and saw another (or none). Whatever else passed,
+            # it did not validate the requested build, so it must never read as a pass for it.
+            state = "failed" if e2e else "not-run"
+            detail = (f"deployed build {attestation['observedSha'] or 'attestation unavailable'} "
+                      f"does not match requested {attestation['requestedSha']}")
         specialized.append({"kind": "synthetic", "state": state,
                             "source": f"journey:{synthetic_journey}", "detail": detail,
-                            **({"variant": variant} if variant else {})})
+                            **({"variant": variant} if variant else {}),
+                            **({"buildAttestation": attestation} if attestation else {})})
     return specialized
 
 
@@ -1101,6 +1147,28 @@ def main() -> None:
             browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":0,"cls":0}}')
             browser_synthetic = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
             assert browser_synthetic == [{"kind": "synthetic", "state": "not-run", "source": "journey:admin-ui-sso-boundary", "detail": "browser Web Vitals sample absent or unattributable", "variant": "chromium"}]
+            # #7451: a run asked to prove a build carries the attestation; a matching one stays a pass,
+            # a mismatching or unavailable one can never read as a pass for the requested build.
+            browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":321,"cls":0.004},"buildAttestation":{"requestedSha":"abc1234","observedSha":"abc1234def5678"}}')
+            attested = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
+            assert attested[0]["state"] == "passed", attested
+            assert attested[0]["buildAttestation"] == {"requestedSha": "abc1234", "observedSha": "abc1234def5678", "matched": True}, attested
+            browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":321,"cls":0.004},"buildAttestation":{"requestedSha":"abc1234","observedSha":"9999999aaaa"}}')
+            mismatch = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
+            assert mismatch[0]["state"] == "failed" and mismatch[0]["buildAttestation"]["matched"] is False, mismatch
+            assert "does not match requested abc1234" in mismatch[0]["detail"], mismatch
+            browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":321,"cls":0.004},"buildAttestation":{"requestedSha":"abc1234","observedSha":null}}')
+            unavailable = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
+            assert unavailable[0]["state"] == "failed" and unavailable[0]["buildAttestation"]["observedSha"] is None, unavailable
+            assert "attestation unavailable" in unavailable[0]["detail"], unavailable
+            # The sidecar's own claim of a match is ignored: `matched` is derived, never trusted.
+            browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":321,"cls":0.004},"buildAttestation":{"requestedSha":"abc1234","observedSha":"9999999aaaa","matched":true}}')
+            forged = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
+            assert forged[0]["buildAttestation"]["matched"] is False and forged[0]["state"] == "failed", forged
+            # And the envelope validator refuses an attestation whose `matched` disagrees with its SHAs.
+            assert valid_build_attestation({"requestedSha": "abc1234", "observedSha": "abc1234def", "matched": True})
+            assert not valid_build_attestation({"requestedSha": "abc1234", "observedSha": "9999999", "matched": True})
+            assert not valid_build_attestation({"requestedSha": "abc1234", "observedSha": None, "matched": True, "extra": 1})
             valid = {
                 "schemaVersion": 1,
                 "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main", "workflow": "CI", "url": "https://github.com/JiRaska/open-bank-oss/actions/runs/1", "observedAt": "2026-08-22T21:12:00Z"},

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -127,6 +127,15 @@ const thresholdBackedState = (claimedState, rawObservation, retainedObservation)
   return claimedState
 }
 
+// #7451. Re-derive `matched` from the two SHAs rather than trusting the envelope's boolean: an
+// attestation whose verdict disagrees with its own evidence is dropped, not rendered.
+const SHA = /^[0-9a-f]{7,40}$/
+const validBuildAttestation = value => Boolean(value) && typeof value === 'object'
+  && typeof value.requestedSha === 'string' && SHA.test(value.requestedSha)
+  && (value.observedSha === null || (typeof value.observedSha === 'string' && SHA.test(value.observedSha)))
+  && typeof value.matched === 'boolean'
+  && value.matched === (value.observedSha !== null && value.observedSha.startsWith(value.requestedSha))
+
 const retainActionableFailure = (previous, next, validRecovery) =>
   previous?.state === 'failed' && next.state !== 'failed' && !validRecovery ? previous : next
 
@@ -254,6 +263,7 @@ function runEnvelope(component) {
         observedAt: run.run?.observedAt ?? observedAt(file),
         source: item.source, environment: 'ci', detail: item.detail, run: provenance,
         ...(normalized.variant ? { variant: normalized.variant } : {}),
+        ...(validBuildAttestation(normalized.buildAttestation) ? { buildAttestation: normalized.buildAttestation } : {}),
         ...(normalized.thresholdResults ? { thresholdResults: normalized.thresholdResults } : {}),
       }
     })],
@@ -850,6 +860,7 @@ function syntheticJourneys() {
             thresholdResults: evidence.thresholdResults,
           } : {}),
           ...(provenance ? { run: provenance } : {}),
+          ...(validBuildAttestation(evidence.buildAttestation) ? { buildAttestation: evidence.buildAttestation } : {}),
         }
         if (evidence.variant) {
           const variants = latestVariants.get(journeyId) ?? new Map()

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -524,6 +524,15 @@ function Synthetics({ report }: { report: TestIntelligenceReport }) {
       {row.ci.variants.map(variant => <div key={variant.browser} aria-label={t(`Evidence browseru ${variant.browser}`, `${variant.browser} browser evidence`)} style={{ padding: 10, borderRadius: 9, border: '1px solid var(--border)', background: 'var(--surface-2)', fontSize: 11 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}><strong>{variant.browser}</strong><StateBadge state={variant.state} /></div>
         <div style={{ color: 'var(--text-secondary)', lineHeight: 1.35, marginTop: 6 }}>{variant.detail}</div>
+        {variant.buildAttestation ? <div
+          aria-label={variant.buildAttestation.matched ? t('Ověřeno proti nasazenému buildu', 'Rollout-attested evidence') : t('Nasazený build neodpovídá', 'Deployed build mismatch')}
+          style={{ marginTop: 7, padding: '5px 7px', borderRadius: 7, fontSize: 10, lineHeight: 1.35,
+            border: `1px solid ${variant.buildAttestation.matched ? 'var(--accent-border)' : 'var(--danger-border, var(--border))'}`,
+            color: variant.buildAttestation.matched ? 'var(--accent-text)' : 'var(--danger-text, var(--warning-text))' }}>
+          <strong>{variant.buildAttestation.matched ? t('Ověřeno proti nasazenému buildu', 'Rollout-attested') : t('Nasazený build neodpovídá', 'Build mismatch')}</strong>
+          {' · '}{t('požadováno', 'requested')} <code>{variant.buildAttestation.requestedSha.slice(0, 12)}</code>
+          {' · '}{t('nasazeno', 'observed')} <code>{variant.buildAttestation.observedSha?.slice(0, 12) ?? t('nedostupné', 'unavailable')}</code>
+        </div> : <div style={{ marginTop: 7, fontSize: 10, color: 'var(--text-tertiary)' }}>{t('CI/browser důkaz — nevztahuje se ke konkrétnímu nasazenému buildu.', 'CI/browser evidence — not tied to a specific deployed build.')}</div>}
         {variant.run ? <a href={variant.run.url} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: 7 }}>run {variant.run.id}</a> : null}
       </div>)}
     </div>}

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -218,6 +218,12 @@ export interface SyntheticJourneyEvidence {
       observedAt: string | null
       detail: string
       run?: TestRunProvenance
+      /**
+       * Present only when the run was asked to prove a specific deployed build (#7451). `matched`
+       * is derived from the SHAs by both collectors, never taken from the browser script's claim.
+       * Its absence means ordinary CI/browser evidence, not a failed attestation.
+       */
+      buildAttestation?: { requestedSha: string; observedSha: string | null; matched: boolean }
     }>
   }
   live?: {

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -20,6 +20,42 @@ const write = (root: string, relative: string, body: string) => {
 afterEach(() => dirs.splice(0).forEach(dir => rmSync(dir, { recursive: true, force: true })))
 
 describe('test-intelligence collector', () => {
+  it('drops a build attestation whose matched verdict disagrees with its own SHAs (#7451)', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-attestation-'))
+    dirs.push(repo)
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', `version: 1
+journeys:
+  - id: admin-ui-sso-boundary
+    title: Admin UI SSO boundary
+    status: active
+    severity: ticket
+    money_moving: false
+    workflow: .github/workflows/admin-ui-browser-synthetic.yml
+    workflow_name: Admin UI browser synthetic
+    browser_variants: [chromium, firefox]
+    schedule: "13 */2 * * *"
+    capability: proves the public SSO hand-off
+    falsification: remove the SSO boundary
+`)
+    const envelope = (id: string, variant: string, buildAttestation: unknown) => JSON.stringify({
+      schemaVersion: 1,
+      run: { id, attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Admin UI browser synthetic', url: `https://github.com/JiRaska/open-bank-oss/actions/runs/${id}`, observedAt: '2026-08-25T08:10:00Z' },
+      component: 'openbank-admin-ui', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: 'checks', variant, buildAttestation }],
+    })
+    // chromium: forged — claims a match the SHAs contradict. firefox: honest mismatch.
+    write(repo, 'openbank-admin-ui/test-run-history/chromium.json', envelope('b-1', 'chromium', { requestedSha: 'abc1234', observedSha: '9999999aaaa', matched: true }))
+    write(repo, 'openbank-admin-ui/test-run-history/firefox.json', envelope('b-2', 'firefox', { requestedSha: 'abc1234', observedSha: '9999999aaaa', matched: false }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+    const variants = report.syntheticJourneys.find(item => item.id === 'admin-ui-sso-boundary')?.ci?.variants ?? []
+    const byBrowser = Object.fromEntries(variants.map(variant => [variant.browser, variant]))
+    expect(byBrowser.chromium?.buildAttestation).toBeUndefined()
+    expect(byBrowser.firefox?.buildAttestation).toEqual({ requestedSha: 'abc1234', observedSha: '9999999aaaa', matched: false })
+  })
+
   it('derives inventory, classifies an IT from JUnit identity, parses Kover and keeps missing evidence explicit', () => {
     const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-collector-'))
     dirs.push(repo)
@@ -118,7 +154,8 @@ scenarios:
       schemaVersion: 1,
       run: { id: 'browser-10', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Admin UI browser synthetic', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/browser-10', observedAt: '2026-08-25T08:10:00Z' },
       component: 'openbank-admin-ui', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
-      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed', variant: 'chromium' }],
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed', variant: 'chromium',
+        buildAttestation: { requestedSha: '1234567', observedSha: '123456789abc', matched: true } }],
     }))
     write(repo, 'openbank-admin-ui/test-intelligence-history/previous-snapshot.json', JSON.stringify({
       schemaVersion: 1, collectedAt: '2026-08-24T06:00:00Z', totals: { components: 2 },
@@ -152,7 +189,8 @@ scenarios:
     expect(report.syntheticJourneys.find(item => item.id === 'admin-ui-sso-boundary')).toMatchObject({
       status: 'active', executor: 'github-actions', ci: {
         state: 'passed', detail: '1/1 declared browser variants passed.',
-        variants: [expect.objectContaining({ browser: 'chromium', state: 'passed' })],
+        variants: [expect.objectContaining({ browser: 'chromium', state: 'passed',
+          buildAttestation: { requestedSha: '1234567', observedSha: '123456789abc', matched: true } })],
       },
     })
     expect(report.journeyCoverage).toMatchObject({ moneyPathTotal: 2, activelyCovered: 1, explicitlyUnwatched: 1 })

--- a/openbank-admin-ui/src/test/test-intelligence-flow-attention.test.tsx
+++ b/openbank-admin-ui/src/test/test-intelligence-flow-attention.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TestIntelligenceFlow, testIntelligenceCollectionNeedsAttention,
@@ -367,5 +367,43 @@ describe('Test Intelligence flow attention', () => {
     expect(queue.getAllByText('Synthetic: Sandbox login')).toHaveLength(1)
     expect(queue.queryByText('Required control: synthetic:sandbox-login')).not.toBeInTheDocument()
     expect(queue.getAllByText('Required control: openbank-libs-runtime:mutation')).toHaveLength(1)
+  })
+
+  it('renders rollout-attested, mismatched and plain CI browser evidence distinctly (#7451)', async () => {
+    const variant = (browser: 'chromium' | 'firefox' | 'webkit', state: 'passed' | 'failed', buildAttestation?: { requestedSha: string; observedSha: string | null; matched: boolean }) => ({
+      browser, state, observedAt: '2026-09-01T00:00:00.000Z', detail: `${browser} checks`,
+      run: { id: `b-${browser}`, attempt: 1, commit: 'abc1234def', branch: 'main', workflow: 'Admin UI browser synthetic', url: `https://github.com/JiRaska/open-bank-oss/actions/runs/b-${browser}` },
+      ...(buildAttestation ? { buildAttestation } : {}),
+    })
+    const report = reportFixture({
+      syntheticJourneys: [{
+        id: 'admin-ui-sso-boundary', title: 'Admin UI SSO boundary', status: 'active', capability: 'proves the SSO hand-off',
+        state: 'unknown', severity: 'ticket', executor: 'github-actions', schedule: null, environment: null, covers: [],
+        falsifies: 'remove the SSO boundary', blocker: null,
+        ci: {
+          state: 'failed', observedAt: '2026-09-01T00:00:00.000Z', detail: '1/3 declared browser variants passed.',
+          run: { id: 'b-chromium', attempt: 1, commit: 'abc1234def', branch: 'main', workflow: 'Admin UI browser synthetic', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/b-chromium' },
+          variants: [
+            variant('chromium', 'passed', { requestedSha: 'abc1234', observedSha: 'abc1234def5678', matched: true }),
+            variant('firefox', 'failed', { requestedSha: 'abc1234', observedSha: null, matched: false }),
+            variant('webkit', 'passed'),
+          ],
+        },
+      }] as unknown as TestIntelligenceReport['syntheticJourneys'],
+    })
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => new Response(JSON.stringify(
+      String(input) === '/api/test-intelligence' ? report : { findings: [], available: false },
+    ), { status: 200, headers: { 'content-type': 'application/json' } })))
+
+    render(<TestIntelligencePage />)
+    fireEvent.click(await screen.findByRole('tab', { name: /Synthetics/ }).catch(() => screen.getByText('Synthetics')))
+
+    const chromium = within(await screen.findByLabelText('chromium browser evidence'))
+    expect(chromium.getByLabelText('Rollout-attested evidence')).toHaveTextContent(/requested\s*abc1234.*observed\s*abc1234def56/)
+    const firefox = within(screen.getByLabelText('firefox browser evidence'))
+    expect(firefox.getByLabelText('Deployed build mismatch')).toHaveTextContent(/observed\s*unavailable/)
+    const webkit = within(screen.getByLabelText('webkit browser evidence'))
+    expect(webkit.queryByLabelText('Rollout-attested evidence')).not.toBeInTheDocument()
+    expect(webkit.getByText(/not tied to a specific deployed build/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Refs #7451 — the rendering half, plus the plumbing it turned out to need.

## What was missing

The browser synthetic already asks the deployed Admin UI who it is (`/.well-known/openbank-build-attestation`) and writes `requestedSha` / `observedSha` into its vitals sidecar. **Nothing carried that any further.** `collect-test-run-evidence.py` read only `metrics` and `browser` out of the sidecar, so the attestation was dropped at the first hop, and the System Tests page could not distinguish a run that proved the deployed build from ordinary CI/browser evidence — both rendered identically.

## The change

The attestation now travels the whole path:

```
vitals sidecar → run envelope → collect-test-intelligence → ci.variants[].buildAttestation → page
```

Three decisions worth reviewing:

- **`matched` is derived, never trusted.** Both collectors recompute it from the two SHAs. The script that writes the sidecar is the thing being checked, so a boolean it asserts about itself is not evidence. A forged `matched: true` over contradicting SHAs is recomputed to `false` in Python and dropped in TypeScript.
- **A mismatch or a missing attestation is `failed`, never a pass for the requested build** — with both SHAs in the detail. That is the issue's own acceptance criterion.
- **No request, no attestation.** A run not asked to prove a build carries no `buildAttestation` and renders as *"CI/browser evidence — not tied to a specific deployed build"*. Its absence is not a failed attestation.

The envelope validator accepts `buildAttestation` only on `synthetic` items, only with exactly those three keys, and only when `matched` agrees with the SHAs.

## Verification

| check | result |
|---|---|
| `collect-test-run-evidence.py --self-test` | match / mismatch / unavailable / forged / validator cases pass |
| `test-intelligence-collector` vitest | 24 passed (new case: forged attestation dropped, honest mismatch kept) |
| `test-intelligence-flow-attention` vitest | 16 passed (new case renders all three states) |
| full admin-ui suite (`npm test`, pretest included) | 561 files, 3012 passed, 1 skipped, 0 failed |
| `tsc --noEmit`, eslint on changed files | clean |

Falsified in four directions, each reddening its own test:

| sabotage | red |
|---|---|
| trust the sidecar's `matched` | Python self-test (forged case) |
| remove the mismatch → `failed` downgrade | Python self-test (mismatch case) |
| loosen the TS validator to accept any `matched` | collector vitest (`toBeUndefined`) |
| delete the render block | page render test |

## Not done here

The other half of #7451: a deploy flow that dispatches `admin-ui-browser-synthetic.yml` with `expected_build_sha` after a **bounded, observable** rollout wait. Nothing calls the workflow with that input today, so this PR renders a state that currently only a manual dispatch produces. That half touches deploy mechanics and the issue is explicit that workflow completion must not become an Argo health claim — it deserves its own change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The attestation carries two public git SHAs, nothing else.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No.**
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
