### PR TITLE
feat(ci): derive each release's end-of-support into its evidence bundle

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3042,6 +3042,25 @@ gates:
   # inside the build and the pact stays unverified, which looks identical to the
   # strand the reconciler was built to remove. Reads the committed pacts, so no
   # broker and no credentials.
+  # End-of-support is DERIVED from SECURITY.md's policy and carried in every release's evidence
+  # bundle (#9881). The derivation has two ways to be quietly wrong — taking the build time instead
+  # of the release date, and inventing the "90 days after supersession" bound for a beta release
+  # that has no successor yet — and nothing else would ever notice either; this runs its table.
+  - id: release-support-period-derivation
+    selftest_exempt: "is-a-test-suite"
+    name: "release end-of-support is derived from the policy, not invented (#9881, enforced)"
+    group: supplychain
+    mode: enforced
+    budget_seconds: 10   # pure date arithmetic over a fixture table
+    rationale: >-
+      The end-of-support date in a release's evidence bundle is a public CRA commitment computed
+      by a script no other check reads; a wrong rule would publish wrong dates on every release
+      while every release still verified green.
+    review_after: 2027-03-13
+    min_subjects: 6   # 8 derivation cases today (2026-09-13)
+    run: |
+      python3 .github/scripts/release_support_period.py --self-test
+
   - id: pacticipant-matches-module
     name: "pacticipant name is a module directory (Pact webhook contract)"
     group: api

--- a/.github/scripts/build-release-evidence.sh
+++ b/.github/scripts/build-release-evidence.sh
@@ -157,9 +157,19 @@ ATTRIB="$( { git log "$RANGE" --pretty='%an <%ae>' -- "$MODULE_DIR" 2>/dev/null;
              git log "$RANGE" --pretty='%(trailers:key=Co-authored-by,valueonly)' -- "$MODULE_DIR" 2>/dev/null; } \
            | sed '/^$/d' | sort -u )"
 
+# ── Support period (#9881) ──────────────────────────────────────────────────────
+# Derived from SECURITY.md's rules against the RELEASE date — the tagged commit's date — never
+# from `built_at`: backfill-release-evidence.yml runs this months after a release, and deriving
+# from the build time would silently push every backfilled end-of-support into the future. Both
+# callers check out the released commit, so HEAD's committer date IS the release date.
+RELEASED_ON="$(git log -1 --format=%cs HEAD)"
+SUPPORT_JSON="$(python3 "$(dirname "$0")/release_support_period.py" "$VERSION" "$RELEASED_ON")" \
+  || { echo "::error::could not derive the support period for $TAG ($VERSION, $RELEASED_ON)"; exit 1; }
+
 # ── Evidence bundle manifest ────────────────────────────────────────────────────
 EV_OUT="${TAG}.evidence.json"
 TS="$TS" COMPONENT="$COMPONENT" VERSION="$VERSION" TAG="$TAG" SHA="$SHA" REPO="$REPO" \
+SUPPORT_JSON="$SUPPORT_JSON" \
 SBOM_BASENAME="$(basename "$SBOM_FILE")" SBOM_SHA="$SBOM_SHA" \
 SLSA_OUT="$SLSA_OUT" VEX_OUT="$VEX_OUT" RUN_URL="$RUN_URL" \
 CHANGELOG_EXCERPT="$CHANGELOG_EXCERPT" ATTRIB="$ATTRIB" \
@@ -183,6 +193,9 @@ bundle = {
     "vex": {"file": os.environ["VEX_OUT"], "format": "openvex/0.2.0",
             "sha256": sha(os.environ["VEX_OUT"]), "signature": os.environ["VEX_OUT"] + ".sig"},
     "changelog": os.environ.get("CHANGELOG_EXCERPT", "").strip(),
+    # End-of-support as data (SECURITY.md; CRA Art. 13(8)). A beta release carries only the
+    # determined floor and `open_ended: true` — its later bound depends on a future release.
+    "support": json.loads(os.environ["SUPPORT_JSON"]),
     "ai_attribution": {
         "contributors": attrib,
         "build_attribution_note": "authors + Co-Authored-By trailers since previous component tag (ADR-0029 D6)",

--- a/.github/scripts/release_support_period.py
+++ b/.github/scripts/release_support_period.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Derive a release's end-of-support from SECURITY.md's policy — never declare it by hand (#9881).
+
+SECURITY.md, "Support period and end-of-support (per released component)":
+
+  * beta (0.x): supported 12 months from the release date, OR 90 days after the release that
+    supersedes it — whichever is later;
+  * from a component's first 1.x release: 5 years from that release's date (CRA Art. 13(8)).
+
+and it states that end-of-support is DATA derived mechanically from those rules against the
+release date, to be carried in the evidence bundle. This module is that derivation.
+
+Two things it is careful about:
+
+1. THE RELEASE DATE, NOT THE BUILD TIME. build-release-evidence.sh stamps `built_at` with the
+   current time. For the release-please job that is minutes after the release; for
+   backfill-release-evidence.yml it can be months later. Deriving from `built_at` would silently
+   push every backfilled release's end-of-support into the future. The caller passes the tagged
+   commit's date.
+
+2. SAYING WHAT IS NOT YET KNOWN. For a 0.x release the "90 days after supersession" half depends
+   on a release that does not exist at build time. The derivation therefore publishes the
+   12-month FLOOR and marks the date `open_ended`, rather than inventing the later bound.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+
+BETA_MONTHS = 12
+BETA_AFTER_SUPERSEDED_DAYS = 90
+PRODUCTION_YEARS = 5
+
+
+def _add_months(d: dt.date, months: int) -> dt.date:
+    y, m = divmod(d.month - 1 + months, 12)
+    year, month = d.year + y, m + 1
+    # Clamp to the month's last day: 2026-02-29 does not exist, a leap-day release maps to Feb 28.
+    for day in (d.day, 30, 29, 28):
+        try:
+            return dt.date(year, month, min(d.day, day))
+        except ValueError:
+            continue
+    raise ValueError(d)
+
+
+def derive(version: str, released_on: dt.date) -> dict:
+    parts = version.lstrip("v").split(".")
+    if len(parts) < 2 or not all(p.isdigit() for p in parts[:2]):
+        raise ValueError(f"not a semantic version: {version!r}")
+    major = int(parts[0])
+    if major >= 1:
+        return {
+            "policy": "production",
+            "released_on": released_on.isoformat(),
+            "end_of_support": _add_months(released_on, PRODUCTION_YEARS * 12).isoformat(),
+            "open_ended": False,
+            "rule": f"{PRODUCTION_YEARS} years from the release date (SECURITY.md; CRA Art. 13(8))",
+        }
+    return {
+        "policy": "beta",
+        "released_on": released_on.isoformat(),
+        "end_of_support_floor": _add_months(released_on, BETA_MONTHS).isoformat(),
+        "open_ended": True,
+        "rule": (f"{BETA_MONTHS} months from the release date, or {BETA_AFTER_SUPERSEDED_DAYS} days after "
+                 f"the superseding release, whichever is later (SECURITY.md) — the later bound depends on "
+                 f"a release that does not exist yet, so only the floor is determined"),
+    }
+
+
+def self_test() -> int:
+    d = dt.date
+    cases = [
+        (("1.22.0", d(2026, 9, 13)), {"policy": "production", "end_of_support": "2031-09-13", "open_ended": False}),
+        (("0.39.0", d(2026, 9, 13)), {"policy": "beta", "end_of_support_floor": "2027-09-13", "open_ended": True}),
+        (("v2.0.1", d(2026, 1, 31)), {"policy": "production", "end_of_support": "2031-01-31"}),
+        (("0.1.0", d(2024, 2, 29)), {"end_of_support_floor": "2025-02-28"}),   # leap day clamps
+        (("0.9.3", d(2026, 12, 31)), {"end_of_support_floor": "2027-12-31"}),  # year rollover
+    ]
+    bad = 0
+    for (ver, when), want in cases:
+        got = derive(ver, when)
+        ok = all(got.get(k) == v for k, v in want.items())
+        # A beta release must never carry a determined end_of_support: that is the invented bound.
+        if got["policy"] == "beta" and "end_of_support" in got:
+            ok = False
+        print(f"  {'ok ' if ok else 'BAD'} {ver} released {when}: {got}")
+        bad += 0 if ok else 1
+    for junk in ("latest", "1", ""):
+        try:
+            derive(junk, d(2026, 1, 1))
+            print(f"  BAD {junk!r} accepted as a version")
+            bad += 1
+        except ValueError:
+            print(f"  ok  {junk!r} rejected")
+    print(f"SUBJECTS={len(cases) + 3}")
+    print("release support-period self-test: " + ("PASS" if not bad else f"FAIL ({bad})"))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        sys.exit(self_test())
+    if len(sys.argv) != 3:
+        sys.exit("usage: release_support_period.py <version> <YYYY-MM-DD> | --self-test")
+    print(json.dumps(derive(sys.argv[1], dt.date.fromisoformat(sys.argv[2]))))


### PR DESCRIPTION
Refs #9881 — end-of-support as data, where `SECURITY.md` already says it belongs.

## Why here, and not the approach the issue first proposed

`SECURITY.md` ("Support period and end-of-support") already sets the policy and says end-of-support is **derived mechanically from the release date** and carried in the **evidence bundle**. No release's `evidence.json` carried it. I first built a hand-declared `endOfSupport` in `governance.yaml` (schema, generator, tests — green) and discarded it: a manual field next to a rule that says the value is computed is a second source of truth. The correction is on #9881.

## The change

`release_support_period.py` derives, and `build-release-evidence.sh` writes the result into every bundle:

```json
"support": {
  "policy": "beta",
  "released_on": "2026-09-13",
  "end_of_support_floor": "2027-09-13",
  "open_ended": true,
  "rule": "12 months from the release date, or 90 days after the superseding release, whichever is later (SECURITY.md) — …"
}
```

| release | derived |
|---|---|
| 1.x | `end_of_support` = release date + 5 years, `open_ended: false` (CRA Art. 13(8)) |
| 0.x | `end_of_support_floor` = release date + 12 months, `open_ended: true` |

## Two ways this could have been quietly wrong

1. **Release date, not build time.** `built_at` is the current time. The release-please job runs minutes after the release, but `backfill-release-evidence.yml` runs this **months** later — deriving from `built_at` would push every backfilled end-of-support into the future. The script uses the tagged commit's committer date; both callers check out the released commit, so `HEAD` is that commit.
2. **Not inventing the unknown bound.** Beta support is "12 months, or 90 days after the superseding release, whichever is later", and the successor does not exist yet. The bundle publishes the **floor** and `open_ended: true` — never a determined `end_of_support` that would be a guess.

## Verification

| check | result |
|---|---|
| derivation self-test (1.x, 0.x, `v`-prefix, leap day, year rollover, 3 junk versions) | 8 pass |
| sabotage: beta carries a determined `end_of_support` | 3 cases red |
| sabotage: remove month-end clamp | leap-day release fails |
| bundle heredoc run with a real derived value | valid JSON, `support` block present |
| `run-gates.py --only release-support-period-derivation`, manifest police, duplicate keys | pass |

Does not affect release verification: `verify-release-evidence.yml` checks only signatures and the `sbom` / `slsa_provenance` / `vex` digests. The block is inside `evidence.json`, which is itself signed, so it is covered by the existing signature.

Not run here: a real release end-to-end — it signs with the KMS cosign key. The first release after merge is the measurement; its `evidence.json` should carry the block with the tagged commit's date.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No.**
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
