### PR TITLE
security: point every security.txt at the public disclosure policy, and check it stays there

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3042,6 +3042,28 @@ gates:
   # inside the build and the pact stays unverified, which looks identical to the
   # strand the reconciler was built to remove. Reads the committed pacts, so no
   # broker and no credentials.
+  # Every published security.txt must send a reporter to a policy they can read (#9880). On
+  # 2026-09-13 the file open-bank.tech actually served, and the admin-ui copy, both pointed Policy
+  # at a PRIVATE repository (404 for every external researcher); the developer-portal copy pointed
+  # Policy at itself. The public SECURITY.md existed the whole time. Offline and decidable: Policy
+  # must name a file in this public repo, not the file itself; Expires must be in the future.
+  - id: security-txt-policy-reachable
+    name: "security.txt points reporters at a public policy that exists (#9880, enforced)"
+    group: security
+    mode: enforced
+    budget_seconds: 20   # three small files plus an rglob, measured well under 1s
+    rationale: >-
+      A disclosure policy link that answers 404 to the people it is for is invisible to every
+      scanner and every reviewer, and it shipped on all three hosts; only a check that resolves the
+      link against this repository can notice it.
+    review_after: 2027-03-13
+    min_subjects: 3   # landing, admin-ui, developer-portal today
+    selftest: python3 .github/scripts/check-security-txt.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/check-security-txt.py"]
+    run: |
+      python3 .github/scripts/check-security-txt.py
+
   - id: pacticipant-matches-module
     name: "pacticipant name is a module directory (Pact webhook contract)"
     group: api

--- a/.github/scripts/check-security-txt.py
+++ b/.github/scripts/check-security-txt.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Every published security.txt must send a reporter somewhere they can actually read (#9880).
+
+WHY THIS EXISTS
+---------------
+Measured 2026-09-13: the security.txt that https://open-bank.tech actually serves (byte-identical
+to openbank-infra/web/landing/.well-known/security.txt) and the admin-ui copy both said
+
+    Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
+
+and that repository is PRIVATE — the URL answers 404 to anyone who is not its owner, which is
+every external security researcher. The developer-portal copy's Policy pointed at the
+security.txt itself. So the one machine-readable pointer RFC 9116 gives a reporter led nowhere,
+on all three hosts, while the real policy (SECURITY.md, public) existed the whole time.
+
+Nothing noticed because nothing looks: the file validates, a scanner sees a well-formed Policy
+field, and the 404 only happens in the browser of the person trying to report something.
+
+WHAT IT CHECKS (fully decidable, offline)
+-----------------------------------------
+For every `.well-known/security.txt` in the tree:
+  * `Contact:` is present;
+  * `Expires:` parses as ISO-8601 and is in the future (RFC 9116 §2.5.5 — a stale file is
+    treated as untrustworthy by scanners);
+  * `Policy:` is present, is NOT the file's own Canonical URL (a policy that is the contact file
+    is no policy), and points INTO THIS PUBLIC REPOSITORY at a file that exists in the tree.
+
+The last rule is deliberately narrower than "some reachable URL". Reachability is a network
+fact this gate cannot establish, and the defect above was a URL that *looked* reachable. A path
+this repository contains is a claim the gate can verify, and this repository is public.
+
+Usage:  check-security-txt.py [--root .]
+        check-security-txt.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import pathlib
+import re
+import sys
+import tempfile
+
+REPO_BLOB = re.compile(r"^https://github\.com/JiRaska/open-bank-oss/blob/main/(?P<path>[^?#]+)$")
+
+
+def fields(text: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out.setdefault(key.strip().lower(), []).append(value.strip())
+    return out
+
+
+def problems(path: pathlib.Path, root: pathlib.Path, now: dt.datetime) -> list[str]:
+    f = fields(path.read_text(encoding="utf-8", errors="replace"))
+    rel = path.relative_to(root).as_posix()
+    out: list[str] = []
+    if not f.get("contact"):
+        out.append(f"{rel}: no Contact: field")
+    expires = (f.get("expires") or [None])[0]
+    if not expires:
+        out.append(f"{rel}: no Expires: field")
+    else:
+        try:
+            when = dt.datetime.fromisoformat(expires.replace("Z", "+00:00"))
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=dt.timezone.utc)
+            if when <= now:
+                out.append(f"{rel}: Expires {expires} is in the past — renew the file")
+        except ValueError:
+            out.append(f"{rel}: Expires {expires!r} is not ISO-8601")
+    policy = (f.get("policy") or [None])[0]
+    canonical = (f.get("canonical") or [None])[0]
+    if not policy:
+        out.append(f"{rel}: no Policy: field")
+    elif canonical and policy == canonical:
+        out.append(f"{rel}: Policy points at this security.txt itself — that is a contact file, not a policy")
+    else:
+        m = REPO_BLOB.match(policy)
+        if not m:
+            out.append(
+                f"{rel}: Policy {policy} does not point into this public repository. A URL this gate "
+                f"cannot resolve is exactly how all three hosts published a policy that answered 404 "
+                f"(#9880) — link a document under https://github.com/JiRaska/open-bank-oss/blob/main/"
+            )
+        elif not (root / m.group("path")).is_file():
+            out.append(f"{rel}: Policy names {m.group('path')}, which does not exist in this tree")
+    return out
+
+
+def scan(root: pathlib.Path, now: dt.datetime) -> tuple[int, list[str]]:
+    files = sorted(p for p in root.rglob(".well-known/security.txt")
+                   if "node_modules" not in p.parts and ".git" not in p.parts)
+    found: list[str] = []
+    for p in files:
+        found.extend(problems(p, root, now))
+    return len(files), found
+
+
+def self_test() -> int:
+    now = dt.datetime(2026, 9, 13, tzinfo=dt.timezone.utc)
+    good = ("Contact: mailto:security@example.org\nExpires: 2027-06-11T00:00:00.000Z\n"
+            "Policy: https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md\n"
+            "Canonical: https://example.org/.well-known/security.txt\n")
+    cases = {
+        "good": (good, []),
+        "private-repo policy (the #9880 defect)": (
+            good.replace("open-bank-oss/blob/main/SECURITY.md", "openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md"),
+            ["does not point into this public repository"]),
+        "policy is itself": (
+            good.replace("Policy: https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md",
+                         "Policy: https://example.org/.well-known/security.txt"),
+            ["Policy points at this security.txt itself"]),
+        "policy names a missing file": (
+            good.replace("SECURITY.md", "docs/NOPE.md"), ["does not exist in this tree"]),
+        "expired": (good.replace("2027-06-11", "2026-01-01"), ["in the past"]),
+        "no contact": (good.replace("Contact: mailto:security@example.org\n", ""), ["no Contact"]),
+    }
+    bad = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        (root / "SECURITY.md").write_text("policy\n")
+        for i, (name, (body, want)) in enumerate(cases.items()):
+            d = root / f"site{i}" / ".well-known"
+            d.mkdir(parents=True)
+            (d / "security.txt").write_text(body)
+            got = problems(d / "security.txt", root, now)
+            ok = (not want and not got) or (want and len(got) == len(want) and all(w in g for w, g in zip(want, got, strict=True)))
+            print(f"  {'ok ' if ok else 'BAD'} {name}: {got}")
+            bad += 0 if ok else 1
+    print(f"SUBJECTS={len(cases)}")
+    print("security.txt self-test: " + ("PASS" if not bad else f"FAIL ({bad})"))
+    return 1 if bad else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    root = pathlib.Path(args.root).resolve()
+    count, found = scan(root, dt.datetime.now(dt.timezone.utc))
+    print(f"SUBJECTS={count}")
+    for p in found:
+        print(f"::error::{p}")
+    print(f"check-security-txt: {count} security.txt file(s), {len(found)} problem(s)")
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-admin-ui/public/.well-known/security.txt
+++ b/openbank-admin-ui/public/.well-known/security.txt
@@ -3,6 +3,6 @@
 
 Contact: mailto:security@open-bank.tech
 Expires: 2027-06-11T00:00:00.000Z
-Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
+Policy: https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md
 Preferred-Languages: cs, en
 Canonical: https://admin.open-bank.tech/.well-known/security.txt

--- a/openbank-developer-portal/site/.well-known/security.txt
+++ b/openbank-developer-portal/site/.well-known/security.txt
@@ -5,4 +5,4 @@ Contact: mailto:security@open-bank.tech
 Expires: 2027-06-15T00:00:00.000Z
 Preferred-Languages: en, cs
 Canonical: https://developer.open-bank.tech/.well-known/security.txt
-Policy: https://developer.open-bank.tech/.well-known/security.txt
+Policy: https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md

--- a/openbank-infra/web/landing/.well-known/security.txt
+++ b/openbank-infra/web/landing/.well-known/security.txt
@@ -3,6 +3,6 @@
 
 Contact: mailto:security@open-bank.tech
 Expires: 2027-06-11T00:00:00.000Z
-Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
+Policy: https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md
 Preferred-Languages: cs, en
 Canonical: https://open-bank.tech/.well-known/security.txt


### PR DESCRIPTION
Refs #9880 — a live defect found while scoping the disclosure-policy work, fixed and guarded.

## The defect

The `security.txt` that **https://open-bank.tech actually serves** (byte-identical to `openbank-infra/web/landing/.well-known/security.txt` — diffed against the live response) and the admin-ui copy both said:

```
Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
```

`JiRaska/openbank-app` is a **private** repository. Anonymous requests:

```
404  https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
404  https://raw.githubusercontent.com/JiRaska/openbank-app/main/docs/VULNERABILITY-DISCLOSURE.md
200  https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md
200  https://github.com/JiRaska/open-bank-oss/security/advisories/new
```

So the one machine-readable pointer RFC 9116 gives a researcher answered **404 to every external reporter** — the only audience it exists for — on the main domain and on admin. The developer-portal copy's `Policy:` pointed at the `security.txt` itself. Meanwhile the real policy, `SECURITY.md`, was public and complete.

Nothing noticed because nothing looks: the file validates, a scanner sees a well-formed `Policy:` field, and the 404 happens only in the browser of the person trying to report something.

## The fix

All three `Policy:` fields now name `https://github.com/JiRaska/open-bank-oss/blob/main/SECURITY.md`. **Only that line changes** — `Contact`, `Expires`, languages and `Canonical` are untouched.

## The guard

`check-security-txt.py`, enforced as `security-txt-policy-reachable`. Offline and decidable, for every `.well-known/security.txt` in the tree:

- `Contact:` present;
- `Expires:` parses and is in the future (RFC 9116 — a stale file is untrustworthy to scanners);
- `Policy:` is not the file's own `Canonical`, and names a file that **exists in this public repository**.

The last rule is deliberately narrower than "some reachable URL". Reachability is a network fact this gate cannot establish — and the defect was precisely a URL that *looked* reachable.

## Verification

| check | result |
|---|---|
| gate on **unfixed `main`** | exit 1 — flags all three files (2 × private-repo policy, 1 × self-referencing) |
| gate on this tree | exit 0 — `3 security.txt file(s), 0 problem(s)` |
| self-test | 6 cases pass |
| sabotage: remove the in-repo rule | the private-repo case goes red |
| duplicate-key check | pass |
| manifest police (`--group lint --group registry`) | **62/63 on the first run** — `python-lint` failed on my new script (ruff `B905`, `zip()` without `strict=`). Fixed with `strict=True` (lengths are compared just before). Re-ran `--only python-lint` and `--only security-txt-policy-reachable` after the fix, both pass; I did **not** re-run the whole police, since the fix touched one line of one script and nothing the other 61 gates read. |

## Not done here

The rest of #9880 — whether `SECURITY.md` should state acknowledgement/remediation **commitments** as numbers. Those are the owner's to set; this PR only makes sure a reporter can reach the policy that exists.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? **No** — a public contact file and a repo check.
- [x] PII path changed? **No.**
- [x] Cardholder data path changed? **No.**

## Compliance impact

- [ ] PCI DSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
