### PR TITLE
fix(ci): validate scheduler crons outside the openbank root and inside profiles

### DIFF
--- a/.github/scripts/check-scheduler-cron-syntax.py
+++ b/.github/scripts/check-scheduler-cron-syntax.py
@@ -92,25 +92,33 @@ def validate(expr: str) -> list[str]:
 
 
 def crons_in(path: Path) -> list[tuple[str, str]]:
-    """(key, raw value) for every *cron* key under the `openbank` root of a service config."""
+    """(dotted key path, raw value) for every *cron* key ANYWHERE in a service config.
+
+    The walk used to start at the `openbank` root only (#6253), which left two populations
+    unvalidated while the gate printed OK: a cron under another root (agent-service's production
+    `agent.oversight.cron`, read by OversightService) and every cron inside a profile block
+    (`"%test": openbank: ...`), which the scheduler parses at that profile's boot just the same.
+    The key is reported as its full path so a finding says where it sits, not only its leaf.
+    """
     try:
         doc = list(yaml.safe_load_all(path.read_text()))[0]
     except (yaml.YAMLError, IndexError):
         return []
     out: list[tuple[str, str]] = []
 
-    def walk(node):
+    def walk(node, prefix: str):
         if isinstance(node, dict):
             for key, value in node.items():
+                here = f"{prefix}.{key}" if prefix else str(key)
                 if isinstance(value, str) and "cron" in str(key):
-                    out.append((str(key), value))
+                    out.append((here, value))
                 else:
-                    walk(value)
+                    walk(value, here)
         elif isinstance(node, list):
-            for item in node:
-                walk(item)
+            for i, item in enumerate(node):
+                walk(item, f"{prefix}[{i}]")
 
-    walk((doc or {}).get("openbank"))
+    walk(doc or {}, "")
     return out
 
 
@@ -158,7 +166,36 @@ def self_test() -> int:
         failed += 1
     else:
         print("  PASS  ${VAR:default} is unwrapped to its default")
-    print(f"self-test: {len(cases) + 1 - failed}/{len(cases) + 1} passed")
+
+    # SCOPE (#6253): everything above exercises validate() alone, so it could not see that
+    # crons_in() only ever looked under `openbank`. Drive the real walker over a fixture whose
+    # crons sit under the `openbank` root, under a profile block, and under a foreign root.
+    import tempfile  # self-test only
+
+    fixture = (
+        "openbank:\n  a:\n    check-cron: 0 15 3 * * ?\n"
+        '"%test":\n  openbank:\n    a:\n      check-cron: 0 0 5 31 2 ?\n'
+        "agent:\n  oversight:\n    cron: ${AGENT_OVERSIGHT_CRON:0 0 25 * * ?}\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        cfg = Path(d) / "application.yaml"
+        cfg.write_text(fixture)
+        found = dict(crons_in(cfg))
+    scope_checks = [
+        ("a cron under the openbank root is found", "openbank.a.check-cron" in found),
+        ("a cron inside a %test profile block is found", "%test.openbank.a.check-cron" in found),
+        ("a cron under a foreign root (agent.oversight.cron) is found", "agent.oversight.cron" in found),
+        # Present AND rejected for the planted reason. `found.get(key, "")` alone would pass when
+        # the key is missing, because validate("") reports a field-count problem -- vacuous.
+        ("the foreign-root cron's committed default is validated and rejected (hour 25)",
+         "agent.oversight.cron" in found
+         and any("hour: 25" in p for p in validate(unwrap(found["agent.oversight.cron"])))),
+    ]
+    for name, ok in scope_checks:
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+    total = len(cases) + 1 + len(scope_checks)
+    print(f"self-test: {total - failed}/{total} passed")
     return 1 if failed else 0
 
 


### PR DESCRIPTION
## What

Another #6253 row (a gate whose scope is narrower than its subject), measured and fixed.

`scheduler-cron-syntax` exists because a malformed cron is refused by the scheduler **at boot**, so
the service crashloops rather than missing a run. `crons_in()` only walked
`doc.get("openbank")`, so it printed *OK* over two populations it never read:

| population | measured on `main` |
|---|---|
| a cron under another root | **1**: `openbank-agent-service` `agent.oversight.cron` (`${AGENT_OVERSIGHT_CRON:0 0/30 * * * ?}`), the production `OversightService` cron |
| crons inside a profile block | **9**: `%test.openbank.<svc>.*-cron` in authz-policy-auditor, case-coordinator-agent, control-liveness-sentinel, devops-agent, docs-truth-agent, finops-agent, flaky-test-hunter, governance-auditor, release-steward |

The #6253 row named only the first. The census (all `application.yaml` files, YAML-parsed, every key
containing `cron`) found both.

## Change

- `crons_in()` walks the whole document and reports each key as its full dotted path
  (`%test.openbank.devops.analysis-cron`), so a finding says where the cron sits.
- The self-test gains four scope checks that drive the **real** walker over a fixture with crons
  under the `openbank` root, inside a `%test` block, and under a foreign root. Until now the
  self-test exercised `validate()` alone and could not detect a scope regression at all.

## Verification

| check | result |
|---|---|
| `--self-test` (exit read from a file, not a pipe) | exit 0, **16/16** |
| gate `--enforce` on the repo | exit 0. Covered crons **27 → 37**, all structurally valid, so main stays green |
| **negative control**: new self-test run against the **old** `crons_in` from `origin/main` (spliced with asserts that each block occurs once) | exit **1**, **12/16**: all four scope checks red |
| `run-gates.py --only scheduler-cron-syntax --only python-lint` | PASS / PASS |
| `ruff` | 2 findings (`SIM114` line 77, `RUF015` line 104), **both already on `origin/main`** in untouched code (checked on a copy of main's file). One `RUF100` I introduced was removed |

Two things the control exposed in my own first draft, both fixed before this PR:

1. *"the foreign-root cron is rejected (hour 25)"* passed **vacuously** against the old walker. The key
   was missing, `found.get(key, "")` gave `""`, and `validate("")` reports a field-count problem. It now
   requires the key to be present **and** the planted `hour: 25` problem to be the one reported.
2. *"a cron under the openbank root is found"* also goes red against the old code, but only because
   the old walker returned leaf keys, not dotted paths. It checks key format, not scope. The
   discriminating checks are the `%test` and `agent.oversight.cron` ones.

Refs #6253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
