### PR TITLE
fix(ci): generate a runbook for every released module that is deployed

### DIFF
--- a/docs/runbooks/svc-admin-ui.md
+++ b/docs/runbooks/svc-admin-ui.md
@@ -1,0 +1,73 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-admin-ui
+
+> Operational runbook for the `admin-ui` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-admin-ui` |
+| HTTP port | `?` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `—`) |
+| Classification | internal |
+| Retention | transient |
+| Lineage role | consumer |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `admin-ui`.
+
+## Health & probes
+
+- Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `admin-ui`); dashboards in Grafana.
+- Logs: `kubectl logs -n admin-ui deploy/admin-ui -f`, or Loki
+  `{namespace="admin-ui"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/admin-ui -n admin-ui` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/admin-ui -n admin-ui --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service owns no database, but check its **PostgreSQL**
+  connectivity before ruling out the datastore — an upstream dependency below, or the
+  OPA sidecar if `AUTHZ_ENFORCE` is on (with no reachable PDP, `@Authorize` fails
+  closed), are the other likely causes.
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO/RTO: not this service's to promise** — it owns no database. Its **PostgreSQL** state has its own recovery posture; see the mechanism below before assuming zero impact.
+- **Mechanism:** this service owns no database — there is no managed backup to restore, and none is expected. It does hold state in **PostgreSQL**.
+- **Before assuming zero impact:** check this service's own `governance.yaml` and `PostgreSQL` keys for anything with a long or no TTL (a durable credential, not a session cache) — losing that requires its own recovery path, not a redeploy.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Verify against the `PostgreSQL` cluster's own health/backup posture, which this runbook does not track.
+- **Verify:** health endpoint green, then re-drive one request end to end.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: admin-ui.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `admin-ui.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-authz-policy-auditor.md
+++ b/docs/runbooks/svc-authz-policy-auditor.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-authz-policy-auditor
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `authz-policy-auditor` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-authz-policy-auditor` |
+| HTTP port | `8147` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_authzaudit`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `github`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `authz-policy-auditor`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `authz-policy-auditor`); dashboards in Grafana.
+- Logs: `kubectl logs -n authz-policy-auditor deploy/authz-policy-auditor -f`, or Loki
+  `{namespace="authz-policy-auditor"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/authz-policy-auditor -n authz-policy-auditor` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/authz-policy-auditor -n authz-policy-auditor --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: authz-policy-auditor.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `authz-policy-auditor.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-case-coordinator-agent.md
+++ b/docs/runbooks/svc-case-coordinator-agent.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-case-coordinator-agent
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `case-coordinator-agent` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-case-coordinator-agent` |
+| HTTP port | `8146` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_casecoordinator`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `temporal`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `case-coordinator-agent`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `platform`); dashboards in Grafana.
+- Logs: `kubectl logs -n platform deploy/case-coordinator-agent -f`, or Loki
+  `{namespace="platform"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/case-coordinator-agent -n platform` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/case-coordinator-agent -n platform --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: case-coordinator-agent.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `case-coordinator-agent.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-clearing-simulator.md
+++ b/docs/runbooks/svc-clearing-simulator.md
@@ -1,0 +1,71 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-clearing-simulator
+
+> Operational runbook for the `clearing-simulator` service. Data domain **payments**,
+> classification **internal**, datastore **none**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-clearing-simulator` |
+| HTTP port | `8139` |
+| Data domain | payments |
+| Datastore | none (database `—`) |
+| Classification | internal |
+| Retention | none (stateless — persists nothing) |
+| Lineage role | internal |
+
+## Dependencies
+
+- **Upstream (this service consumes):** `sepa-payment`
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `clearing-simulator`.
+
+## Health & probes
+
+- Readiness: `GET :8087/q/health/ready` · Liveness: `GET :8087/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/clearing-simulator -f`, or Loki
+  `{namespace="payments"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/clearing-simulator -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/clearing-simulator -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: clearing-simulator.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `clearing-simulator.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-control-liveness-sentinel.md
+++ b/docs/runbooks/svc-control-liveness-sentinel.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-control-liveness-sentinel
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `control-liveness-sentinel` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-control-liveness-sentinel` |
+| HTTP port | `8144` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_liveness`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `prometheus`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `control-liveness-sentinel`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `control-liveness-sentinel`); dashboards in Grafana.
+- Logs: `kubectl logs -n control-liveness-sentinel deploy/control-liveness-sentinel -f`, or Loki
+  `{namespace="control-liveness-sentinel"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/control-liveness-sentinel -n control-liveness-sentinel` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/control-liveness-sentinel -n control-liveness-sentinel --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: control-liveness-sentinel.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `control-liveness-sentinel.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-customer-edge.md
+++ b/docs/runbooks/svc-customer-edge.md
@@ -1,0 +1,73 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-customer-edge
+
+> Operational runbook for the `customer-edge` service. Data domain **platform**,
+> classification **confidential**, datastore **Redis**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-customer-edge` |
+| HTTP port | `8128` |
+| Data domain | platform |
+| Datastore | Redis (database `—`) |
+| Classification | confidential |
+| Retention | passkeys until revoked; all other Redis keys 30 days or less |
+| Lineage role | internal |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** `party-service`, `account-service`, `sca-service`
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `customer-edge`.
+
+## Health & probes
+
+- Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `customer-edge`); dashboards in Grafana.
+- Logs: `kubectl logs -n customer-edge -l app.kubernetes.io/name=customer-edge -f`, or Loki
+  `{namespace="customer-edge"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl argo rollouts restart customer-edge -n customer-edge` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout customer-edge -n customer-edge --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/customer-edge -n customer-edge --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service owns no database, but check its **Redis**
+  connectivity before ruling out the datastore — an upstream dependency below, or the
+  OPA sidecar if `AUTHZ_ENFORCE` is on (with no reachable PDP, `@Authorize` fails
+  closed), are the other likely causes.
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO/RTO: not this service's to promise** — it owns no database. Its **Redis** state has its own recovery posture; see the mechanism below before assuming zero impact.
+- **Mechanism:** this service owns no database — there is no managed backup to restore, and none is expected. It does hold state in **Redis**.
+- **Before assuming zero impact:** check this service's own `governance.yaml` and `Redis` keys for anything with a long or no TTL (a durable credential, not a session cache) — losing that requires its own recovery path, not a redeploy.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Verify against the `Redis` cluster's own health/backup posture, which this runbook does not track.
+- **Verify:** health endpoint green, then re-drive one request end to end.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: customer-edge.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `customer-edge.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-devops-agent.md
+++ b/docs/runbooks/svc-devops-agent.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-devops-agent
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `devops-agent` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-devops-agent` |
+| HTTP port | `8142` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_devops`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `prometheus`, `temporal`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `devops-agent`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `devops-agent`); dashboards in Grafana.
+- Logs: `kubectl logs -n devops-agent deploy/devops-agent -f`, or Loki
+  `{namespace="devops-agent"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/devops-agent -n devops-agent` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/devops-agent -n devops-agent --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: devops-agent.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `devops-agent.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-docs-truth-agent.md
+++ b/docs/runbooks/svc-docs-truth-agent.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-docs-truth-agent
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `docs-truth-agent` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-docs-truth-agent` |
+| HTTP port | `8146` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_docstruth`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `github`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `docs-truth-agent`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `docs-truth-agent`); dashboards in Grafana.
+- Logs: `kubectl logs -n docs-truth-agent deploy/docs-truth-agent -f`, or Loki
+  `{namespace="docs-truth-agent"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/docs-truth-agent -n docs-truth-agent` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/docs-truth-agent -n docs-truth-agent --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: docs-truth-agent.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `docs-truth-agent.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-domestic-payment.md
+++ b/docs/runbooks/svc-domestic-payment.md
@@ -3,7 +3,7 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-domestic-payment-service
+# Runbook — openbank-domestic-payment
 
 > Operational runbook for the `domestic-payment` service. Data domain **payments**,
 > classification **confidential**, datastore **PostgreSQL**.
@@ -32,13 +32,13 @@ triaging an incident that starts on `domestic-payment`.
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=domestic-payment-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=domestic-payment -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart domestic-payment-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout domestic-payment-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/domestic-payment-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl argo rollouts restart domestic-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout domestic-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/domestic-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-finops-agent.md
+++ b/docs/runbooks/svc-finops-agent.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-finops-agent
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `finops-agent` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-finops-agent` |
+| HTTP port | `8141` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_finops`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `prometheus`, `alertmanager`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `finops-agent`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `finops-agent`); dashboards in Grafana.
+- Logs: `kubectl logs -n finops-agent deploy/finops-agent -f`, or Loki
+  `{namespace="finops-agent"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/finops-agent -n finops-agent` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/finops-agent -n finops-agent --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: finops-agent.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `finops-agent.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-flaky-test-hunter.md
+++ b/docs/runbooks/svc-flaky-test-hunter.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-flaky-test-hunter
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `flaky-test-hunter` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-flaky-test-hunter` |
+| HTTP port | `8148` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_flakytest`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `github`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `flaky-test-hunter`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `flaky-test-hunter`); dashboards in Grafana.
+- Logs: `kubectl logs -n flaky-test-hunter deploy/flaky-test-hunter -f`, or Loki
+  `{namespace="flaky-test-hunter"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/flaky-test-hunter -n flaky-test-hunter` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/flaky-test-hunter -n flaky-test-hunter --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: flaky-test-hunter.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `flaky-test-hunter.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-governance-auditor.md
+++ b/docs/runbooks/svc-governance-auditor.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-governance-auditor
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `governance-auditor` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-governance-auditor` |
+| HTTP port | `8143` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_govaudit`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `github`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `governance-auditor`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `governance-auditor`); dashboards in Grafana.
+- Logs: `kubectl logs -n governance-auditor deploy/governance-auditor -f`, or Loki
+  `{namespace="governance-auditor"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/governance-auditor -n governance-auditor` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/governance-auditor -n governance-auditor --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: governance-auditor.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `governance-auditor.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-product-catalog.md
+++ b/docs/runbooks/svc-product-catalog.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-product-catalog
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `product-catalog` service. Data domain **core**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-product-catalog` |
+| HTTP port | `8104` |
+| Data domain | core |
+| Datastore | PostgreSQL (database `openbank_products`) |
+| Classification | internal |
+| Retention | indefinite |
+| Lineage role | producer |
 
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `product-catalog`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `accounts`); dashboards in Grafana.
+- Logs: `kubectl logs -n accounts deploy/product-catalog -f`, or Loki
+  `{namespace="accounts"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/product-catalog -n accounts` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/product-catalog -n accounts --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: product-catalog.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `product-catalog.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-release-steward.md
+++ b/docs/runbooks/svc-release-steward.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-release-steward
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `release-steward` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-release-steward` |
+| HTTP port | `8145` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_releasesteward`) |
+| Classification | internal |
+| Retention | "7 years" |
+| Lineage role | internal |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Upstream (this service consumes):** `github`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `release-steward`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `release-steward`); dashboards in Grafana.
+- Logs: `kubectl logs -n release-steward deploy/release-steward -f`, or Loki
+  `{namespace="release-steward"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/release-steward -n release-steward` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/release-steward -n release-steward --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: release-steward.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `release-steward.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-security-scanner.md
+++ b/docs/runbooks/svc-security-scanner.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-payment
+# Runbook — openbank-security-scanner
 
-> Operational runbook for the `sepa-payment` service. Data domain **payments**,
-> classification **confidential**, datastore **PostgreSQL**.
+> Operational runbook for the `security-scanner` service. Data domain **platform**,
+> classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-sepa-payment` |
-| HTTP port | `8115` |
-| Data domain | payments |
-| Datastore | PostgreSQL (database `openbank_sepa_payments`) |
-| Classification | confidential |
-| Retention | 7 years |
-| Lineage role | both |
+| Service | `openbank-security-scanner` |
+| HTTP port | `8120` |
+| Data domain | platform |
+| Datastore | PostgreSQL (database `openbank_security`) |
+| Classification | internal |
+| Retention | 1 year |
+| Lineage role | internal |
 
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `sepa-payment`.
+triaging an incident that starts on `security-scanner`.
 
 ## Health & probes
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment -f`, or Loki
-  `{namespace="payments"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `security-scanner`); dashboards in Grafana.
+- Logs: `kubectl logs -n security-scanner deploy/security-scanner-service -f`, or Loki
+  `{namespace="security-scanner"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-payment -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-payment -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl rollout restart deploy/security-scanner-service -n security-scanner` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/security-scanner-service -n security-scanner --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `sepa-payment`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: security-scanner.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+  `security-scanner.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-sepa-instant.md
+++ b/docs/runbooks/svc-sepa-instant.md
@@ -3,7 +3,7 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-sepa-instant-service
+# Runbook — openbank-sepa-instant
 
 > Operational runbook for the `sepa-instant` service. Data domain **payments**,
 > classification **confidential**, datastore **PostgreSQL**.
@@ -32,13 +32,13 @@ triaging an incident that starts on `sepa-instant`.
 
 - Readiness: `GET :8085/q/health/ready` · Liveness: `GET :8085/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-instant-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-instant -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl argo rollouts restart sepa-instant-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-instant-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
-- **Scale:** `kubectl scale rollout/sepa-instant-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
+- **Restart:** `kubectl argo rollouts restart sepa-instant -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-instant -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/sepa-instant -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a later ArgoCD sync reconciles manual changes).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -341,7 +341,7 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-{short}-service
+# Runbook — {module}
 
 > Operational runbook for the `{short}` service. Data domain **{domain}**,
 > classification **{classification}**, datastore **{datastore}**.
@@ -413,7 +413,9 @@ def ops_commands(short: str, ns: str) -> dict[str, str]:
     plugin-free restart is offered alongside the plugin form on purpose: a runbook that assumes a
     kubectl plugin on the reader's laptop fails in exactly the situation it exists for.
     """
-    svc = f"{short}-service"
+    # The workload's real name, not `<short>-service`: released modules without the suffix deploy
+    # under their bare name (customer-edge, admin-ui), so the suffix would address nothing (#6253).
+    svc = gitops_facts.workload_name(short, GITOPS) or f"{short}-service"
     if gitops_facts.workload_kind(short, GITOPS) == "Rollout":
         return {
             "logs_cmd": f"`kubectl logs -n {ns} -l app.kubernetes.io/name={svc} -f`",
@@ -555,6 +557,18 @@ def all_services() -> list[str]:
     # three modules that move SEPA and domestic payments had no operational runbook at all (#2364).
     for short in gitops_facts.money_path_services(REPO):
         if gitops_facts.module_dir(short, REPO).is_dir():
+            out.add(short)
+    # Every RELEASED module that is actually DEPLOYED needs one too (#6253). The `-service` glob
+    # plus the money-path list left 14 out — customer-edge (durable passkey state in Redis),
+    # product-catalog, security-scanner, admin-ui and the control-plane agents — and
+    # `git diff --exit-code docs/runbooks/` could never report a runbook nobody generated.
+    # Released = has a version.txt (rules.yaml: released_unit_marker); deployed = a Deployment or
+    # Rollout in gitops whose own metadata.name is the module, so a merely-mentioned module or an
+    # undeployed one (no workload to operate) does not get a runbook of fictional commands.
+    for version_txt in REPO.glob("openbank-*/version.txt"):
+        short = version_txt.parent.name.removeprefix("openbank-")
+        short = short.removesuffix("-service")
+        if gitops_facts.workload_name(short, GITOPS) is not None:
             out.add(short)
     return sorted(out)
 

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -711,13 +711,33 @@ def self_test() -> int:
     case("the assertion is read case- and whitespace-insensitively",
          owns_no_database({"ownsNoDatabase": " TRUE ", "primaryDatastore": "PostgreSQL"}) is True)
 
+    # ORPHANS (#6253): the drift gate cannot see a runbook the generator stops producing — the file
+    # stays on disk and diffs clean. Reverting the population widening proved it (gate green).
+    case("a committed runbook the population no longer generates is an orphan",
+         orphan_runbooks({"svc-ledger.md", "svc-customer-edge.md"}, {"ledger"}) == ["svc-customer-edge.md"])
+    case("a population that generates every committed runbook has no orphans",
+         orphan_runbooks({"svc-ledger.md", "svc-customer-edge.md"}, {"ledger", "customer-edge"}) == [])
+
     if fails:
         for f in fails:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: runbook deployment/DR classifier is falsifiable (20 cases)")
+    print("self-test ok: runbook deployment/DR classifier is falsifiable (22 cases)")
     return 0
+
+
+def orphan_runbooks(existing: set[str], population: set[str]) -> list[str]:
+    """`svc-*.md` filenames on disk that no module in the population generates.
+
+    The drift gate regenerates and diffs, so it sees a runbook whose CONTENT drifted and one that
+    is MISSING — but a file the generator simply stops writing stays on disk unchanged and diffs
+    clean. Measured (#6253): reverting the population widening dropped 14 modules from the
+    population and the gate still passed. An orphan is exactly that silent state.
+    """
+    wanted = {f"svc-{short}.md" for short in population}
+    return sorted(name for name in existing if name not in wanted)
+
 
 def main():
     if "--self-test" in sys.argv:
@@ -741,6 +761,19 @@ def main():
         out.write_text(render(short), encoding="utf-8")
         created += 1
     print(f"runbooks: {created} written, {skipped} kept (existing)")
+    # Only a FULL run knows the whole population; a run naming services cannot judge the rest.
+    if not args.services:
+        existing = {p.name for p in RUNBOOKS.glob("svc-*.md")}
+        orphans = orphan_runbooks(existing, set(targets))
+        for name in orphans:
+            print(
+                f"::error file=docs/runbooks/{name}::{name} is committed but no module in the "
+                f"generator's population produces it, so it can never be regenerated and will go "
+                f"stale unseen. Either the module left the population (restore it) or it is gone "
+                f"(delete the runbook)."
+            )
+        if orphans:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -195,6 +195,34 @@ def workload_kind(short: str, gitops: Path) -> str:
     return "Deployment"
 
 
+def workload_name(short: str, gitops: Path) -> str | None:
+    """The `metadata.name` of the Deployment/Rollout that carries this service, or None.
+
+    Not derivable from the module name. Most workloads are `<short>-service`, but a released module
+    without the `-service` suffix deploys under its bare name — `openbank-customer-edge` runs as
+    Deployment `customer-edge`, `openbank-admin-ui` as `admin-ui`. A runbook that assumed the
+    suffix would hand an on-call engineer `kubectl ... deploy/customer-edge-service`, a resource
+    that does not exist, during the incident it was written for (#6253).
+
+    Same matching discipline as [workload_kind]: only a Deployment/Rollout whose own
+    `metadata.name` is one of the module's names counts.
+    """
+    names = module_names(short)
+    haystacks = (f"openbank-{short}-service", f"openbank-{short}")
+    for f in sorted(gitops.rglob("*.yaml")):
+        text = read(f)
+        if not any(h in text for h in haystacks):
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
+                continue
+            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            if name and name.group(1) in names:
+                return name.group(1)
+    return None
+
+
 def service_namespace(short: str, gitops: Path) -> str | None:
     """The single namespace this service runs in, or None if it is not deployed.
 


### PR DESCRIPTION
## What

A #6253 row, measured wider than written and fixed.

`service-runbook-drift` regenerates `docs/runbooks/svc-*.md` and fails on a diff. It can only report
drift in runbooks the generator writes. Its population was `openbank-*-service` ∪ `money_path_services`, so
**14 released, deployed modules had no runbook at all**, and nothing could say so:

`admin-ui`, `authz-policy-auditor`, `case-coordinator-agent`, `clearing-simulator`,
`control-liveness-sentinel`, `customer-edge`, `devops-agent`, `docs-truth-agent`, `finops-agent`,
`flaky-test-hunter`, `governance-auditor`, `product-catalog`, `release-steward`, `security-scanner`

The row named only `customer-edge`. That is the one that matters most: the generator's own docstring notes
that its Redis holds durable, TTL-less passkey credentials.

## Why widening the population was not enough

The generated `kubectl` commands hard-coded the workload as `f"{short}-service"`. These modules
deploy under their **bare** name (`customer-edge` is Rollout `customer-edge`, `admin-ui` is
`admin-ui`). A population-only fix would have produced 14 runbooks telling on-call to run
`kubectl … deploy/customer-edge-service`, a resource that does not exist, during the incident the
runbook is for.

## Change

- `gitops_facts.workload_name(short, gitops)`: the Deployment/Rollout's **own** `metadata.name`,
  with the same matching discipline as `workload_kind()` (a manifest that merely mentions the service
  does not count).
- The generator uses it for every command, falling back to `<short>-service` only when there is no
  workload (unchanged behaviour for those).
- The title uses the real module directory (`{module}`, the same value the Service row already
  used). This also corrects three existing money-path runbooks whose title said
  `openbank-sepa-payment-service`, `openbank-sepa-instant-service` or `openbank-domestic-payment-service`.
- The population now also covers every module with a `version.txt` whose workload exists in gitops.

## Second commit: the gate could not protect this fix

Control B showed that `service-runbook-drift` cannot see a runbook the generator **stops** producing. The committed file stays on disk and diffs clean, so reverting the widening would have gone unnoticed. A full run of the generator now reports every committed `svc-*.md` outside the population as an **orphan** and exits 1: `orphan_runbooks()`, plus two self-test cases (22/22). On the real tree it is green (64 runbooks, 64 generated).

## Verification

| check | result |
|---|---|
| baseline: `--force` on clean `origin/main` | 50 written, tree clean (the gate was green before this change) |
| after | **64** written: 14 new, 3 existing changed (**title line only**, one line each), 47 untouched |
| **cross-check by effect**: every workload name in every runbook's commands (`deploy/X`, `rollout/X`, `argo rollouts restart X`, `patch rollout X`, `app.kubernetes.io/name=X`) resolved against a Deployment/Rollout with that `metadata.name` **and kind** in gitops | 83 references; **all 14 new runbooks resolve** (e.g. `customer-edge` is correctly a Rollout) |
| generator `--self-test` | 22/22 (20 existing plus 2 orphan cases) |
| `gitops_facts_test.py` | 12/12 |
| `regen-derived.sh` | no other derived artefact changed |
| `run-gates.py --only service-runbook-drift --only stale-comment-references --only python-lint` | PASS / PASS / PASS |
| **control A**: a staged edit to a new runbook's command (`rollout/customer-edge` → `rollout/customer-edge-service`) | drift gate exit **1**, so it guards the new runbooks' content |
| **control B**: population widening reverted, uncommitted | before the orphan check: gate exit **0**, population 64 → 50 and still green. After it: exit **1**, all 14 named as orphans |
| `ruff` | 17 findings on the branch, the same 17 on `origin/main`; none introduced |

Effect on the readiness matrix: both collectors score C9 from the existence of `svc-<short>.md`, so
these 14 modules move from `1 (no per-service runbook)` to `2 (service runbook)`. That is the point:
they had none.

## Found by the cross-check, pre-existing and not changed here

Four runbooks that already existed on `main` fail the same cross-check. This PR leaves their content
unchanged; they fail identically before and after it.

| runbook | problem | related |
|---|---|---|
| `svc-loyalty.md`, `svc-tax-reporting.md` | commands address `loyalty-service` / `tax-reporting-service`, but no such workload exists in gitops at all | #9800, #5760 (released with no deployment footprint) |
| `svc-communication.md`, `svc-referral.md` | the workloads exist (`communication-service`, `referral-service`), but the runbook carries no workload command at all | not yet filed |

The first pair is the generator's `<short>-service` fallback describing a service that isn't deployed.
Whether an undeployed module should get a runbook at all is a question for those issues.

Refs #6253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
