### PR TITLE
fix(pid): publish the NATURAL_PERSON party type the service actually accepts

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -168,8 +168,17 @@ BASELINE: dict[str, str] = {
     # with the libs scan merged in, that quartet EXACTLY matches libs-domain's ApprovalStatus
     # (the ADR-0155 four-eyes vocabulary it was always meant to publish), so it no longer drifts.
     # The stale-entry check below enforces the removal.
+    # NOT drift — a DELIBERATE SUBSET, reason measured 2026-09-13 (#5962; it used to say only
+    # "ambiguous"). The values are `PackActivationView.state`, typed as libs ProposalState
+    # (PROPOSED, APPROVED, REJECTED, WITHDRAWN, EXECUTED). CompliancePackActivationService persists
+    # PROPOSED on propose and, in decide, either `approve(...).markExecuted(...)` (EXECUTED) or
+    # `reject(...)` (REJECTED); no path anywhere in the service sets WITHDRAWN, so the spec is
+    # right not to publish it. APPROVED is only ever transient in memory, so publishing it is a
+    # harmless superset on a response, not a value a client can be refused for.
     "openbank-lending-service:APPROVED,EXECUTED,PROPOSED,REJECTED":
-        "Compliance pack ProposalState, not CollateralStatus; value-overlap pairing is ambiguous.",
+        "#5962 — PackActivationView.state: NOT drift. A deliberate subset of libs ProposalState; "
+        "no compliance-pack activation path sets WITHDRAWN (propose/decide persist PROPOSED, "
+        "EXECUTED or REJECTED only).",
     # NOT drift, and the earlier reason here was WRONG in the dangerous direction (#5962). It said
     # APPROVED/PROPOSED/REJECTED "have never existed in the code" and asked for a spec correction
     # dropping them — which would have removed working API vocabulary from a money-path contract.
@@ -196,15 +205,11 @@ BASELINE: dict[str, str] = {
         "#5962 — listRecentApplications `status`: NOT drift. A deliberate superset of "
         "OriginationState; PROPOSED/APPROVED/REJECTED are retired names the repository still "
         "translates via LegacyOriginationMigration.mapLegacyStatus, so they return rows.",
-    # Also deliberate: the enum is right to flag (INDIVIDUAL has never existed; the DB CHECK is
-    # ('NATURAL_PERSON','LEGAL_ENTITY','SOLE_TRADER')), but it sits inside `CreatePartyRequest`,
-    # whose declared properties — legalName, tradingName, taxId, dateOfBirth, nationality —
-    # match none of the Kotlin DTO's (givenName, familyName, birthdate, nationalities,
-    # verificationSource, bankIdSub, birthNumberRaw, initialRole, onboardingChannel). Same
-    # reason as above: fix the schema, then the enum.
-    "openbank-pid-service:INDIVIDUAL,LEGAL_ENTITY,SOLE_TRADER":
-        "#5962 — CreatePartyRequest.partyType: spec-only INDIVIDUAL, inside a request schema "
-        "whose properties do not match the DTO at all; needs a schema fix first.",
+    # REMOVED 2026-09-13 (#5962): `openbank-pid-service:INDIVIDUAL,LEGAL_ENTITY,SOLE_TRADER`. Its
+    # precondition ("fix the schema first") had already been met — CreatePartyRequest's properties
+    # now match the Kotlin DTO — so only the enum was left, and it is corrected to the domain's
+    # NATURAL_PERSON (PartyType, the DTO default, and the DB CHECK). The stale-entry check enforces
+    # the removal.
     # NOT drift — a DELIBERATE SUBSET (#5962). TransitionStatusRequest.targetStatus publishes
     # every status `SepaPayment.canTransitionTo` can reach; RECEIVED is the entry state and is
     # the target of no transition, so it is absent here while present on the read filter, which

--- a/openbank-pid-service/src/main/resources/openapi.yaml
+++ b/openbank-pid-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PID Service API (Party Identity)
-  version: 1.15.0
+  version: 1.16.0
   description: Party identity data management — create, update, KYC linking, BankID/ROB sync, identity resolution and four-eyes verification cases (ADR-0072).
   license:
     name: Apache-2.0
@@ -894,7 +894,7 @@ components:
       properties:
         partyType:
           type: string
-          enum: [INDIVIDUAL, LEGAL_ENTITY, SOLE_TRADER]
+          enum: [NATURAL_PERSON, LEGAL_ENTITY, SOLE_TRADER]
         givenName:
           type: string
         familyName:


### PR DESCRIPTION
## What

Part of the #5962 tail. Of the 15 drifts baselined on `main`, 13 already carry a measured "NOT
drift" reason: a deliberate subset or a mis-pairing. This PR settles the other two.

### 1. pid-service: a live defect, fixed

`CreatePartyRequest.partyType` in the spec advertised `INDIVIDUAL`. `PartyType` has never had that
value. The domain enum, the DTO default (`PartyType.NATURAL_PERSON`) and the DB CHECK all say
`NATURAL_PERSON`. So a client generated from the spec would send the one value the service rejects.

The baseline entry deferred the fix because the request schema's properties
(`legalName, tradingName, taxId, …`) matched none of the DTO's. That is **no longer true** on `main`:
the schema now lists exactly the DTO's fields. Only the enum was left, so the entry had gone stale.

- spec: `INDIVIDUAL` → `NATURAL_PERSON`
- `info.version` 1.15.0 → **1.16.0**. `check-api-contract.py` classifies it mechanically as a
  `correction`, since the only change is removing a spec value no client could ever have used
  successfully and nothing else in the service changes: *"correction change, info.version 1.15.0 ->
  1.16.0 — OK (required >= MINOR)"*.
- the pid baseline entry is removed. The gate's stale-entry check would otherwise fail on it.

The ADR-0048 D2 invariant holds: `openbank.api.version: "1"`, all six `@Path`s are `/api/v1`, and
the major version stays 1.

### 2. lending-service: not drift, the reason is now measured

`openbank-lending-service:APPROVED,EXECUTED,PROPOSED,REJECTED` stayed baselined with the reason
*"value-overlap pairing is ambiguous"*. Measured: the values are `PackActivationView.state`, which is
typed as libs `ProposalState` (`… WITHDRAWN …`). `CompliancePackActivationService` persists
`PROPOSED` on propose. `decide` persists either `approve(…).markExecuted(…)` (EXECUTED) or `reject(…)`
(REJECTED). No path anywhere in the service sets `WITHDRAWN`. So this is a deliberate subset, the same
class as the campaign, document and ledger entries. The entry stays, with that evidence as its reason.

## Verification

| check | result |
|---|---|
| `check-openapi-enum-vs-domain.py --enforce` | exit 0: *14 paired enum(s) drift, all 14 baselined; no new drift* (was 15) |
| `--self-test` | passed |
| **negative control**: `INDIVIDUAL` put back in the spec with the baseline entry gone | exit **1**: `::error ... drifts from the domain enum PartyType it serves: spec omits ['NATURAL_PERSON'], spec advertises values the code does not have: ['INDIVIDUAL']`. Restored, tree clean, exit 0. The sabotage was aimed at line 897 by index and asserted before the gate ran. The same enum text also appears in `RegisterIdentityRequest` (line 1304, already correct), and two earlier attempts silently failed to land, one of them exactly because of that duplicate. So this row is the third, verified attempt. |
| `check-api-contract.py --enforce` (oasdiff) | exit 0, `correction`, MINOR accepted |
| `regen-derived.sh` | exit 0, working tree unchanged (no derived artefact depends on this spec change) |

`Refs`, not `Closes`: #5962 also tracks the deliberate-subset entries that remain baselined.

Refs #5962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
