### PR TITLE
fix(ci): classify "Pacticipant not found" as never-published, and run the reconciler's self-test

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3065,6 +3065,28 @@ gates:
     run: |
       bash .github/scripts/resolve-record-deployment-version.sh --self-test
 
+  # The verification reconciler's decision table (pact-reconcile-verifications.py) had a
+  # --self-test that NOTHING ran: the workflow invokes the script for real every ~30 minutes and
+  # never with --self-test, so its classification of owed / failing / never-published / broker
+  # error could regress with every run still green. #9776 is the case that made it matter — the
+  # broker's "Pacticipant X not found" was counted as an error for days, leaving an edge
+  # permanently unevaluated. The self-test pins that classification narrowly (exact sentence,
+  # exact edge side, 4xx only); falsified three ways before wiring in. No broker, no credentials.
+  - id: pact-reconcile-decision-table
+    selftest_exempt: "is-a-test-suite"
+    name: "pact verification reconciler classifies every broker answer (#9776, enforced)"
+    group: api
+    mode: enforced
+    budget_seconds: 20   # pure classification over fixtures + a pacts/*.json scan, measured 0.1s
+    rationale: >-
+      The reconciler is the only control that finds a stranded pact, and its decision table ran
+      in no CI at all; a regression in how it classifies a broker answer would leave edges
+      silently unevaluated while every scheduled run stays green, which is how #9776 hid.
+    review_after: 2027-03-13
+    min_subjects: 25   # 27 decision cases today (2026-09-13); a floor just below the count, far above an emptied table
+    run: |
+      python3 .github/scripts/pact-reconcile-verifications.py --self-test
+
   # The other half of every other gate in this file. Every other gate here reads committed text,
   # because that is what CI can see; this one compares that text to what the cluster actually
   # does. Only the COMPARISON runs in CI — it is a pure function of (snapshot, repo) and is what

--- a/.github/scripts/pact-reconcile-verifications.py
+++ b/.github/scripts/pact-reconcile-verifications.py
@@ -81,6 +81,7 @@ import base64
 import json
 import os
 import pathlib
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -123,6 +124,34 @@ def broker_error_message(reason, url: str, detail: str) -> str:
     if len(detail) > HTTP_ERROR_DETAIL_CHARS:
         detail = detail[:HTTP_ERROR_DETAIL_CHARS] + "\u2026"
     return f"{reason} for {redact_origin(url)}" + (f" \u2014 {detail}" if detail else "")
+
+
+PACTICIPANT_NOT_FOUND = re.compile(r"Pacticipant (\S+?) not found")
+
+
+def missing_pacticipant(error: Exception, consumer: str, provider: str) -> str | None:
+    """Which side of the edge the broker says does not exist, or None if that is not the error.
+
+    #9776. The broker answers a matrix query for a pacticipant that has never published anything
+    with HTTP 400 and `{"errors":["Pacticipant <name> not found"]}`. That is not a broker failure
+    and not a stranded pact: it is the same "never published" state `has_branch_version` already
+    classifies, reached one call earlier. Counting it as an error left the edge permanently
+    unevaluated and indistinguishable from an outage — two days of runs could not say why, and
+    after #9818 printed the body the answer was this sentence.
+
+    Deliberately narrow. Only a 400/404, only this exact sentence, and only when the named
+    pacticipant is EXACTLY one side of this edge — a name that merely contains the provider's
+    name, or a "not found" about something else, stays an error. Anything wider would let a real
+    broker fault be quietly reclassified as a benign state, which is the one direction this
+    reconciler must never drift.
+    """
+    if not isinstance(error, urllib.error.HTTPError) or error.code not in (400, 404):
+        return None
+    for name in PACTICIPANT_NOT_FOUND.findall(str(error)):
+        name = name.strip('"\',')
+        if name in (consumer, provider):
+            return name
+    return None
 
 
 def http_json(url, user, password, timeout=30):
@@ -284,11 +313,23 @@ def main() -> int:
     password = os.environ.get("PACT_BROKER_PASSWORD", "")
 
     owed, failing, unpublished, cannot_publish, errors = {}, [], {}, {}, 0
+    consumer_unpublished = []
     branch_cache = {}
     for consumer, provider in edges:
         try:
             s = matrix_summary(args.broker, consumer, provider, user, password, args.branch)
         except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as e:
+            missing = missing_pacticipant(e, consumer, provider)
+            if missing == provider:
+                # Never published at all: the same state as "no main version", one call earlier.
+                branch_cache[provider] = False
+                unpublished.setdefault(provider, []).append(consumer)
+                continue
+            if missing == consumer:
+                # The consumer's pact was never published, so there is nothing for the provider
+                # to verify and nothing this reconciler could dispatch to change that.
+                consumer_unpublished.append(f"{consumer} -> {provider}")
+                continue
             # Do NOT treat an unreachable broker as "needs verification": that would
             # dispatch the fleet on an outage. Count it and surface it instead.
             sys.stderr.write(f"::warning::{consumer} -> {provider}: broker query failed: {e}\n")
@@ -329,6 +370,12 @@ def main() -> int:
             f"broker — building it cannot publish a result, so its consumers "
             f"({', '.join(sorted(cannot_publish[p]))}) would stay unverified and this "
             f"would re-dispatch every cycle. It needs the @PactBroker half."
+        )
+    for pair in consumer_unpublished:
+        print(
+            f"  CONSUMER NEVER PUBLISHED, not dispatching: {pair} — the broker has no such "
+            f"consumer pacticipant, so no pact exists for the provider to verify. The committed "
+            f"pact file is not on the broker yet."
         )
     for p in sorted(unpublished):
         print(
@@ -526,6 +573,41 @@ def self_test() -> int:
     if not trunc_ok:
         bad.append("truncation")
 
+    # #9776: "Pacticipant X not found" is never-published, not a broker failure — but ONLY for
+    # this exact sentence about exactly one side of this edge.
+    print("\nself-test: an unknown pacticipant is classified, anything else stays an error")
+    def http_err(code, body):
+        return urllib.error.HTTPError(
+            "https://b/matrix", code, broker_error_message("Bad Request", "https://b/matrix?q", body), {}, None,
+        )
+    live = '{"errors":["Pacticipant openbank-case-coordinator-agent not found"]}'
+    classify = [
+        (http_err(400, live), "openbank-case-coordinator-agent",
+         "the live #9776 answer names the PROVIDER as never published"),
+        (http_err(400, '{"errors":["Pacticipant openbank-admin-ui not found"]}'), "openbank-admin-ui",
+         "a missing CONSUMER is named as the consumer"),
+        (http_err(400, '{"errors":["Pacticipant openbank-case-coordinator-agent-v2 not found"]}'), None,
+         "a name that merely CONTAINS the provider is not this edge"),
+        (http_err(400, '{"errors":["Version 1.2.3 not found"]}'), None,
+         "a different 'not found' stays an error"),
+        # The discriminating case: a DIFFERENT sentence that still ends with an edge side's name
+        # right before "not found". Without the "Pacticipant " anchor this would be misread as a
+        # never-published provider and silently stop counting a real broker fault.
+        (http_err(400, '{"errors":["Branch main for openbank-case-coordinator-agent not found"]}'), None,
+         "an edge name in a non-Pacticipant sentence stays an error"),
+        (http_err(500, live), None, "the same sentence on a 5xx stays an error — a fault is a fault"),
+        (urllib.error.URLError("Connection refused"), None, "a transport failure stays an error"),
+    ]
+    for err, want, why in classify:
+        got = missing_pacticipant(err, "openbank-admin-ui", "openbank-case-coordinator-agent")
+        okmark = "ok " if got == want else "BAD"
+        print(f"  {okmark} {why:70s} -> {got}")
+        if got != want:
+            bad.append(why)
+
+    # The floor run-gates holds this gate to: every decision case evaluated above. An emptied
+    # table must not pass as a clean one.
+    gatelib.subjects(len(cases) + len(checks) + len(dispatch_cases) + 1 + len(classify))
     if bad:
         print("\n::error::self-test FAILED: " + "; ".join(bad))
         return 1


### PR DESCRIPTION
Closes #9776.

## The answer the issue was waiting for

After #9818 made the reconciler print the broker's response body, the next scheduled run said:

```
openbank-admin-ui -> openbank-case-coordinator-agent: broker query failed: HTTP Error 400: Bad Request
  for /matrix?q[][pacticipant]=openbank-admin-ui&…&q[][pacticipant]=openbank-case-coordinator-agent&…
  — {"errors":["Pacticipant openbank-case-coordinator-agent not found"]}
```

The provider **has never published anything** to the broker. That is exactly the case the issue predicted — *"If it turns out to be a pacticipant that never published, the honest fix is the same shape the script already uses for providers with no `main` version: report it as unpublished, not as an error."* This does that.

## The change

`missing_pacticipant()` classifies that answer, and deliberately narrowly:

- only HTTP **400/404**;
- only the exact sentence anchored on `Pacticipant `;
- only when the named pacticipant is **exactly** one side of this edge.

A missing provider joins the existing `unpublished` bucket (`NO main VERSION, not dispatching`). A missing consumer is reported as `CONSUMER NEVER PUBLISHED`. **Everything else stays an error** — a wider match would let a real broker fault be quietly reclassified as a benign state, which is the one direction this reconciler must never drift.

## The half that matters as much: the self-test was run by nothing

`pact-verification-reconcile.yml` runs the script for real every ~30 minutes and **never with `--self-test`**, and no gate ran it either. So its whole decision table — owed / failing / never-published / broker error / dispatch deferral — could regress with every run still green. It is now an enforced gate, `pact-reconcile-decision-table`. The model I copied (`record-deployment-version-resolver`) is baselined debt, so the manifest police rightly refused a new gate without its metadata; this one declares `rationale`, `review_after`, `budget_seconds` and **`min_subjects: 25`**, and the self-test now prints `SUBJECTS=27` via `gatelib.subjects` — an emptied decision table fails instead of passing as clean.

## Verification

`run-gates.py --only pact-reconcile-decision-table` → PASS (`SUBJECTS=27`, floor 25). `run-gates.py --group lint --group registry` — the manifest police `--only` skips — and `check-duplicate-yaml-keys.sh` both run too. Falsified three ways, each reddening its own case:

| sabotage | red case |
|---|---|
| accept the sentence on a 5xx | `the same sentence on a 5xx stays an error` |
| prefix-match the pacticipant name | `a name that merely CONTAINS the provider is not this edge` |
| drop the `Pacticipant ` anchor | `an edge name in a non-Pacticipant sentence stays an error` |

Worth stating: the third sabotage **initially passed**. My first "different not found" fixture (`Version 1.2.3 not found`) captured a token that named neither side, so it could not tell the anchored regex from an unanchored one. The fixture that now discriminates puts an edge side's name inside a non-Pacticipant sentence.

## What this does not do

It does not make `case-coordinator-agent` publish. Whether it *should* have a `@PactBroker` provider verification is a separate question — this only stops the reconciler reporting a known state as an unknown failure.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The warning path still redacts the broker host (existing, self-tested).
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No.**
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
