### PR TITLE
test(consent): log test.ic state around the kover read that intermittently hits EOF

### DIFF
--- a/openbank-consent-service/build.gradle.kts
+++ b/openbank-consent-service/build.gradle.kts
@@ -87,6 +87,45 @@ kover {
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 
+// DIAGNOSTIC, not a fix — issue #9919. koverVerify intermittently reads a TRUNCATED test.ic here
+// (`Failed to load coverage data ... java.io.EOFException`, coverage 35-46% against a floor of 69),
+// on ~10% of CI builds including main, never locally, and never in sibling modules. The EOF warning
+// is also present in GREEN runs, so truncation is routine and only sometimes costs enough to fail.
+// The mechanism is not established, and the two live candidates need opposite fixes:
+//   (a) the test JVM exits before kover's shutdown hook finishes writing (the file is already short
+//       when Gradle moves on, and nothing is writing it afterwards), or
+//   (b) something still holds and writes the file after `test` ends — a JVM that inherited the
+//       agent — so koverCachedVerify reads a file that is still growing.
+// Two readings tell them apart: size + mtime when `test` finishes, and again immediately before
+// koverCachedVerify reads it, plus any live process still carrying the kover agent. (a) reads equal
+// sizes and no agent process; (b) reads a larger second size or a live agent process. Remove this
+// block once a failing run has printed both lines and #9919 has its answer.
+val koverTestIc = layout.buildDirectory.file("kover/bin-reports/test.ic")
+fun describeKoverIc(moment: String, ic: File): String {
+    // Epoch millis, not java.time: inside a build script `java` resolves to the project's java
+    // extension, so `java.time.Instant` does not compile here.
+    val state = if (ic.isFile) "size=${ic.length()} mtimeMs=${ic.lastModified()}" else "absent"
+    // Only a JVM actually carrying the agent. A bare "kover" substring also matches the Gradle and
+    // Kotlin daemons (the plugin is on their classpath), which would report (b) on every run.
+    val self = ProcessHandle.current().pid()
+    val agentJvms = ProcessHandle.allProcesses()
+        .filter { it.pid() != self }
+        .filter {
+            val cmd = it.info().commandLine().orElse("")
+            cmd.contains("-javaagent:") && cmd.contains("kover-jvm-agent")
+        }
+        .map { it.pid() }
+        .toList()
+    return "[kover-ic #9919] $moment: test.ic $state; " +
+        "live kover-agent JVMs=$agentJvms; nowMs=${System.currentTimeMillis()}"
+}
+tasks.named<Test>("test") {
+    doLast { logger.lifecycle(describeKoverIc("after test", koverTestIc.get().asFile)) }
+}
+tasks.matching { it.name == "koverCachedVerify" }.configureEach {
+    doFirst { logger.lifecycle(describeKoverIc("before koverCachedVerify", koverTestIc.get().asFile)) }
+}
+
 // Mutation testing on the security-critical domain (ADR-0063 / ADR-0030 D3, issue #8349). Weekly +
 // manual via pitest.yml, advisory — never a per-PR gate.
 //


### PR DESCRIPTION
## What

A **diagnostic**, not a fix, for #9919. On roughly 10 % of CI builds, `:openbank-consent-service:koverVerify` reads a truncated
`build/kover/bin-reports/test.ic`, including builds on `main`. Kover logs
`Failed to load coverage data ... java.io.EOFException`, and coverage reads 35–46 % against a floor of 69.
It never happens locally or in sibling modules. The EOF warning also shows up in green runs.

The mechanism is not established. A background investigation over four CI jobs could not tell EOF
runs from clean ones: no kill, no OOM and no exit-code line in either. The two live candidates need
opposite fixes:

- **(a)** the test JVM exits before kover's shutdown hook finishes writing. The file is already short when
  Gradle moves on, and nothing writes it afterwards.
- **(b)** something still holds and writes the file after `test` ends, e.g. a JVM that inherited the
  agent, so `koverCachedVerify` reads a file that is still growing.

## Change

In `openbank-consent-service/build.gradle.kts` only, two lifecycle log lines:

```
[kover-ic #9919] after test: test.ic size=… mtimeMs=…; live kover-agent JVMs=[…]; nowMs=…
[kover-ic #9919] before koverCachedVerify: test.ic size=… mtimeMs=…; live kover-agent JVMs=[…]; nowMs=…
```

`koverCachedVerify` is the reader. From the red job 103653687178 the order is `test` → `providerPactTest`
→ `koverGenerateArtifactJvm` → `koverCachedVerify` → `koverVerify FAILED`, with the EOF warning printed there.

How to read a failing run:

- equal sizes and no agent JVM → (a), truncated at exit
- a larger second size or a live agent JVM → (b)

The block says to remove it once a failing run has printed both lines.

## Verification

| check | result |
|---|---|
| both lines print, in order, around the reader | local run: `after test: size=3778925 …; live kover-agent JVMs=[]` then `before koverCachedVerify: size=3778925 …; live kover-agent JVMs=[]` (equal sizes, no agent JVM, which is the healthy reading) |
| agent-JVM filter, **known positive**: while the tests ran, a separate temurin `java` process (the Gradle test executor) carried `-javaagent:…kover-jvm-agent` and matched | matched pid 2142 |
| agent-JVM filter, **negative control** (the first version was wrong): matching the bare substring `kover` also caught the Gradle/Kotlin daemons, so it reported live "agent JVMs" with no test running, which would have read as (b) on every run. Now it requires `-javaagent:` + `kover-jvm-agent` and excludes its own PID | fixed |
| `ktlintCheck` (incl. `ktlintKotlinScriptCheck`) | pass. The first draft failed `max-line-length` (121 > 120), now split |
| script compiles | yes. `java.time` does not resolve inside a build script (`java` is the project extension), so it logs epoch millis |

The local run filters `test` to the domain tests and skips `providerPactTest`, so the `koverVerify` floor
failure in it is expected. It is not a regression.

Consent is a money-path service, so this needs the two approvals. It changes no production code, no
test and no coverage floor.

## Security checklist

- [x] No production code, configuration or dependency changes — build-script logging only
- [x] No secrets, tokens, hostnames or credentials logged — file size, mtime, PIDs and timestamps only
- [x] No change to authn/authz, network policy, data handling or the money path
- [x] Coverage floor unchanged (69)

Refs #9919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
