### PR TITLE
ci(governance): add a helper that puts the Security checklist into a --body-file PR body

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4149,6 +4149,26 @@ gates:
       LIVE_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .body 2>/dev/null || true)"
       python3 .github/scripts/check-security-checklist.py --body "${LIVE_BODY:-${PR_BODY}}" --base "${PR_DIFF_BASE}" --enforce
 
+  # #8757: the gate above requires the template's Security checklist, and CLAUDE.md mandates
+  # `gh pr create --body-file`, which never applies the template — so the section is absent by
+  # construction. append-security-checklist.py is the missing third step; this gate keeps it
+  # honest against the REAL template (a renamed or dropped section reddens here, instead of the
+  # helper silently appending nothing and every money-path PR failing the gate above again).
+  - id: security-checklist-append-helper
+    name: "append-security-checklist copies the template's section, unticked and idempotent (#8757, enforced)"
+    group: security
+    mode: enforced
+    selftest_exempt: >-
+      is-a-test-suite — the run: below IS the self-test. It asserts the copy stops at the next
+      heading, leaves boxes unticked, keeps the attribution last, is idempotent, and reads the real
+      PULL_REQUEST_TEMPLATE.md; falsified by removing the idempotency guard (self-test FAIL).
+    budget_seconds: 5   # pure text, one temp file
+    min_subjects: 6
+    rationale: "Following the mandated --body-file flag guaranteed the Security checklist was missing, and 50 of 67 open PRs lacked it on 2026-09-05; a tracked helper tested against the real template removes the manual step that kept failing money-path PRs."
+    review_after: "2027-03-13"
+    run: |
+      python3 .github/scripts/append-security-checklist.py --self-test
+
   # ADR-0030 D2, third half (#6037, PR #6048): the coverage gate proves a threat model EXISTS
   # and the diff gate proves it is TOUCHED when a trust boundary moves. Neither reads a single
   # CLAIM, so a model can be present, current, freshly edited — and false. Settlement's R2

--- a/.github/scripts/append-security-checklist.py
+++ b/.github/scripts/append-security-checklist.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Append the PR template's `## Security checklist` section to a PR body FILE (issue #8757).
+
+WHY. CLAUDE.md mandates `gh pr create --body-file <file>` (never `--body`, #2890). A body passed
+explicitly means GitHub never applies `.github/PULL_REQUEST_TEMPLATE.md`, and the template is the
+only place the Security checklist exists. So following the mandated flag guarantees the section is
+absent, and the enforced `security-checklist-money-path` gate then fails every money-path PR. The
+two rules were each correct and could not both be followed without a third step nothing performed;
+people added the block by hand after CI reddened (50 of 67 open PRs lacked it on 2026-09-05).
+
+This is that third step, tracked so it is reviewable here rather than living in each machine's
+gitignored skills:
+
+    python3 .github/scripts/append-security-checklist.py /tmp/body.md
+    gh pr create --body-file /tmp/body.md ...
+
+WHAT IT DOES
+  * copies the section VERBATIM from the template — never a second copy that can drift from it;
+  * leaves every box UNTICKED. The gate's point is the pause; ticking stays the author's act;
+  * is idempotent: a body that already has the section is left byte-identical;
+  * inserts before the trailing `🤖 Generated with` attribution line when there is one, so the
+    attribution stays last; otherwise appends.
+
+It appends regardless of which paths the PR touches: the section is harmless off the money path,
+and deciding scope here would duplicate the gate's diff logic and could disagree with it.
+
+Exit 0 = body now contains the section. Exit 1 = template or body unreadable, or the template has
+no such section (fail loudly: silently appending nothing is the defect this script exists to end).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import tempfile
+
+TEMPLATE_REL = ".github/PULL_REQUEST_TEMPLATE.md"
+SECTION = re.compile(r"^##\s+Security checklist\s*$", re.MULTILINE | re.IGNORECASE)
+NEXT_HEADING = re.compile(r"^##\s+", re.MULTILINE)
+ATTRIBUTION = re.compile(r"^🤖 Generated with ", re.MULTILINE)
+
+
+def template_section(template_text: str) -> str | None:
+    m = SECTION.search(template_text)
+    if not m:
+        return None
+    rest = template_text[m.end():]
+    nxt = NEXT_HEADING.search(rest)
+    body = rest[: nxt.start()] if nxt else rest
+    return (template_text[m.start():m.end()] + body).rstrip() + "\n"
+
+
+def with_section(body: str, section: str) -> str:
+    if SECTION.search(body):
+        return body
+    m = ATTRIBUTION.search(body)
+    if m:
+        head = body[: m.start()].rstrip()
+        return f"{head}\n\n{section}\n{body[m.start():]}"
+    return f"{body.rstrip()}\n\n{section}"
+
+
+def repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: append-security-checklist.py <pr-body-file> | --self-test", file=sys.stderr)
+        return 1
+    if argv[0] == "--self-test":
+        return self_test()
+    tpl_path = repo_root() / TEMPLATE_REL
+    try:
+        section = template_section(tpl_path.read_text(encoding="utf-8"))
+        body_path = pathlib.Path(argv[0])
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"::error::append-security-checklist: {e}", file=sys.stderr)
+        return 1
+    if section is None:
+        print(f"::error::{TEMPLATE_REL} has no '## Security checklist' section to copy", file=sys.stderr)
+        return 1
+    new = with_section(body, section)
+    if new == body:
+        print("append-security-checklist: body already has the section — unchanged")
+    else:
+        body_path.write_text(new, encoding="utf-8")
+        print("append-security-checklist: appended the template's Security checklist (unticked)")
+    return 0
+
+
+def self_test() -> int:
+    tpl = (
+        "## Summary\n\n<!-- x -->\n\n## Security checklist\n\n- [ ] No secrets.\n"
+        "- [ ] Auth changed? tag it.\n\n## Compliance impact\n\n- [ ] GDPR\n"
+    )
+    section = template_section(tpl)
+    fails = 0
+
+    def check(name: str, cond: bool) -> None:
+        nonlocal fails
+        print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+        if not cond:
+            fails += 1
+
+    check("section copied up to the next heading, not beyond",
+          section is not None and "No secrets" in section and "Compliance" not in section)
+    check("template without the section yields None (caller fails loudly)",
+          template_section("## Summary\n") is None)
+
+    plain = "## What\n\nfix\n"
+    out = with_section(plain, section or "")
+    check("appended to a body lacking it", SECTION.search(out) is not None and out.startswith(plain.rstrip()))
+    check("boxes stay unticked", "- [x]" not in out and "- [ ] No secrets." in out)
+
+    attributed = "## What\n\nfix\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
+    out2 = with_section(attributed, section or "")
+    check("inserted BEFORE the attribution line, which stays last",
+          out2.rstrip().endswith("(https://claude.com/claude-code)") and out2.index("Security checklist") < out2.index("🤖"))
+
+    ticked = "## What\n\n## Security checklist\n\n- [x] done\n"
+    check("idempotent: an existing (even ticked) section is left byte-identical",
+          with_section(ticked, section or "") == ticked)
+
+    # End-to-end through main() against the REAL template, so a template edit that drops or
+    # renames the section reddens here instead of silently appending nothing.
+    real = template_section((repo_root() / TEMPLATE_REL).read_text(encoding="utf-8"))
+    check("the real PULL_REQUEST_TEMPLATE.md has a copyable section with boxes",
+          real is not None and "- [ ]" in real)
+    with tempfile.TemporaryDirectory() as d:
+        f = pathlib.Path(d) / "body.md"
+        f.write_text(plain, encoding="utf-8")
+        rc1 = main([str(f)])
+        once = f.read_text(encoding="utf-8")
+        rc2 = main([str(f)])
+        check("main(): appends once, second run is a no-op", rc1 == 0 and rc2 == 0 and once == f.read_text(encoding="utf-8") and SECTION.search(once) is not None)
+
+    print(f"SUBJECTS={8}")
+    print(f"self-test: {'PASS' if fails == 0 else f'FAIL ({fails})'}")
+    return 0 if fails == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Two rules conflict, and #8757 measured the result:

- `CLAUDE.md` mandates `gh pr create --body-file`, for good reason (#2890).
- A body passed that way never gets `.github/PULL_REQUEST_TEMPLATE.md`. The template is the only place the
  `## Security checklist` section exists.
- The enforced `security-checklist-money-path` gate requires that section on every money-path PR.

So following the mandated flag guarantees the gate fails. On 2026-09-05, 50 of 67 open PRs had no
section at all. By 09-10 half of them had one, but only because people added it by hand after CI
went red. Nothing in the tooling had changed.

#9909 (open) names that remediation in the gate's error and in `CLAUDE.md`. This PR adds the step
itself as a tracked tool, so it can be reviewed here instead of living in each machine's gitignored
skills.

```bash
python3 .github/scripts/append-security-checklist.py /tmp/body.md
gh pr create --body-file /tmp/body.md ...
```

## Behaviour

- Copies the section **verbatim from the real template**, up to the next heading. There is no second
  copy that could drift.
- Leaves every box **unticked**. The gate exists for the pause, so ticking stays the author's job.
- Is **idempotent**: a body that already has the section, ticked or not, stays byte-identical.
- Inserts before the trailing `🤖 Generated with` line, so the attribution stays last.
- Fails loudly (exit 1) if the template has no such section. It never silently appends nothing.
- Appends regardless of which paths the PR touches. The section does no harm outside the money path,
  and re-deriving scope here could disagree with the gate's own diff logic.

The new enforced gate `security-checklist-append-helper` runs the self-test on every PR, including
a case against the real `PULL_REQUEST_TEMPLATE.md`.

## Verification

| check | result |
|---|---|
| `--self-test` | 8/8 PASS |
| **sabotage**: idempotency guard removed | self-test red on the idempotent and `main()` second-run cases |
| `run-gates.py --only security-checklist-append-helper` | PASS |
| `run-gates.py --group lint --group registry` | 63/63 PASS |
| `check-duplicate-yaml-keys.sh` | 86 files, no duplicate keys |
| `ruff` | clean (after `--fix` for 4 `re.M`/`re.I` aliases and `chmod +x`); `python-lint` gate PASS |

This PR's Security checklist below was written and ticked by hand, not produced by the helper (the helper never ticks). It touches no money-path directory, so the gate would not require it anyway.

`Refs`, not `Closes`: the agent skills that compose PR bodies still have to call the helper, and they
live outside this repo.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (No: CI tooling only.)
- [x] PII path changed? → tag `gdpr-review-required`. (No.)
- [x] Cardholder data path changed? → tag `pci-review-required`. (No.)

Refs #8757, #9909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
