### PR TITLE
fix(governance): bound a pentest attestation's ops by the declared OpenAPI surface

### DIFF
--- a/.github/scripts/check-readiness-attestations.py
+++ b/.github/scripts/check-readiness-attestations.py
@@ -110,6 +110,40 @@ EXERCISE_REF_DEBT: dict[str, str] = {}
 PENTEST_OPS_FLOOR = 5
 CI_BY_RE = re.compile(r"^ci-")
 
+# R8b (issue #9673) -- `ops` is hand-transcribed into this file next to the claim it justifies,
+# and nothing tied it to anything. Bound it by the one thing in the repo it cannot exceed: the
+# operations the service's committed OpenAPI declares (exercised = selected - auth_blocked <=
+# selected <= declared). A count above the declared surface is a typo, a sibling service's number
+# copied across, or a measurement of a surface the service no longer has -- all three were
+# undetectable. It is an upper bound only: an optimistic count BELOW the surface still passes, and
+# only the run's fuzz-reports/<svc>-ops*.json can settle that, which this offline gate cannot read.
+#
+# Counted with a line grammar, not yaml, because this gate degrades rather than requires pyyaml.
+# Checked against yaml.safe_load over all 56 committed specs: zero disagreements.
+SPEC_REL = "src/main/resources/openapi.yaml"
+_SPEC_OPERATION_RE = re.compile(r"^    (get|put|post|delete|patch|head|options|trace):\s*$")
+
+
+def spec_operation_count(module: pathlib.Path) -> int | None:
+    """Operations declared under the top-level `paths:` of the module's OpenAPI, or None."""
+    spec = module / SPEC_REL
+    if not spec.is_file():
+        return None
+    inside = False
+    count = 0
+    for line in spec.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line.rstrip() == "paths:":
+            inside = True
+            continue
+        if inside and not line[0].isspace():
+            inside = False  # the next top-level key (components:, tags:, ...) ends `paths:`
+        if inside and _SPEC_OPERATION_RE.match(line):
+            count += 1
+    return count
+
+
 # CI-minted pentest attestations that predate R8. Shrink-only, checked BOTH WAYS:
 # a new ci-* pentest entry without ops fails, and a baselined entry that gains ops
 # (or leaves the file) is reported so the exemption cannot rot into permanence.
@@ -374,6 +408,24 @@ def check(
                         f"a meaningfully larger surface first"
                     )
                     continue
+                declared = spec_operation_count(repo / f"openbank-{svc}-service")
+                if declared is None:
+                    errors.append(
+                        f"{where}: `{debt_key}` records ops={ops}, but openbank-{svc}-service has "
+                        f"no {SPEC_REL} -- there is no declared surface a fuzz run could have "
+                        f"exercised, so the count cannot be checked against anything (#9673)"
+                    )
+                    continue
+                if ops > declared:
+                    errors.append(
+                        f"{where}: `{debt_key}` records ops={ops}, more than the {declared} "
+                        f"operation(s) openbank-{svc}-service/{SPEC_REL} declares -- exercised "
+                        f"operations cannot exceed the declared surface, so this is a "
+                        f"transcription error, a count copied from another service, or a "
+                        f"measurement of a surface the service no longer has. Re-read ops from "
+                        f"the run's fuzz-reports/<svc>-ops*.json (#9673)"
+                    )
+                    continue
 
         # Freshness. Exact calendar arithmetic, deliberately: the collector approximates a
         # month as 30 days, which lets a TTL run a day or two past its own expiry.
@@ -605,6 +657,18 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
             "clean",
             True,
         ),
+        (
+            "R8b: ops one above the declared OpenAPI surface is a transcription, not a measurement (#9673)",
+            f"audit:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-schemathesis, ref: {good_ref}, ops: 14 }}\n",
+            "error",
+            True,
+        ),
+        (
+            "R8b: ops for a service with no committed OpenAPI cannot be checked (#9673)",
+            f"consent:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-schemathesis, ref: {good_ref}, ops: 13 }}\n",
+            "error",
+            True,
+        ),
     ]
 
     failures = 0
@@ -614,6 +678,17 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
         (tmp / "openbank-ledger-service").mkdir()
         (tmp / "openbank-consent-service").mkdir()
         (tmp / "openbank-audit-service").mkdir()
+        # R8b fixture: exactly 13 declared operations, so the TRUE ENTRY at ops: 13 sits ON the
+        # bound and ops: 14 is one above it. The trailing `components:` block carries
+        # method-shaped keys at the same indent: a counter that does not stop at the end of
+        # `paths:` reads 15 and lets ops: 14 through. A comment at column 0 inside `paths:` must
+        # not end the block either.
+        (tmp / "openbank-audit-service/src/main/resources").mkdir(parents=True)
+        (tmp / "openbank-audit-service" / SPEC_REL).write_text(
+            "openapi: 3.0.3\npaths:\n# a column-0 comment inside paths\n"
+            + "".join(f"  /r{i}:\n    get:\n      responses: {{}}\n" for i in range(13))
+            + "components:\n  x:\n    get:\n      y: 1\n    post:\n      y: 1\n"
+        )
         (tmp / "docs/runbooks").mkdir(parents=True)
         (tmp / "docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md").write_text("x")
         (tmp / "docs/bcp").mkdir(parents=True)


### PR DESCRIPTION
## What

R8 in `check-readiness-attestations.py` requires a CI-minted `pentest` attestation to carry
`ops: N`. That `N` is typed by hand into `attestations.yaml`, right next to the claim it is meant to
justify. Nothing tied it to anything, so a typo, a count copied from a sibling service, or a
measurement of a surface the service has since lost would all pass (#9673, property 1).

This adds **R8b**: `ops` may not exceed the number of operations the service's committed
`src/main/resources/openapi.yaml` declares. The bound is sound because
`exercised = selected - auth_blocked <= selected <= declared`. A CI-minted pentest with `ops` and
no committed spec is also an error, because there is no declared surface to check the count
against.

## What it does not do, stated so it is not read as more

- **Upper bound only.** A count below the true surface still passes. Only the run's
  `fuzz-reports/<svc>-ops*.json` can settle that, and this gate runs offline with no access to run
  artifacts. Comparing the attestation with that artifact is the remaining half of #9673, so this
  PR says `Refs`, not `Closes`.
- **Staleness (#9673 property 2) is covered only where the surface shrank.** If a service drops
  operations below the recorded `ops`, R8b now fails. A surface that changed shape at the same size
  is still invisible.
- The bound is against the committed spec. The fuzz lane reads the running app's `/q/openapi`, so a
  service serving operations its committed spec omits could legitimately record more. That would
  itself be spec drift, and the error message points at re-reading the artifact.

## Counting without pyyaml

The gate degrades rather than requires pyyaml (`yaml_pairs`), so operations are counted with a line
grammar over the top-level `paths:` block. Checked against `yaml.safe_load` using the shipped
function itself: **56 of 56 committed specs, zero disagreements**.

## Verification

| check | result |
|---|---|
| `--self-test` on `main` | 32/32 |
| `--self-test` on this branch | 34/34 (two new R8b cases) |
| gate on the real `attestations.yaml` | exit 0, output byte-identical to `main` (consent `ops: 14`, spec declares 14, so it sits exactly on the bound) |
| **sabotage** real file, consent `ops: 14` → `15` | exit **1**, names `consent.pentest`; restored, exit 0, tree clean |
| **sabotage** A: bound check disabled | self-test red on `R8b: ops one above ...` |
| **sabotage** B: counter does not stop at the end of `paths:` | self-test red on the same case (the fixture's `components:` block carries method-shaped keys, so a leaky counter reads 15) |
| **sabotage** C: column-0 comment inside `paths:` ends the block | self-test red on both R8 TRUE ENTRY cases |
| `ruff` | the same 4 pre-existing findings as `main`, none on the new lines; `python-lint` gate PASS |
| `run-gates.py --group lint --group registry` | 63/63 PASS |

Refs #9673, #5769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
