### PR TITLE
fix(ci): make spot-kill auto-retry reach its decision again

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -120,24 +120,36 @@ jobs:
   discover:
     name: Find recent runs requiring reconciliation
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Room for the rate-limit waits below (3 calls x up to 2 waits of 120s) plus the calls.
+    timeout-minutes: 15
     outputs:
       retry: ${{ steps.select.outputs.retry }}
       flakes: ${{ steps.select.outputs.flakes }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          sparse-checkout: .github/scripts/select-ci-reconcile-candidates.py
+          sparse-checkout: |
+            .github/scripts/select-ci-reconcile-candidates.py
+            .github/scripts/gh-retry.sh
+            .github/scripts/gh-transient-patterns.txt
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # Through gh_retry, like every other API call in this workflow. Bare, this call was the one
+      # the #6255 lesson never reached: 8 of the last 13 failures of this workflow (2026-09-12/13)
+      # were `API rate limit exceeded for installation` (HTTP 403) on its first request, so the
+      # tick found no candidates and raised the retry-failure issue with nothing to retry.
+      # The wait is capped short on purpose: the 30-minute lookback spans six ticks, so a tick that
+      # still loses to the limit is re-covered by the next one rather than waited out here.
       - name: Read recent completions from the three watched workflows
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_RETRY_MAX_WAIT_SECONDS: "120"
         run: |
           set -euo pipefail
+          source .github/scripts/gh-retry.sh
           cutoff=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           for workflow in services-ci.yml security.yml dependency-submission.yml; do
-            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
+            gh_retry 3 -- gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
               -f status=completed -f per_page=100 -f "created=>=${cutoff}" --paginate --slurp \
               | jq 'map(.workflow_runs) | add' > "${RUNNER_TEMP}/${workflow}.json"
           done
@@ -205,6 +217,11 @@ jobs:
             .github/scripts/gh-retry.sh
             .github/scripts/gh-transient-patterns.txt
           sparse-checkout-cone-mode: false
+          # Under `with:`, not in the step below. #9730 inserted the assert step directly above
+          # this key, which moved it into that step's `run:` script: every candidate then died on
+          # `persist-credentials:: command not found` (exit 127) before any decision, and this
+          # checkout silently fell back to persisting the token in a job holding `actions: write`.
+          persist-credentials: false
 
       - name: Assert the sparse checkout is complete
         run: |
@@ -227,7 +244,6 @@ jobs:
             echo "[$section] patterns: $n"
           done
           [ "$missing" -eq 0 ]
-          persist-credentials: false
 
       - name: Re-run only if the runner was reclaimed
         env:


### PR DESCRIPTION
## What

`auto-retry-cancelled.yml` has not re-run a spot-killed CI run since 2026-09-12. #9867 has been
refreshed 11 times. Its body points at the `-R` / `GH_REPO` regression, or at a rate limit that outlasted
`gh_retry`. Neither is what happened. The last 13 failures (`gh run list --workflow
auto-retry-cancelled.yml -L 100`, 2026-09-12T16:29Z..09-13T05:48Z) have **two** causes, split by
failing job:

| failing job | count | decisive log line |
|---|---:|---|
| `Re-run spot-killed run (once)` | 5 | `persist-credentials:: command not found`, exit 127 |
| `Find recent runs requiring reconciliation` | 8 | `gh: API rate limit exceeded for installation ... (HTTP 403)` |

### 1. Every candidate died before its decision (exit 127)

#9730 added the `Assert the sparse checkout is complete` step directly above the checkout's
`persist-credentials: false` line. That moved the line out of `with:` and into the new step's `run:`
script (`git blame`: the key dates from 2026-08-23, the step from #9730 on 2026-09-12). So the step
ran `persist-credentials: false` as a shell command. Two consequences:

- every run with a retry candidate exited 127 in the assert step, before `spot-kill-retry.sh`
  classified anything. That job is the whole point of the workflow.
- the checkout in a job holding `actions: write` silently went back to the default
  `persist-credentials: true`. The run log shows it: `persist-credentials: true`.

The fix puts the key back under `with:`, with a comment saying why it has to stay there.

### 2. Discovery had no transient handling

The `discover` job's `gh api` call was the one bare API call left in this workflow. The #6255
lesson reached the rerun path, not this one. A single installation 403 failed the tick, and
`raise-issue` then filed "a spot-killed run was not re-run" with no candidate in hand.
The call now goes through `gh_retry` (3 attempts, `GH_RETRY_MAX_WAIT_SECONDS=120`). Both library
files join the sparse checkout. `timeout-minutes` goes from 5 to 15 to fit the waits.

The cap is short on purpose. The selector's 30-minute lookback spans six 5-minute ticks, so a tick
that still loses to the limit is covered again by the next tick. Waiting out a long limit here would
only hold the `ci-reconcile` concurrency group.

## Verification

| check | result |
|---|---|
| `Assert` step's `run:` script, extracted from `origin/main` and executed | exit **127**, `persist-credentials:: command not found` (reproduces the CI failure) |
| same step extracted from this branch | exit 0 |
| `retry` checkout `with.persist-credentials` parsed from the YAML | `False` |
| fleet scan: any workflow `run:` line shaped like a step key (`persist-credentials:`, `uses:`, `with:` ...) | 1 hit on `main` (this one), 0 on this branch |
| discover pipeline with a stub `gh`: one installation-403, then data | exit 0, 1 retry, JSON through `jq` |
| same stub **without** `gh_retry` (today's shape) | exit 1 |
| stub rate-limited on all 3 attempts | exit 1 after 2 retries (still reaches `raise-issue`) |
| stub answering a final error (`HTTP 404`) | exit 1, 0 retries |
| `actionlint` | clean |
| `run-gates.py --group lint --group registry` | 63/63 PASS |

Not verified end-to-end. A real spot reclaim cannot be produced on demand. The decision script itself
is unchanged and still covered by the `spot-kill-retry-selftest` gate.

## Follow-ups, not in this PR

- `raise-issue`'s body names `-R` and exhausted retries as the likely causes, and fills both
  "this run" and "triggering run" with this workflow's own URL (on a `schedule` event there is no
  triggering run). That sent diagnosis the wrong way for 11 refreshes.
- A key moved into a `run:` block passes `actionlint` and every gate. The fleet scan above is cheap
  enough to become one.

A workflow change: needs a human to land it.

Closes #9867
Refs #9730, #6255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
